### PR TITLE
feat: virtual outputs streamed via PipeWire

### DIFF
--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -32,6 +32,18 @@ resolution = { width = 1920, height = 1080 }
 refresh_hz = 60.0
 position = { x = 1920, y = 0 }
 
+# Virtual outputs (optional) — headless outputs streamed via PipeWire.
+# Each entry creates a compositor output with no physical display.
+# Frames are pushed to a PipeWire stream; connect with any PipeWire client
+# (e.g. OBS Studio, pw-play, gst-launch-1.0). The PipeWire node ID is
+# logged at startup: "Virtual output 'virtual-1' started (PipeWire node 42)".
+#
+# [[virtual_outputs]]
+# name = "virtual-1"
+# resolution = { width = 1920, height = 1080 }
+# refresh_hz = 60.0
+# position = { x = 3840, y = 0 }   # optional: place next to physical outputs
+
 [input]
 # Touchpad tap-to-click (1-finger = left click, 2-finger = right click, 3-finger = middle click)
 tap_enabled = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub accent_color: String,
     #[serde(default = "shortcuts::default_shortcut_map")]
     pub keyboard_shortcuts: ShortcutMap,
+    #[serde(default)]
+    pub virtual_outputs: Vec<VirtualOutputConfig>,
     #[serde(skip)]
     #[serde(default)]
     shortcut_bindings: Vec<ShortcutBinding>,
@@ -77,6 +79,7 @@ impl Default for Config {
             accent_color: default_accent_color(),
             keyboard_shortcuts: shortcuts::default_shortcut_map(),
             shortcut_bindings: Vec::new(),
+            virtual_outputs: Vec::new(),
         };
         config.rebuild_shortcut_bindings();
         config
