### PR TITLE
fix: minimise window on auto-hide dock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ mpris = "2.0"
 otto-kit = { path = "components/otto-kit" }
 
 [dependencies.laye-rs]
-# path = "../layers"
-git = "https://github.com/nongio/layers"
-tag = "v1.4.3"
+path = "../layers"
+# git = "https://github.com/nongio/layers"
+# branch = "feat/animation-ref-future"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ mpris = "2.0"
 otto-kit = { path = "components/otto-kit" }
 
 [dependencies.laye-rs]
-path = "../layers"
-# git = "https://github.com/nongio/layers"
-# branch = "feat/animation-ref-future"
+# path = "../layers"
+git = "https://github.com/nongio/layers"
+tag = "v1.5.0"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ otto-kit = { path = "components/otto-kit" }
 [dependencies.laye-rs]
 # path = "../layers"
 git = "https://github.com/nongio/layers"
-tag = "v1.5.0"
+tag = "v1.6.0"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -23,7 +23,7 @@ pipewire = "0.9"
 [dependencies.laye-rs]
 # path = "../layers"
 git = "https://github.com/nongio/layers"
-tag = "v1.5.0"
+tag = "v1.6.0"
 features = ["export-taffy"]
 
 [features]

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -21,9 +21,9 @@ lazy_static = "1.4"
 pipewire = "0.9"
 
 [dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.4.3"
-# path = "../../../layers"
+path = "../../../layers"
+# git = "https://github.com/nongio/layers"
+# branch = "feat/animation-ref-future"
 features = ["export-taffy"]
 
 [features]

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -21,9 +21,9 @@ lazy_static = "1.4"
 pipewire = "0.9"
 
 [dependencies.laye-rs]
-path = "../../../layers"
-# git = "https://github.com/nongio/layers"
-# branch = "feat/animation-ref-future"
+# path = "../layers"
+git = "https://github.com/nongio/layers"
+tag = "v1.5.0"
 features = ["export-taffy"]
 
 [features]

--- a/components/otto-kit/src/components/layers/frame.rs
+++ b/components/otto-kit/src/components/layers/frame.rs
@@ -14,7 +14,7 @@ impl LayerFrame {
             .expect("Layers engine not initialized. Make sure to call this after app starts.");
 
         let layer = engine.new_layer();
-        engine.add_layer(&layer.id());
+        let _ = engine.add_layer(&layer.id());
 
         LayerFrame { layer }
     }
@@ -56,7 +56,7 @@ impl LayerFrame {
     }
 
     pub fn add_child(&self, child: &LayerFrame) {
-        self.layer.add_sublayer(&child.id());
+        let _ = self.layer.add_sublayer(&child.id());
     }
 
     pub fn set_draw(&self, draw_fn: impl Into<ContentDrawFunction>) {

--- a/components/otto-kit/src/components/layers/stack.rs
+++ b/components/otto-kit/src/components/layers/stack.rs
@@ -38,7 +38,7 @@ impl LayerStack {
             ..Default::default()
         });
 
-        engine.add_layer(&layer.id());
+        let _ = engine.add_layer(&layer.id());
 
         LayerStack { layer }
     }
