### PR TITLE
fix: various otto bug fixes and refactors

### DIFF
--- a/protocols/otto-surface-style-unstable-v1.xml
+++ b/protocols/otto-surface-style-unstable-v1.xml
@@ -272,6 +272,7 @@
       <entry name="resize_aspect_fill" value="2" summary="scale uniformly to fill, preserving aspect ratio (crop)"/>
       <entry name="center" value="3" summary="natural buffer size, centred in bounds"/>
       <entry name="top_left" value="4" summary="natural buffer size, pinned to top-left"/>
+      <entry name="top_right" value="5" summary="natural buffer size, pinned to top-right"/>
     </enum>
     
     <request name="set_blend_mode">

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -5,7 +5,7 @@ use smithay::{
         self, Axis, AxisSource, ButtonState, Event, InputBackend, PointerAxisEvent,
         PointerButtonEvent,
     },
-    desktop::{layer_map_for_output, space::SpaceElement, WindowSurfaceType},
+    desktop::{utils::under_from_surface_tree, WindowSurfaceType},
     input::pointer::{AxisFrame, ButtonEvent, MotionEvent},
     reexports::wayland_server::{protocol::wl_pointer, Resource},
     utils::{IsAlive, Logical, Point, Serial, SERIAL_COUNTER as SCOUNTER},
@@ -69,7 +69,7 @@ impl<BackendData: Backend> Otto<BackendData> {
         let input_method = self.seat.input_method();
 
         // Get current focus to deactivate it
-        let old_focus = keyboard.current_focus();
+        let _old_focus = keyboard.current_focus();
 
         // change the keyboard focus unless the pointer or keyboard is grabbed
         // We test for any matching surface type here but always use the root
@@ -105,41 +105,39 @@ impl<BackendData: Backend> Otto<BackendData> {
                             self.xwm.as_mut().unwrap().raise_window(surf).unwrap();
                         }
 
-                        // Deactivate old focus if it was a different window
-                        if let Some(crate::focus::KeyboardFocusTarget::Window(old_window)) =
-                            old_focus.as_ref()
-                        {
-                            if old_window.wl_surface() != window.wl_surface() {
-                                old_window.set_activate(false);
-                                old_window.toplevel().map(|t| t.send_configure());
-                            }
-                        }
-
-                        // Activate new window and set focus
-                        window.set_activate(true);
-                        window.toplevel().map(|t| t.send_configure());
-                        keyboard.set_focus(self, Some(window.into()), serial);
+                        self.set_keyboard_focus_on_window(&window);
                         return;
                     }
                 }
 
-                // Check if an overlay/top layer surface should receive keyboard focus
-                let layers = layer_map_for_output(output);
-                if let Some(layer) = layers
-                    .layer_under(WlrLayer::Overlay, self.pointer.current_location())
-                    .or_else(|| layers.layer_under(WlrLayer::Top, self.pointer.current_location()))
-                {
-                    if layer.can_receive_keyboard_focus() {
-                        if let Some((_, _)) = layer.surface_under(
-                            self.pointer.current_location()
-                                - output_geo.loc.to_f64()
-                                - layers.layer_geometry(layer).unwrap().loc.to_f64(),
-                            WindowSurfaceType::ALL,
-                        ) {
-                            keyboard.set_focus(self, Some(layer.clone().into()), serial);
-                            return;
+                // Check if a Top/Overlay layer shell surface should receive keyboard focus
+                // using lay-rs hit testing (matches visual position from Taffy layout)
+                // Sort by stacking order: Overlay above Top
+                let scale = output.current_scale().fractional_scale();
+                let phys = self.pointer.current_location().to_physical(scale);
+                let mut found_layer_focus = false;
+                let mut layer_surfs: Vec<_> = self
+                    .layer_surfaces
+                    .values()
+                    .filter(|s| matches!(s.wlr_layer(), WlrLayer::Overlay | WlrLayer::Top))
+                    .collect();
+                layer_surfs.sort_by_key(|s| match s.wlr_layer() {
+                    WlrLayer::Overlay => 0,
+                    _ => 1,
+                });
+                for layer_shell_surf in layer_surfs {
+                    let lay_layer = &layer_shell_surf.layer;
+                    if lay_layer.cointains_point((phys.x as f32, phys.y as f32)) {
+                        let ls = layer_shell_surf.layer_surface();
+                        if ls.can_receive_keyboard_focus() {
+                            keyboard.set_focus(self, Some(ls.clone().into()), serial);
+                            found_layer_focus = true;
+                            break;
                         }
                     }
+                }
+                if found_layer_focus {
+                    return;
                 }
             }
             let scale = output
@@ -168,34 +166,7 @@ impl<BackendData: Backend> Otto<BackendData> {
                             }
                             self.workspaces.focus_app_with_window(&id);
 
-                            // Deactivate old focus if it was a different window
-                            if let Some(crate::focus::KeyboardFocusTarget::Window(old_window)) =
-                                old_focus.as_ref()
-                            {
-                                if old_window.wl_surface() != window.wl_surface() {
-                                    old_window.set_activate(false);
-                                    // Update shadow for deactivated window
-                                    if let Some(view) =
-                                        self.workspaces.get_window_view(&old_window.id())
-                                    {
-                                        view.set_active(false);
-                                    }
-                                    if let Some(toplevel) = old_window.toplevel() {
-                                        toplevel.send_configure();
-                                    }
-                                }
-                            }
-
-                            // Activate new window and set focus
-                            window.set_activate(true);
-                            // Update shadow for activated window
-                            if let Some(view) = self.workspaces.get_window_view(&id) {
-                                view.set_active(true);
-                            }
-                            if let Some(toplevel) = window.toplevel() {
-                                toplevel.send_configure();
-                            }
-                            keyboard.set_focus(self, Some(window.clone().into()), serial);
+                            self.set_keyboard_focus_on_window(&window);
                             self.workspaces.update_workspace_model();
                         }
                     }
@@ -208,25 +179,22 @@ impl<BackendData: Backend> Otto<BackendData> {
                 }
             }
 
