### PR TITLE
refactor: migrate otto to use otto-kit features

### DIFF
--- a/components/xdg-desktop-portal-otto/src/otto_client/settings.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/settings.rs
@@ -19,4 +19,9 @@ trait OttoSettings {
     /// - 1: Prefer dark appearance
     /// - 2: Prefer light appearance
     async fn get_color_scheme(&self) -> Result<u32>;
+
+    /// Get the icon theme name from the compositor.
+    ///
+    /// Returns an empty string if no theme is configured.
+    async fn get_icon_theme(&self) -> Result<String>;
 }

--- a/components/xdg-desktop-portal-otto/src/portal/settings.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/settings.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tracing::{debug, error};
 use zbus::fdo;
 use zbus::interface;
-use zbus::zvariant::OwnedValue;
+use zbus::zvariant::{OwnedValue, Value};
 
 use crate::otto_client::settings::OttoSettingsProxy;
 use crate::otto_client::OttoClient;
@@ -24,11 +24,16 @@ impl SettingsPortal {
     /// Returns all settings as a nested HashMap.
     async fn get_all_settings(&self) -> fdo::Result<HashMap<String, HashMap<String, OwnedValue>>> {
         let color_scheme = self.read_color_scheme().await?;
+        let icon_theme = self.read_icon_theme().await?;
 
         let mut namespaces = HashMap::new();
         let mut appearance = HashMap::new();
 
         appearance.insert("color-scheme".to_string(), color_scheme.into());
+        appearance.insert(
+            "icon-theme".to_string(),
+            Value::from(icon_theme).try_into().unwrap(),
+        );
 
         namespaces.insert("org.freedesktop.appearance".to_string(), appearance);
         Ok(namespaces)
@@ -40,6 +45,10 @@ impl SettingsPortal {
             ("org.freedesktop.appearance", "color-scheme") => {
                 let color_scheme = self.read_color_scheme().await?;
                 Ok(color_scheme.into())
+            }
+            ("org.freedesktop.appearance", "icon-theme") => {
+                let icon_theme = self.read_icon_theme().await?;
+                Ok(Value::from(icon_theme).try_into().unwrap())
             }
             _ => Err(fdo::Error::Failed(format!(
                 "Unknown setting: {}.{}",
@@ -64,6 +73,15 @@ impl SettingsPortal {
         proxy.get_color_scheme().await.map_err(|err| {
             error!(?err, "Failed to read color scheme from compositor");
             fdo::Error::Failed(format!("Failed to read color scheme: {err}"))
+        })
+    }
+
+    /// Reads the icon theme name from the compositor.
+    async fn read_icon_theme(&self) -> fdo::Result<String> {
+        let proxy = self.get_settings_proxy().await?;
+        proxy.get_icon_theme().await.map_err(|err| {
+            error!(?err, "Failed to read icon theme from compositor");
+            fdo::Error::Failed(format!("Failed to read icon theme: {err}"))
         })
     }
 

--- a/src/settings_service.rs
+++ b/src/settings_service.rs
@@ -27,6 +27,13 @@ impl SettingsInterface {
             ThemeScheme::Light => 2,
         })
     }
+
+    /// Returns the configured icon theme name (e.g. "Adwaita", "Papirus").
+    ///
+    /// Returns an empty string if no theme is configured (auto-detect).
+    async fn get_icon_theme(&self) -> String {
+        Config::with(|config| config.icon_theme.clone().unwrap_or_default())
+    }
 }
 
 /// Registers the Settings interface on the existing D-Bus connection.

--- a/src/workspaces/apps_info.rs
+++ b/src/workspaces/apps_info.rs
@@ -4,14 +4,9 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use freedesktop_desktop_entry::DesktopEntry;
-
 use layers::skia;
 
-use crate::{
-    config::Config,
-    utils::{find_icon_with_theme, image_from_path},
-};
+use crate::utils::{find_icon_with_theme, image_from_path};
 
 #[derive(Clone)]
 pub struct Application {
@@ -22,7 +17,7 @@ pub struct Application {
     pub picture: Option<skia::Picture>,
     pub override_name: Option<String>,
     pub desktop_file_id: Option<String>,
-    desktop_entry: Option<DesktopEntry>,
+    app_info: Option<otto_kit::desktop_entry::AppInfo>,
 }
 
 impl Application {
@@ -30,15 +25,10 @@ impl Application {
         if let Some(name) = &self.override_name {
             return Some(name.clone());
         }
-        Config::with(|c| {
-            self.desktop_entry
-                .as_ref()
-                .and_then(|entry| entry.name(&c.locales))
-                .map(|name| name.to_string())
-        })
+        self.app_info.as_ref().map(|info| info.name.clone())
     }
     pub fn command(&self, extra_args: &[String]) -> Option<(String, Vec<String>)> {
-        let exec = self.desktop_entry.as_ref()?.exec()?;
+        let exec = self.app_info.as_ref()?.exec.as_ref()?;
         let mut parts = shell_words::split(exec).ok()?;
         if parts.is_empty() {
             return None;
@@ -129,96 +119,48 @@ impl ApplicationsInfo {
         app
     }
 
-    async fn get_desktop_entry(app_id: &str) -> Option<DesktopEntry> {
-        // Normalize the app_id - remove .desktop suffix if present
-        let normalized_id = if let Some(stripped) = app_id.strip_suffix(".desktop") {
-            stripped
-        } else {
-            app_id
-        };
-
-        tracing::trace!(normalized_id = %normalized_id, "[get_desktop_entry] searching");
-
-        // Exact filename match (case-insensitive)
-        let entry_path = freedesktop_desktop_entry::Iter::new(
-            freedesktop_desktop_entry::default_paths(),
-        )
-        .find(|path| {
-            if let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) {
-                file_stem.eq_ignore_ascii_case(normalized_id)
-            } else {
-                false
-            }
-        });
-
-        if let Some(entry_path) = entry_path {
-            tracing::trace!(path = ?entry_path, "[get_desktop_entry] found");
-            let locales = &["en"];
-            return DesktopEntry::from_path(entry_path, Some(locales)).ok();
-        }
-
-        tracing::trace!(normalized_id = %normalized_id, "[get_desktop_entry] not found");
-        None
-    }
-
     async fn load_app_info(app_id: &str) -> Option<Application> {
         tracing::trace!(app_id = %app_id, "[load_app_info] start");
-        let desktop_entry = ApplicationsInfo::get_desktop_entry(app_id).await;
 
-        if let Some(desktop_entry) = desktop_entry {
-            let match_id = desktop_entry.id().to_string();
+        // Use otto-kit's desktop entry lookup for metadata
+        let info = otto_kit::desktop_entry::lookup_app(app_id);
+
+        let icon_name = info.as_ref().and_then(|i| i.icon_name.clone());
+        let desktop_file_id = info.as_ref().and_then(|i| i.desktop_file_id.clone());
+
+        let icon_path = icon_name.and_then(|icon_name| find_icon_with_theme(&icon_name, 512, 1));
+
+        let mut icon = icon_path
+            .as_ref()
+            .and_then(|icon_path| image_from_path(icon_path, (512, 512)));
+
+        // If icon loading failed, try to use the fallback icon
+        if icon.is_none() {
+            let fallback_path = find_icon_with_theme("application-default-icon", 512, 1)
+                .or_else(|| find_icon_with_theme("application-x-executable", 512, 1));
+
+            icon = fallback_path.as_ref().and_then(|fallback_path| {
+                let result = image_from_path(fallback_path, (512, 512));
+                tracing::trace!(
+                    loaded = result.is_some(),
+                    "[load_app_info] fallback icon loaded"
+                );
+                result
+            });
+        }
+
+        if let Some(info) = info {
+            let match_id = info
+                .desktop_file_id
+                .clone()
+                .unwrap_or_else(|| app_id.to_string());
             let identifier = if app_id.ends_with(".desktop") {
                 match_id.clone()
             } else {
                 app_id.to_string()
             };
-            let icon_name = desktop_entry.icon().map(|icon| icon.to_string());
 
-            let icon_path =
-                icon_name.and_then(|icon_name| find_icon_with_theme(&icon_name, 512, 1));
-
-            let mut icon = icon_path
-                .as_ref()
-                .and_then(|icon_path| image_from_path(icon_path, (512, 512)));
-
-            // If icon loading failed, try to use the fallback icon
-            if icon.is_none() {
-                let fallback_path = find_icon_with_theme("application-default-icon", 512, 1)
-                    .or_else(|| find_icon_with_theme("application-x-executable", 512, 1));
-
-                icon = fallback_path.as_ref().and_then(|fallback_path| {
-                    let result = image_from_path(fallback_path, (512, 512));
-                    tracing::trace!(
-                        loaded = result.is_some(),
-                        "[load_app_info] fallback icon loaded"
-                    );
-                    result
-                });
-            }
-            // let picture = icon_path
-            //     .as_ref()
-            //     .and_then(|icon_path| {
-            //         let path = std::path::Path::new(icon_path);
-            //         if path.extension().and_then(std::ffi::OsStr::to_str) == Some("svg") {
-            //             if let Ok(svg) = svg_dom(icon_path, (100, 100)) {
-            //                 let mut rec = skia::PictureRecorder::new();
-            //                 let canvas = rec.begin_recording(skia::Rect::from_iwh(512, 512), None);
-            //                 svg.render(&canvas);
-            //                 // let paint = skia::Paint::new(skia::Color4f::new(1.0, 0.0, 0.0, 1.0), None);
-            //                 // canvas.draw_circle((50.0, 50.0), 50.0, &paint);
-            //                 return rec.finish_recording_as_picture(None)
-            //             }
-            //         }
-            //         None
-            //     });
-
-            let desktop_file_id = desktop_entry
-                .path
-                .file_stem()
-                .and_then(|os| os.to_str())
-                .map(|s| s.to_string());
-
-            let app = Application {
+            Some(Application {
                 identifier,
                 match_id,
                 icon_path,
@@ -226,101 +168,32 @@ impl ApplicationsInfo {
                 picture: None,
                 override_name: None,
                 desktop_file_id,
-                desktop_entry: Some(desktop_entry),
-            };
-
-            return Some(app);
-        }
-
-        // No desktop entry found - create minimal Application with fallback icon
-        tracing::debug!("[load_app_info] no desktop entry; creating fallback application");
-
-        let fallback_icon_path = find_icon_with_theme("application-default-icon", 512, 1)
-            .or_else(|| {
-                tracing::trace!("[load_app_info] application-default-icon not found; trying application-x-executable");
-                find_icon_with_theme("application-x-executable", 512, 1)
-            });
-
-        let fallback_icon = fallback_icon_path.as_ref().and_then(|path| {
-            let result = image_from_path(path, (512, 512));
-            tracing::trace!(
-                loaded = result.is_some(),
-                "[load_app_info] fallback application icon loaded"
-            );
-            result
-        });
-
-        // Format the app_id (executable name) as a nice display name
-        let display_name = app_id
-            .split('/')
-            .next_back()
-            .unwrap_or(app_id)
-            .split('-')
-            .map(|word| {
-                let mut c = word.chars();
-                match c.next() {
-                    None => String::new(),
-                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-                }
+                app_info: Some(info),
             })
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        if fallback_icon.is_some() {
-            tracing::debug!(display_name = %display_name, "[load_app_info] fallback application created");
         } else {
-            tracing::warn!(display_name = %display_name, "[load_app_info] fallback application created without icon");
-        }
+            // No desktop entry found - create minimal Application with fallback icon
+            tracing::debug!("[load_app_info] no desktop entry; creating fallback application");
 
-        Some(Application {
-            identifier: app_id.to_string(),
-            match_id: app_id.to_string(),
-            icon_path: fallback_icon_path,
-            icon: fallback_icon,
-            picture: None,
-            override_name: Some(display_name),
-            desktop_file_id: None,
-            desktop_entry: None,
-        })
-    }
-}
+            let display_name = otto_kit::desktop_entry::display_name_for_app(app_id);
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_desktop_entry_matching_logic() {
-        // Test exact filename matching (case-insensitive)
-        let test_cases = vec![
-            // (app_id, desktop_file_stem, should_match)
-            ("thunar", "thunar", true),
-            ("thunar", "thunar-bulk-rename", false),
-            ("thunar", "thunar-settings", false),
-            ("firefox", "firefox", true),
-            ("firefox", "firefox-esr", false),
-            ("code", "code", true),
-            ("code", "code-url-handler", false),
-            ("Thunar", "thunar", true), // Case insensitive
-            ("THUNAR", "thunar", true),
-            ("org.kde.dolphin", "org.kde.dolphin", true),
-            ("org.gnome.gedit", "org.gnome.gedit", true),
-            ("io.elementary.files", "io.elementary.files", true),
-            ("com.mitchellh.ghostty", "com.mitchellh.ghostty", true),
-        ];
-        #[allow(clippy::manual_strip)]
-        for (app_id, file_stem, expected_match) in test_cases {
-            let normalized_id = if app_id.ends_with(".desktop") {
-                &app_id[..app_id.len() - 8]
+            if icon.is_some() {
+                tracing::debug!(display_name = %display_name, "[load_app_info] fallback application created");
             } else {
-                app_id
-            };
+                tracing::warn!(display_name = %display_name, "[load_app_info] fallback application created without icon");
+            }
 
-            let exact_match = file_stem.eq_ignore_ascii_case(normalized_id);
-
-            assert_eq!(
-                exact_match, expected_match,
-                "Match failed for app_id='{}' vs file_stem='{}' (expected: {})",
-                app_id, file_stem, expected_match
-            );
+            Some(Application {
+                identifier: app_id.to_string(),
+                match_id: app_id.to_string(),
+                icon_path,
+                icon,
+                picture: None,
+                override_name: Some(display_name),
+                desktop_file_id: None,
+                app_info: None,
+            })
         }
     }
 }
+
+// Tests for desktop entry matching are now in otto_kit::desktop_entry


### PR DESCRIPTION
Wire otto and xdg-desktop-portal-otto to new otto-kit modules.

- Expose icon-theme via D-Bus settings chain
- Extract desktop entry lookup into otto-kit
- Add icon theme support to xdg-desktop-portal-otto

**Stack:** 3/5 → `otto-kit-update`