@@ -78,11 +78,11 @@ impl LayerStack {
     }
 
     pub fn add_child(&self, child: &super::frame::LayerFrame) {
-        self.layer.add_sublayer(&child.id());
+        let _ = self.layer.add_sublayer(&child.id());
     }
 
     pub fn add_stack(&self, child: &LayerStack) {
-        self.layer.add_sublayer(&child.id());
+        let _ = self.layer.add_sublayer(&child.id());
     }
 
     pub fn set_draw(&self, draw_fn: impl Into<ContentDrawFunction>) {

--- a/components/otto-kit/src/rendering/layers_renderer.rs
+++ b/components/otto-kit/src/rendering/layers_renderer.rs
@@ -15,7 +15,7 @@ impl LayersRenderer {
         let root = engine.new_layer();
         root.set_key("root");
         root.set_size(layers::types::Size::points(width, height), None);
-        engine.add_layer(&root);
+        let _ = engine.add_layer(&root);
         engine.scene_set_root(root);
         engine.scene_set_size(width, height);
         #[cfg(feature = "debugger")]

--- a/components/otto-kit/src/surfaces/common.rs
+++ b/components/otto-kit/src/surfaces/common.rs
@@ -41,7 +41,7 @@ impl BaseWaylandSurface {
         let layer_node = AppContext::layers_engine().map(|engine| {
             let l = engine.new_layer();
             l.set_size(Size::points(width as f32, height as f32), None);
-            engine.add_layer(&l);
+            let _ = engine.add_layer(&l);
             l
         });
         let surface_style = AppContext::surface_style_manager()

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -2,6 +2,10 @@
 screen_scale = 1.0
 locales = ["en"]  # Language preferences for app names/desktop entries (e.g., ["fr", "en"])
 
+# Occlusion culling: skip rendering of layers fully hidden behind opaque layers.
+# Improves GPU/CPU throughput when windows overlap. Disable if you see missing content.
+# occlusion_culling = false
+
 # Theme
 cursor_size = 24
 font_family = "Inter"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub keyboard_shortcuts: ShortcutMap,
     #[serde(default)]
     pub virtual_outputs: Vec<VirtualOutputConfig>,
+    #[serde(default)]
+    pub occlusion_culling: bool,
     #[serde(skip)]
     #[serde(default)]
     shortcut_bindings: Vec<ShortcutBinding>,
@@ -80,6 +82,7 @@ impl Default for Config {
             keyboard_shortcuts: shortcuts::default_shortcut_map(),
             shortcut_bindings: Vec::new(),
             virtual_outputs: Vec::new(),
+            occlusion_culling: false,
         };
         config.rebuild_shortcut_bindings();
         config

--- a/src/render_elements/scene_element.rs
+++ b/src/render_elements/scene_element.rs
@@ -28,7 +28,6 @@ pub struct SceneElement {
     last_update: Instant,
     pub size: (f32, f32),
     damage: Rc<RefCell<DamageBag<i32, Physical>>>,
-    empty_damage_count: Rc<RefCell<u32>>,
     /// When set, render from this node instead of the global scene root.
     /// Used to render only a specific output's sub-tree (coordinates are output-local).
     pub output_root: Option<NodeRef>,
@@ -45,7 +44,6 @@ impl SceneElement {
             last_update: Instant::now(),
             size: (0.0, 0.0),
             damage: Rc::new(RefCell::new(DamageBag::new(5))),
-            empty_damage_count: Rc::new(RefCell::new(0)),
             output_root: None,
             #[cfg(feature = "perf-counters")]
             perf_stats: Rc::new(RefCell::new(ScenePerfStats::new())),
@@ -76,6 +74,10 @@ impl SceneElement {
             stats.log_if_due();
             return false;
         }
+
+        // Reset occlusion data for the new frame; each output will
+        // recompute its own occlusion set during draw().
+        self.engine.clear_occlusion();
 
         #[cfg(feature = "perf-counters")]
         {
@@ -238,24 +240,21 @@ impl Element for SceneElement {
         commit: Option<CommitCounter>,
     ) -> smithay::backend::renderer::utils::DamageSet<i32, Physical> {
         let geometry_size = self.geometry(scale).size;
+        if geometry_size.w <= 0 || geometry_size.h <= 0 {
+            return DamageSet::default();
+        }
+
+        let full_damage = Rectangle::new((0, 0).into(), geometry_size);
         let damage = self.damage.borrow().damage_since(commit);
 
         match damage {
-            Some(rects) if !rects.is_empty() => {
-                *self.empty_damage_count.borrow_mut() = 0;
-                DamageSet::from_slice(&rects)
-            }
-            None if geometry_size.w > 0 && geometry_size.h > 0 => {
-                let mut count = self.empty_damage_count.borrow_mut();
-                *count += 1;
-                if *count >= 3 {
-                    *count = 0;
-                    let full_damage = Rectangle::new((0, 0).into(), geometry_size);
-                    DamageSet::from_slice(&[full_damage])
-                } else {
-                    DamageSet::default()
-                }
-            }
+            // Known damage rects — return them as partial damage.
+            // The canvas will be clipped to these rects so only the
+            // changed region is cleared and redrawn.
+            Some(rects) if !rects.is_empty() => DamageSet::from_slice(&rects),
+            // Commit too old or unknown (new buffer) — must repaint everything.
+            None => DamageSet::from_slice(&[full_damage]),
+            // Nothing changed — Smithay can safely skip this element.
             _ => DamageSet::default(),
         }
     }
@@ -292,7 +291,6 @@ impl RenderElement<SkiaRenderer> for SceneElement {
         let mut surface = frame.skia_surface.clone();
 
         let canvas = surface.canvas();
-        // canvas.clear(layers::skia::Color::TRANSPARENT);
         let scene = self.engine.scene();
         // Use per-output root if set, otherwise fall back to global scene root.
         let root_id = self.output_root.or_else(|| self.engine.scene_root());
@@ -307,6 +305,31 @@ impl RenderElement<SkiaRenderer> for SceneElement {
         );
         canvas.clip_rect(output_clip, Some(layers::skia::ClipOp::Intersect), false);
 
+        // Build a Skia Region from the damage rects for canvas clipping and
+        // node-level culling. Each damage rect is offset by the destination
+        // position so it aligns with scene-space coordinates on the canvas.
+        let damage_region = if !damage.is_empty() {
+            let irects: Vec<layers::skia::IRect> = damage
+                .iter()
+                .map(|r| {
+                    layers::skia::IRect::from_xywh(
+                        r.loc.x + dst.loc.x,
+                        r.loc.y + dst.loc.y,
+                        r.size.w,
+                        r.size.h,
+                    )
+                })
+                .collect();
+            let mut region = layers::skia::Region::new();
+            region.set_rects(&irects);
+            // Clip the canvas to the damage region so Skia skips drawing
+            // outside the damaged area entirely.
+            canvas.clip_region(&region, Some(layers::skia::ClipOp::Intersect));
+            Some(region)
+        } else {
+            None
+        };
+
         // If rendering from an output sub-tree, translate so the output_layer's
         // scene-space position maps to (0,0) on the output framebuffer.
         if let Some(oid) = self.output_root {
@@ -318,83 +341,39 @@ impl RenderElement<SkiaRenderer> for SceneElement {
             }
         }
 
+        // Compute occlusion for this output's root and retrieve the occluded set.
+        let occluded_set = if crate::config::Config::with(|c| c.occlusion_culling) {
+            if let Some(root_id) = root_id {
+                self.engine.compute_occlusion(root_id);
+                scene.occlusion_map()
+                    .and_then(|m| m.get(&root_id).cloned())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let occluded_ref = occluded_set.as_ref();
+        let damage_ref = damage_region.as_ref();
+
         scene.with_arena(|arena| {
             scene.with_renderable_arena(|renderable_arena| {
                 if let Some(root_id) = root_id {
-                    // Check if we should use damage clipping or render full scene
-                    // Only use damage clipping when:
-                    // 1. Damage is provided (not empty)
-                    // 2. Damage is partial (not covering entire element)
-                    // This ensures buffer preservation is working correctly
-
-                    let should_clip = if damage.is_empty() {
-                        false // No damage info, render full
-                    } else {
-                        // Check if damage covers the entire element
-                        let total_damage_area: i32 =
-                            damage.iter().map(|r| r.size.w * r.size.h).sum();
-                        let element_area = dst.size.w * dst.size.h;
-
-                        // If damage is less than 95% of element, use clipping
-                        // (95% threshold to account for rounding)
-                        total_damage_area < (element_area * 95 / 100)
-                    };
-
-                    if should_clip {
-                        // Use Skia Region for efficient multi-rect clipping
-                        let mut clip_region = layers::skia::Region::new();
-                        for d in damage.iter() {
-                            if d.size.w <= 0 || d.size.h <= 0 {
-                                continue;
-                            }
-                            let irect = layers::skia::IRect::from_xywh(
-                                d.loc.x, d.loc.y, d.size.w, d.size.h,
-                            );
-                            clip_region.op_rect(irect, layers::skia::region::RegionOp::Union);
-                        }
-
-                        // Render scene once with complex clip region
-                        if !clip_region.is_empty() {
-                            canvas.save();
-                            canvas.clip_region(&clip_region, Some(layers::skia::ClipOp::Intersect));
-                            render_node_tree(root_id, arena, renderable_arena, canvas, 1.0);
-                            canvas.restore();
-                        }
-                    } else {
-                        // No damage or full screen damage - render everything
-                        render_node_tree(root_id, arena, renderable_arena, canvas, 1.0);
-                    }
-                    // Optional debug: outline damage rect
-                    // let mut paint = layers::skia::Paint::default();
-                    // paint.set_color(layers::skia::Color::from_argb(255, 255, 0, 0));
-                    // paint.set_stroke(true);
-                    // paint.set_stroke_width(1.0);
-                    // for damage_rect in damage.iter() {
-                    //     if !damage_rect.is_empty() {
-                    //         let r = layers::skia::Rect::from_xywh(
-                    //             damage_rect.loc.x as f32,
-                    //             damage_rect.loc.y as f32,
-                    //             damage_rect.size.w as f32,
-                    //             damage_rect.size.h as f32,
-                    //         );
-                    //         canvas.draw_rect(r, &paint);
-                    //     }
-                    // }
-                    // let typeface = crate::workspace::utils::FONT_CACHE
-                    // .with(|font_cache| {
-                    //     font_cache
-                    //         .font_mgr
-                    //         .match_family_style("Inter", layers::skia::FontStyle::default())
-                    // })
-                    // .unwrap();
-                    // let font = layers::skia::Font::from_typeface_with_params(typeface, 22.0, 1.0, 0.0);
-                    // let pos = self.engine.get_pointer_position();
-                    // canvas.draw_str(format!("{},{}", pos.x, pos.y), (50.0, 50.0), &font, &paint);
+                    render_node_tree(
+                        root_id,
+                        arena,
+                        renderable_arena,
+                        canvas,
+                        1.0,
+                        occluded_ref,
+                        damage_ref,
+                    );
                 }
                 self.engine.clear_damage();
             });
         });
         canvas.restore_to_count(save_point);
+
         Ok(())
     }
 }

--- a/src/render_elements/scene_element.rs
+++ b/src/render_elements/scene_element.rs
@@ -345,8 +345,7 @@ impl RenderElement<SkiaRenderer> for SceneElement {
         let occluded_set = if crate::config::Config::with(|c| c.occlusion_culling) {
             if let Some(root_id) = root_id {
                 self.engine.compute_occlusion(root_id);
-                scene.occlusion_map()
-                    .and_then(|m| m.get(&root_id).cloned())
+                scene.occlusion_map().and_then(|m| m.get(&root_id).cloned())
             } else {
                 None
             }

--- a/src/renderer/frame.rs
+++ b/src/renderer/frame.rs
@@ -3,14 +3,13 @@
 //! This module contains all the trait implementations for SkiaFrame,
 //! handling frame rendering, texture drawing, and buffer blitting operations.
 
-use layers::{sb, skia};
+use layers::skia;
 use smithay::{
     backend::renderer::{gles::GlesError, sync::SyncPoint, Color32F, ContextId, Frame, Renderer},
     utils::{Buffer, Physical, Rectangle, Transform},
 };
-use std::sync::atomic::Ordering;
 
-use super::{finished_proc, FlushInfo2, SkiaFrame, SkiaSync, SkiaTexture, FINISHED_PROC_STATE};
+use super::{SkiaFrame, SkiaSync, SkiaTexture};
 
 impl Frame for SkiaFrame<'_> {
     type Error = GlesError;
@@ -185,46 +184,30 @@ impl Frame for SkiaFrame<'_> {
     fn finish(self) -> Result<SyncPoint, Self::Error> {
         let mut surface = self.skia_surface;
 
-        let info = FlushInfo2 {
-            fNumSemaphores: 0,
-            fGpuStatsFlags: 0,
-            fSignalSemaphores: std::ptr::null_mut(),
-            fFinishedProc: Some(finished_proc),
-            fFinishedWithStatsProc: None,
-            fFinishedContext: std::ptr::null_mut(),
-            fSubmittedProc: None,
-            fSubmittedContext: std::ptr::null_mut(),
-        };
+        // IMPORTANT: Use the *surface-specific* flush, not a bare context flush.
+        //
+        // Skia defers draw calls and records them against the target surface.
+        // `gr_context.flush_and_submit()` flushes the context globally, but does
+        // NOT guarantee that the pending ops recorded against *this* surface have
+        // been resolved to GL commands on its FBO.
+        //
+        // `flush_and_submit_surface()` explicitly resolves the given surface's
+        // recorded ops first, then submits the resulting GL commands.  Without
+        // this, the EGL fence we create below may be inserted *before* Skia has
+        // actually emitted the GL draw calls for this frame's content — causing
+        // the GPU to scan out a partially/un-rendered buffer (black frame).
+        surface
+            .gr_context
+            .flush_and_submit_surface(&mut surface.surface, None);
 
-        // Transmute flushinfo2 into flushinfo
-        let info = unsafe {
-            let native = &*(&info as *const FlushInfo2 as *const sb::GrFlushInfo);
-            &*(native as *const sb::GrFlushInfo as *const layers::skia::gpu::FlushInfo)
-        };
+        let sync = SkiaSync::create(self.renderer.egl_context().display())
+            .map(SyncPoint::from)
+            .unwrap_or_else(|err| {
+                tracing::warn!(?err, "Failed to create EGL fence, falling back to signaled");
+                SyncPoint::signaled()
+            });
 
-        FINISHED_PROC_STATE.store(false, Ordering::SeqCst);
-
-        let semaphores = surface.gr_context.flush(info);
-
-        // FIXME review sync logic
-        let syncpoint = if semaphores == skia::gpu::SemaphoresSubmitted::Yes {
-            profiling::scope!("FINISHED_PROC_STATE");
-            let skia_sync = SkiaSync::create(self.renderer.egl_context().display())
-                .map_err(|_err| GlesError::FramebufferBindingError)?;
-            SyncPoint::from(skia_sync)
-        } else {
-            SyncPoint::signaled()
-        };
-
-        {
-            profiling::scope!("context_submit");
-            surface.gr_context.submit(None);
-            // surface
-            //     .gr_context
-            //     .flush_and_submit_surface(&mut surface.surface, GrSyncCpu::Yes);
-        }
-
-        Ok(syncpoint)
+        Ok(sync)
     }
 
     fn wait(

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -24,7 +24,7 @@ pub mod textures;
 // Re-export commonly used types
 pub use egl_context::EGLSurfaceWrapper;
 pub use skia_surface::SkiaSurface;
-pub use sync::{finished_proc, FlushInfo2, SkiaSync, FINISHED_PROC_STATE};
+pub use sync::SkiaSync;
 pub use textures::{SkiaFrame, SkiaGLesFbo, SkiaTexture, SkiaTextureImage, SkiaTextureMapping};
 
 use smithay::{

--- a/src/renderer/sync.rs
+++ b/src/renderer/sync.rs
@@ -91,9 +91,7 @@ impl Fence for SkiaSync {
         // missing the call returns -1 and we fall back to CPU wait.
         use smithay::backend::egl::ffi::egl;
 
-        let fd = unsafe {
-            egl::DupNativeFenceFDANDROID(**self.0.display_handle, self.0.handle)
-        };
+        let fd = unsafe { egl::DupNativeFenceFDANDROID(**self.0.display_handle, self.0.handle) };
         if fd >= 0 {
             Some(unsafe { std::os::unix::io::OwnedFd::from_raw_fd(fd) })
         } else {

--- a/src/renderer/sync.rs
+++ b/src/renderer/sync.rs
@@ -1,20 +1,25 @@
-//! EGL fence and synchronization primitives for GPU rendering.
+//! Per-frame EGL fence synchronization for GPU rendering.
 //!
-//! This module handles GPU synchronization using EGL sync objects and Skia's
-//! flush callbacks. The sync logic ensures proper ordering of GPU commands
-//! between the compositor and clients.
+//! Each frame gets its own EGL fence inserted into the GL command stream
+//! immediately after Skia flushes.  The fence is returned inside a
+//! `SyncPoint` that Smithay can:
+//!
+//!   * **export** as a native fd for DRM in-fence (zero-copy GPU-side sync), or
+//!   * **wait** on from the CPU (fallback when kernel fencing isn't available).
+//!
+//! This replaces the previous global `AtomicBool` + `finished_proc` callback
+//! approach which was racy across multi-buffer rendering: a callback from
+//! frame N could falsely signal frame N+1's fence because they shared a
+//! single boolean.
 //!
 //! # Safety
 //!
-//! This module contains unsafe FFI calls to EGL. The safety invariants are:
+//! This module contains unsafe FFI calls to EGL.  The safety invariants are:
 //! - EGLSync handles must be created from a valid EGL display
 //! - EGLSync handles are destroyed exactly once when the last Arc reference drops
 //! - Display handle must remain valid for the lifetime of the sync object
 
-use std::{
-    sync::atomic::{AtomicBool, Ordering},
-    time::Duration,
-};
+use std::{os::unix::io::FromRawFd, time::Duration};
 
 use smithay::backend::{
     egl::{
@@ -24,52 +29,11 @@ use smithay::backend::{
     renderer::sync::{Fence, Interrupted},
 };
 
-// This is a "hack" to expose finished_proc and submitted_proc
-// until a PR is made to skia-bindings
-use layers::sb;
-
-/// FFI structure for Skia flush callbacks.
-///
-/// This structure mirrors Skia's internal GrFlushInfo but with explicit
-/// callback pointers exposed. Used to hook into Skia's rendering pipeline
-/// for synchronization.
-///
-/// # Safety
-///
-/// This is an FFI type that must match Skia's C++ layout exactly.
-#[repr(C)]
-#[allow(dead_code, non_snake_case)]
-#[derive(Debug)]
-pub struct FlushInfo2 {
-    pub fNumSemaphores: usize,
-    pub fGpuStatsFlags: sb::skgpu_GpuStatsFlags,
-    pub fSignalSemaphores: *mut sb::GrBackendSemaphore,
-    pub fFinishedProc: sb::GrGpuFinishedProc,
-    pub fFinishedWithStatsProc: sb::GrGpuFinishedWithStatsProc,
-    pub fFinishedContext: sb::GrGpuFinishedContext,
-    pub fSubmittedProc: sb::GrGpuSubmittedProc,
-    pub fSubmittedContext: sb::GrGpuSubmittedContext,
-}
-
-/// Global state tracking whether Skia has finished processing.
-///
-/// This is set by the `finished_proc` callback when Skia completes GPU work.
-pub static FINISHED_PROC_STATE: AtomicBool = AtomicBool::new(false);
-
-/// Callback invoked by Skia when GPU work completes.
-///
-/// # Safety
-///
-/// Called from Skia's internal GPU thread. Must be thread-safe and not panic.
-pub unsafe extern "C" fn finished_proc(_: *mut ::core::ffi::c_void) {
-    FINISHED_PROC_STATE.store(true, Ordering::SeqCst);
-}
-
 /// Inner fence data containing the EGL sync handle.
 ///
-/// This is wrapped in an Arc to allow cheap cloning while ensuring
-/// proper cleanup when the last reference is dropped.
-#[derive(Debug, Clone)]
+/// Wrapped in an Arc so cloning a `SkiaSync` is cheap while the underlying
+/// kernel sync object is freed exactly once.
+#[derive(Debug)]
 struct InnerSkiaFence {
     display_handle: std::sync::Arc<EGLDisplayHandle>,
     handle: EGLSync,
@@ -78,19 +42,20 @@ struct InnerSkiaFence {
 unsafe impl Send for InnerSkiaFence {}
 unsafe impl Sync for InnerSkiaFence {}
 
-/// EGL-based GPU synchronization fence.
+/// Per-frame EGL fence sync object.
 ///
-/// Wraps an EGL sync object to provide GPU-CPU synchronization.
-/// The fence can be waited on to ensure GPU commands have completed.
+/// Created immediately after Skia flushes its GL command stream so that the
+/// fence captures *exactly* the GPU work for one buffer.  Each buffer in the
+/// swapchain gets its own fence — no shared global state.
 #[derive(Debug, Clone)]
 pub struct SkiaSync(std::sync::Arc<InnerSkiaFence>);
 
 impl SkiaSync {
-    /// Creates a new EGL fence sync object.
+    /// Insert an `EGL_SYNC_FENCE` into the current GL command stream.
     ///
-    /// # Safety
-    ///
-    /// The display must be valid and current on the calling thread's context.
+    /// Must be called while the EGL context that performed the rendering is
+    /// still current.  The returned fence will signal once every GL command
+    /// submitted *before* this call has completed on the GPU.
     pub fn create(display: &EGLDisplay) -> Result<Self, egl::Error> {
         use smithay::backend::egl::ffi::egl::{CreateSync, SYNC_FENCE};
 
@@ -109,10 +74,7 @@ impl SkiaSync {
 
 impl Drop for InnerSkiaFence {
     fn drop(&mut self) {
-        // Best-effort destroy of the EGLSync fence to avoid leaking kernel objects/FDs.
-        // Safe if called once at last Arc drop; ignored by drivers if already destroyed.
         unsafe {
-            // Use the raw egl ffi to destroy the sync; ignore errors.
             let _ =
                 smithay::backend::egl::ffi::egl::DestroySync(**self.display_handle, self.handle);
         }
@@ -121,58 +83,75 @@ impl Drop for InnerSkiaFence {
 
 impl Fence for SkiaSync {
     fn export(&self) -> Option<std::os::unix::prelude::OwnedFd> {
-        None
+        // Try to duplicate the EGL fence as a native sync fd.
+        //
+        // If the driver supports EGL_ANDROID_native_fence_sync this gives
+        // Smithay an fd it can pass as a DRM in-fence — the display hardware
+        // waits on the GPU without any CPU involvement.  If the extension is
+        // missing the call returns -1 and we fall back to CPU wait.
+        use smithay::backend::egl::ffi::egl;
+
+        let fd = unsafe {
+            egl::DupNativeFenceFDANDROID(**self.0.display_handle, self.0.handle)
+        };
+        if fd >= 0 {
+            Some(unsafe { std::os::unix::io::OwnedFd::from_raw_fd(fd) })
+        } else {
+            None
+        }
     }
 
     fn is_exportable(&self) -> bool {
+        // We attempt export in `export()` and let it fail gracefully.
+        // Returning false here makes Smithay skip the native-fence path
+        // and go straight to `wait()`, which is fine as a default.
         false
     }
 
     fn is_signaled(&self) -> bool {
-        FINISHED_PROC_STATE.load(Ordering::SeqCst)
+        // Non-blocking poll of the per-frame EGL fence.
+        use smithay::backend::egl::ffi;
+
+        let status = unsafe {
+            ffi::egl::ClientWaitSync(
+                **self.0.display_handle,
+                self.0.handle,
+                0, // no flush — Skia already submitted
+                0, // timeout = 0 → non-blocking
+            )
+        };
+        status == ffi::egl::CONDITION_SATISFIED as ffi::egl::types::EGLint
     }
 
     fn wait(&self) -> Result<(), Interrupted> {
         use smithay::backend::egl::ffi;
 
-        let timeout = Some(Duration::from_millis(2))
-            .map(|t| t.as_nanos() as ffi::egl::types::EGLuint64KHR)
-            .unwrap_or(ffi::egl::FOREVER);
+        // 100 ms is generous — a single frame's GPU work rarely exceeds a
+        // few milliseconds.  SYNC_FLUSH_COMMANDS_BIT ensures any commands
+        // still queued in the GL pipeline are flushed before we block.
+        let timeout_ns: ffi::egl::types::EGLuint64KHR =
+            Duration::from_millis(100).as_nanos() as ffi::egl::types::EGLuint64KHR;
 
-        let flush = false;
-        let flags = if flush {
-            ffi::egl::SYNC_FLUSH_COMMANDS_BIT as ffi::egl::types::EGLint
-        } else {
-            0
-        };
-        let _status = wrap_egl_call(
+        let status = wrap_egl_call(
             || unsafe {
-                ffi::egl::ClientWaitSync(**self.0.display_handle, self.0.handle, flags, timeout)
+                ffi::egl::ClientWaitSync(
+                    **self.0.display_handle,
+                    self.0.handle,
+                    ffi::egl::SYNC_FLUSH_COMMANDS_BIT as ffi::egl::types::EGLint,
+                    timeout_ns,
+                )
             },
             ffi::egl::FALSE as ffi::egl::types::EGLint,
         )
         .map_err(|err| {
-            tracing::warn!(?err, "Waiting for fence was interrupted");
+            tracing::warn!(?err, "EGL fence wait failed");
             Interrupted
         })?;
 
-        // FIXME do we need to destroy the sync?
-        // wrap_egl_call(
-        //     || unsafe {
-        //         ffi::egl::DestroySync(**self.0.display_handle, self.0.handle) as i32
-        //     },
-        //     ffi::egl::FALSE as ffi::egl::types::EGLint,
-        // )
-        // .map_err(|err| {
-        //     tracing::warn!(?err, "Waiting for fence was interrupted");
-        //     Interrupted
-        // })?;
+        if status == ffi::egl::TIMEOUT_EXPIRED as ffi::egl::types::EGLint {
+            tracing::warn!("EGL fence wait timed out after 100 ms — possible GPU hang");
+        }
+
         Ok(())
-        // while !self.is_signaled() {
-        //     if start.elapsed() >=  {
-        //         break;
-        //     }
-        // }
-        // while !self.is_signaled() {}
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -465,7 +465,8 @@ impl<BackendData: Backend> Otto<BackendData> {
                 if let Some(parent_id) = parent_id {
                     if surface_id != parent_id {
                         if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                            self.layers_engine
+                            let _ = self
+                                .layers_engine
                                 .append_layer(&surface_layer, parent_layer.id());
                         }
                     }

--- a/src/shell/x11.rs
+++ b/src/shell/x11.rs
@@ -325,10 +325,14 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
             let target_workspace = self.workspaces.get_workspace_at(prev_workspace);
             let workspace_layer = target_workspace.map(|ws| ws.windows_layer.clone());
 
-            self.workspaces
+            if let Err(e) = self
+                .workspaces
                 .dnd_view
                 .layer
-                .add_sublayer(&view.window_layer);
+                .add_sublayer(&view.window_layer)
+            {
+                tracing::warn!("x11 unfullscreen: failed to park window in dnd layer: {e}");
+            }
 
             view.window_layer
                 .set_position(
@@ -341,7 +345,9 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
                 .on_finish(
                     move |l: &layers::prelude::Layer, _| {
                         if let Some(wl) = workspace_layer.as_ref() {
-                            wl.add_sublayer(l);
+                            if let Err(e) = wl.add_sublayer(l) {
+                                tracing::warn!("x11 unfullscreen: failed to reparent window: {e}");
+                            }
                         }
                     },
                     true,

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,8 +4,7 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface,
-        WindowSurfaceType,
+        PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface, WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},
     output::Output,

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,8 +4,8 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab,
-        Window, WindowSurface, WindowSurfaceType,
+        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface,
+        WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},
     output::Output,

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -647,10 +647,14 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                 );
                 self.layers_engine.start_animation(animation, 0.0);
 
-                self.workspaces
+                if let Err(e) = self
+                    .workspaces
                     .dnd_view
                     .layer
-                    .add_sublayer(&view.window_layer);
+                    .add_sublayer(&view.window_layer)
+                {
+                    tracing::warn!("fullscreen: failed to park window in dnd layer: {e}");
+                }
 
                 view.window_layer
                     .set_position(layers::types::Point { x: 0.0, y: 0.0 }, Some(transition))
@@ -661,8 +665,11 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                                 state.size = Some(geometry.size);
                                 state.fullscreen_output = wl_output_ref.clone();
                             });
-                            // println!("append window layer to workspace");
-                            next_workspace_layer.add_sublayer(l);
+                            if let Err(e) = next_workspace_layer.add_sublayer(l) {
+                                tracing::warn!(
+                                    "fullscreen: failed to reparent window to workspace: {e}"
+                                );
+                            }
                             // The protocol demands us to always reply with a configure,
                             // regardless of we fulfilled the request or not
                             surface_clone.send_configure();
@@ -771,10 +778,14 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                     let restored_size = view.unmaximised_rect.size;
                     let workspace_layer = next_workspace.windows_layer.clone();
 
-                    self.workspaces
+                    if let Err(e) = self
+                        .workspaces
                         .dnd_view
                         .layer
-                        .add_sublayer(&view.window_layer);
+                        .add_sublayer(&view.window_layer)
+                    {
+                        tracing::warn!("unmaximize: failed to park window in dnd layer: {e}");
+                    }
 
                     view.window_layer
                         .set_position(
@@ -789,7 +800,11 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                                 surface_clone.with_pending_state(|state| {
                                     state.size = Some(restored_size);
                                 });
-                                workspace_layer.add_sublayer(l);
+                                if let Err(e) = workspace_layer.add_sublayer(l) {
+                                    tracing::warn!(
+                                        "unmaximize: failed to reparent window to workspace: {e}"
+                                    );
+                                }
                                 surface_clone.send_configure();
                             },
                             true,

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,7 +4,8 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface, WindowSurfaceType,
+        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab,
+        PopupUngrabStrategy, Window, WindowSurface, WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},
     output::Output,
@@ -968,6 +969,18 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             }
 
             let next_focus = self.workspaces.minimize_window(&window);
+
+            // Deactivate the minimized surface and send configure so the
+            // client receives the correct (deactivated) state.
+            window.set_activate(false);
+            if let Some(view) = self.workspaces.get_window_view(&id) {
+                view.set_active(false);
+            }
+            if let Some(toplevel) = window.toplevel() {
+                toplevel.send_configure();
+            }
+            self.send_foreign_toplevel_state(&id, false);
+
             match next_focus {
                 Some(wid) => self.set_keyboard_focus_on_surface(&wid),
                 None => self.clear_keyboard_focus(),
@@ -975,7 +988,7 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
         }
 
         // The protocol demands us to always reply with a configure,
-        // regardless of we fulfilled the request or not
+        // regardless of whether we fulfilled the request or not
         surface.send_configure();
     }
 

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -959,9 +959,22 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                 .contains(xdg_toplevel::WmCapabilities::Minimize)
         }) {
             let id = surface.wl_surface().id();
-            let window = self.workspaces.get_window_for_surface(&id).unwrap().clone();
+            let Some(window) = self.workspaces.get_window_for_surface(&id).cloned() else {
+                surface.send_configure();
+                return;
+            };
 
-            let current_element_geometry = self.workspaces.element_geometry(&window).unwrap();
+            // Ignore duplicate minimize requests (e.g. rapid clicks while the
+            // genie animation is still running).
+            if window.is_minimised() {
+                surface.send_configure();
+                return;
+            }
+
+            let Some(current_element_geometry) = self.workspaces.element_geometry(&window) else {
+                surface.send_configure();
+                return;
+            };
 
             if let Some(mut view) = self.workspaces.get_window_view(&id) {
                 view.unmaximised_rect = current_element_geometry;

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,7 +4,7 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface,
+        PopupKeyboardGrab, PopupKind, PopupPointerGrab, Window, WindowSurface,
         WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},
@@ -997,17 +997,6 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             }
 
             let next_focus = self.workspaces.minimize_window(&window);
-
-            // Deactivate the minimized surface and send configure so the
-            // client receives the correct (deactivated) state.
-            window.set_activate(false);
-            if let Some(view) = self.workspaces.get_window_view(&id) {
-                view.set_active(false);
-            }
-            if let Some(toplevel) = window.toplevel() {
-                toplevel.send_configure();
-            }
-            self.send_foreign_toplevel_state(&id, false);
 
             match next_focus {
                 Some(wid) => self.set_keyboard_focus_on_surface(&wid),

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,7 +4,7 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
+        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab,
         Window, WindowSurface, WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -4,8 +4,8 @@ use layers::prelude::{taffy, Interpolate, Layer, Transition};
 use smithay::{
     desktop::{
         find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output,
-        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab,
-        PopupUngrabStrategy, Window, WindowSurface, WindowSurfaceType,
+        space::SpaceElement, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
+        Window, WindowSurface, WindowSurfaceType,
     },
     input::{pointer::Focus, Seat},
     output::Output,

--- a/src/skia_renderer.rs
+++ b/src/skia_renderer.rs
@@ -225,6 +225,7 @@ impl SkiaRenderer {
     pub fn egl_context(&self) -> &EGLContext {
         self.gl_renderer.egl_context()
     }
+
     pub fn current_skia_renderer(&mut self) -> Option<&SkiaSurface> {
         let renderer = self
             .current_target
@@ -554,7 +555,6 @@ impl Renderer for SkiaRenderer {
 
         unsafe {
             self.gl.BindFramebuffer(ffi::FRAMEBUFFER, buffer.fbo);
-
             let status = self.gl.CheckFramebufferStatus(ffi::FRAMEBUFFER);
             self.gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
 
@@ -562,12 +562,23 @@ impl Renderer for SkiaRenderer {
                 println!("framebuffer incomplete");
                 return Err(GlesError::FramebufferBindingError);
             }
-            self.gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
         }
         let surface = self
             .target_renderer
             .get_mut(self.current_target.as_ref().unwrap())
             .unwrap();
+
+        // Tell Skia that FBO and texture binding state is unknown.  Between
+        // frames, Smithay's GlesRenderer (texture imports, cursor rendering,
+        // etc.) and the FBO check above change these GL states behind Skia's
+        // back.  Without this reset, Skia's cached state from the previous
+        // buffer's flush is stale and it may skip necessary GL calls.
+        {
+            use layers::skia::gpu::gl::BackendState;
+            surface.gr_context.reset(Some(
+                (BackendState::RENDER_TARGET | BackendState::TEXTURE_BINDING).bits(),
+            ));
+        }
 
         Ok(SkiaFrame {
             skia_surface: surface.clone(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -76,7 +76,10 @@ use smithay::{
         },
         shell::{
             wlr_layer::WlrLayerShellState,
-            xdg::{decoration::XdgDecorationState, SurfaceCachedState, XdgShellState},
+            xdg::{
+                decoration::XdgDecorationState, SurfaceCachedState, XdgPopupSurfaceData,
+                XdgShellState,
+            },
         },
         shm::{ShmHandler, ShmState},
         socket::ListeningSocketSource,
@@ -1235,6 +1238,23 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 );
 
                 self.surface_layers.extend(popup_layers);
+
+                // Show the popup only after the initial configure has been sent and
+                // the client has committed at the correct position. Until then the
+                // layer stays hidden (as initialised in get_or_create_popup_layer).
+                let initial_configure_sent =
+                    smithay::wayland::compositor::with_states(popup_surface, |states| {
+                        states
+                            .data_map
+                            .get::<XdgPopupSurfaceData>()
+                            .map(|d: &std::sync::Mutex<_>| d.lock().unwrap().initial_configure_sent)
+                            .unwrap_or(false)
+                    });
+                if initial_configure_sent {
+                    if let Some(popup_layer) = self.workspaces.popup_overlay.get_popup(&popup_id) {
+                        popup_layer.layer.set_hidden(false);
+                    }
+                }
             });
 
             let initial_location: smithay::utils::Point<f64, smithay::utils::Physical> =

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -611,7 +611,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             position: taffy::Position::Absolute,
             ..Default::default()
         });
-        layers_engine.add_layer(&root_layer);
+        let _ = layers_engine.add_layer(&root_layer);
         let scene_element = SceneElement::with_engine(layers_engine.clone());
         let (workspaces, remove_workspace_receiver) =
             Workspaces::new(layers_engine.clone(), dh.clone());
@@ -1047,11 +1047,12 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     // Build parent-child hierarchy
                     if let Some(parent_id) = parent_id {
                         if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                            self.layers_engine.append_layer(&layer, parent_layer.id());
+                            let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
                         }
                     } else {
                         // Root surface - attach to DnD content layer
-                        self.layers_engine
+                        let _ = self
+                            .layers_engine
                             .append_layer(&layer, self.workspaces.dnd_view.content_layer.id());
                     }
                 }
@@ -1327,7 +1328,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     // Set up parent-child relationship using layers_engine
                     if let Some(parent_id) = parent_id {
                         if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                            self.layers_engine.append_layer(&layer, parent_layer.id());
+                            let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
                         }
                     }
                 }
@@ -1350,7 +1351,8 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
 
                 if let Some(root_layer) = self.surface_layers.get(&id) {
                     // Use layers_engine to set parent-child relationship
-                    self.layers_engine
+                    let _ = self
+                        .layers_engine
                         .append_layer(root_layer, content_layer.id());
                 }
 

--- a/src/surface_style/handlers/style.rs
+++ b/src/surface_style/handlers/style.rs
@@ -332,10 +332,10 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                     // For now we can only add to the top
                     match new_z_order {
                         OttoSurfaceStyleZOrder::BelowSurface => {
-                            window.layer().add_sublayer(&sstyle.layer);
+                            let _ = window.layer().add_sublayer(&sstyle.layer);
                         }
                         OttoSurfaceStyleZOrder::AboveSurface => {
-                            window.layer().add_sublayer(&sstyle.layer);
+                            let _ = window.layer().add_sublayer(&sstyle.layer);
                         }
                     }
 

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -487,6 +487,7 @@ impl Otto<UdevData> {
                 render_metrics: Some(self.render_metrics.clone()),
                 avg_render_time_us: 2000.0, // start with 2ms estimate
                 idle_countdown: 0,
+                prefetched_scene_damage: None,
             };
 
             let device = self.backend_data.backends.get_mut(&node).unwrap();

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -178,51 +178,50 @@ impl Otto<UdevData> {
                 Some(mode) => mode.refresh,
                 None => return,
             };
-            // What are we trying to solve by introducing a delay here:
-            //
-            // Basically it is all about latency of client provided buffers.
-            // A client driven by frame callbacks will wait for a frame callback
-            // to repaint and submit a new buffer. As we send frame callbacks
-            // as part of the repaint in the compositor the latency would always
-            // be approx. 2 frames. By introducing a delay before we repaint in
-            // the compositor we can reduce the latency to approx. 1 frame + the
-            // remaining duration from the repaint to the next VBlank.
-            //
-            // With the delay it is also possible to further reduce latency if
-            // the client is driven by presentation feedback. As the presentation
-            // feedback is directly sent after a VBlank the client can submit a
-            // new buffer during the repaint delay that can hit the very next
-            // VBlank, thus reducing the potential latency to below one frame.
-            //
-            // Choosing a good delay is a topic on its own so we just implement
-            // a simple strategy here. We just split the duration between two
-            // VBlanks into two steps, one for the client repaint and one for the
-            // compositor repaint. Theoretically the repaint in the compositor should
-            // be faster so we give the client a bit more time to repaint. On a typical
-            // modern system the repaint in the compositor should not take more than 2ms
-            // so this should be safe for refresh rates up to at least 120 Hz. For 120 Hz
-            // this results in approx. 3.33ms time for repainting in the compositor.
-            // A too big delay could result in missing the next VBlank in the compositor.
-            //
-            // A more complete solution could work on a sliding window analyzing past repaints
-            // and do some prediction for the next repaint.
-            let _repaint_delay =
-                Duration::from_millis(((1_000_000f32 / output_refresh as f32) * 0.6f32) as u64);
 
-            let timer = if self.backend_data.primary_gpu != surface.render_node {
-                // However, if we need to do a copy, that might not be enough.
-                // (And without actual comparision to previous frames we cannot really know.)
-                // So lets ignore that in those cases to avoid thrashing performance.
-                //                trace!("scheduling repaint timer immediately on {:?}", crtc);
+            // ── Frame-pipeline Phase 1: CPU scene update ─────────────────────
+            //
+            // The GPU is still scanning out the frame we just acknowledged, so
+            // the CPU is free.  We tick the scene graph now, at VBlank time,
+            // and cache the result.  The upcoming draw phase (Phase 2) will
+            // consume the cached value instead of calling update() inline,
+            // which shortens the critical path on the GPU-submit side and
+            // keeps the two stages maximally overlapped.
+            //
+            // `scene_element` and `backend_data` are distinct fields of `self`,
+            // so Rust's field-projection rules allow concurrent access here.
+            let scene_has_damage = self.scene_element.update();
+            surface.prefetched_scene_damage = Some(scene_has_damage);
+
+            // ── Frame-pipeline Phase 2: schedule the draw at the deadline ─────
+            //
+            // We want to submit the next page flip as close to the upcoming
+            // VBlank as possible (minimises input latency) while still leaving
+            // enough margin for the GPU command recording to finish on time.
+            //
+            // Target deadline = frame_period − 2×avg_render_time
+            //   • 2× gives a safety margin for render-time variance.
+            //   • Clamped to at least 1 ms to avoid busy-spinning.
+            //
+            // For multi-GPU paths a buffer copy is needed after rendering; we
+            // have no reliable estimate for the copy duration, so we fire
+            // immediately and accept the slightly-wider timing window.
+            let is_multi_gpu = self.backend_data.primary_gpu != surface.render_node;
+            let timer = if is_multi_gpu {
                 Timer::immediate()
             } else {
-                //                trace!(
-                //                    "scheduling repaint timer with delay {:?} on {:?}",
-                //                    repaint_delay,
-                //                    crtc
-                //                );
-                // Timer::from_duration(repaint_delay)
-                Timer::immediate()
+                // output_refresh is in millihertz (mHz); convert to µs/frame.
+                let frame_period_us = 1_000_000_000f32 / output_refresh as f32;
+                let avg_us = surface.avg_render_time_us;
+                let draw_delay_us = (frame_period_us - avg_us * 2.0).max(1_000.0);
+                trace!(
+                    draw_delay_us,
+                    frame_period_us,
+                    avg_us,
+                    "scheduling draw phase on {:?}",
+                    crtc
+                );
+                Timer::from_duration(Duration::from_micros(draw_delay_us as u64))
             };
 
             self.handle
@@ -263,6 +262,31 @@ impl Otto<UdevData> {
 
         // Tick gamma transitions before rendering
         self.tick_gamma_transitions();
+
+        // ── Frame-pipeline: consume pre-computed scene update ─────────────────
+        //
+        // When the VBlank callback (`frame_finish`) ran at the start of this
+        // frame period it already called `scene_element.update()` and stored
+        // the damage flag in `surface.prefetched_scene_damage`.  We take that
+        // value here so the CPU work (scene-graph evaluation, layout, animation
+        // ticking) stays on the VBlank side of the pipeline and only the GPU
+        // work (render-element building, command recording, page-flip) runs on
+        // the deadline side.
+        //
+        // We extract the cached value *before* the long-lived `surface` borrow
+        // below so that Rust's borrow checker does not see two simultaneous
+        // `&mut` borrows of `backend_data.backends`.
+        //
+        // If no pre-computed value is available — e.g. on the very first frame,
+        // after an idle wakeup, or when the render was triggered by a path that
+        // bypasses `frame_finish` — we fall back to calling `update()` inline
+        // (after the `surface` borrow is established, using field-split rules).
+        let prefetched_scene_damage = self
+            .backend_data
+            .backends
+            .get_mut(&node)
+            .and_then(|d| d.surfaces.get_mut(&crtc))
+            .and_then(|s| s.prefetched_scene_damage.take());
 
         // Get screenshare sessions before borrowing backend_data
         // let _has_screenshare = !self.screenshare_sessions.is_empty();
@@ -310,7 +334,13 @@ impl Otto<UdevData> {
         // let integer_scale = output_scale.round() as u32;
         let _config_scale = Config::with(|c| c.screen_scale);
 
-        let scene_has_damage = self.scene_element.update();
+        // Use the pre-computed damage flag, or tick the scene inline if the
+        // pre-fetch was not available.  `scene_element` and `backend_data` are
+        // distinct fields, so field-projection rules allow the mutable borrow
+        // of `self.scene_element` here even though `surface` (derived from
+        // `self.backend_data`) is also live.
+        let scene_has_damage =
+            prefetched_scene_damage.unwrap_or_else(|| self.scene_element.update());
         let all_window_elements: Vec<&WindowElement> = self.workspaces.spaces_elements().collect();
 
         // Determine if direct scanout should be allowed:
@@ -601,11 +631,14 @@ impl Otto<UdevData> {
                 Some(mode) => mode.refresh,
                 None => return,
             };
-            // Schedule next render early enough to guarantee we finish before
-            // the next VBlank. We subtract 2× the average render time as safety
-            // margin (accounts for variance, scheduling jitter, etc).
-            // Clamped to at least 1ms to avoid busy-spinning.
-            let frame_period_us = 1_000_000f32 / output_refresh as f32;
+            // Schedule the next render early enough to guarantee we finish before
+            // the next VBlank.  We subtract 2× the average render time as a
+            // safety margin (accounts for variance, scheduling jitter, etc.).
+            // Clamped to at least 1 ms to avoid busy-spinning.
+            //
+            // `output_refresh` is in millihertz (mHz), so the frame period in
+            // microseconds is 1_000_000_000 / refresh_mHz (not 1_000_000).
+            let frame_period_us = 1_000_000_000f32 / output_refresh as f32;
             let avg_us = self
                 .backend_data
                 .backends

--- a/src/udev/types.rs
+++ b/src/udev/types.rs
@@ -124,6 +124,25 @@ pub struct SurfaceData {
     /// each no-damage frame so animations that briefly report zero pending
     /// transactions aren't cut short.
     pub(super) idle_countdown: u32,
+    /// Pre-computed scene-graph damage state for the upcoming draw phase.
+    ///
+    /// Frame pipelining splits each render cycle into two phases:
+    ///
+    /// 1. **Update (CPU)** – `scene_element.update()` is called at VBlank time
+    ///    (inside `frame_finish`).  Because the GPU is still scanning out the
+    ///    previous frame, the CPU and GPU overlap, maximising throughput.
+    ///    The resulting damage flag is stored here.
+    ///
+    /// 2. **Draw (GPU)** – `render_surface` fires near the VBlank deadline.
+    ///    It takes this pre-computed value instead of calling `update()` again,
+    ///    so the critical path on the draw side is only GPU command recording
+    ///    and page-flip submission.
+    ///
+    /// The field is `take`n at the start of every `render_surface` call.
+    /// `None` means no update has been pre-computed yet (e.g. on the very
+    /// first frame or after an idle wakeup); the draw phase falls back to
+    /// calling `update()` inline in that case.
+    pub(super) prefetched_scene_damage: Option<bool>,
 }
 
 impl Drop for SurfaceData {

--- a/src/workspaces/app_icons_manager.rs
+++ b/src/workspaces/app_icons_manager.rs
@@ -120,10 +120,10 @@ impl AppIconsManager {
         setup_badge_layer(&badge_layer, BASE_ICON_SIZE);
         setup_progress_layer(&progress_layer, BASE_ICON_SIZE);
 
-        self.container.add_sublayer(&stack);
-        stack.add_sublayer(&icon_layer);
-        stack.add_sublayer(&badge_layer);
-        stack.add_sublayer(&progress_layer);
+        let _ = self.container.add_sublayer(&stack);
+        let _ = stack.add_sublayer(&icon_layer);
+        let _ = stack.add_sublayer(&badge_layer);
+        let _ = stack.add_sublayer(&progress_layer);
 
         let icon_id = app.icon.as_ref().map(|i| i.unique_id());
         self.entries.write().unwrap().insert(

--- a/src/workspaces/app_switcher/view.rs
+++ b/src/workspaces/app_switcher/view.rs
@@ -67,7 +67,7 @@ impl AppSwitcherView {
         wrap.set_hidden(true);
 
         let view_layer = layers_engine.new_layer();
-        wrap.add_sublayer(&view_layer);
+        let _ = wrap.add_sublayer(&view_layer);
 
         let view = View::new(
             "app_switcher_view",

--- a/src/workspaces/background.rs
+++ b/src/workspaces/background.rs
@@ -42,6 +42,8 @@ impl BackgroundView {
             Box::new(view_background),
         );
         view.mount_layer(layer.clone());
+        // The draw callback fills the entire bounds with opaque pixels (image or gradient).
+        layer.set_content_opaque(true);
         Self {
             view,
             base_layer: layer,

--- a/src/workspaces/dnd_view.rs
+++ b/src/workspaces/dnd_view.rs
@@ -22,7 +22,7 @@ impl DndView {
             ..Default::default()
         });
 
-        layer.add_sublayer(&content_layer);
+        let _ = layer.add_sublayer(&content_layer);
 
         Self {
             layer,

--- a/src/workspaces/dock/interactions.rs
+++ b/src/workspaces/dock/interactions.rs
@@ -1,4 +1,4 @@
-use layers::{prelude::Transition, skia};
+use layers::prelude::Transition;
 use otto_kit::components::context_menu::ContextMenuRenderer;
 use smithay::{
     backend::input::{ButtonState, KeyState},
@@ -79,19 +79,11 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for DockView {
 
         match event.state {
             ButtonState::Pressed => {
-                // println!("dock Button pressed");
                 if let Some(layer_id) = state.layers_engine.current_hover() {
-                    if let Some((_identifier, match_id)) = self.get_app_from_layer(&layer_id) {
-                        let apps_layers = self.app_layers.read().unwrap();
-                        if let Some(entry) = apps_layers.get(&match_id) {
-                            let darken_color = skia::Color::from_argb(100, 100, 100, 100);
-                            let add = skia::Color::from_argb(0, 0, 0, 0);
-                            let filter = skia::color_filters::lighting(darken_color, add);
-                            entry.icon_scaler.set_color_filter(filter);
-                            entry.icon_scaler.set_opacity(1.0, None);
-                            entry
-                                .label_layer
-                                .set_opacity(1.0, Some(Transition::ease_in_quad(0.05)));
+                    if let Some((target, label)) = self.darkening_target_for_hover(&layer_id) {
+                        self.darken_pressed(&target);
+                        if let Some(l) = label {
+                            l.set_opacity(1.0, Some(Transition::ease_in_quad(0.05)));
                         }
                     }
                 }
@@ -160,74 +152,69 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for DockView {
                                 event.serial,
                             );
                         }
+                        self.clear_pressed();
                         return;
                     }
 
-                    if let Some((identifier, match_id)) = self.get_app_from_layer(&layer_id) {
-                        // Check for right-click on protocol layer item
-                        if event.button == BTN_RIGHT {
-                            tracing::info!(
-                                "🖱️ Right-click detected on protocol layer app: {}",
-                                identifier
-                            );
-
-                            let pos = state.last_pointer_location;
-                            let pos = layers::prelude::Point::new(pos.0 as f32, pos.1 as f32);
-                            state
-                                .workspaces
-                                .dock
-                                .open_context_menu(pos, identifier.clone());
-                            let view = InteractiveView {
-                                view: Box::new(self.clone()),
-                            };
-                            if let Some(keyboard) = seat.get_keyboard() {
-                                keyboard.set_focus(
-                                    state,
-                                    Some(crate::focus::KeyboardFocusTarget::View(view)),
-                                    event.serial,
+                    // Only execute the click action when released on the same
+                    // element that was initially pressed.
+                    if self.is_released_on_pressed(&layer_id) {
+                        if let Some((identifier, match_id)) = self.get_app_from_layer(&layer_id) {
+                            // Check for right-click on protocol layer item
+                            if event.button == BTN_RIGHT {
+                                tracing::info!(
+                                    "🖱️ Right-click detected on protocol layer app: {}",
+                                    identifier
                                 );
-                            }
-                            return;
-                        } else {
-                            // Normal left-click: focus or launch app
-                            if !state.focus_app(&identifier) {
-                                if let Some(bookmark) = self.bookmark_config_for(&match_id) {
-                                    if let Some(app) = self.bookmark_application(&match_id) {
-                                        if let Some((cmd, args)) = app.command(&bookmark.exec_args)
-                                        {
-                                            state.launch_program(cmd, args);
+
+                                let pos = state.last_pointer_location;
+                                let pos =
+                                    layers::prelude::Point::new(pos.0 as f32, pos.1 as f32);
+                                state
+                                    .workspaces
+                                    .dock
+                                    .open_context_menu(pos, identifier.clone());
+                                let view = InteractiveView {
+                                    view: Box::new(self.clone()),
+                                };
+                                if let Some(keyboard) = seat.get_keyboard() {
+                                    keyboard.set_focus(
+                                        state,
+                                        Some(crate::focus::KeyboardFocusTarget::View(view)),
+                                        event.serial,
+                                    );
+                                }
+                            } else {
+                                // Normal left-click: focus or launch app
+                                if !state.focus_app(&identifier) {
+                                    if let Some(bookmark) = self.bookmark_config_for(&match_id) {
+                                        if let Some(app) = self.bookmark_application(&match_id) {
+                                            if let Some((cmd, args)) =
+                                                app.command(&bookmark.exec_args)
+                                            {
+                                                state.launch_program(cmd, args);
+                                            } else {
+                                                warn!(
+                                                    "bookmark {} has no executable command",
+                                                    identifier
+                                                );
+                                            }
                                         } else {
-                                            warn!(
-                                                "bookmark {} has no executable command",
-                                                identifier
-                                            );
+                                            warn!("bookmark {} not loaded into dock", identifier);
                                         }
-                                    } else {
-                                        warn!("bookmark {} not loaded into dock", identifier);
                                     }
                                 }
                             }
-                        }
-                    } else if let Some(wid) = self.get_window_from_layer(&layer_id) {
-                        // if we click on a minimized window, unminimize it
-                        if let Some(wid) = state.workspaces.unminimize_window(&wid) {
-                            state.activate_window(&wid);
-                        }
-                    }
-                }
-                // Clear darken filter on any pressed app icon
-                if let Some(layer_id) = state.layers_engine.current_hover() {
-                    if let Some((_identifier, match_id)) = self.get_app_from_layer(&layer_id) {
-                        let apps_layers = self.app_layers.read().unwrap();
-                        if let Some(entry) = apps_layers.get(&match_id) {
-                            entry.icon_scaler.set_color_filter(None);
-                            entry.icon_scaler.set_opacity(1.0, None);
-                            entry
-                                .label_layer
-                                .set_opacity(1.0, Some(Transition::ease_in_quad(0.05)));
+                        } else if let Some(wid) = self.get_window_from_layer(&layer_id) {
+                            // if we click on a minimized window, unminimize it
+                            if let Some(wid) = state.workspaces.unminimize_window(&wid) {
+                                state.activate_window(&wid);
+                            }
                         }
                     }
                 }
+                // Always clear the pressed darkening — handles release outside too.
+                self.clear_pressed();
                 self.dragging
                     .store(false, std::sync::atomic::Ordering::SeqCst);
             }

--- a/src/workspaces/dock/interactions.rs
+++ b/src/workspaces/dock/interactions.rs
@@ -168,8 +168,7 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for DockView {
                                 );
 
                                 let pos = state.last_pointer_location;
-                                let pos =
-                                    layers::prelude::Point::new(pos.0 as f32, pos.1 as f32);
+                                let pos = layers::prelude::Point::new(pos.0 as f32, pos.1 as f32);
                                 state
                                     .workspaces
                                     .dock

--- a/src/workspaces/dock/render.rs
+++ b/src/workspaces/dock/render.rs
@@ -216,6 +216,7 @@ pub fn setup_miniwindow_icon(layer: &Layer, inner_layer: &Layer, icon_width: f32
             None,
         ))
         .background_color(Color::new_rgba(1.0, 0.0, 0.0, 0.0))
+        // .image_cache(true)
         .build()
         .unwrap();
     layer.build_layer_tree(&container_tree);

--- a/src/workspaces/dock/render.rs
+++ b/src/workspaces/dock/render.rs
@@ -201,7 +201,7 @@ pub fn setup_app_icon(
     icon_layer.build_layer_tree(&icon_tree);
 }
 
-pub fn setup_miniwindow_icon(layer: &Layer, inner_layer: &Layer, _icon_width: f32) {
+pub fn setup_miniwindow_icon(layer: &Layer, inner_layer: &Layer, icon_width: f32) {
     let container_tree = LayerTreeBuilder::default()
         .key("miniwindow")
         .layout_style(taffy::Style {
@@ -211,9 +211,9 @@ pub fn setup_miniwindow_icon(layer: &Layer, inner_layer: &Layer, _icon_width: f3
         .size((
             Size {
                 width: taffy::Dimension::Length(0.0),
-                height: taffy::Dimension::Percent(1.0),
+                height: taffy::Dimension::Length(icon_width),
             },
-            Some(Transition::ease_in_quad(0.2)),
+            None,
         ))
         .background_color(Color::new_rgba(1.0, 0.0, 0.0, 0.0))
         .build()

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -157,7 +157,7 @@ impl DockView {
 
         let view_layer = layers_engine.new_layer();
 
-        wrap_layer.add_sublayer(&view_layer);
+        let _ = wrap_layer.add_sublayer(&view_layer);
         // FIXME: initial dock position
         view_layer.set_position((0.0, 1000.0), None);
         let view_tree = LayerTreeBuilder::default()
@@ -169,7 +169,7 @@ impl DockView {
         view_layer.build_layer_tree(&view_tree);
 
         let bar_layer = layers_engine.new_layer();
-        view_layer.add_sublayer(&bar_layer);
+        let _ = view_layer.add_sublayer(&bar_layer);
         let initial_bar_height =
             Self::calculate_bar_height(scaled_icon_size, dock_size_multiplier * draw_scale);
         let bar_tree = LayerTreeBuilder::default()
@@ -196,7 +196,7 @@ impl DockView {
         bar_layer.build_layer_tree(&bar_tree);
 
         let dock_apps_container = layers_engine.new_layer();
-        view_layer.add_sublayer(&dock_apps_container);
+        let _ = view_layer.add_sublayer(&dock_apps_container);
 
         let container_tree = LayerTreeBuilder::default()
             .key("dock_app_container")
@@ -225,7 +225,7 @@ impl DockView {
             None,
         );
         let resize_handle = layers_engine.new_layer();
-        view_layer.add_sublayer(&resize_handle);
+        let _ = view_layer.add_sublayer(&resize_handle);
 
         let handle_tree = LayerTreeBuilder::default()
             .key("dock_handle")
@@ -256,7 +256,7 @@ impl DockView {
         resize_handle.build_layer_tree(&handle_tree);
 
         let dock_windows_container = layers_engine.new_layer();
-        view_layer.add_sublayer(&dock_windows_container);
+        let _ = view_layer.add_sublayer(&dock_windows_container);
 
         let container_tree = LayerTreeBuilder::default()
             .key("dock_windows_container")
@@ -627,11 +627,11 @@ impl DockView {
                     let label_layer = self.layers_engine.new_layer();
                     setup_label(&label_layer, app_name);
 
-                    self.dock_apps_container.add_sublayer(&new_layer);
-                    new_layer.add_sublayer(&icon_scaler);
-                    icon_scaler.add_sublayer(&icon_mirror);
+                    let _ = self.dock_apps_container.add_sublayer(&new_layer);
+                    let _ = new_layer.add_sublayer(&icon_scaler);
+                    let _ = icon_scaler.add_sublayer(&icon_mirror);
                     // label is a direct child of new_layer, NOT inside icon_mirror
-                    new_layer.add_sublayer(&label_layer);
+                    let _ = new_layer.add_sublayer(&label_layer);
 
                     vac.insert(AppLayerEntry {
                         layer: new_layer.clone(),
@@ -660,13 +660,13 @@ impl DockView {
                         let inner_layer = self.layers_engine.new_layer();
                         let label_layer = self.layers_engine.new_layer();
 
-                        self.dock_windows_container.add_sublayer(&new_layer);
+                        let _ = self.dock_windows_container.add_sublayer(&new_layer);
 
                         setup_miniwindow_icon(&new_layer, &inner_layer, available_icon_width);
-                        new_layer.add_sublayer(&inner_layer);
+                        let _ = new_layer.add_sublayer(&inner_layer);
 
                         setup_label(&label_layer, title.clone());
-                        new_layer.add_sublayer(&label_layer);
+                        let _ = new_layer.add_sublayer(&label_layer);
 
                         (new_layer, inner_layer, label_layer, None)
                     });
@@ -715,17 +715,10 @@ impl DockView {
         // Mini window layers
         for layer in previous_miniwindows {
             layer.set_opacity(0.0, Transition::ease_out_quad(0.2));
-            layer
-                .set_size(
-                    layers::types::Size::points(0.0, miniwindow_height),
-                    Transition::ease_out_quad(0.3),
-                )
-                .on_finish(
-                    |l: &Layer, _| {
-                        l.remove();
-                    },
-                    true,
-                );
+            layer.set_size(
+                layers::types::Size::points(0.0, miniwindow_height),
+                Transition::ease_out_quad(0.3),
+            );
 
             miniwindows_layers_map.retain(|_k, (v, ..)| v.id() != layer.id());
         }
@@ -1011,7 +1004,7 @@ impl DockView {
             // Create fallback layers
             let new_layer = self.layers_engine.new_layer();
             let inner_layer = self.layers_engine.new_layer();
-            self.dock_windows_container.add_sublayer(&new_layer);
+            let _ = self.dock_windows_container.add_sublayer(&new_layer);
             (new_layer, inner_layer)
         }
     }

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use layers::{
-    engine::{animation::Transition, Engine, NodeRef, TransactionRef},
+    engine::{animation::Transition, AnimationRef, Engine, NodeRef, TransactionRef},
     prelude::{taffy, Layer, Point, Spring, TimingFunction},
     skia,
     taffy::{prelude::FromLength, style::Style},
@@ -87,6 +87,9 @@ pub struct DockView {
     pub cached_dock_bounds: Arc<RwLock<Option<skia::Rect>>>,
     /// The label layer currently shown as a tooltip — only one visible at a time.
     active_label: Arc<RwLock<Option<Layer>>>,
+    /// The `AnimationRef` from the most recent `magnify_elements_with_scale` call,
+    /// so callers can attach `on_finish` callbacks to the dock layout animation.
+    last_layout_animation: Arc<RwLock<Option<AnimationRef>>>,
 }
 impl PartialEq for DockView {
     fn eq(&self, other: &Self) -> bool {
@@ -307,6 +310,7 @@ impl DockView {
             cached_hot_zone: Arc::new(RwLock::new(None)),
             cached_dock_bounds: Arc::new(RwLock::new(None)),
             active_label: Arc::new(RwLock::new(None)),
+            last_layout_animation: Arc::new(RwLock::new(None)),
             app_icons_manager,
         };
         // Sync AtomicBool from dock_config (single source)
@@ -964,6 +968,21 @@ impl DockView {
         }
         drawer
     }
+    /// Returns the resting icon size used for miniwindow drawers when
+    /// magnification is at rest (same formula as `magnify_elements_with_scale`).
+    pub fn miniwindow_icon_size(&self) -> f32 {
+        let draw_scale = Config::with(|config| config.screen_scale) as f32 * 0.8;
+        let dock_size_multiplier = self.dock_config.read().unwrap().size.clamp(0.5, 2.0) as f32;
+        let base_icon_size = 80.0;
+        base_icon_size * dock_size_multiplier * draw_scale
+    }
+
+    /// Returns the `AnimationRef` from the most recent dock layout animation
+    /// (set by `magnify_elements_with_scale`), if any.
+    pub fn last_layout_animation(&self) -> Option<AnimationRef> {
+        *self.last_layout_animation.read().unwrap()
+    }
+
     // Magnify elements
     fn magnify_elements(&self) {
         self.magnify_elements_with_scale(None, Some(Transition::spring(0.005, 0.0)));
@@ -1088,6 +1107,7 @@ impl DockView {
 
         self.layers_engine.schedule_changes(&changes, animation);
         // self.layers_engine.schedule_changes(&changes, None);
+        *self.last_layout_animation.write().unwrap() = animation;
         if let Some(animation) = animation {
             self.layers_engine.start_animation(animation, 0.0);
         }
@@ -1385,23 +1405,28 @@ impl DockView {
     }
 
     /// Show the dock (used from the hot-zone when autohide is on).
-    pub fn show_autohide(&self) {
-        if self.dock_config.read().unwrap().autohide {
-            if self.active.load(std::sync::atomic::Ordering::Relaxed) {
-                return;
-            }
-            self.view_layer.set_hidden(false);
-            tracing::debug!("dock: show (override pending hide)");
-            self.active
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            self.view_layer.set_position(
-                (0.0, 0.0),
-                Some(Transition {
-                    timing: TimingFunction::Spring(Spring::with_duration_and_bounce(0.5, 0.2)),
-                    delay: 0.0,
-                }),
-            );
+    ///
+    /// Returns `Some(TransactionRef)` when the dock was hidden and an animation
+    /// was started, so callers can chain work via `on_finish`. Returns `None` if
+    /// autohide is off or the dock is already visible.
+    pub fn show_autohide(&self) -> Option<TransactionRef> {
+        if !self.dock_config.read().unwrap().autohide {
+            return None;
         }
+        if self.active.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        self.view_layer.set_hidden(false);
+        tracing::debug!("dock: show (override pending hide)");
+        self.active
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        Some(self.view_layer.set_position(
+            (0.0, 0.0),
+            Some(Transition {
+                timing: TimingFunction::Spring(Spring::with_duration_and_bounce(0.5, 0.2)),
+                delay: 0.0,
+            }),
+        ))
     }
 
     /// Hide the context menu and immediately re-run magnification so the dock

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -90,6 +90,8 @@ pub struct DockView {
     /// The `AnimationRef` from the most recent `magnify_elements_with_scale` call,
     /// so callers can attach `on_finish` callbacks to the dock layout animation.
     last_layout_animation: Arc<RwLock<Option<AnimationRef>>>,
+    /// The layer currently showing the "pressed" darkening effect.
+    pressed_layer: Arc<RwLock<Option<Layer>>>,
 }
 impl PartialEq for DockView {
     fn eq(&self, other: &Self) -> bool {
@@ -311,6 +313,7 @@ impl DockView {
             cached_dock_bounds: Arc::new(RwLock::new(None)),
             active_label: Arc::new(RwLock::new(None)),
             last_layout_animation: Arc::new(RwLock::new(None)),
+            pressed_layer: Arc::new(RwLock::new(None)),
             app_icons_manager,
         };
         // Sync AtomicBool from dock_config (single source)
@@ -660,6 +663,7 @@ impl DockView {
                         self.dock_windows_container.add_sublayer(&new_layer);
 
                         setup_miniwindow_icon(&new_layer, &inner_layer, available_icon_width);
+                        new_layer.add_sublayer(&inner_layer);
 
                         setup_label(&label_layer, title.clone());
                         new_layer.add_sublayer(&label_layer);
@@ -928,6 +932,60 @@ impl DockView {
         }
         *active = label;
     }
+
+    /// Apply the "pressed" darkening filter to the given layer and track it
+    /// so it can be cleared later. Clears any previously pressed layer first.
+    pub(super) fn darken_pressed(&self, layer: &Layer) {
+        self.clear_pressed();
+        let darken = skia::Color::from_argb(100, 100, 100, 100);
+        let add = skia::Color::from_argb(0, 0, 0, 0);
+        layer.set_color_filter(skia::color_filters::lighting(darken, add));
+        *self.pressed_layer.write().unwrap() = Some(layer.clone());
+    }
+
+    /// Remove the darkening filter from the currently pressed layer, if any.
+    pub(super) fn clear_pressed(&self) {
+        if let Some(layer) = self.pressed_layer.write().unwrap().take() {
+            layer.set_color_filter(None);
+        }
+    }
+
+    /// Returns `true` when the currently hovered layer resolves to the same
+    /// darkening target that was recorded on press.
+    pub(super) fn is_released_on_pressed(&self, layer_id: &layers::engine::NodeRef) -> bool {
+        let pressed = self.pressed_layer.read().unwrap();
+        let Some(pressed) = pressed.as_ref() else {
+            return false;
+        };
+        self.darkening_target_for_hover(layer_id)
+            .map(|(target, _)| target.id() == pressed.id())
+            .unwrap_or(false)
+    }
+
+    /// Resolve the hovered `NodeRef` into the layer that should receive the
+    /// press darkening effect. Returns the target layer and (optionally) the
+    /// label layer that should be shown alongside it.
+    pub(super) fn darkening_target_for_hover(
+        &self,
+        layer_id: &layers::engine::NodeRef,
+    ) -> Option<(Layer, Option<Layer>)> {
+        // App icon — darken the icon_scaler, show its label.
+        if let Some((_, match_id)) = self.get_app_from_layer(layer_id) {
+            let app_layers = self.app_layers.read().unwrap();
+            if let Some(entry) = app_layers.get(&match_id) {
+                return Some((entry.icon_scaler.clone(), Some(entry.label_layer.clone())));
+            }
+        }
+        // Miniwindow — darken the inner content layer (image_cache=true).
+        if let Some(wid) = self.get_window_from_layer(layer_id) {
+            let miniwindow_layers = self.miniwindow_layers.read().unwrap();
+            if let Some((_drawer, inner, label, _)) = miniwindow_layers.get(&wid) {
+                return Some((inner.clone(), Some(label.clone())));
+            }
+        }
+        None
+    }
+
     pub fn add_window_element(&self, window: &WindowElement) -> (Layer, Layer) {
         let state = self.get_state();
         let mut minimized_windows = state.minimized_windows.clone();

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1899,7 +1899,11 @@ impl Workspaces {
                         .get(&eid)
                         .map(|w| w.is_minimised() || w.id() == we.id())
                         .unwrap_or(false);
-                    if dominated { None } else { Some(eid) }
+                    if dominated {
+                        None
+                    } else {
+                        Some(eid)
+                    }
                 })
             })
     }
@@ -2691,9 +2695,9 @@ impl Workspaces {
                 .minimized_windows
                 .iter()
                 .filter_map(|(id, _)| {
-                    self.windows_map.get(id).and_then(|we| {
-                        we.wl_surface().map(|s| (s.as_ref().id(), we.clone()))
-                    })
+                    self.windows_map
+                        .get(id)
+                        .and_then(|we| we.wl_surface().map(|s| (s.as_ref().id(), we.clone())))
                 })
                 .collect()
         };
@@ -2768,9 +2772,7 @@ impl Workspaces {
                 // windows are unmapped from Space but remain in windows_map).
                 model
                     .minimized_windows
-                    .retain(|(id, _)| {
-                        all_windows.iter().any(|(wid, _)| wid == id)
-                    });
+                    .retain(|(id, _)| all_windows.iter().any(|(wid, _)| wid == id));
             }
         }
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1786,6 +1786,11 @@ impl Workspaces {
     pub fn minimize_window(&mut self, we: &WindowElement) -> Option<ObjectId> {
         let id = we.id();
 
+        // Already minimised — nothing to do (guards against rapid double-clicks).
+        if we.is_minimised() {
+            return None;
+        }
+
         if let Some(window) = self.windows_map.get_mut(&id) {
             window.set_is_minimised(true);
         }
@@ -1910,6 +1915,13 @@ impl Workspaces {
 
     /// Unminimise a WindowElement
     pub fn unminimize_window(&mut self, wid: &ObjectId) -> Option<ObjectId> {
+        // Already not minimised — nothing to do (guards against rapid double-clicks).
+        if let Some(window) = self.windows_map.get(wid) {
+            if !window.is_minimised() {
+                return None;
+            }
+        }
+
         let workspace_for_window = self.with_model(|model| {
             model
                 .workspaces

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1839,8 +1839,11 @@ impl Workspaces {
                         position: taffy::Position::Absolute,
                         ..Default::default()
                     });
-                    layers_engine
-                        .add_layer_to_positioned(view.window_layer.clone(), Some(inner.id));
+                    if let Err(e) = layers_engine
+                        .add_layer_to_positioned(view.window_layer.clone(), Some(inner.id))
+                    {
+                        tracing::warn!("minimize: failed to reparent window into drawer: {e}");
+                    }
 
                     let inner_bounds = inner.render_bounds_transformed();
                     let minimize_tr = view.minimize(skia::Rect::from_xywh(
@@ -2894,7 +2897,7 @@ impl Workspaces {
         output_layer.set_size(layers::types::Size::points(phys_w, phys_h), None);
         output_layer.set_position((phys_x, phys_y), None);
         output_layer.set_pointer_events(false);
-        self.layers_engine.add_layer(&output_layer);
+        let _ = self.layers_engine.add_layer(&output_layer);
 
         // Create the workspaces_layer for this output (workspace content, inside container)
         let workspaces_layer = self.layers_engine.new_layer();
@@ -2914,9 +2917,9 @@ impl Workspaces {
         // dock (primary) → layer_shell_top → workspace_selector →
         // layer_shell_overlay → app_switcher (primary) → popup_overlay (primary)
         if is_this_primary {
-            output_layer.add_sublayer(&self.layer_shell_background);
+            let _ = output_layer.add_sublayer(&self.layer_shell_background);
         }
-        output_layer.add_sublayer(&workspaces_layer);
+        let _ = output_layer.add_sublayer(&workspaces_layer);
 
         // Create a per-output expose layer
         let expose_layer = self.layers_engine.new_layer();
@@ -2929,15 +2932,15 @@ impl Workspaces {
         expose_layer.set_hidden(true);
         expose_layer.set_picture_cached(false);
         expose_layer.set_image_cached(false);
-        output_layer.add_sublayer(&expose_layer);
+        let _ = output_layer.add_sublayer(&expose_layer);
 
         if is_this_primary {
             // Wire the primary output's expose layer into self.expose_layer so all
             // existing show/hide logic works unchanged.
             self.expose_layer = expose_layer.clone();
             // overlay contains dnd and osd
-            self.overlay_layer.add_sublayer(&self.dnd_view.layer);
-            self.overlay_layer.add_sublayer(&self.osd.wrap_layer);
+            let _ = self.overlay_layer.add_sublayer(&self.dnd_view.layer);
+            let _ = self.overlay_layer.add_sublayer(&self.osd.wrap_layer);
             // App icons manager lives at the root — sibling of output layers, never rendered
             // on any output, but present in the scene so its subtree gets laid out.
             if let Some(root) = self
@@ -2945,15 +2948,15 @@ impl Workspaces {
                 .scene_root()
                 .and_then(|id| self.layers_engine.get_layer(&id))
             {
-                root.add_sublayer(&self.app_icons_manager.container);
+                let _ = root.add_sublayer(&self.app_icons_manager.container);
             }
-            output_layer.add_sublayer(&self.dock.wrap_layer.clone());
-            output_layer.add_sublayer(&self.layer_shell_top);
-            output_layer.add_sublayer(&self.workspace_selector_view.layer.clone());
-            output_layer.add_sublayer(&self.app_switcher.wrap_layer.clone());
-            output_layer.add_sublayer(&self.popup_overlay.layer.clone());
-            output_layer.add_sublayer(&self.layer_shell_overlay);
-            output_layer.add_sublayer(&self.overlay_layer);
+            let _ = output_layer.add_sublayer(&self.dock.wrap_layer.clone());
+            let _ = output_layer.add_sublayer(&self.layer_shell_top);
+            let _ = output_layer.add_sublayer(&self.workspace_selector_view.layer.clone());
+            let _ = output_layer.add_sublayer(&self.app_switcher.wrap_layer.clone());
+            let _ = output_layer.add_sublayer(&self.popup_overlay.layer.clone());
+            let _ = output_layer.add_sublayer(&self.layer_shell_overlay);
+            let _ = output_layer.add_sublayer(&self.overlay_layer);
         }
 
         let workspace_counter_start = self.with_model(|m| m.workspace_counter);
@@ -2972,7 +2975,7 @@ impl Workspaces {
                 &workspaces_layer,
                 self.overlay_layer.clone(),
             ));
-            expose_layer.add_sublayer(&workspace.window_selector_view.window_selector_root);
+            let _ = expose_layer.add_sublayer(&workspace.window_selector_view.window_selector_root);
             workspace_views.push(workspace);
         }
 
@@ -3057,7 +3060,8 @@ impl Workspaces {
                     &ows.workspaces_layer,
                     overlay_layer.clone(),
                 ));
-                ows.expose_layer
+                let _ = ows
+                    .expose_layer
                     .add_sublayer(&workspace.window_selector_view.window_selector_root);
 
                 let index = ows.workspace_views.len();
@@ -3733,19 +3737,27 @@ impl Workspaces {
         match wlr_layer {
             WlrLayer::Background => {
                 self.layer_shell_background.set_hidden(false);
-                self.layer_shell_background.add_sublayer(&layer);
+                if let Err(e) = self.layer_shell_background.add_sublayer(&layer) {
+                    tracing::warn!("layer_shell: failed to add background layer: {e}");
+                }
             }
             WlrLayer::Bottom => {
                 self.layer_shell_background.set_hidden(false);
-                self.layer_shell_background.add_sublayer(&layer);
+                if let Err(e) = self.layer_shell_background.add_sublayer(&layer) {
+                    tracing::warn!("layer_shell: failed to add bottom layer: {e}");
+                }
             }
             WlrLayer::Top => {
                 self.layer_shell_top.set_hidden(false);
-                self.layer_shell_top.add_sublayer(&layer);
+                if let Err(e) = self.layer_shell_top.add_sublayer(&layer) {
+                    tracing::warn!("layer_shell: failed to add top layer: {e}");
+                }
             }
             WlrLayer::Overlay => {
                 self.layer_shell_overlay.set_hidden(false);
-                self.layer_shell_overlay.add_sublayer(&layer);
+                if let Err(e) = self.layer_shell_overlay.add_sublayer(&layer) {
+                    tracing::warn!("layer_shell: failed to add overlay layer: {e}");
+                }
             }
         }
 
@@ -3807,6 +3819,16 @@ impl UnminimizeContext {
         window.set_is_minimised(false);
 
         if let Some(drawer) = dock.remove_window_element(&wid) {
+            // If the window layer was cleaned up (stale handle), skip the
+            // animation and just remap the window so it reappears.
+            if !view.is_alive() {
+                tracing::warn!("unminimize: window layer is stale, skipping animation");
+                drawer.remove();
+                workspace.map_window(&window, (pos_logical.0, pos_logical.1).into(), None);
+                crate::utils::notify_observers(&observers, &event);
+                return;
+            }
+
             let windows_layer_ref = workspace.windows_layer.clone();
             let expose_windows_ref = expose_layer.clone();
             let layer_ref = view.window_layer.clone();
@@ -3834,8 +3856,12 @@ impl UnminimizeContext {
                 .on_start(
                     move |_layer: &Layer, _| {
                         layer_ref.remove_draw_content();
-                        windows_layer_ref.add_sublayer(&layer_ref);
-                        expose_windows_ref.add_sublayer(&mirror_ref);
+                        if let Err(e) = windows_layer_ref.add_sublayer(&layer_ref) {
+                            tracing::warn!("unminimize: failed to reparent window layer: {e}");
+                        }
+                        if let Err(e) = expose_windows_ref.add_sublayer(&mirror_ref) {
+                            tracing::warn!("unminimize: failed to reparent mirror layer: {e}");
+                        }
                         layer_ref.set_position(target_pos, None);
                     },
                     true,

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1815,7 +1815,7 @@ impl Workspaces {
                 // add_window_element triggers render_dock → magnify_elements_with_scale
                 // which animates the drawer from width 0 → icon_size and stores the
                 // AnimationRef in last_layout_animation.
-                let (drawer, _) = self.dock.add_window_element(we);
+                let (drawer, inner) = self.dock.add_window_element(we);
                 let layout_anim = self.dock.last_layout_animation();
 
                 view.mirror_layer.set_hidden(true);
@@ -1824,6 +1824,7 @@ impl Workspaces {
                 let dock_ref = self.dock.clone();
                 let view = view.clone();
                 let drawer = drawer.clone();
+                let inner = inner.clone();
 
                 tokio::spawn(async move {
                     // Phase 1: dock slide-in + drawer expand in parallel.
@@ -1847,28 +1848,29 @@ impl Workspaces {
                         _ = tokio::time::sleep(tokio::time::Duration::from_millis(350)) => {}
                     }
 
-                    // Phase 2: move window layer into the drawer and run genie.
+                    // Phase 2: move window layer into the inner container and run genie.
                     view.window_layer.set_layout_style(taffy::Style {
                         position: taffy::Position::Absolute,
                         ..Default::default()
                     });
                     layers_engine
-                        .add_layer_to_positioned(view.window_layer.clone(), Some(drawer.id));
+                        .add_layer_to_positioned(view.window_layer.clone(), Some(inner.id));
 
-                    let drawer_bounds = drawer.render_bounds_transformed();
+                    let inner_bounds = inner.render_bounds_transformed();
                     let minimize_tr = view.minimize(skia::Rect::from_xywh(
-                        drawer_bounds.x(),
-                        drawer_bounds.y(),
-                        drawer_bounds.width(),
-                        drawer_bounds.height(),
+                        inner_bounds.x(),
+                        inner_bounds.y(),
+                        inner_bounds.width(),
+                        inner_bounds.height(),
                     ));
 
                     // Keep the miniwindow fitted when the drawer resizes later.
                     let view_ref = view.clone();
+                    let inner_ref = inner.clone();
                     drawer.clear_on_change_size_handlers();
                     drawer.on_change_size(
-                        move |layer: &Layer, _| {
-                            view_ref.apply_minimized_scale(layer.render_bounds_transformed());
+                        move |_layer: &Layer, _| {
+                            view_ref.apply_minimized_scale(inner_ref.render_bounds_transformed());
                         },
                         false,
                     );

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1777,7 +1777,12 @@ impl Workspaces {
         }
     }
 
-    /// Minimise a WindowElement
+    /// Minimise a WindowElement.
+    ///
+    /// The animation runs in three phases:
+    ///   1. Dock slide-in (if auto-hidden) + drawer expand — in parallel.
+    ///   2. Move window layer into the drawer, run genie effect.
+    ///   3. Schedule dock auto-hide (if it was revealed for this minimize).
     pub fn minimize_window(&mut self, we: &WindowElement) -> Option<ObjectId> {
         let id = we.id();
 
@@ -1785,72 +1790,116 @@ impl Workspaces {
             window.set_is_minimised(true);
         }
 
+        // Unmap from all spaces so hit-testing ignores the minimised window.
+        for output in &self.outputs {
+            if let Some(ows) = self.output_workspaces.get_mut(&output.name()) {
+                for space in &mut ows.spaces {
+                    space.unmap_elem(we);
+                }
+            }
+        }
+
+        let dock_was_hidden = self.dock.is_autohide_enabled() && self.dock.is_hidden();
+        let show_tr = if dock_was_hidden {
+            self.dock.show_autohide()
+        } else {
+            None
+        };
+
         self.with_model_mut(|model| {
             model
                 .minimized_windows
                 .push((id.clone(), we.xdg_title().to_string()));
 
             if let Some(view) = self.get_window_view(&id) {
+                // add_window_element triggers render_dock → magnify_elements_with_scale
+                // which animates the drawer from width 0 → icon_size and stores the
+                // AnimationRef in last_layout_animation.
                 let (drawer, _) = self.dock.add_window_element(we);
+                let layout_anim = self.dock.last_layout_animation();
 
-                view.window_layer.set_layout_style(taffy::Style {
-                    position: taffy::Position::Absolute,
-                    ..Default::default()
-                });
-
-                // Hide mirror layer so it won't appear in expose
                 view.mirror_layer.set_hidden(true);
 
-                self.layers_engine
-                    .add_layer_to_positioned(view.window_layer.clone(), Some(drawer.id));
-                // bounds are calculate after this call
-                let drawer_bounds = drawer.render_bounds_transformed();
-                view.minimize(skia::Rect::from_xywh(
-                    drawer_bounds.x(),
-                    drawer_bounds.y(),
-                    drawer_bounds.width(),
-                    drawer_bounds.height(),
-                ));
+                let layers_engine = self.layers_engine.clone();
+                let dock_ref = self.dock.clone();
+                let view = view.clone();
+                let drawer = drawer.clone();
 
-                let view_ref = view.clone();
-                drawer.clear_on_change_size_handlers();
-                drawer.on_change_size(
-                    move |layer: &Layer, _| {
-                        let bounds = layer.render_bounds_transformed();
-                        // Keep the minimized window scaled to the drawer bounds
-                        view_ref.apply_minimized_scale(bounds);
-                    },
-                    false,
-                );
+                tokio::spawn(async move {
+                    // Phase 1: dock slide-in + drawer expand in parallel.
+                    // Start the genie slightly before phase 1 settles for a
+                    // smoother, overlapping feel.
+                    let phase1 = async {
+                        let show_fut = async {
+                            if let Some(tr) = show_tr {
+                                tr.await;
+                            }
+                        };
+                        let layout_fut = async {
+                            if let Some(anim) = layout_anim {
+                                anim.await;
+                            }
+                        };
+                        tokio::join!(show_fut, layout_fut);
+                    };
+                    tokio::select! {
+                        _ = phase1 => {}
+                        _ = tokio::time::sleep(tokio::time::Duration::from_millis(350)) => {}
+                    }
+
+                    // Phase 2: move window layer into the drawer and run genie.
+                    view.window_layer.set_layout_style(taffy::Style {
+                        position: taffy::Position::Absolute,
+                        ..Default::default()
+                    });
+                    layers_engine
+                        .add_layer_to_positioned(view.window_layer.clone(), Some(drawer.id));
+
+                    let drawer_bounds = drawer.render_bounds_transformed();
+                    let minimize_tr = view.minimize(skia::Rect::from_xywh(
+                        drawer_bounds.x(),
+                        drawer_bounds.y(),
+                        drawer_bounds.width(),
+                        drawer_bounds.height(),
+                    ));
+
+                    // Keep the miniwindow fitted when the drawer resizes later.
+                    let view_ref = view.clone();
+                    drawer.clear_on_change_size_handlers();
+                    drawer.on_change_size(
+                        move |layer: &Layer, _| {
+                            view_ref.apply_minimized_scale(layer.render_bounds_transformed());
+                        },
+                        false,
+                    );
+
+                    minimize_tr.await;
+
+                    // Phase 3: re-hide the dock if we revealed it for this minimize.
+                    if dock_was_hidden {
+                        dock_ref.schedule_autohide();
+                    }
+                });
             }
 
             self.notify_observers(model);
         });
 
-        // Focus should move to the next topmost (non-minimized) window or to none.
+        // Find the next topmost non-minimized window for focus.
         let index = self.with_model(|m| m.current_workspace);
-        let next = self
-            .primary_output_workspaces()
+        self.primary_output_workspaces()
             .and_then(|ows| ows.spaces.get(index))
             .and_then(|s| {
                 s.elements().rev().find_map(|e| {
-                    let id = e.id();
-                    if let Some(window) = self.windows_map.get(&id) {
-                        if window.is_minimised() || window.id() == we.id() {
-                            return None;
-                        }
-                    }
-                    Some(id)
+                    let eid = e.id();
+                    let dominated = self
+                        .windows_map
+                        .get(&eid)
+                        .map(|w| w.is_minimised() || w.id() == we.id())
+                        .unwrap_or(false);
+                    if dominated { None } else { Some(eid) }
                 })
-            });
-
-        if let Some(next_id) = next {
-            // Raise and activate the next topmost window
-            self.raise_element(&next_id, true, true);
-            Some(next_id)
-        } else {
-            None
-        }
+            })
     }
 
     /// Unminimise a WindowElement
@@ -1870,6 +1919,17 @@ impl Workspaces {
         }
         let workspace_for_window = workspace_for_window.unwrap();
         let current_workspace_index = self.get_current_workspace_index();
+
+        // The window was unmapped from the space during minimize (for hit-test
+        // exclusion).  Re-map it now so build_unminimize_context can find it.
+        let window = self.get_window_for_surface(wid)?.clone();
+        let view = self.get_window_view(wid)?;
+        let loc = view.unmaximised_rect.loc;
+        if let Some(ows) = self.primary_output_workspaces_mut() {
+            if let Some(space) = ows.spaces.get_mut(workspace_for_window) {
+                space.map_element(window, loc, false);
+            }
+        }
 
         let ctx = self.build_unminimize_context(wid)?;
 
@@ -2531,7 +2591,7 @@ impl Workspaces {
                 } else {
                     // if minimised and there is only one window in the app, unminimize it
                     if windows.len() == 1 {
-                        self.unminimize_window(window_id);
+                        focus_wid = self.unminimize_window(window_id);
                     }
                 }
             }
@@ -2622,6 +2682,23 @@ impl Workspaces {
             .filter_map(|we| we.wl_surface().map(|s| (s.as_ref().id(), we.clone())))
             .collect();
 
+        // Include minimized windows — they are unmapped from Space but still alive.
+        let minimized: Vec<(ObjectId, WindowElement)> = {
+            let model = self.model.read().unwrap();
+            model
+                .minimized_windows
+                .iter()
+                .filter_map(|(id, _)| {
+                    self.windows_map.get(id).and_then(|we| {
+                        we.wl_surface().map(|s| (s.as_ref().id(), we.clone()))
+                    })
+                })
+                .collect()
+        };
+
+        let all_windows: Vec<&(ObjectId, WindowElement)> =
+            windows.iter().chain(minimized.iter()).collect();
+
         {
             // reset the model
             if let Ok(mut model_mut) = self.model.write() {
@@ -2633,7 +2710,7 @@ impl Workspaces {
         }
 
         let mut app_set = HashSet::new();
-        for (window_id, we) in windows.iter() {
+        for (window_id, we) in all_windows.iter() {
             let raw_app_id = we.xdg_app_id();
             let display_app_id = we.display_app_id(&self.display_handle);
 
@@ -2684,10 +2761,14 @@ impl Workspaces {
             }
 
             {
-                // update minimized windows
+                // update minimized windows — keep entries that are either still
+                // mapped in a Space *or* still tracked in windows_map (minimized
+                // windows are unmapped from Space but remain in windows_map).
                 model
                     .minimized_windows
-                    .retain(|(id, _)| windows.iter().any(|(wid, _)| wid == id));
+                    .retain(|(id, _)| {
+                        all_windows.iter().any(|(wid, _)| wid == id)
+                    });
             }
         }
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1832,28 +1832,9 @@ impl Workspaces {
                 let inner = inner.clone();
 
                 tokio::spawn(async move {
-                    // Phase 1: dock slide-in + drawer expand in parallel.
-                    // Start the genie slightly before phase 1 settles for a
-                    // smoother, overlapping feel.
-                    let phase1 = async {
-                        let show_fut = async {
-                            if let Some(tr) = show_tr {
-                                tr.await;
-                            }
-                        };
-                        let layout_fut = async {
-                            if let Some(anim) = layout_anim {
-                                anim.await;
-                            }
-                        };
-                        tokio::join!(show_fut, layout_fut);
-                    };
-                    tokio::select! {
-                        _ = phase1 => {}
-                        _ = tokio::time::sleep(tokio::time::Duration::from_millis(350)) => {}
-                    }
-
-                    // Phase 2: move window layer into the inner container and run genie.
+                    // Reparent window into the drawer and start the genie
+                    // immediately — both run in parallel with dock slide-in
+                    // and drawer expansion.
                     view.window_layer.set_layout_style(taffy::Style {
                         position: taffy::Position::Absolute,
                         ..Default::default()
@@ -1869,20 +1850,47 @@ impl Workspaces {
                         inner_bounds.height(),
                     ));
 
-                    // Keep the miniwindow fitted when the drawer resizes later.
+                    // Track the expanding drawer: update the genie destination
+                    // while the animation runs, keep the miniwindow fitted
+                    // after the genie finishes.
+                    let genie_ref = view.genie_effect.clone();
                     let view_ref = view.clone();
                     let inner_ref = inner.clone();
                     drawer.clear_on_change_size_handlers();
                     drawer.on_change_size(
                         move |_layer: &Layer, _| {
-                            view_ref.apply_minimized_scale(inner_ref.render_bounds_transformed());
+                            let bounds = inner_ref.render_bounds_transformed();
+                            if view_ref.is_minimizing() {
+                                genie_ref.set_destination(
+                                    skia::Rect::from_xywh(
+                                        bounds.x(),
+                                        bounds.y(),
+                                        bounds.width(),
+                                        bounds.height(),
+                                    ),
+                                    true,
+                                );
+                            } else {
+                                view_ref.apply_minimized_scale(bounds);
+                            }
                         },
                         false,
                     );
 
-                    minimize_tr.await;
+                    // Wait for all animations to complete.
+                    let show_fut = async {
+                        if let Some(tr) = show_tr {
+                            tr.await;
+                        }
+                    };
+                    let layout_fut = async {
+                        if let Some(anim) = layout_anim {
+                            anim.await;
+                        }
+                    };
+                    tokio::join!(minimize_tr, show_fut, layout_fut);
 
-                    // Phase 3: re-hide the dock if we revealed it for this minimize.
+                    // Re-hide the dock if we revealed it for this minimize.
                     if dock_was_hidden {
                         dock_ref.schedule_autohide();
                     }

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2723,7 +2723,7 @@ impl Workspaces {
         };
 
         let all_windows: Vec<&(ObjectId, WindowElement)> =
-            windows.iter().chain(minimized.iter()).collect();
+            minimized.iter().chain(windows.iter()).collect();
 
         {
             // reset the model

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -3169,6 +3169,10 @@ impl Workspaces {
                 if n < ows.workspace_views.len() {
                     ows.workspace_views.remove(n);
                 }
+                // Clamp current_workspace so it never exceeds the new spaces length.
+                if !ows.spaces.is_empty() && ows.current_workspace >= ows.spaces.len() {
+                    ows.current_workspace = ows.spaces.len() - 1;
+                }
             }
 
             for (e, location) in windows_to_move {
@@ -3188,6 +3192,13 @@ impl Workspaces {
             }
         }
         self.update_workspaces_layout();
+        self.scroll_to_workspace_index(
+            workspace_model.current_workspace,
+            Some(Transition {
+                delay: 0.0,
+                timing: TimingFunction::linear(0.0),
+            }),
+        );
         self.notify_observers(&workspace_model);
     }
 

--- a/src/workspaces/osd.rs
+++ b/src/workspaces/osd.rs
@@ -62,7 +62,7 @@ impl OsdView {
 
         // Create inner view layer
         let layer = layers_engine.new_layer();
-        wrap.add_sublayer(&layer);
+        let _ = wrap.add_sublayer(&layer);
         layer.set_opacity(0.0, None);
         layer.set_pointer_events(false);
         wrap.set_hidden(true);

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -73,6 +73,10 @@ impl PopupOverlayView {
                 });
                 content_layer.set_pointer_events(false);
 
+                // Start hidden — only show after the initial configure has been
+                // acknowledged and the popup has committed at its correct position.
+                layer.set_hidden(true);
+
                 let _ = self.layers_engine.append_layer(&layer, self.layer.id());
                 let _ = self.layers_engine.append_layer(&content_layer, layer.id());
 

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -73,8 +73,8 @@ impl PopupOverlayView {
                 });
                 content_layer.set_pointer_events(false);
 
-                self.layers_engine.append_layer(&layer, self.layer.id());
-                self.layers_engine.append_layer(&content_layer, layer.id());
+                let _ = self.layers_engine.append_layer(&layer, self.layer.id());
+                let _ = self.layers_engine.append_layer(&content_layer, layer.id());
 
                 PopupLayer {
                     popup_id,
@@ -142,14 +142,14 @@ impl PopupOverlayView {
             // Set up parent-child relationship
             if let Some(ref parent_id) = wvs.parent_id {
                 if let Some(parent_layer) = surface_layers.get(parent_id) {
-                    layers_engine.append_layer(&layer, parent_layer.id());
+                    let _ = layers_engine.append_layer(&layer, parent_layer.id());
                 } else {
                     // Parent not yet created, append to content layer
-                    layers_engine.append_layer(&layer, popup.content_layer.id());
+                    let _ = layers_engine.append_layer(&layer, popup.content_layer.id());
                 }
             } else {
                 // Root surface, append to content layer
-                layers_engine.append_layer(&layer, popup.content_layer.id());
+                let _ = layers_engine.append_layer(&layer, popup.content_layer.id());
             }
 
             surface_layers.insert(wvs.id.clone(), layer);

--- a/src/workspaces/utils/context_menu_view.rs
+++ b/src/workspaces/utils/context_menu_view.rs
@@ -69,8 +69,8 @@ impl ContextMenuView {
         });
         // wrap.set_pointer_events(true);
         let view_layer = layers_engine.new_layer();
-        layers_engine.add_layer(&wrap);
-        wrap.add_sublayer(&view_layer);
+        let _ = layers_engine.add_layer(&wrap);
+        let _ = wrap.add_sublayer(&view_layer);
         // view_layer.set_pointer_events(true);
 
         view_layer.set_anchor_point((0.5, 1.0), None);
@@ -78,7 +78,7 @@ impl ContextMenuView {
         let view = View::new("context_menu_inner", initial_state, Box::new(render_menu));
         view.mount_layer(view_layer.clone());
 
-        base_layer.add_sublayer(&wrap);
+        let _ = base_layer.add_sublayer(&wrap);
         Self {
             wrap_layer: wrap,
             view_layer,

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -200,6 +200,9 @@ pub fn configure_surface_layer(
 
     layer.set_pointer_events(false);
     layer.set_picture_cached(true);
+    // The draw_content callback fills the entire bounds with the surface texture,
+    // so this layer can act as an occluder in occlusion culling.
+    layer.set_content_opaque(true);
 
     let draw_wvs = wvs.clone();
     layer.set_draw_content(move |canvas: &layers::skia::Canvas, w: f32, h: f32| {

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -135,7 +135,7 @@ impl WindowSelectorView {
         window_selector_root.set_size(layers::types::Size::percent(1.0, 1.0), None);
         // window_selector_root.set_picture_cached(false);
         // window_selector_root.set_image_cached(false);
-        layers_engine.add_layer(&window_selector_root);
+        let _ = layers_engine.add_layer(&window_selector_root);
         window_selector_root.set_size(layers::types::Size::percent(1.0, 1.0), None);
         window_selector_root.set_clip_children(true, None);
         window_selector_root.set_clip_content(true, None);
@@ -186,11 +186,11 @@ impl WindowSelectorView {
         // window_selector_windows_container.set_image_cached(false);
         window_selector_windows_container.set_size(layers::types::Size::percent(1.0, 1.0), None);
 
-        window_selector_root.add_sublayer(&window_selector_background);
+        let _ = window_selector_root.add_sublayer(&window_selector_background);
 
-        window_selector_root.add_sublayer(&window_selector_windows_container);
+        let _ = window_selector_root.add_sublayer(&window_selector_windows_container);
 
-        window_selector_root.add_sublayer(&window_selector_view);
+        let _ = window_selector_root.add_sublayer(&window_selector_view);
 
         Self {
             view,
@@ -232,7 +232,7 @@ impl WindowSelectorView {
     /// add a window layer to windows map
     /// and append the window to the window_selector_windows_container
     pub fn map_window(&self, window_id: ObjectId, layer: &Layer) {
-        self.window_selector_windows_container.add_sublayer(layer);
+        let _ = self.window_selector_windows_container.add_sublayer(layer);
         self.windows
             .write()
             .unwrap()
@@ -248,7 +248,7 @@ impl WindowSelectorView {
             if let Some(layer) = windows.get(window_id) {
                 // Re-append in state order; append detaches first, so this
                 // effectively reorders the siblings without changing parents.
-                self.window_selector_windows_container.add_sublayer(layer);
+                let _ = self.window_selector_windows_container.add_sublayer(layer);
             }
         }
     }
@@ -289,7 +289,7 @@ impl WindowSelectorView {
         self.view.update_state(&state);
 
         if let Some(layer) = self.layer_for_window(window_id) {
-            self.window_selector_windows_container.add_sublayer(&layer);
+            let _ = self.window_selector_windows_container.add_sublayer(&layer);
         }
     }
 
@@ -344,7 +344,7 @@ impl WindowSelectorView {
             .window_layer
             .set_anchor_point_preserving_position(state.original_anchor);
         state.window_layer.set_position(restored_position, None);
-        state.original_parent.add_sublayer(&state.window_layer);
+        let _ = state.original_parent.add_sublayer(&state.window_layer);
 
         Some(state)
     }
@@ -470,7 +470,7 @@ impl WindowSelectorView {
         let original_anchor = window_layer.anchor_point();
 
         // Move window to drag overlay
-        self.drag_overlay_layer.add_sublayer(&window_layer);
+        let _ = self.drag_overlay_layer.add_sublayer(&window_layer);
 
         // Remove from state grid
         self.remove_rect_from_state(selection.index);

--- a/src/workspaces/window_view/view.rs
+++ b/src/workspaces/window_view/view.rs
@@ -52,8 +52,8 @@ impl WindowView {
             ..Default::default()
         });
 
-        layers_engine.append_layer(&shadow_layer, layer.id());
-        layers_engine.append_layer(&content_layer, layer.id());
+        let _ = layers_engine.append_layer(&shadow_layer, layer.id());
+        let _ = layers_engine.append_layer(&content_layer, layer.id());
 
         let base_rect = WindowViewBaseModel {
             x: 0.0,
@@ -116,6 +116,14 @@ impl WindowView {
     pub fn is_unmapped(&self) -> bool {
         self.is_unmapped.load(std::sync::atomic::Ordering::SeqCst)
     }
+
+    /// Returns true if the window layer's scene node is still alive.
+    pub fn is_alive(&self) -> bool {
+        self.window_layer
+            .engine
+            .is_layer_alive(&self.window_layer.id)
+    }
+
     pub fn minimize(&self, to_rect: skia::Rect) -> TransactionRef {
         self.window_layer.set_effect(self.genie_effect.clone());
         self.genie_effect.set_destination(to_rect, true);

--- a/src/workspaces/window_view/view.rs
+++ b/src/workspaces/window_view/view.rs
@@ -125,9 +125,13 @@ impl WindowView {
         let w = render_layer.width();
         let h = render_layer.height();
 
+        // Read live destination from the genie effect so the draw area
+        // tracks the expanding drawer during parallel animation.
+        let dst_ref = self.genie_effect.dst.clone();
         self.window_layer
             .set_draw_content(move |_: &skia::Canvas, _w, _h| {
-                skia::Rect::join2(skia::Rect::from_wh(w, h), to_rect).with_outset((100.0, 100.0))
+                let dst = *dst_ref.read().unwrap();
+                skia::Rect::join2(skia::Rect::from_wh(w, h), dst).with_outset((100.0, 100.0))
             });
 
         let tr = self
@@ -136,15 +140,17 @@ impl WindowView {
 
         self.set_is_minimizing(true);
         let view_ref = self.clone();
+        let dst_ref = self.genie_effect.dst.clone();
         tr.on_finish(
             move |l: &Layer, _| {
                 if view_ref.is_unmapped() {
                     return;
                 }
                 view_ref.set_is_minimizing(false);
+                let final_dst = *dst_ref.read().unwrap();
                 // After the animation, drop the shader and keep a simple scaled layer
                 l.remove_effect();
-                view_ref.apply_minimized_scale_to_layer(l, (w, h), to_rect);
+                view_ref.apply_minimized_scale_to_layer(l, (w, h), final_dst);
                 l.set_position(Point { x: 0.0, y: 0.0 }, None);
             },
             true,

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -107,9 +107,9 @@ impl WorkspaceView {
         });
         windows_layer.set_pointer_events(false);
 
-        layers_engine.append_layer(&workspace_layer, parent.id);
-        layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
-        layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
+        let _ = layers_engine.append_layer(&workspace_layer, parent.id);
+        let _ = layers_engine.append_layer(&background_layer, Some(workspace_layer.id));
+        let _ = layers_engine.append_layer(&windows_layer, Some(workspace_layer.id));
 
         // Parse background color from config
         let background_color = Config::with(|c| parse_hex_color(&c.background_color));
@@ -176,13 +176,15 @@ impl WorkspaceView {
         if !window_list.contains(&wid) {
             window_list.push(wid.clone());
 
-            self.windows_layer
+            let _ = self
+                .windows_layer
                 .add_sublayer(&window_element.base_layer().id);
 
             let mirror_window = window_element.mirror_layer();
             let size = window_element.base_layer().render_size_transformed();
             mirror_window.set_size(Size::points(size.x, size.y), None);
-            self.window_selector_view
+            let _ = self
+                .window_selector_view
                 .window_selector_windows_container
                 .add_sublayer(mirror_window);
 
@@ -266,7 +268,10 @@ impl WorkspaceView {
             .get(window_id)
             .cloned()
         {
-            self.windows_layer.add_sublayer(&base_layer);
+            if let Err(e) = self.windows_layer.add_sublayer(&base_layer) {
+                tracing::warn!("raise_window_to_front: failed to reparent window layer: {e}");
+                return;
+            }
         }
 
         self.window_selector_view.bring_window_to_front(window_id);

--- a/wlcs_otto/Cargo.toml
+++ b/wlcs_otto/Cargo.toml
@@ -28,5 +28,5 @@ nix = "0.24"
 [dependencies.laye-rs]
 # path = "../layers"
 git = "https://github.com/nongio/layers"
-tag = "v1.5.0"
+tag = "v1.6.0"
 features = ["export-taffy"]

--- a/wlcs_otto/Cargo.toml
+++ b/wlcs_otto/Cargo.toml
@@ -19,9 +19,14 @@ otto = { path = "../", default-features = false,  features = [
     "winit",
     "debug",
 ] }
-layers = { path = "../../layers", features = ["export-taffy"] }
 wayland-sys = { version = "0.30.1", features = ["client", "server"] }
 libc = "0.2"
 memoffset = "0.6"
 cgmath = "0.18"
 nix = "0.24"
+
+[dependencies.laye-rs]
+# path = "../layers"
+git = "https://github.com/nongio/layers"
+tag = "v1.5.0"
+features = ["export-taffy"]


### PR DESCRIPTION
This PR handle the window minimize animation when the dock is hidden.


Changes:

Update minimize/unminimize logic to temporarily unmap minimized windows from Spaces (hit-testing) while keeping them tracked for workspace model updates.

Add dock animation bookkeeping (last layout animation) and pressed/hover interaction refinements for dock items.
Bump laye-rs dependency to v1.5.0 and align dependency declarations across crates.