-            // Check if a bottom/background layer surface should receive keyboard focus
+            // Check if a Bottom/Background layer shell surface should receive keyboard focus
             if let Some(output) = output.as_ref() {
-                let output_geo = self.workspaces.output_geometry(output).unwrap();
-                let layers = layer_map_for_output(output);
-                if let Some(layer) = layers
-                    .layer_under(WlrLayer::Bottom, self.pointer.current_location())
-                    .or_else(|| {
-                        layers.layer_under(WlrLayer::Background, self.pointer.current_location())
-                    })
-                {
-                    if layer.can_receive_keyboard_focus() {
-                        if let Some((_, _)) = layer.surface_under(
-                            self.pointer.current_location()
-                                - output_geo.loc.to_f64()
-                                - layers.layer_geometry(layer).unwrap().loc.to_f64(),
-                            WindowSurfaceType::ALL,
-                        ) {
-                            keyboard.set_focus(self, Some(layer.clone().into()), serial);
+                let scale = output.current_scale().fractional_scale();
+                let phys = self.pointer.current_location().to_physical(scale);
+                for layer_shell_surf in self.layer_surfaces.values() {
+                    let wlr = layer_shell_surf.wlr_layer();
+                    if !matches!(wlr, WlrLayer::Bottom | WlrLayer::Background) {
+                        continue;
+                    }
+                    let lay_layer = &layer_shell_surf.layer;
+                    if lay_layer.cointains_point((phys.x as f32, phys.y as f32)) {
+                        let ls = layer_shell_surf.layer_surface();
+                        if ls.can_receive_keyboard_focus() {
+                            keyboard.set_focus(self, Some(ls.clone().into()), serial);
                         }
+                        break;
                     }
                 }
             }
@@ -241,8 +209,6 @@ impl<BackendData: Backend> Otto<BackendData> {
             let geometry = self.workspaces.output_geometry(o).unwrap();
             geometry.contains(pos.to_i32_round())
         })?;
-        let output_geo = self.workspaces.output_geometry(output).unwrap();
-        let layers = layer_map_for_output(output);
         let scale = output.current_scale().fractional_scale();
         let physical_pos = pos.to_physical(scale);
         let mut under = None;
@@ -286,75 +252,154 @@ impl<BackendData: Backend> Otto<BackendData> {
             return Some((focus, (position.x as f64, position.y as f64).into()));
         }
 
-        if let Some(layer) = layers
-            .layer_under(WlrLayer::Overlay, pos)
-            .or_else(|| layers.layer_under(WlrLayer::Top, pos))
-        {
-            let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            let layer_abs_pos = output_geo.loc + layer_loc;
+        // Check popup surfaces (layer shell popups) — they sit above everything
+        // Sort by stacking order: Overlay above Top
+        if under.is_none() {
+            use smithay::desktop::PopupManager;
 
-            // Check for surfaces under this layer (including popups)
-            // Pass position relative to layer surface
-            if let Some((surface, surface_loc)) =
-                layer.surface_under(pos - layer_abs_pos.to_f64(), WindowSurfaceType::ALL)
-            {
-                // surface_loc is relative to layer surface, convert to absolute
-                under = Some((
-                    PointerFocusTarget::WlSurface(surface),
-                    layer_abs_pos + surface_loc,
-                ));
-            } else {
-                // No popup, use the layer surface itself
-                under = Some((layer.clone().into(), layer_abs_pos));
-            }
-        }
-        // Check dock
-        else if self
-            .workspaces
-            .is_cursor_over_dock(physical_pos.x as f32, physical_pos.y as f32)
-        {
-            // Dock
-            under = Some((self.workspaces.dock.as_ref().clone().into(), (0, 0).into()));
-        } else if let Some((focus, location)) =
-            self.workspaces
-                .element_under(pos)
-                .and_then(|(window, loc)| {
-                    if let Some(id) = window.wl_surface().as_ref().map(|s| s.id()) {
-                        if let Some(w) = self.workspaces.get_window_for_surface(&id) {
-                            if w.is_minimised() {
-                                return None;
-                            }
+            let mut layer_surfs: Vec<_> = self
+                .layer_surfaces
+                .values()
+                .filter(|s| matches!(s.wlr_layer(), WlrLayer::Overlay | WlrLayer::Top))
+                .collect();
+            layer_surfs.sort_by_key(|s| match s.wlr_layer() {
+                WlrLayer::Overlay => 0,
+                _ => 1,
+            });
+            for layer_shell_surf in layer_surfs {
+                let layer_wl = layer_shell_surf.layer_surface().wl_surface();
+                let popups: Vec<_> = PopupManager::popups_for_surface(layer_wl).collect();
+                if !popups.is_empty() {
+                    let lay_layer = &layer_shell_surf.layer;
+                    let render_pos = lay_layer.render_position();
+                    let layer_abs_pos: Point<f64, Logical> =
+                        Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
+                    let cursor_rel_layer = pos - layer_abs_pos;
+                    // Match Smithay's LayerSurface::surface_under approach:
+                    // offset = popup_location - popup.geometry().loc
+                    for (popup, popup_location) in popups.into_iter() {
+                        let offset = popup_location - popup.geometry().loc;
+                        let popup_surface = popup.wl_surface();
+                        if let Some((surface, surface_loc)) = under_from_surface_tree(
+                            popup_surface,
+                            cursor_rel_layer,
+                            offset,
+                            WindowSurfaceType::ALL,
+                        ) {
+                            under = Some((
+                                PointerFocusTarget::WlSurface(surface),
+                                layer_abs_pos + surface_loc.to_f64(),
+                            ));
+                            break;
                         }
                     }
-                    window
-                        .surface_under(pos - loc.to_f64(), WindowSurfaceType::ALL)
-                        .map(|(surface, surf_loc)| (surface, surf_loc + loc))
-                })
-        {
-            under = Some((focus, location));
-        } else if let Some(layer) = layers
-            .layer_under(WlrLayer::Bottom, pos)
-            .or_else(|| layers.layer_under(WlrLayer::Background, pos))
-        {
-            let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            let layer_abs_pos = output_geo.loc + layer_loc;
-
-            // Check for surfaces under this layer (including popups)
-            // Pass position relative to layer surface
-            if let Some((surface, surface_loc)) =
-                layer.surface_under(pos - layer_abs_pos.to_f64(), WindowSurfaceType::ALL)
-            {
-                // surface_loc is relative to layer surface, convert to absolute
-                under = Some((
-                    PointerFocusTarget::WlSurface(surface),
-                    layer_abs_pos + surface_loc,
-                ));
-            } else {
-                // No popup, use the layer surface itself
-                under = Some((layer.clone().into(), layer_abs_pos));
+                }
+                if under.is_some() {
+                    break;
+                }
             }
-        };
-        under.map(|(s, l)| (s, l.to_f64()))
+        }
+
+        // Check Top/Overlay layer shell surfaces using lay-rs hit testing
+        // (Smithay's layer_map geometry doesn't reflect Taffy/animated positions)
+        // Sort by stacking order: Overlay above Top
+        if under.is_none() {
+            let mut layer_surfs: Vec<_> = self
+                .layer_surfaces
+                .values()
+                .filter(|s| matches!(s.wlr_layer(), WlrLayer::Overlay | WlrLayer::Top))
+                .collect();
+            layer_surfs.sort_by_key(|s| match s.wlr_layer() {
+                WlrLayer::Overlay => 0,
+                _ => 1,
+            });
+            for layer_shell_surf in layer_surfs {
+                let lay_layer = &layer_shell_surf.layer;
+                if lay_layer.cointains_point((physical_pos.x as f32, physical_pos.y as f32)) {
+                    let render_pos = lay_layer.render_position();
+                    let layer_abs_pos: Point<f64, Logical> =
+                        Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
+                    let ls = layer_shell_surf.layer_surface().clone();
+                    let relative_pos = pos - layer_abs_pos;
+                    if let Some((surface, surface_loc)) =
+                        ls.surface_under(relative_pos, WindowSurfaceType::ALL)
+                    {
+                        under = Some((
+                            PointerFocusTarget::WlSurface(surface),
+                            layer_abs_pos + surface_loc.to_f64(),
+                        ));
+                    } else {
+                        under = Some((ls.into(), layer_abs_pos));
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Check dock
+        if under.is_none()
+            && self
+                .workspaces
+                .is_cursor_over_dock(physical_pos.x as f32, physical_pos.y as f32)
+        {
+            under = Some((
+                self.workspaces.dock.as_ref().clone().into(),
+                (0.0, 0.0).into(),
+            ));
+        }
+
+        // Check windows
+        if under.is_none() {
+            if let Some((focus, location)) =
+                self.workspaces
+                    .element_under(pos)
+                    .and_then(|(window, loc)| {
+                        if let Some(id) = window.wl_surface().as_ref().map(|s| s.id()) {
+                            if let Some(w) = self.workspaces.get_window_for_surface(&id) {
+                                if w.is_minimised() {
+                                    return None;
+                                }
+                            }
+                        }
+                        window
+                            .surface_under(pos - loc.to_f64(), WindowSurfaceType::ALL)
+                            .map(|(surface, surf_loc)| (surface, (surf_loc + loc).to_f64()))
+                    })
+            {
+                under = Some((focus, location));
+            }
+        }
+
+        // Check Bottom/Background layer shell surfaces using lay-rs hit testing
+        if under.is_none() {
+            for layer_shell_surf in self.layer_surfaces.values() {
+                let wlr = layer_shell_surf.wlr_layer();
+                if !matches!(wlr, WlrLayer::Bottom | WlrLayer::Background) {
+                    continue;
+                }
+                let lay_layer = &layer_shell_surf.layer;
+                if lay_layer.cointains_point((physical_pos.x as f32, physical_pos.y as f32)) {
+                    let render_pos = lay_layer.render_position();
+                    let layer_abs_pos: Point<f64, Logical> =
+                        Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
+                    let ls = layer_shell_surf.layer_surface().clone();
+                    let relative_pos = pos - layer_abs_pos;
+                    if let Some((surface, surface_loc)) =
+                        ls.surface_under(relative_pos, WindowSurfaceType::ALL)
+                    {
+                        under = Some((
+                            PointerFocusTarget::WlSurface(surface),
+                            layer_abs_pos + surface_loc.to_f64(),
+                        ));
+                    } else {
+                        under = Some((ls.into(), layer_abs_pos));
+                    }
+                    break;
+                }
+            }
+        }
+
+        under
     }
 
     pub(crate) fn on_pointer_axis<B: InputBackend>(&mut self, evt: B::PointerAxisEvent) {

--- a/src/shell/layer.rs
+++ b/src/shell/layer.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use layers::prelude::Layer;
+use layers::taffy;
 use smithay::{
     desktop::LayerSurface,
     output::Output,
@@ -231,6 +232,98 @@ impl LayerShellSurface {
         height = height.max(0);
 
         Rectangle::new((x, y).into(), (width, height).into())
+    }
+
+    /// Build a Taffy layout style that encodes the layer shell anchors and margins
+    /// so the layout engine positions the layer automatically.
+    /// The layer's actual size (set via surface style or `set_size`) drives layout;
+    /// Taffy only provides the inset constraints for positioning.
+    /// `scale` is the output scale factor (physical / logical).
+    pub fn taffy_style(&self, scale: f64) -> taffy::Style {
+        let anchor = self.anchor();
+        let (mt, mr, mb, ml) = self.margin();
+
+        let anchor_top = anchor.contains(Anchor::TOP);
+        let anchor_bottom = anchor.contains(Anchor::BOTTOM);
+        let anchor_left = anchor.contains(Anchor::LEFT);
+        let anchor_right = anchor.contains(Anchor::RIGHT);
+
+        let s = |v: i32| taffy::LengthPercentageAuto::Length((v as f64 * scale) as f32);
+        let auto = taffy::LengthPercentageAuto::Auto;
+        let zero = taffy::LengthPercentageAuto::Length(0.0);
+
+        // wlr-layer-shell centering: surfaces not anchored on an axis are centered
+        // along that axis. For absolute items in Taffy, centering requires
+        // inset 0 on both sides + auto margins on that axis.
+        let horizontal_anchored = anchor_left || anchor_right;
+        let vertical_anchored = anchor_top || anchor_bottom;
+
+        let top = if anchor_top {
+            s(mt)
+        } else if !vertical_anchored {
+            zero
+        } else {
+            auto
+        };
+        let bottom = if anchor_bottom {
+            s(mb)
+        } else if !vertical_anchored {
+            zero
+        } else {
+            auto
+        };
+        let left = if anchor_left {
+            s(ml)
+        } else if !horizontal_anchored {
+            zero
+        } else {
+            auto
+        };
+        let right = if anchor_right {
+            s(mr)
+        } else if !horizontal_anchored {
+            zero
+        } else {
+            auto
+        };
+
+        let margin_top = if !vertical_anchored {
+            auto
+        } else {
+            taffy::LengthPercentageAuto::Length(0.0)
+        };
+        let margin_bottom = if !vertical_anchored {
+            auto
+        } else {
+            taffy::LengthPercentageAuto::Length(0.0)
+        };
+        let margin_left = if !horizontal_anchored {
+            auto
+        } else {
+            taffy::LengthPercentageAuto::Length(0.0)
+        };
+        let margin_right = if !horizontal_anchored {
+            auto
+        } else {
+            taffy::LengthPercentageAuto::Length(0.0)
+        };
+
+        taffy::Style {
+            position: taffy::Position::Absolute,
+            inset: taffy::Rect {
+                left,
+                right,
+                top,
+                bottom,
+            },
+            margin: taffy::Rect {
+                left: margin_left,
+                right: margin_right,
+                top: margin_top,
+                bottom: margin_bottom,
+            },
+            ..Default::default()
+        }
     }
 }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -30,7 +30,7 @@ use smithay::{
                 Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,
                 WlrLayerShellState,
             },
-            xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData},
+            xdg::{PopupSurface, XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
     },
 };
@@ -353,6 +353,23 @@ impl<BackendData: Backend> Otto<BackendData> {
             );
 
             self.surface_layers.extend(popup_layers);
+
+            // Show the popup only after the initial configure has been sent and
+            // the client has committed at the correct position. Until then the
+            // layer stays hidden (as initialised in get_or_create_popup_layer).
+            let initial_configure_sent =
+                smithay::wayland::compositor::with_states(popup_surface, |states| {
+                    states
+                        .data_map
+                        .get::<XdgPopupSurfaceData>()
+                        .map(|d: &std::sync::Mutex<_>| d.lock().unwrap().initial_configure_sent)
+                        .unwrap_or(false)
+                });
+            if initial_configure_sent {
+                if let Some(popup_layer) = self.workspaces.popup_overlay.get_popup(&popup_id) {
+                    popup_layer.layer.set_hidden(false);
+                }
+            }
         });
 
         // Ensure all surfaces in the tree have rendering layers
@@ -474,9 +491,10 @@ impl<BackendData: Backend> Otto<BackendData> {
             }
         }
 
-        // Update the container layer with size and position.
-        // Skip size/position if a surface style with non-Resize gravity is registered
-        // (the style owns the layer bounds in that case).
+        // Update the container layer's Taffy layout style from anchors/margins/size.
+        // This lets the layout engine position the layer automatically — including
+        // during surface-style size animations (the animated size feeds back into
+        // Taffy and the position adjusts every frame).
         let layer = {
             let Some(layer_shell_surf) = self.layer_surfaces.get(surface_id) else {
                 return;
@@ -490,21 +508,22 @@ impl<BackendData: Backend> Otto<BackendData> {
             .and_then(|v: &Vec<_>| v.first());
         let container_owns_size = container_style.map(|s| s.client_owns_size).unwrap_or(false);
 
+        // Always refresh the Taffy style so position tracks anchor+margin changes.
+        // When the client owns the size (surface style animation), Taffy still
+        // controls the inset positioning — the animated size on the layer feeds
+        // back into layout automatically.
+        {
+            let Some(layer_shell_surf) = self.layer_surfaces.get(surface_id) else {
+                return;
+            };
+            let style = layer_shell_surf.taffy_style(scale_factor);
+            layer.set_layout_style(style);
+        }
+
         if !container_owns_size {
-            layer.set_size(
-                layers::types::Size::points(
-                    (geometry.size.w as f64 * scale_factor) as f32,
-                    (geometry.size.h as f64 * scale_factor) as f32,
-                ),
-                None,
-            );
-            layer.set_position(
-                (
-                    (geometry.loc.x as f64 * scale_factor) as f32,
-                    (geometry.loc.y as f64 * scale_factor) as f32,
-                ),
-                None,
-            );
+            let container_w = (geometry.size.w as f64 * scale_factor) as f32;
+            let container_h = (geometry.size.h as f64 * scale_factor) as f32;
+            layer.set_size(layers::types::Size::points(container_w, container_h), None);
         }
         layer.set_hidden(false);
 
@@ -565,6 +584,28 @@ impl<BackendData: Backend> WlrLayerShellHandler for Otto<BackendData> {
 
         // Arrange the layer map which will handle the exclusive zone
         map.arrange();
+    }
+
+    fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {
+        // At this point Smithay has already set the popup's XdgPopupSurfaceData.parent
+        // to the layer surface's wl_surface (in zwlr_layer_surface_v1.get_popup handler).
+        // The earlier XdgShellHandler::new_popup fired before the parent was set, so
+        // track_popup failed there. Re-track now that the parent chain is valid.
+        let popup_kind = PopupKind::from(popup.clone());
+        let popup_id = popup.wl_surface().id();
+
+        if let Ok(root) = find_popup_root_surface(&popup_kind) {
+            let root_id = root.id();
+            self.popup_root_cache.insert(popup_id.clone(), root_id);
+            tracing::debug!("layer new_popup: {:?} root={:?}", popup_id, root.id());
+        }
+
+        if let Err(err) = self.popups.track_popup(popup_kind) {
+            tracing::warn!("layer new_popup: failed to track popup: {}", err);
+        }
+
+        // Unconstrain now that the parent chain is established
+        self.unconstrain_popup(&popup);
     }
 
     fn layer_destroyed(&mut self, surface: WlrLayerSurface) {

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -25,7 +25,6 @@ use smithay::{
         },
     },
 };
-use tracing::warn;
 
 use crate::{
     focus::KeyboardFocusTarget,
@@ -181,6 +180,9 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
 
         let keyboard = self.seat.get_keyboard().unwrap();
         keyboard.set_focus(self, Some(window_element.into()), Serial::from(0));
+
+        // Notify foreign toplevel watchers that the new window is activated
+        self.send_foreign_toplevel_state(&surface_id, true);
     }
 
     fn toplevel_destroyed(&mut self, toplevel: ToplevelSurface) {
@@ -258,13 +260,34 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
         let popup_surface = popup_kind.wl_surface();
         let popup_id = popup_surface.id();
 
-        // Cache the root surface mapping for fast lookup during commit/destroy
-        if let Ok(root) = find_popup_root_surface(&popup_kind) {
+        // Cache the root surface mapping for fast lookup during commit/destroy.
+        // For layer shell popups the parent is still NULL here — it gets set later
+        // when zwlr_layer_surface_v1.get_popup fires (handled in WlrLayerShellHandler::new_popup).
+        let has_parent = if let Ok(root) = find_popup_root_surface(&popup_kind) {
+            tracing::debug!(
+                "new_popup: {:?} root={:?} (xdg parent)",
+                popup_id,
+                root.id()
+            );
             self.popup_root_cache.insert(popup_id.clone(), root.id());
-        }
+            true
+        } else {
+            tracing::debug!(
+                "new_popup: {:?} has no parent yet (layer shell popup — deferred to WlrLayerShellHandler)",
+                popup_id
+            );
+            false
+        };
 
-        if let Err(err) = self.popups.track_popup(popup_kind) {
-            warn!("Failed to track popup: {}", err);
+        // Only track popups that already have a parent. Layer shell popups with
+        // NULL parent would go into PopupManager::unmapped_popups, and then
+        // PopupManager::commit would re-insert them — creating a duplicate entry
+        // that breaks popup iteration order (parent checked before child).
+        // WlrLayerShellHandler::new_popup handles tracking for those.
+        if has_parent {
+            if let Err(err) = self.popups.track_popup(popup_kind) {
+                tracing::debug!("new_popup: tracking failed for {:?}: {}", popup_id, err);
+            }
         }
     }
 
@@ -1247,40 +1270,61 @@ impl<BackendData: Backend> Otto<BackendData> {
         pointer.set_grab(self, grab, serial, Focus::Clear);
     }
 
-    fn unconstrain_popup(&self, popup: &PopupSurface) {
+    pub(crate) fn unconstrain_popup(&self, popup: &PopupSurface) {
         let Ok(root) = find_popup_root_surface(&PopupKind::Xdg(popup.clone())) else {
             return;
         };
-        let id = root.id();
-        let Some(window) = self.workspaces.get_window_for_surface(&id) else {
-            return;
-        };
+        let root_id = root.id();
 
-        let mut outputs_for_window = self.workspaces.outputs_for_element(window);
-        if outputs_for_window.is_empty() {
-            return;
+        // Try window path first, then layer shell path
+        if let Some(window) = self.workspaces.get_window_for_surface(&root_id) {
+            let mut outputs_for_window = self.workspaces.outputs_for_element(window);
+            if outputs_for_window.is_empty() {
+                return;
+            }
+
+            let mut outputs_geo = self
+                .workspaces
+                .output_geometry(&outputs_for_window.pop().unwrap())
+                .unwrap();
+            for output in outputs_for_window {
+                outputs_geo = outputs_geo.merge(self.workspaces.output_geometry(&output).unwrap());
+            }
+
+            let window_geo = self.workspaces.element_geometry(window).unwrap();
+
+            let mut target = outputs_geo;
+            target.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(popup.clone()));
+            target.loc -= window_geo.loc;
+
+            popup.with_pending_state(|state| {
+                state.geometry = state.positioner.get_unconstrained_geometry(target);
+                clamp_popup_to_target(&mut state.geometry, target);
+            });
+        } else if let Some(layer_shell_surf) = self.layer_surfaces.get(&root_id) {
+            // Layer shell popup: constrain within the output bounds
+            let output = layer_shell_surf.output().clone();
+            let Some(output_geo) = self.workspaces.output_geometry(&output) else {
+                return;
+            };
+            let layer_geo = layer_shell_surf.compute_geometry(output_geo);
+
+            // Target is relative to the layer surface position
+            let mut target = output_geo;
+            target.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(popup.clone()));
+            target.loc -= layer_geo.loc;
+
+            popup.with_pending_state(|state| {
+                state.geometry = state.positioner.get_unconstrained_geometry(target);
+                tracing::debug!(
+                    "unconstrain layer popup: geo={:?} target={:?}",
+                    state.geometry,
+                    target
+                );
+                clamp_popup_to_target(&mut state.geometry, target);
+                tracing::debug!("  after clamp: geo={:?}", state.geometry);
+            });
         }
-
-        // Get a union of all outputs' geometries.
-        let mut outputs_geo = self
-            .workspaces
-            .output_geometry(&outputs_for_window.pop().unwrap())
-            .unwrap();
-        for output in outputs_for_window {
-            outputs_geo = outputs_geo.merge(self.workspaces.output_geometry(&output).unwrap());
-        }
-
-        let window_geo = self.workspaces.element_geometry(window).unwrap();
-
-        // The target geometry for the positioner should be relative to its parent's geometry, so
-        // we will compute that here.
-        let mut target = outputs_geo;
-        target.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(popup.clone()));
-        target.loc -= window_geo.loc;
-
-        popup.with_pending_state(|state| {
-            state.geometry = state.positioner.get_unconstrained_geometry(target);
-        });
     }
 
     /// Get or create a layer for a surface
@@ -1298,6 +1342,7 @@ impl<BackendData: Backend> Otto<BackendData> {
         let key = format!("surface_{:?}", surface_id);
         let layer = self.layers_engine.new_layer();
         layer.set_key(&key);
+        layer.set_picture_cached(true);
 
         self.surface_layers
             .insert(surface_id.clone(), layer.clone());
@@ -1330,5 +1375,31 @@ impl<BackendData: Backend> Otto<BackendData> {
         if let Some(layer) = self.surface_layers.remove(surface_id) {
             self.layers_engine.mark_for_delete(layer.id);
         }
+    }
+}
+
+/// Slide popup geometry so it stays within the target rectangle.
+/// This is the compositor's final safety net — applied regardless of the
+/// client's constraint_adjustment flags.
+fn clamp_popup_to_target(
+    geo: &mut Rectangle<i32, smithay::utils::Logical>,
+    target: Rectangle<i32, smithay::utils::Logical>,
+) {
+    // Slide horizontally
+    let right_overshoot = (geo.loc.x + geo.size.w) - (target.loc.x + target.size.w);
+    if right_overshoot > 0 {
+        geo.loc.x -= right_overshoot;
+    }
+    if geo.loc.x < target.loc.x {
+        geo.loc.x = target.loc.x;
+    }
+
+    // Slide vertically
+    let bottom_overshoot = (geo.loc.y + geo.size.h) - (target.loc.y + target.size.h);
+    if bottom_overshoot > 0 {
+        geo.loc.y -= bottom_overshoot;
+    }
+    if geo.loc.y < target.loc.y {
+        geo.loc.y = target.loc.y;
     }
 }

--- a/src/state/app_management.rs
+++ b/src/state/app_management.rs
@@ -229,43 +229,46 @@ impl<BackendData: Backend> Otto<BackendData> {
     }
 
     pub fn set_keyboard_focus_on_surface(&mut self, wid: &ObjectId) {
-        if let Some(window) = self.workspaces.get_window_for_surface(wid) {
-            let keyboard = self.seat.get_keyboard().unwrap();
-            let serial = SERIAL_COUNTER.next_serial();
-
-            // Deactivate the previously focused window
-            if let Some(crate::focus::KeyboardFocusTarget::Window(old_window)) =
-                keyboard.current_focus()
-            {
-                if old_window.wl_surface() != window.wl_surface() {
-                    old_window.set_activate(false);
-                    // Update shadow for deactivated window
-                    if let Some(view) = self.workspaces.get_window_view(&old_window.id()) {
-                        view.set_active(false);
-                    }
-                    if let Some(toplevel) = old_window.toplevel() {
-                        toplevel.send_configure();
-                    }
-                    // Notify foreign toplevel: deactivated
-                    let old_id = old_window.id();
-                    self.send_foreign_toplevel_state(&old_id, false);
-                }
-            }
-
-            // Activate the new window and send configure
-            window.set_activate(true);
-            // Update shadow for activated window
-            if let Some(view) = self.workspaces.get_window_view(wid) {
-                view.set_active(true);
-            }
-            if let Some(toplevel) = window.toplevel() {
-                toplevel.send_configure();
-            }
-            // Notify foreign toplevel: activated
-            let wid = wid.clone();
-            self.send_foreign_toplevel_state(&wid, true);
-            keyboard.set_focus(self, Some(window.clone().into()), serial);
+        let window = self.workspaces.get_window_for_surface(wid).cloned();
+        if let Some(window) = window {
+            self.set_keyboard_focus_on_window(&window);
         }
+    }
+
+    /// Centralized keyboard focus change: deactivates old window, activates new one,
+    /// sends xdg configure and foreign-toplevel state for both.
+    pub fn set_keyboard_focus_on_window(&mut self, window: &crate::shell::WindowElement) {
+        let keyboard = self.seat.get_keyboard().unwrap();
+        let serial = SERIAL_COUNTER.next_serial();
+
+        // Deactivate the previously focused window
+        if let Some(crate::focus::KeyboardFocusTarget::Window(old_window)) =
+            keyboard.current_focus()
+        {
+            if old_window.wl_surface() != window.wl_surface() {
+                old_window.set_activate(false);
+                if let Some(view) = self.workspaces.get_window_view(&old_window.id()) {
+                    view.set_active(false);
+                }
+                if let Some(toplevel) = old_window.toplevel() {
+                    toplevel.send_configure();
+                }
+                let old_id = old_window.id();
+                self.send_foreign_toplevel_state(&old_id, false);
+            }
+        }
+
+        // Activate the new window and send configure
+        window.set_activate(true);
+        if let Some(view) = self.workspaces.get_window_view(&window.id()) {
+            view.set_active(true);
+        }
+        if let Some(toplevel) = window.toplevel() {
+            toplevel.send_configure();
+        }
+        let wid = window.id();
+        self.send_foreign_toplevel_state(&wid, true);
+        keyboard.set_focus(self, Some(window.clone().into()), serial);
     }
 
     pub fn clear_keyboard_focus(&mut self) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1157,16 +1157,6 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     commit: render_surface.current_commit(),
                     transform: surface_attributes.buffer_transform.into(),
                 };
-                // tracing::trace!(
-                //     "window_view_for_surface: id={:?} texture_id={:?} \
-                //      src=({},{} {}x{}) dst=({},{} {}x{}) log_offset=({},{}) scale={}",
-                //     id,
-                //     wvs.texture_id,
-                //     wvs.phy_src_x, wvs.phy_src_y, wvs.phy_src_w, wvs.phy_src_h,
-                //     wvs.phy_dst_x, wvs.phy_dst_y, wvs.phy_dst_w, wvs.phy_dst_h,
-                //     wvs.log_offset_x, wvs.log_offset_y,
-                //     scale
-                // );
                 return Some(wvs);
             }
         };

--- a/src/surface_style/handlers/mod.rs
+++ b/src/surface_style/handlers/mod.rs
@@ -79,13 +79,16 @@ fn commit_transaction<BackendData: Backend>(
         if let Some(duration) = txn.duration {
             // Recreate the timing function with the correct duration
             trans.timing = match trans.timing {
-                TimingFunction::Easing(easing, _) => TimingFunction::Easing(easing, duration),
+                TimingFunction::Easing(easing, _) => {
+                    tracing::debug!("Transaction commit: Easing timing, duration={}s", duration);
+                    TimingFunction::Easing(easing, duration)
+                }
                 TimingFunction::Spring(_) => {
                     if txn.spring_uses_duration {
                         // Duration-based spring - use stored bounce and velocity
                         if let Some(bounce) = txn.spring_bounce {
                             tracing::debug!(
-                                "Creating duration-based spring: duration={}s, bounce={}, initial_velocity={}",
+                                "Transaction commit: duration-based spring: duration={}s, bounce={}, initial_velocity={}",
                                 duration,
                                 bounce,
                                 txn.spring_initial_velocity
@@ -96,18 +99,31 @@ fn commit_transaction<BackendData: Backend>(
                                 txn.spring_initial_velocity,
                             ))
                         } else {
+                            tracing::debug!(
+                                "Transaction commit: spring fallback (no bounce), duration={}s",
+                                duration
+                            );
                             // Fallback if bounce not set
                             TimingFunction::Spring(Spring::with_duration_and_bounce(duration, 0.0))
                         }
                     } else {
+                        tracing::debug!(
+                            "Transaction commit: physics-based spring (ignoring duration)"
+                        );
                         // Physics-based spring from timing function - keep as is
                         trans.timing
                     }
                 }
             };
+        } else {
+            tracing::debug!("Transaction commit: timing function present but no duration");
         }
         Some(trans)
     } else {
+        tracing::debug!(
+            "Transaction commit: no timing function, using default ease_out_quad, duration={:?}",
+            txn.duration
+        );
         txn.duration.map(Transition::ease_out_quad)
     };
 
@@ -290,13 +306,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleManagerV1, ()> for Otto<Back
             otto_surface_style_manager_v1::Request::CreateTimingFunction { id } => {
                 use timing_function::ScTimingFunctionData;
 
-                // Create default timing function (linear)
-                let timing_data = ScTimingFunctionData {
-                    timing: layers::prelude::TimingFunction::linear(0.0),
-                    spring_uses_duration: false,
-                    spring_bounce: None,
-                    spring_initial_velocity: 0.0,
-                };
+                let timing_data = ScTimingFunctionData::new();
 
                 data_init.init(id, timing_data);
             }

--- a/src/surface_style/handlers/style.rs
+++ b/src/surface_style/handlers/style.rs
@@ -270,6 +270,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                     Some(WlGravity::ResizeAspectFill) => ContentsGravity::ResizeAspectFill,
                     Some(WlGravity::Center) => ContentsGravity::Center,
                     Some(WlGravity::TopLeft) => ContentsGravity::TopLeft,
+                    Some(WlGravity::TopRight) => ContentsGravity::TopRight,
                     _ => {
                         tracing::warn!("Invalid contents_gravity value: {:?}", gravity);
                         return;

--- a/src/surface_style/handlers/timing_function.rs
+++ b/src/surface_style/handlers/timing_function.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use wayland_backend::server::ClientId;
 use wayland_server::{Client, DataInit, Dispatch, DisplayHandle};
 
@@ -5,15 +7,42 @@ use super::super::protocol::gen::otto_timing_function_v1::{self, OttoTimingFunct
 use crate::{state::Backend, Otto};
 use layers::prelude::{Easing, Spring, TimingFunction};
 
-/// User data for sc_timing_function
+/// Interior-mutable state for timing function parameters.
+/// Uses `Mutex` to satisfy wayland-server's `Send + Sync` requirement.
+/// Never contended — Wayland dispatch is single-threaded.
 pub struct ScTimingFunctionData {
+    inner: Mutex<ScTimingFunctionInner>,
+}
+
+pub struct ScTimingFunctionInner {
     pub timing: TimingFunction,
-    /// If true, this spring should use the transaction's duration
     pub spring_uses_duration: bool,
-    /// Bounce parameter for duration-based springs
     pub spring_bounce: Option<f32>,
-    /// Initial velocity for springs
     pub spring_initial_velocity: f32,
+}
+
+impl ScTimingFunctionData {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(ScTimingFunctionInner {
+                timing: TimingFunction::linear(0.0),
+                spring_uses_duration: false,
+                spring_bounce: None,
+                spring_initial_velocity: 0.0,
+            }),
+        }
+    }
+
+    /// Read a snapshot of the current state.
+    pub fn read(&self) -> ScTimingFunctionInner {
+        let guard = self.inner.lock().unwrap();
+        ScTimingFunctionInner {
+            timing: guard.timing,
+            spring_uses_duration: guard.spring_uses_duration,
+            spring_bounce: guard.spring_bounce,
+            spring_initial_velocity: guard.spring_initial_velocity,
+        }
+    }
 }
 
 impl<BackendData: Backend> Dispatch<OttoTimingFunctionV1, ScTimingFunctionData>
@@ -60,14 +89,7 @@ impl<BackendData: Backend> Dispatch<OttoTimingFunctionV1, ScTimingFunctionData>
                         TimingFunction::linear(0.0)
                     }
                 };
-
-                // Update the timing function data
-                // Note: We can't mutate data here directly, so we'll need a different approach
-                // Store it in a way that can be retrieved when the timing function is used
-                unsafe {
-                    let data_ptr = data as *const ScTimingFunctionData as *mut ScTimingFunctionData;
-                    (*data_ptr).timing = timing;
-                }
+                data.inner.lock().unwrap().timing = timing;
             }
 
             otto_timing_function_v1::Request::SetBezier { c1x, c1y, c2x, c2y } => {
@@ -77,32 +99,24 @@ impl<BackendData: Backend> Dispatch<OttoTimingFunctionV1, ScTimingFunctionData>
                     x2: c2x as f32,
                     y2: c2y as f32,
                 };
-                let timing = TimingFunction::Easing(easing, 0.0);
-
-                unsafe {
-                    let data_ptr = data as *const ScTimingFunctionData as *mut ScTimingFunctionData;
-                    (*data_ptr).timing = timing;
-                }
+                data.inner.lock().unwrap().timing = TimingFunction::Easing(easing, 0.0);
             }
 
             otto_timing_function_v1::Request::SetSpring {
                 bounce,
                 initial_velocity,
             } => {
-                // Store bounce and velocity - will be used with transaction duration on commit
-                // Using a placeholder spring that will be recreated with actual duration
                 tracing::debug!(
                     "Setting duration-based spring parameters: bounce={}, initial_velocity={}",
                     bounce,
                     initial_velocity
                 );
-
-                unsafe {
-                    let data_ptr = data as *const ScTimingFunctionData as *mut ScTimingFunctionData;
-                    (*data_ptr).spring_bounce = Some(bounce as f32);
-                    (*data_ptr).spring_initial_velocity = initial_velocity as f32;
-                    (*data_ptr).spring_uses_duration = true;
-                }
+                let mut inner = data.inner.lock().unwrap();
+                inner.timing =
+                    TimingFunction::Spring(Spring::with_duration_and_bounce(0.0, bounce as f32));
+                inner.spring_bounce = Some(bounce as f32);
+                inner.spring_initial_velocity = initial_velocity as f32;
+                inner.spring_uses_duration = true;
             }
 
             otto_timing_function_v1::Request::SetSpringStiffnessDamping {
@@ -112,20 +126,15 @@ impl<BackendData: Backend> Dispatch<OttoTimingFunctionV1, ScTimingFunctionData>
             } => {
                 let mut spring = Spring::new(1.0, stiffness as f32, damping as f32);
                 spring.initial_velocity = initial_velocity as f32;
-                let timing = TimingFunction::Spring(spring);
-
                 tracing::debug!(
                     "Creating physics-based spring (ignores duration): stiffness={}, damping={}, initial_velocity={}",
                     stiffness,
                     damping,
                     initial_velocity
                 );
-
-                unsafe {
-                    let data_ptr = data as *const ScTimingFunctionData as *mut ScTimingFunctionData;
-                    (*data_ptr).timing = timing;
-                    (*data_ptr).spring_uses_duration = false;
-                }
+                let mut inner = data.inner.lock().unwrap();
+                inner.timing = TimingFunction::Spring(spring);
+                inner.spring_uses_duration = false;
             }
 
             otto_timing_function_v1::Request::Destroy => {

--- a/src/surface_style/handlers/timing_function.rs
+++ b/src/surface_style/handlers/timing_function.rs
@@ -21,6 +21,12 @@ pub struct ScTimingFunctionInner {
     pub spring_initial_velocity: f32,
 }
 
+impl Default for ScTimingFunctionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScTimingFunctionData {
     pub fn new() -> Self {
         Self {

--- a/src/surface_style/handlers/transactions.rs
+++ b/src/surface_style/handlers/transactions.rs
@@ -37,14 +37,14 @@ impl<BackendData: Backend> Dispatch<OttoStyleTransactionV1, ()> for Otto<Backend
                     if let Some(timing_data) =
                         timing.data::<super::timing_function::ScTimingFunctionData>()
                     {
-                        // Store the timing function for later use when creating the transition
+                        let snap = timing_data.read();
                         txn.timing_function = Some(layers::prelude::Transition {
-                            timing: timing_data.timing,
-                            delay: 0.0, // Will be set from txn.delay
+                            timing: snap.timing,
+                            delay: 0.0,
                         });
-                        txn.spring_uses_duration = timing_data.spring_uses_duration;
-                        txn.spring_bounce = timing_data.spring_bounce;
-                        txn.spring_initial_velocity = timing_data.spring_initial_velocity;
+                        txn.spring_uses_duration = snap.spring_uses_duration;
+                        txn.spring_bounce = snap.spring_bounce;
+                        txn.spring_initial_velocity = snap.spring_initial_velocity;
                     }
                 }
             }

--- a/src/surface_style/protocol.rs
+++ b/src/surface_style/protocol.rs
@@ -41,6 +41,8 @@ pub enum ContentsGravity {
     Center,
     /// Natural buffer size, pinned to top-left.
     TopLeft,
+    /// Natural buffer size, pinned to top-right.
+    TopRight,
 }
 
 /// Compositor-side layer state (pure augmentation, no wl_surface)

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -712,22 +712,33 @@ impl Otto<UdevData> {
             }
         }
 
-        // Disconnect laptop panels that should be disabled
-        let disconnect_with_connectors: Vec<_> = to_disconnect
-            .into_iter()
-            .filter_map(|(node, crtc)| {
-                self.backend_data.backends.get(&node).and_then(|device| {
-                    device
-                        .drm_scanner
-                        .crtcs()
-                        .find(|(_, c)| *c == crtc)
-                        .map(|(connector, _)| (node, connector.clone(), crtc))
-                })
-            })
-            .collect();
+        // Suspend laptop panels that should be disabled.
+        // Unlike a real connector disconnect, we only tear down the DRM surface
+        // (stops rendering and drops the Wayland global) but keep all workspace
+        // data intact so windows survive the lid-close/reopen cycle.
+        for (node, crtc) in to_disconnect {
+            let device = match self.backend_data.backends.get_mut(&node) {
+                Some(d) => d,
+                None => continue,
+            };
 
-        for (node, connector, crtc) in disconnect_with_connectors {
-            self.connector_disconnected(node, connector, crtc);
+            // Find the output before removing the surface (which drops the Wayland global).
+            let output = self
+                .workspaces
+                .outputs()
+                .find(|o| {
+                    o.user_data()
+                        .get::<UdevOutputId>()
+                        .map(|id| id.device_id == node && id.crtc == crtc)
+                        .unwrap_or(false)
+                })
+                .cloned();
+
+            device.surfaces.remove(&crtc);
+
+            if let Some(output) = output {
+                self.workspaces.suspend_output(&output);
+            }
         }
 
         // Reconnect laptop panels that should be re-enabled

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,12 +1,6 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock, RwLock},
-};
-
 use layers::{
     prelude::{ContentDrawFunction, Layer, PointerHandlerFunction, Transition},
     skia::{self},
-    utils::load_svg_image,
 };
 
 use crate::{config::Config, workspaces::utils::FONT_CACHE};