@@ -611,6 +614,25 @@ impl DisplayResolution {
 pub struct DisplayPosition {
     pub x: i32,
     pub y: i32,
+}
+
+/// Configuration for a virtual (headless) output streamed via PipeWire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VirtualOutputConfig {
+    /// Unique name for the virtual output (e.g. "virtual-1").
+    pub name: String,
+    /// Output resolution.
+    pub resolution: DisplayResolution,
+    /// Target refresh rate in Hz.
+    #[serde(default = "default_virtual_refresh_hz")]
+    pub refresh_hz: f64,
+    /// Output position in the compositor layout.
+    #[serde(default)]
+    pub position: Option<DisplayPosition>,
+}
+
+fn default_virtual_refresh_hz() -> f64 {
+    60.0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,16 @@ pub mod render_elements;
 #[cfg(feature = "metrics")]
 pub mod render_metrics;
 pub mod renderer;
-pub mod surface_style;
 pub mod screenshare;
 pub mod settings_service;
 pub mod shell;
 pub mod skia_renderer;
 pub mod state;
+pub mod surface_style;
 pub mod textures_storage;
 #[cfg(feature = "udev")]
 pub mod udev;
+pub mod virtual_output;
 #[cfg(feature = "winit")]
 pub mod winit;
 #[cfg(feature = "x11")]

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -782,8 +782,12 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             let outputs_for_window = self.workspaces.outputs_for_element(&window);
             let output = outputs_for_window
                 .first()
-                // The window hasn't been mapped yet, use the primary output instead
-                .or_else(|| self.workspaces.outputs().next())
+                // The window hasn't been mapped yet, use the primary physical output instead
+                .or_else(|| {
+                    self.workspaces
+                        .outputs()
+                        .find(|o| !crate::virtual_output::is_virtual_output(o))
+                })
                 // Assumes that at least one output exists
                 .expect("No outputs found")
                 .clone(); // Clone to avoid borrow conflicts

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -267,6 +267,9 @@ pub struct Otto<BackendData: Backend + 'static> {
     /// Manager for the screenshare D-Bus service (started lazily when needed).
     pub screenshare_manager: Option<crate::screenshare::ScreenshareManager>,
 
+    /// Virtual outputs defined in config, each streamed via PipeWire.
+    pub virtual_outputs: Vec<crate::virtual_output::VirtualOutputState>,
+
     // foreign toplevel list - maps surface ObjectId to unified toplevel handles (both protocols)
     pub foreign_toplevels: HashMap<ObjectId, foreign_toplevel_shared::ForeignToplevelHandles>,
 
@@ -684,6 +687,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             // screenshare
             screenshare_sessions: HashMap::new(),
             screenshare_manager: None,
+            virtual_outputs: Vec::new(),
 
             // foreign toplevel list
             foreign_toplevels: HashMap::new(),

--- a/src/virtual_output/mod.rs
+++ b/src/virtual_output/mod.rs
@@ -1,0 +1,127 @@
+/// Marker stored in `Output::user_data()` to identify virtual outputs.
+/// Used to exclude them from window placement, maximize, and output-under-cursor queries.
+pub struct VirtualOutputMarker;
+
+/// Returns true if the output is a virtual (PipeWire) output.
+pub fn is_virtual_output(output: &smithay::output::Output) -> bool {
+    output.user_data().get::<VirtualOutputMarker>().is_some()
+}
+
+use smithay::{
+    backend::{
+        allocator::{gbm::GbmDevice, Fourcc},
+        drm::DrmDeviceFd,
+        renderer::damage::OutputDamageTracker,
+    },
+    output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
+    reexports::wayland_server::backend::GlobalId,
+    utils::Point,
+};
+
+use crate::{
+    config::VirtualOutputConfig,
+    screenshare::{BackendCapabilities, PipeWireStream, StreamConfig},
+};
+
+/// Runtime state for one virtual output.
+pub struct VirtualOutputState {
+    /// The Smithay output (Wayland global, workspace mapping).
+    pub output: Output,
+    /// Global handle — must be kept alive for the Wayland global to exist.
+    pub _global: GlobalId,
+    /// PipeWire stream receiving rendered frames.
+    pub pipewire_stream: PipeWireStream,
+    /// Damage tracker for this output (always renders full frames, age=0).
+    pub damage_tracker: OutputDamageTracker,
+}
+
+impl VirtualOutputState {
+    /// Build an `Output` from config (without registering a Wayland global yet).
+    ///
+    /// The caller is responsible for calling `output.create_global::<D>()` and
+    /// storing the returned `GlobalId` in `_global`, then calling `finish()`.
+    pub fn build_output(config: &VirtualOutputConfig) -> Output {
+        let output = Output::new(
+            config.name.clone(),
+            PhysicalProperties {
+                size: (0, 0).into(),
+                subpixel: Subpixel::None,
+                make: "Otto".to_string(),
+                model: "Virtual".to_string(),
+                serial_number: String::new(),
+            },
+        );
+
+        let mode = Mode {
+            size: (
+                config.resolution.width as i32,
+                config.resolution.height as i32,
+            )
+                .into(),
+            refresh: (config.refresh_hz * 1000.0) as i32,
+        };
+
+        let screen_scale = crate::config::Config::with(|c| c.screen_scale);
+        let position: Point<i32, smithay::utils::Logical> = config
+            .position
+            .map(|p| (p.x, p.y).into())
+            .unwrap_or_else(|| (0, 0).into());
+
+        output.set_preferred(mode);
+        output.change_current_state(
+            Some(mode),
+            None,
+            Some(Scale::Fractional(screen_scale)),
+            Some(position),
+        );
+        output.user_data().insert_if_missing(|| VirtualOutputMarker);
+
+        output
+    }
+
+    /// Create a PipeWire stream and damage tracker for `output`, then start streaming.
+    ///
+    /// Returns the state and the PipeWire node ID that clients connect to.
+    pub fn start(
+        output: Output,
+        global: GlobalId,
+        config: &VirtualOutputConfig,
+        gbm_device: Option<GbmDevice<DrmDeviceFd>>,
+        format_modifiers: Vec<u64>,
+    ) -> Result<(Self, u32), String> {
+        let damage_tracker = OutputDamageTracker::from_output(&output);
+
+        let capabilities = if gbm_device.is_some() {
+            BackendCapabilities {
+                supports_dmabuf: true,
+                formats: vec![Fourcc::Argb8888, Fourcc::Xrgb8888],
+                modifiers: format_modifiers.iter().map(|&m| m as i64).collect(),
+            }
+        } else {
+            BackendCapabilities::default()
+        };
+
+        let stream_config = StreamConfig {
+            width: config.resolution.width,
+            height: config.resolution.height,
+            framerate_num: config.refresh_hz.round() as u32,
+            framerate_denom: 1,
+            capabilities,
+            gbm_device,
+        };
+
+        let mut pipewire_stream = PipeWireStream::new(stream_config);
+        let node_id = pipewire_stream
+            .start_sync()
+            .map_err(|e| format!("Failed to start PipeWire stream for '{}': {e}", config.name))?;
+
+        let state = Self {
+            output,
+            _global: global,
+            pipewire_stream,
+            damage_tracker,
+        };
+
+        Ok((state, node_id))
+    }
+}

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2539,7 +2539,11 @@ impl Workspaces {
     // Space management
 
     pub fn outputs_for_element(&self, element: &WindowElement) -> Vec<Output> {
-        self.space().outputs_for_element(element)
+        self.space()
+            .outputs_for_element(element)
+            .into_iter()
+            .filter(|o| !crate::virtual_output::is_virtual_output(o))
+            .collect()
     }
 
     fn apply_scroll_offset(
@@ -2627,7 +2631,9 @@ impl Workspaces {
         &self,
         point: P,
     ) -> impl Iterator<Item = &Output> {
-        self.space().output_under(point)
+        self.space()
+            .output_under(point)
+            .filter(|o| !crate::virtual_output::is_virtual_output(o))
     }
 
     pub fn element_geometry(


### PR DESCRIPTION
Add headless compositor outputs configured via TOML, each streamed as a PipeWire video node. Any PipeWire client (OBS, GStreamer, pw-play) can subscribe to the node ID logged at startup.

- New VirtualOutputConfig in config: name, resolution, refresh_hz, position
- New src/virtual_output/mod.rs: VirtualOutputState, build_output(), start()
  - VirtualOutputMarker user_data tag for filtering virtual outputs
- udev/init.rs: create virtual outputs from config, register Wayland globals, map into workspace at configured position, start PipeWire streams, register calloop::Timer for independent render loop at configured Hz
- udev/render.rs: render_virtual_outputs() renders scene + taps screenshare sessions targeting the virtual output connector name
- workspaces: filter virtual outputs from output_under() and outputs_for_element() so window placement ignores virtual outputs
- shell/xdg.rs: maximize_request fallback skips virtual outputs
- otto_config.example.toml: document [[virtual_outputs]] section