### PR TITLE
feat: wlr layer background support

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -537,7 +537,7 @@ impl<BackendData: Backend> WlrLayerShellHandler for Otto<BackendData> {
         // Create a lay_rs layer for rendering (container layer for the layer shell surface)
         let layer = self
             .workspaces
-            .create_layer_shell_layer(wlr_layer, &namespace);
+            .create_layer_shell_layer(wlr_layer, &namespace, &output);
 
         // For layer shells, the workspace layer IS the rendering layer
         // Register it in surface_layers so get_or_create_layer_for_surface returns it

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -69,6 +69,9 @@ pub struct OutputWorkspaces {
     pub workspaces_layer: Layer,
     /// Per-output expose layer (window overview mode).
     pub expose_layer: Layer,
+    /// Per-output container for wlr-layer-shell background/bottom surfaces.
+    /// Mirrored into each workspace view and expose window selector.
+    pub layer_shell_background: Layer,
     pub workspace_views: Vec<Arc<WorkspaceView>>,
 }
 
@@ -137,8 +140,6 @@ pub struct Workspaces {
     // layers
     pub layers_engine: Arc<Engine>,
     pub overlay_layer: Layer,
-    /// Container for wlr-layer-shell background layer surfaces
-    pub layer_shell_background: Layer,
 
     pub layer_shell_top: Layer,
     /// Container for wlr-layer-shell overlay layer surfaces  
@@ -153,31 +154,37 @@ pub struct Workspaces {
 /// ```diagram
 /// Workspaces
 /// root
-/// ├── workspaces
-/// │   ├── workspace_view_1
-/// │   │   ├── background_view (mirrored)
-/// │   │   └── workwspace_windows_container_1
-/// │   │       ├── window_view_1
-/// │   │       ├── window_view_2
-/// │   │       ...
-/// │   ├── workspace_view_2
-/// │   ...
-/// ├── expose
-/// │   ├── windows_selector_root_1
-/// │   │   ├── window_selector_background_1 (mirror: background_view)
-/// │   │   ├── window_selector_windows_container_1
-/// │   │   │   ├── mirror_window_1
-/// │   │   │   ├── mirror_window_2
-/// │   │   │   ...
-/// │   │   ├── window_selector_view_1
-/// │   ├── expose_view
-/// │   ├── app_switcher
+/// ├── output_layer (per output)
+/// │   ├── layer_shell_background (per-output wlr-layer-shell bg/bottom surfaces)
+/// │   ├── workspaces
+/// │   │   ├── workspace_view_1
+/// │   │   │   ├── background_view (config-driven)
+/// │   │   │   ├── layer_shell_bg_mirror (mirror: layer_shell_background)
+/// │   │   │   └── workspace_windows_container_1
+/// │   │   │       ├── window_view_1
+/// │   │   │       ├── window_view_2
+/// │   │   │       ...
+/// │   │   ├── workspace_view_2
+/// │   │   ...
+/// │   ├── expose
+/// │   │   ├── window_selector_root_1
+/// │   │   │   ├── window_selector_background_1 (mirror: background_view)
+/// │   │   │   ├── layer_shell_bg_expose_mirror (mirror: layer_shell_background)
+/// │   │   │   ├── window_selector_windows_container_1
+/// │   │   │   │   ├── mirror_window_1
+/// │   │   │   │   ├── mirror_window_2
+/// │   │   │   │   ...
+/// │   │   │   ├── window_selector_view_1
+/// │   │   ├── expose_view
+/// │   │   ├── app_switcher
+/// │   │
+/// │   ├── dock (primary only)
+/// │   ├── layer_shell_top (primary only)
+/// │   ├── popup_overlay (primary only)
+/// │   ├── layer_shell_overlay (primary only)
+/// │   ├── overlay (primary only)
 /// │
-/// ├── dnd_view
-/// ├── dock
-/// ├── popup_overlay (popups rendered on top of everything)
-/// ├── app_switcher
-/// ├── workspace_selector_view
+/// ├── workspace_selector_view (primary only)
 /// │   ├── workspace_selector_view_content
 /// │   │   ├── workspace_selector_desktop_1
 /// │   │   │   ├── workspace_selector_desktop_content_1
@@ -228,21 +235,6 @@ impl Workspaces {
         display_handle: DisplayHandle,
     ) -> (Self, smithay::reexports::calloop::channel::Channel<usize>) {
         let model = WorkspacesModel::default();
-
-        // Layer shell background layer (z-order: below workspaces)
-        let layer_shell_background = layers_engine.new_layer();
-        layer_shell_background.set_key("layer_shell_background");
-        layer_shell_background.set_layout_style(taffy::Style {
-            position: taffy::Position::Absolute,
-            size: taffy::Size {
-                width: taffy::Dimension::Percent(1.0),
-                height: taffy::Dimension::Percent(1.0),
-            },
-            ..Default::default()
-        });
-        layer_shell_background.set_pointer_events(false);
-        layer_shell_background.set_hidden(true);
-        // attached to output_layer in map_output_with_primary
 
         let expose_layer = layers_engine.new_layer();
         expose_layer.set_key("expose");
@@ -340,7 +332,6 @@ impl Workspaces {
             osd,
             app_icons_manager,
             overlay_layer,
-            layer_shell_background,
             layer_shell_top,
             layer_shell_overlay,
             show_all: Arc::new(AtomicBool::new(false)),
@@ -2901,14 +2892,26 @@ impl Workspaces {
 
         let is_this_primary = self.primary_output.as_ref().map(|o| o.name()) == Some(output.name());
 
+        // Create per-output layer_shell_background container
+        let layer_shell_background = self.layers_engine.new_layer();
+        layer_shell_background.set_key(format!("layer_shell_background_{}", output.name()));
+        layer_shell_background.set_layout_style(taffy::Style {
+            position: taffy::Position::Absolute,
+            size: taffy::Size {
+                width: taffy::Dimension::Percent(1.0),
+                height: taffy::Dimension::Percent(1.0),
+            },
+            ..Default::default()
+        });
+        layer_shell_background.set_pointer_events(false);
+        layer_shell_background.set_hidden(true);
+
         // Attach layers to output_layer in z-order (bottom to top):
-        // layer_shell_background (primary) → workspaces → expose → overlay (dnd, osd) →
+        // layer_shell_background → workspaces → expose → overlay (dnd, osd) →
         // dock (primary) → layer_shell_top → workspace_selector →
         // layer_shell_overlay → app_switcher (primary) → popup_overlay (primary)
-        if is_this_primary {
-            let _ = output_layer.add_sublayer(&self.layer_shell_background);
-        }
-        let _ = output_layer.add_sublayer(&workspaces_layer);
+        output_layer.add_sublayer(&layer_shell_background);
+        output_layer.add_sublayer(&workspaces_layer);
 
         // Create a per-output expose layer
         let expose_layer = self.layers_engine.new_layer();
@@ -2963,6 +2966,7 @@ impl Workspaces {
                 self.layers_engine.clone(),
                 &workspaces_layer,
                 self.overlay_layer.clone(),
+                &layer_shell_background,
             ));
             let _ = expose_layer.add_sublayer(&workspace.window_selector_view.window_selector_root);
             workspace_views.push(workspace);
@@ -2978,6 +2982,7 @@ impl Workspaces {
             output_layer,
             workspaces_layer,
             expose_layer,
+            layer_shell_background,
             workspace_views,
         };
         self.output_workspaces.insert(output.name(), ows);
@@ -3048,6 +3053,7 @@ impl Workspaces {
                     layers_engine.clone(),
                     &ows.workspaces_layer,
                     overlay_layer.clone(),
+                    &ows.layer_shell_background,
                 ));
                 let _ = ows
                     .expose_layer
@@ -3717,6 +3723,7 @@ impl Workspaces {
         &self,
         wlr_layer: smithay::wayland::shell::wlr_layer::Layer,
         namespace: &str,
+        output: &Output,
     ) -> Layer {
         use smithay::wayland::shell::wlr_layer::Layer as WlrLayer;
 
@@ -3730,21 +3737,17 @@ impl Workspaces {
             position: taffy::Position::Absolute,
             ..Default::default()
         });
-        // Layer shell surfaces handle their own pointer events
-        layer.set_pointer_events(true);
+        // Background layer surfaces sit behind everything — no pointer events.
+        // Other layer shell surfaces handle their own pointer events.
+        let has_pointer = !matches!(wlr_layer, WlrLayer::Background);
+        layer.set_pointer_events(has_pointer);
 
         // Add to appropriate container based on layer
         match wlr_layer {
-            WlrLayer::Background => {
-                self.layer_shell_background.set_hidden(false);
-                if let Err(e) = self.layer_shell_background.add_sublayer(&layer) {
-                    tracing::warn!("layer_shell: failed to add background layer: {e}");
-                }
-            }
-            WlrLayer::Bottom => {
-                self.layer_shell_background.set_hidden(false);
-                if let Err(e) = self.layer_shell_background.add_sublayer(&layer) {
-                    tracing::warn!("layer_shell: failed to add bottom layer: {e}");
+            WlrLayer::Background | WlrLayer::Bottom => {
+                if let Some(ows) = self.output_workspaces.get(&output.name()) {
+                    ows.layer_shell_background.set_hidden(false);
+                    ows.layer_shell_background.add_sublayer(&layer);
                 }
             }
             WlrLayer::Top => {

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -154,8 +154,8 @@ pub struct Workspaces {
 /// ```diagram
 /// Workspaces
 /// root
+/// ├── layer_shell_background (per output, hidden — content source only, not rendered directly)
 /// ├── output_layer (per output)
-/// │   ├── layer_shell_background (per-output wlr-layer-shell bg/bottom surfaces)
 /// │   ├── workspaces
 /// │   │   ├── workspace_view_1
 /// │   │   │   ├── background_view (config-driven)
@@ -2836,6 +2836,10 @@ impl Workspaces {
                 for space in ows.spaces.iter_mut() {
                     space.map_output(output, location);
                 }
+                // Keep layer_shell_background bounds in sync with the (possibly new) output size.
+                if let Some((w, h)) = output.current_mode().map(|m| (m.size.w as f32, m.size.h as f32)) {
+                    ows.layer_shell_background.set_size(layers::types::Size::points(w, h), None);
+                }
             }
             self.sync_model_from_primary();
             self.update_workspaces_layout();
@@ -2892,17 +2896,15 @@ impl Workspaces {
 
         let is_this_primary = self.primary_output.as_ref().map(|o| o.name()) == Some(output.name());
 
-        // Create per-output layer_shell_background container
+        // Create per-output layer_shell_background container, sized to the output's physical
+        // dimensions so mirror bounds are output-local rather than scene-root-relative.
         let layer_shell_background = self.layers_engine.new_layer();
         layer_shell_background.set_key(format!("layer_shell_background_{}", output.name()));
         layer_shell_background.set_layout_style(taffy::Style {
             position: taffy::Position::Absolute,
-            size: taffy::Size {
-                width: taffy::Dimension::Percent(1.0),
-                height: taffy::Dimension::Percent(1.0),
-            },
             ..Default::default()
         });
+        layer_shell_background.set_size(layers::types::Size::points(phys_w, phys_h), None);
         layer_shell_background.set_pointer_events(false);
         layer_shell_background.set_hidden(true);
 
@@ -3758,6 +3760,13 @@ impl Workspaces {
                 if let Some(ows) = self.output_workspaces.get(&output.name()) {
                     ows.layer_shell_background.set_hidden(false);
                     let _ = ows.layer_shell_background.add_sublayer(&layer);
+                } else {
+                    tracing::warn!(
+                        "create_layer_shell_layer: no output_workspaces entry for output '{}' \
+                         when creating {:?} layer; layer-shell surface may not be visible",
+                        output.name(),
+                        wlr_layer,
+                    );
                 }
             }
             WlrLayer::Top => {

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2906,11 +2906,21 @@ impl Workspaces {
         layer_shell_background.set_pointer_events(false);
         layer_shell_background.set_hidden(true);
 
+        // Attach layer_shell_background to the scene root (not the output_layer) so it
+        // doesn't get rendered directly — it only serves as a content source for mirror
+        // layers inside workspaces and expose views.
+        if let Some(root) = self
+            .layers_engine
+            .scene_root()
+            .and_then(|id| self.layers_engine.get_layer(&id))
+        {
+            root.add_sublayer(&layer_shell_background);
+        }
+
         // Attach layers to output_layer in z-order (bottom to top):
-        // layer_shell_background → workspaces → expose → overlay (dnd, osd) →
+        // workspaces → expose → overlay (dnd, osd) →
         // dock (primary) → layer_shell_top → workspace_selector →
         // layer_shell_overlay → app_switcher (primary) → popup_overlay (primary)
-        output_layer.add_sublayer(&layer_shell_background);
         output_layer.add_sublayer(&workspaces_layer);
 
         // Create a per-output expose layer

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2914,14 +2914,14 @@ impl Workspaces {
             .scene_root()
             .and_then(|id| self.layers_engine.get_layer(&id))
         {
-            root.add_sublayer(&layer_shell_background);
+            let _ = root.add_sublayer(&layer_shell_background);
         }
 
         // Attach layers to output_layer in z-order (bottom to top):
         // workspaces → expose → overlay (dnd, osd) →
         // dock (primary) → layer_shell_top → workspace_selector →
         // layer_shell_overlay → app_switcher (primary) → popup_overlay (primary)
-        output_layer.add_sublayer(&workspaces_layer);
+        let _ = output_layer.add_sublayer(&workspaces_layer);
 
         // Create a per-output expose layer
         let expose_layer = self.layers_engine.new_layer();
@@ -3757,7 +3757,7 @@ impl Workspaces {
             WlrLayer::Background | WlrLayer::Bottom => {
                 if let Some(ows) = self.output_workspaces.get(&output.name()) {
                     ows.layer_shell_background.set_hidden(false);
-                    ows.layer_shell_background.add_sublayer(&layer);
+                    let _ = ows.layer_shell_background.add_sublayer(&layer);
                 }
             }
             WlrLayer::Top => {

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2837,8 +2837,12 @@ impl Workspaces {
                     space.map_output(output, location);
                 }
                 // Keep layer_shell_background bounds in sync with the (possibly new) output size.
-                if let Some((w, h)) = output.current_mode().map(|m| (m.size.w as f32, m.size.h as f32)) {
-                    ows.layer_shell_background.set_size(layers::types::Size::points(w, h), None);
+                if let Some((w, h)) = output
+                    .current_mode()
+                    .map(|m| (m.size.w as f32, m.size.h as f32))
+                {
+                    ows.layer_shell_background
+                        .set_size(layers::types::Size::points(w, h), None);
                 }
             }
             self.sync_model_from_primary();

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -192,8 +192,7 @@ impl WindowSelectorView {
         // Mirror the per-output wlr-layer-shell background into expose,
         // above the config background mirror and below windows.
         let layer_shell_bg_expose_mirror = layers_engine.new_layer();
-        layer_shell_bg_expose_mirror
-            .set_key(format!("layer_shell_bg_expose_mirror_{}", index));
+        layer_shell_bg_expose_mirror.set_key(format!("layer_shell_bg_expose_mirror_{}", index));
         layer_shell_bg_expose_mirror.set_layout_style(taffy::Style {
             position: taffy::Position::Absolute,
             ..Default::default()

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -124,6 +124,7 @@ impl WindowSelectorView {
         layers_engine: Arc<Engine>,
         background_layer: Layer,
         drag_overlay_layer: Layer,
+        layer_shell_background: &Layer,
     ) -> Self {
         let window_selector_root = layers_engine.new_layer();
         window_selector_root.set_layout_style(taffy::Style {
@@ -188,7 +189,23 @@ impl WindowSelectorView {
 
         let _ = window_selector_root.add_sublayer(&window_selector_background);
 
-        let _ = window_selector_root.add_sublayer(&window_selector_windows_container);
+        // Mirror the per-output wlr-layer-shell background into expose,
+        // above the config background mirror and below windows.
+        let layer_shell_bg_expose_mirror = layers_engine.new_layer();
+        layer_shell_bg_expose_mirror
+            .set_key(format!("layer_shell_bg_expose_mirror_{}", index));
+        layer_shell_bg_expose_mirror.set_layout_style(taffy::Style {
+            position: taffy::Position::Absolute,
+            ..Default::default()
+        });
+        layer_shell_bg_expose_mirror.set_size(layers::types::Size::percent(1.0, 1.0), None);
+        layer_shell_bg_expose_mirror.set_draw_content(layer_shell_background.as_content());
+        layer_shell_bg_expose_mirror.set_picture_cached(false);
+        layer_shell_background.add_follower_node(&layer_shell_bg_expose_mirror);
+        layer_shell_bg_expose_mirror.set_pointer_events(false);
+        window_selector_root.add_sublayer(&layer_shell_bg_expose_mirror);
+
+        window_selector_root.add_sublayer(&window_selector_windows_container);
 
         let _ = window_selector_root.add_sublayer(&window_selector_view);
 

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -202,9 +202,9 @@ impl WindowSelectorView {
         layer_shell_bg_expose_mirror.set_picture_cached(false);
         layer_shell_background.add_follower_node(&layer_shell_bg_expose_mirror);
         layer_shell_bg_expose_mirror.set_pointer_events(false);
-        window_selector_root.add_sublayer(&layer_shell_bg_expose_mirror);
+        let _ = window_selector_root.add_sublayer(&layer_shell_bg_expose_mirror);
 
-        window_selector_root.add_sublayer(&window_selector_windows_container);
+        let _ = window_selector_root.add_sublayer(&window_selector_windows_container);
 
         let _ = window_selector_root.add_sublayer(&window_selector_view);
 

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -109,8 +109,8 @@ impl WorkspaceView {
         });
         windows_layer.set_pointer_events(false);
 
-        layers_engine.append_layer(&workspace_layer, parent.id);
-        layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
+        let _ = layers_engine.append_layer(&workspace_layer, parent.id);
+        let _ = layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
 
         // Mirror the per-output wlr-layer-shell background container into this workspace,
         // above the config-driven background_view and below windows.
@@ -125,9 +125,9 @@ impl WorkspaceView {
         layer_shell_bg_mirror.set_picture_cached(false);
         layer_shell_background.add_follower_node(&layer_shell_bg_mirror);
         layer_shell_bg_mirror.set_pointer_events(false);
-        layers_engine.append_layer(&layer_shell_bg_mirror, Some(workspace_layer.id));
+        let _ = layers_engine.append_layer(&layer_shell_bg_mirror, Some(workspace_layer.id));
 
-        layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
+        let _ = layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
 
         // Parse background color from config
         let background_color = Config::with(|c| parse_hex_color(&c.background_color));

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -58,7 +58,8 @@ impl fmt::Debug for WorkspaceView {
 /// ```diagram
 /// WorkspaceView
 /// └── workspace_view
-///     ├── background_view
+///     ├── background_view (config-driven gradient/image)
+///     ├── layer_shell_bg_mirror (mirror: per-output wlr-layer-shell background)
 ///     ├── workspace_windows_container
 ///     │   ├── window
 ///     │   ├── window
@@ -73,6 +74,7 @@ impl WorkspaceView {
         layers_engine: Arc<Engine>,
         parent: &Layer,
         overlay_layer: Layer,
+        layer_shell_background: &Layer,
     ) -> Self {
         println!("add_workspace {}", index);
 
@@ -107,9 +109,25 @@ impl WorkspaceView {
         });
         windows_layer.set_pointer_events(false);
 
-        let _ = layers_engine.append_layer(&workspace_layer, parent.id);
-        let _ = layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
-        let _ = layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
+        layers_engine.append_layer(&workspace_layer, parent.id);
+        layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
+
+        // Mirror the per-output wlr-layer-shell background container into this workspace,
+        // above the config-driven background_view and below windows.
+        let layer_shell_bg_mirror = layers_engine.new_layer();
+        layer_shell_bg_mirror.set_key(format!("layer_shell_bg_mirror_{}", index));
+        layer_shell_bg_mirror.set_layout_style(taffy::Style {
+            position: taffy::Position::Absolute,
+            ..Default::default()
+        });
+        layer_shell_bg_mirror.set_size(layers::types::Size::percent(1.0, 1.0), None);
+        layer_shell_bg_mirror.set_draw_content(layer_shell_background.as_content());
+        layer_shell_bg_mirror.set_picture_cached(false);
+        layer_shell_background.add_follower_node(&layer_shell_bg_mirror);
+        layer_shell_bg_mirror.set_pointer_events(false);
+        layers_engine.append_layer(&layer_shell_bg_mirror, Some(workspace_layer.id));
+
+        layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
 
         // Parse background color from config
         let background_color = Config::with(|c| parse_hex_color(&c.background_color));
@@ -126,6 +144,7 @@ impl WorkspaceView {
             layers_engine.clone(),
             background_view.base_layer.clone(),
             overlay_layer,
+            layer_shell_background,
         );
 
         let window_selector_view = Arc::new(window_selector_view);


### PR DESCRIPTION
## wlr-layer-shell background support (per-output)

Adds proper support for the **wlr-layer-shell background/bottom layer**, enabling the most common Wayland background pickers and wallpaper setters to work with Otto — including **swaybg**, **swww**, **hyprpaper**, **mpvpaper**, and **wbg**.

### What changed

- **Per-output background container**: each output gets its own `layer_shell_background` layer, sized to the output's physical dimensions. Background/Bottom layer-shell surfaces are routed into the matching output's container.
- **Workspace mirrors**: the per-output background container is mirrored into every workspace view (above the config-driven background, below windows) so the wallpaper appears in normal mode.
- **Expose mirrors**: the background is also mirrored into every window-selector (expose) view so the wallpaper is visible during the overview.
- **Pointer events disabled** for Background layer surfaces.
- **Hidden content source**: the background container lives under the scene root (not directly on the output layer) so it is never rendered directly — only through its mirrors.
- **Resize-aware**: on output re-mapping (e.g. resolution change) the background container size is updated to match the new mode.
- **Unmatched output warning**: if a background surface is created before an output is mapped, a `tracing::warn!` is emitted instead of silently dropping the surface.