@@ -31,68 +25,16 @@ pub fn parse_hex_color(hex: &str) -> skia::Color4f {
     skia::Color4f::new(r, g, b, 1.0)
 }
 
-static ICON_CACHE: OnceLock<Arc<RwLock<HashMap<String, skia::Image>>>> = OnceLock::new();
+// Delegate icon functions to otto-kit
+pub use otto_kit::icons::{image_from_path, named_icon};
 
-fn icon_cache() -> Arc<RwLock<HashMap<String, skia::Image>>> {
-    ICON_CACHE
-        .get_or_init(|| Arc::new(RwLock::new(HashMap::new())))
-        .clone()
-}
-
-// FIXME check why skia_safe svg is broken
-// pub fn image_from_svg(
-//     image_data: &[u8],
-//     ctx: Option<skia::gpu::DirectContext>,
-// ) -> layers::skia::Image {
-//     let options = usvg::Options::default();
-//     let mut rtree = usvg::Tree::from_data(image_data, &options).unwrap();
-//     rtree.size = usvg::Size::from_wh(512.0, 512.0).unwrap();
-//     let xml_options = usvg::XmlOptions::default();
-//     let xml = usvg::TreeWriting::to_string(&rtree, &xml_options);
-//     let font_mgr = layers::skia::FontMgr::new();
-//     let svg = layers::skia::svg::Dom::from_bytes(xml.as_bytes(), font_mgr).unwrap();
-
-//     let mut surface = {
-//         if let Some(mut ctx) = ctx {
-//             let image_info = skia::ImageInfo::new(
-//                 (512, 512),
-//                 skia::ColorType::RGBA8888,
-//                 skia::AlphaType::Premul,
-//                 None,
-//             );
-//             skia::gpu::surfaces::render_target(
-//                 &mut ctx,
-//                 skia::gpu::Budgeted::No,
-//                 &image_info,
-//                 None,
-//                 skia::gpu::SurfaceOrigin::TopLeft,
-//                 None,
-//                 false,
-//                 false,
-//             )
-//             .unwrap()
-//         } else {
-//             skia::surfaces::raster_n32_premul((512, 512)).unwrap()
-//         }
-//     };
-
-//     let canvas = surface.canvas();
-//     svg.render(canvas);
-//     surface.image_snapshot()
-// }
-
-pub fn image_from_path(path: &str, size: impl Into<skia::ISize>) -> Option<layers::skia::Image> {
-    let image_path = std::path::Path::new(path);
-
-    let image = if image_path.extension().and_then(std::ffi::OsStr::to_str) == Some("svg") {
-        load_svg_image(path, size).ok()?
-    } else {
-        let image_data = std::fs::read(image_path).ok()?;
-        layers::skia::Image::from_encoded(layers::skia::Data::new_copy(image_data.as_slice()))
-            .unwrap()
-    };
-
-    Some(image)
+/// Find an icon using the configured theme or auto-detection.
+///
+/// Reads the theme name from otto's Config and delegates to otto-kit.
+pub fn find_icon_with_theme(icon_name: &str, size: i32, scale: i32) -> Option<String> {
+    Config::with(|config| {
+        otto_kit::icons::find_icon_in_theme(icon_name, size, scale, config.icon_theme.as_deref())
+    })
 }
 
 /// Load an image from resources directory, falling back to system locations and theme icons
@@ -142,64 +84,6 @@ pub fn resource_path(path: &str) -> Option<std::path::PathBuf> {
     }
 
     None
-}
-
-pub fn named_icon(icon_name: &str) -> Option<layers::skia::Image> {
-    let ic = icon_cache();
-    let mut ic = ic.write().unwrap();
-    if let Some(icon) = ic.get(icon_name) {
-        return Some(icon.clone());
-    }
-    // not found
-    let icon_path = find_icon_with_theme(icon_name, 512, 1);
-    let icon = icon_path
-        .as_ref()
-        .and_then(|icon_path| image_from_path(icon_path, (512, 512)));
-    if let Some(i) = icon.as_ref() {
-        ic.insert(icon_name.to_string(), i.clone());
-    }
-    icon
-}
-
-/// Find an icon using the configured theme or auto-detection
-pub fn find_icon_with_theme(icon_name: &str, size: i32, scale: i32) -> Option<String> {
-    Config::with(|config| {
-        if let Some(theme_name) = &config.icon_theme {
-            // Use specified theme
-            let dir_list_vector = xdgkit::icon_finder::generate_dir_list();
-
-            // Try to find the theme by name
-            let theme_dir = dir_list_vector
-                .iter()
-                .find(|dir| &dir.theme == theme_name)
-                .cloned();
-
-            if let Some(theme_dir) = theme_dir {
-                // Load the IconTheme from the found directory
-                let theme = xdgkit::icon_theme::IconTheme::from_pathbuff(theme_dir.index());
-
-                xdgkit::icon_finder::multiple_find_icon(
-                    icon_name.to_string(),
-                    size,
-                    scale,
-                    dir_list_vector,
-                    theme,
-                )
-                .map(|p| p.to_str().unwrap().to_string())
-            } else {
-                tracing::warn!(
-                    "Icon theme '{}' not found, falling back to auto-detection",
-                    theme_name
-                );
-                xdgkit::icon_finder::find_icon(icon_name.to_string(), size, scale)
-                    .map(|p| p.to_str().unwrap().to_string())
-            }
-        } else {
-            // Use auto-detection (None or omitted)
-            xdgkit::icon_finder::find_icon(icon_name.to_string(), size, scale)
-                .map(|p| p.to_str().unwrap().to_string())
-        }
-    })
 }
 pub fn draw_named_icon(icon_name: &str) -> Option<ContentDrawFunction> {
     let icon = named_icon(icon_name);

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2889,22 +2889,36 @@ impl Workspaces {
     ) {
         let location = location.into();
 
-        // Guard against re-mapping an already-mapped output (e.g., on resize).
-        // Just re-register the output with each space so Smithay knows the new geometry,
-        // then refresh layout sizes.
+        // Guard against re-mapping an already-mapped output (e.g., on resize or
+        // resume after suspend).  Re-register the output with each space so
+        // Smithay knows the new geometry, then refresh layout sizes.
         if self.output_workspaces.contains_key(&output.name()) {
+            // The output may have been suspended (removed from self.outputs but
+            // output_workspaces kept intact). Re-add it if missing.
+            if !self.outputs.iter().any(|o| o.name() == output.name()) {
+                self.outputs.push(output.clone());
+            }
+            if is_primary || self.primary_output.is_none() {
+                self.primary_output = Some(output.clone());
+            }
+
             if let Some(ows) = self.output_workspaces.get_mut(&output.name()) {
                 for space in ows.spaces.iter_mut() {
                     space.map_output(output, location);
                 }
-                // Keep layer_shell_background bounds in sync with the (possibly new) output size.
+                // Keep layer sizes in sync with the (possibly new) output mode.
                 if let Some((w, h)) = output
                     .current_mode()
                     .map(|m| (m.size.w as f32, m.size.h as f32))
                 {
                     ows.layer_shell_background
                         .set_size(layers::types::Size::points(w, h), None);
+                    ows.output_layer
+                        .set_size(layers::types::Size::points(w, h), None);
                 }
+                let scale = output.current_scale().fractional_scale() as f32;
+                let phys_x = location.x as f32 * scale;
+                ows.output_layer.set_position((phys_x, 0.0_f32), None);
             }
             self.sync_model_from_primary();
             self.update_workspaces_layout();
@@ -3090,6 +3104,20 @@ impl Workspaces {
         }
         // Remove the output's workspace set (dropping workspaces_layer removes it from scene)
         self.output_workspaces.remove(&output.name());
+        self.sync_model_from_primary();
+    }
+
+    /// Suspend an output without destroying its workspace data.
+    ///
+    /// Used for lid-close: the DRM surface is torn down (no rendering) but
+    /// all workspaces, windows, and scene-graph layers are preserved so they
+    /// can be instantly restored when the output comes back.
+    pub fn suspend_output(&mut self, output: &Output) {
+        self.outputs.retain(|o| o != output);
+        if self.primary_output.as_ref() == Some(output) {
+            self.primary_output = self.outputs.first().cloned();
+        }
+        // Intentionally do NOT remove from output_workspaces — keep windows alive.
         self.sync_model_from_primary();
     }
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -954,6 +954,13 @@ impl Workspaces {
     pub fn expose_set_visible(&self, show: bool) {
         use layers::prelude::*;
 
+        // Already in the target state — nothing to animate.
+        // Avoids scheduling a no-op animation whose on_finish callback would
+        // reset layer shell opacity, conflicting with fullscreen fade-outs.
+        if show == self.get_show_all() {
+            return;
+        }
+
         // If show desktop is active, exit it first
         if self.get_show_desktop() && show {
             self.expose_show_desktop(-1.0, true);
@@ -1345,9 +1352,16 @@ impl Workspaces {
             let workspace_selector_y = (-400.0).interpolate(&0.0, delta);
             let workspace_selector_y = workspace_selector_y.clamp(-400.0, 0.0);
 
-            // Layer shell overlay fades out when entering expose (inverse of workspace opacity)
-            let layer_shell_overlay_opacity = 1.0.interpolate(&0.0, delta);
-            let layer_shell_overlay_opacity = layer_shell_overlay_opacity.clamp(0.0, 1.0);
+            // Layer shell overlay and top fade out when entering expose.
+            // When closing expose on a fullscreen workspace the resting opacity
+            // must stay at 0.0 (fullscreen hides the top bar / overlay).
+            let current_ws_fullscreen = self
+                .get_workspace_at(current_workspace_index)
+                .map(|ws| ws.get_fullscreen_mode())
+                .unwrap_or(false);
+            let layer_shell_resting_opacity = if current_ws_fullscreen { 0.0 } else { 1.0 };
+            let layer_shell_fade_opacity = layer_shell_resting_opacity.interpolate(&0.0, delta);
+            let layer_shell_fade_opacity = layer_shell_fade_opacity.clamp(0.0, 1.0);
 
             // Set overlay opacity to match the workspace selector opacity (fade in as we enter expose)
 
@@ -1355,10 +1369,12 @@ impl Workspaces {
             let expose_layer = self.expose_layer.clone();
             let workspace_selector_view_layer = self.workspace_selector_view.layer.clone();
             let layer_shell_overlay_ref = self.layer_shell_overlay.clone();
+            let layer_shell_top_ref = self.layer_shell_top.clone();
             let show_all_ref = self.show_all.clone();
             let show_all_gesture_ref = self.show_all_gesture.clone();
             let expose_gesture_active_ref = self.expose_gesture_active.clone();
             let expose_dragged_window_ref = self.expose_dragged_window.clone();
+            let model_ref = self.model.clone();
 
             // Collect secondary output expose layers to sync with primary
             let secondary_expose_layers: Vec<Layer> = self
@@ -1449,8 +1465,26 @@ impl Workspaces {
                         for wl in &all_workspaces_layers {
                             wl.set_hidden(show_all);
                         }
-                        // Restore layer shell overlay when exiting expose mode
-                        layer_shell_overlay_ref.set_opacity(if show_all { 0.0 } else { 1.0 }, None);
+                        // Restore layer shell overlay and top when exiting expose mode,
+                        // but only if the current workspace isn't fullscreen (which has
+                        // its own opacity management via set_fullscreen_overlay_visibility).
+                        let is_fullscreen = model_ref
+                            .read()
+                            .ok()
+                            .and_then(|m| {
+                                m.workspaces
+                                    .get(m.current_workspace)
+                                    .map(|ws| ws.get_fullscreen_mode())
+                            })
+                            .unwrap_or(false);
+                        if !is_fullscreen {
+                            layer_shell_overlay_ref.set_opacity(if show_all { 0.0 } else { 1.0 }, None);
+                            layer_shell_top_ref.set_opacity(if show_all { 0.0 } else { 1.0 }, None);
+                            layer_shell_top_ref.set_hidden(show_all);
+                        } else {
+                            // Fullscreen: keep layers hidden and transparent
+                            layer_shell_top_ref.set_hidden(true);
+                        }
 
                         show_all_ref.store(show_all, std::sync::atomic::Ordering::Relaxed);
                     },
@@ -1459,9 +1493,18 @@ impl Workspaces {
             }
             let _tr = self.workspace_selector_view.layer.set_opacity(1.0, None);
 
-            // Animate layer shell overlay opacity (fade out when entering expose)
+            // Animate layer shell overlay and top opacity (fade out when entering expose)
+            if layer_shell_fade_opacity > 0.0 {
+                self.layer_shell_top.set_hidden(false);
+            }
             self.layer_shell_overlay
-                .set_opacity(layer_shell_overlay_opacity, transition);
+                .set_opacity(layer_shell_fade_opacity, transition);
+            self.layer_shell_top
+                .set_opacity(layer_shell_fade_opacity, transition);
+            // When fully faded out without an ongoing animation, hide immediately
+            if layer_shell_fade_opacity == 0.0 && transition.is_none() {
+                self.layer_shell_top.set_hidden(true);
+            }
         }
         // Animate dock position
         if let Some(current_workspace) = current_workspace {
@@ -1499,15 +1542,33 @@ impl Workspaces {
         }
     }
 
-    /// Set layer_shell_overlay visibility when entering/exiting fullscreen
-    /// When entering fullscreen (is_fullscreen=true), fades out the overlay
-    /// When exiting fullscreen (is_fullscreen=false), fades in the overlay
+    /// Set layer_shell_overlay and layer_shell_top visibility when entering/exiting fullscreen
+    /// When entering fullscreen (is_fullscreen=true), fades out both layers and hides them
+    /// When exiting fullscreen (is_fullscreen=false), shows and fades in both layers
     pub fn set_fullscreen_overlay_visibility(&self, is_fullscreen: bool) {
         let target_opacity = if is_fullscreen { 0.0 } else { 1.0 };
         let transition = Some(Transition::ease_in_out_quad(1.4));
 
+        if !is_fullscreen {
+            // Unhide before fading in so the animation is visible
+            self.layer_shell_overlay.set_hidden(false);
+            self.layer_shell_top.set_hidden(false);
+        }
         self.layer_shell_overlay
             .set_opacity(target_opacity, transition);
+        let layer_shell_top_ref = self.layer_shell_top.clone();
+        let layer_shell_overlay_ref = self.layer_shell_overlay.clone();
+        self.layer_shell_top
+            .set_opacity(target_opacity, transition)
+            .on_finish(
+                move |_: &Layer, _| {
+                    if is_fullscreen {
+                        layer_shell_top_ref.set_hidden(true);
+                        layer_shell_overlay_ref.set_hidden(true);
+                    }
+                },
+                true,
+            );
     }
 
     /// Set the mode to show desktop mode using a delta for gestures
@@ -3333,6 +3394,28 @@ impl Workspaces {
             }
         }
 
+        // Animate layer_shell_top opacity based on target workspace fullscreen state
+        if let Some(workspace) = self.get_workspace_at(i) {
+            let is_fullscreen = workspace.get_fullscreen_mode();
+            let target_opacity = if is_fullscreen { 0.0 } else { 1.0 };
+            if !is_fullscreen {
+                self.layer_shell_top.set_hidden(false);
+            }
+            self.layer_shell_overlay
+                .set_opacity(target_opacity, Some(resolved_transition));
+            let layer_shell_top_ref = self.layer_shell_top.clone();
+            self.layer_shell_top
+                .set_opacity(target_opacity, Some(resolved_transition))
+                .on_finish(
+                    move |_: &Layer, _| {
+                        if is_fullscreen {
+                            layer_shell_top_ref.set_hidden(true);
+                        }
+                    },
+                    true,
+                );
+        }
+
         // Scroll only this output's layer
         let workspace_gap_px = WORKSPACE_SPACING * scale;
         let offset = i as f32 * (workspace_width + workspace_gap_px);
@@ -3393,14 +3476,25 @@ impl Workspaces {
                 }
             }
 
-            // Animate layer_shell_overlay based on target workspace fullscreen state
-            let target_opacity = if workspace.get_fullscreen_mode() {
-                0.0
-            } else {
-                1.0
-            };
+            // Animate layer_shell_overlay and layer_shell_top based on target workspace fullscreen state
+            let is_fullscreen = workspace.get_fullscreen_mode();
+            let target_opacity = if is_fullscreen { 0.0 } else { 1.0 };
+            if !is_fullscreen {
+                self.layer_shell_top.set_hidden(false);
+            }
             self.layer_shell_overlay
                 .set_opacity(target_opacity, Some(transition));
+            let layer_shell_top_ref = self.layer_shell_top.clone();
+            self.layer_shell_top
+                .set_opacity(target_opacity, Some(transition))
+                .on_finish(
+                    move |_: &Layer, _| {
+                        if is_fullscreen {
+                            layer_shell_top_ref.set_hidden(true);
+                        }
+                    },
+                    true,
+                );
 
             if self.get_show_all() {
                 // In expose mode, ensure the target workspace has its layout calculated
@@ -3502,6 +3596,35 @@ impl Workspaces {
         // Apply only to this output's layers (workspaces + expose in sync)
         ows.workspaces_layer.set_position((-new_offset, 0.0), None);
         ows.expose_layer.set_position((-new_offset, 0.0), None);
+
+        // Interpolate layer_shell_top opacity during swipe based on fullscreen state
+        // of the two workspaces we're swiping between.
+        let step = workspace_width + workspace_gap_px;
+        if step > 0.0 {
+            let progress = new_offset / step;
+            let left_index = (progress.floor() as usize).min(num_workspaces.saturating_sub(1));
+            let right_index = (left_index + 1).min(num_workspaces.saturating_sub(1));
+            let t = (progress - left_index as f32).clamp(0.0, 1.0);
+
+            let left_fs = ows
+                .workspace_views
+                .get(left_index)
+                .map(|ws| ws.get_fullscreen_mode())
+                .unwrap_or(false);
+            let right_fs = ows
+                .workspace_views
+                .get(right_index)
+                .map(|ws| ws.get_fullscreen_mode())
+                .unwrap_or(false);
+
+            let left_opacity: f32 = if left_fs { 0.0 } else { 1.0 };
+            let right_opacity: f32 = if right_fs { 0.0 } else { 1.0 };
+            let opacity = left_opacity.interpolate(&right_opacity, t);
+
+            self.layer_shell_top.set_opacity(opacity, None);
+            self.layer_shell_top.set_hidden(opacity == 0.0);
+            self.layer_shell_overlay.set_opacity(opacity, None);
+        }
     }
 
     /// End workspace swipe gesture and snap to nearest workspace.
@@ -3774,7 +3897,15 @@ impl Workspaces {
                 }
             }
             WlrLayer::Top => {
-                self.layer_shell_top.set_hidden(false);
+                // Only unhide if current workspace is not fullscreen
+                let is_fullscreen = self
+                    .get_current_workspace()
+                    .map(|ws| ws.get_fullscreen_mode())
+                    .unwrap_or(false);
+                if !is_fullscreen {
+                    self.layer_shell_top.set_hidden(false);
+                    self.layer_shell_top.set_opacity(1.0, None);
+                }
                 if let Err(e) = self.layer_shell_top.add_sublayer(&layer) {
                     tracing::warn!("layer_shell: failed to add top layer: {e}");
                 }

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -65,6 +65,7 @@ impl PopupOverlayView {
                     ..Default::default()
                 });
                 layer.set_pointer_events(false);
+                layer.set_picture_cached(true);
 
                 let content_layer = self.layers_engine.new_layer();
                 content_layer.set_layout_style(taffy::Style {
@@ -72,6 +73,7 @@ impl PopupOverlayView {
                     ..Default::default()
                 });
                 content_layer.set_pointer_events(false);
+                content_layer.set_picture_cached(true);
 
                 // Start hidden — only show after the initial configure has been
                 // acknowledged and the popup has committed at its correct position.
@@ -139,7 +141,7 @@ impl PopupOverlayView {
             crate::workspaces::utils::configure_surface_layer(
                 &layer,
                 wvs,
-                crate::surface_style::ContentsGravity::Resize,
+                crate::surface_style::ContentsGravity::TopLeft,
                 false,
             );
 

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -248,19 +248,14 @@ pub fn configure_surface_layer(
             y: pos_y + (wvs.phy_dst_h * anchor_point.y),
         };
         layer.set_position(adjusted_pos, None);
-    } else {
-        tracing::debug!(
-            "configure_surface_layer: client owns bounds, skipping set_size/set_position (gravity={:?}, buf={}x{})",
-            gravity, wvs.phy_dst_w, wvs.phy_dst_h
-        );
     }
 
     layer.set_pointer_events(false);
-    // Do NOT cache the picture — the draw closure reads from textures_storage
-    // which is updated on every wl_surface.commit.  Caching would keep a stale
-    // bitmap when a surface commits partial damage, causing half the window to
-    // show old content.
-    layer.set_picture_cached(false);
+    // Picture caching is enabled so opacity/transform animations on the layer
+    // (e.g. popup fade-in) can composite the cached bitmap without re-rasterizing.
+    // The draw closure still reads live state from textures_storage, but lay-rs
+    // invalidates the cache when set_draw_content marks the layer dirty on commit.
+    layer.set_picture_cached(true);
     // The draw_content callback fills the entire bounds with the surface texture,
     // so this layer can act as an occluder in occlusion culling.
     layer.set_content_opaque(true);
@@ -276,8 +271,11 @@ pub fn configure_surface_layer(
         }
         let tex = tex.unwrap();
 
-        let src_h = (draw_wvs.phy_src_h - draw_wvs.phy_src_y).max(1.0);
-        let src_w = (draw_wvs.phy_src_w - draw_wvs.phy_src_x).max(1.0);
+        // Use the viewport source dimensions, NOT the raw GPU texture size.
+        // Clients like Chrome reuse oversized GPU texture allocations; the
+        // viewport crop (phy_src) tells us the actual content region.
+        let src_w = draw_wvs.phy_src_w.max(1.0);
+        let src_h = draw_wvs.phy_src_h.max(1.0);
 
         // Use live w/h for all gravity modes so the draw scales correctly during animations.
         let (scale_x, scale_y, tx, ty) = match gravity {
@@ -300,6 +298,10 @@ pub fn configure_surface_layer(
                 (1.0f32, 1.0f32, tx, ty)
             }
             ContentsGravity::TopLeft => (1.0f32, 1.0f32, 0.0f32, 0.0f32),
+            ContentsGravity::TopRight => {
+                let tx = w - src_w;
+                (1.0f32, 1.0f32, tx, 0.0f32)
+            }
         };
 
         // Convert buffer-pixel damage to layer-local coords using the same


### PR DESCRIPTION
Collection of compositor bug fixes and refactors.

- Centralize keyboard focus change logic
- Fix layer shell popup tracking, hit-testing, and menu activation
- Fix viewport source size for gravity scaling
- Replace unsafe UB in timing function handlers with Mutex
- Use lay-rs hit testing for layer shells
- Hide layer_shell_top during fullscreen and expose transitions
- Send foreign toplevel activated state for new windows
- Context menu and popup overlay improvements

**Stack:** 4/5 → `otto-to-otto-kit-migration`