### PR TITLE
feat: otto-islands — experimental notification manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install cargo-deb
         run: cargo install cargo-deb
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
       - name: Build Debian package
         run: cargo deb --no-strip
       - name: Upload Debian package
@@ -108,7 +108,7 @@ jobs:
       - name: Install cargo-generate-rpm
         run: cargo install cargo-generate-rpm
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
       - name: Build RPM package
         run: cargo generate-rpm
       - name: Upload RPM package
@@ -137,7 +137,7 @@ jobs:
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
       - name: Build Arch tarball
         run: |
           PKGVER=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -146,6 +146,7 @@ jobs:
           PKGDIR="otto-${PKGVER}"
           install -Dm755 target/release/otto "$tmpdir/$PKGDIR/target/release/otto"
           install -Dm755 target/release/otto-bar "$tmpdir/$PKGDIR/target/release/otto-bar"
+          install -Dm755 target/release/otto-islands "$tmpdir/$PKGDIR/target/release/otto-islands"
           install -Dm755 target/release/xdg-desktop-portal-otto "$tmpdir/$PKGDIR/target/release/xdg-desktop-portal-otto"
           install -m644 LICENSE "$tmpdir/$PKGDIR/LICENSE"
           install -m644 README.md "$tmpdir/$PKGDIR/README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ members = [
     "components/apps-manager",
     "components/otto-kit",
     "components/otto-bar",
+    "components/otto-islands",
     "sample-clients/client-rainbow",
     "sample-clients/submenu",
     "sample-clients/submenu-gtk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ priority = "optional"
 assets = [
     ["target/release/otto", "usr/bin/", "755"],
     ["target/release/otto-bar", "usr/bin/", "755"],
+    ["target/release/otto-islands", "usr/bin/", "755"],
     ["target/release/xdg-desktop-portal-otto", "usr/libexec/", "755"],
     ["README.md", "usr/share/doc/otto/", "644"],
     ["LICENSE", "usr/share/doc/otto/", "644"],
@@ -180,6 +181,7 @@ assets = [
 assets = [
     { source = "target/release/otto", dest = "/usr/bin/otto", mode = "755" },
     { source = "target/release/otto-bar", dest = "/usr/bin/otto-bar", mode = "755" },
+    { source = "target/release/otto-islands", dest = "/usr/bin/otto-islands", mode = "755" },
     { source = "target/release/xdg-desktop-portal-otto", dest = "/usr/libexec/xdg-desktop-portal-otto", mode = "755" },
     { source = "README.md", dest = "/usr/share/doc/otto/README.md", mode = "644", doc = true },
     { source = "LICENSE", dest = "/usr/share/doc/otto/LICENSE", mode = "644", doc = true },
@@ -229,6 +231,7 @@ optdepends = [
 files = [
     ["target/release/otto", "/usr/bin/otto", "755"],
     ["target/release/otto-bar", "/usr/bin/otto-bar", "755"],
+    ["target/release/otto-islands", "/usr/bin/otto-islands", "755"],
     ["target/release/xdg-desktop-portal-otto", "/usr/libexec/xdg-desktop-portal-otto", "755"],
     ["README.md", "/usr/share/doc/otto/README.md", "644"],
     ["LICENSE", "/usr/share/licenses/otto/LICENSE", "644"],

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,6 +20,7 @@ package() {
     # Install binaries
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
+    install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
     
     # Install documentation

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -27,6 +27,7 @@ build() {
     unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
     cargo build --release
     cargo build --release -p otto-bar
+    cargo build --release -p otto-islands
     cargo build --release -p xdg-desktop-portal-otto
 }
 
@@ -36,6 +37,7 @@ package() {
     # Install binaries
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
+    install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation

--- a/PKGBUILD-nightly-bin
+++ b/PKGBUILD-nightly-bin
@@ -32,6 +32,7 @@ package() {
     # Install binaries
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
+    install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation

--- a/components/otto-islands/Cargo.toml
+++ b/components/otto-islands/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "otto-islands"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+zbus = "4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+skia-safe = "=0.93"
+smithay-client-toolkit = { version = "0.19", default-features = false }
+wayland-client = "0.31"
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
+libc = "0.2"

--- a/components/otto-islands/README.md
+++ b/components/otto-islands/README.md
@@ -1,167 +1,136 @@
 # Otto Islands
 
-A standalone otto-kit application that renders notification groups and live activities (music, timers) as a morphing pill-shaped UI anchored to the top-center of the screen.
+An experimental notification manager for Otto, inspired by the iOS dynamic island. It renders notification groups as morphing pill-shaped surfaces anchored to the top-center of the screen.
+
+Otto Islands is a standalone Wayland app that takes advantage of Otto's **experimental surface style protocol** (`otto-surface-style-v1`). This protocol gives clients direct access to the compositor's animated scene graph — similar to Core Animation on iOS/macOS. The app draws flat content once with Skia, and the compositor handles all animation, clipping, shadows, and blur at display refresh rate.
+
+## Surface Style Protocol
+
+The surface style protocol provides:
+
+- **Animated properties** — position, size, corner radius, opacity, with spring and easing curves, batched in transactions
+- **Graphical properties** — background color, shadow, background blur (frosted glass), masks-to-bounds (clipping)
+- **Content gravity** — how the client's buffer maps to the surface bounds on screen: resize, aspect fit, aspect fill, center (like `contentsGravity` in Core Animation)
+- **Transactions** — group multiple property changes into a single animated transition with shared timing
+
+Because animation runs compositor-side, the app has no render loop. It redraws a buffer only when notification content changes (new text, icon, count). All interpolation between states — spring physics, opacity fades, size morphing — is computed by the compositor every frame.
+
+```rust
+// Declare animation target — compositor interpolates
+let timing = scene.create_timing_function(qh, ());
+timing.set_spring(bounce, initial_velocity);
+let anim = scene.begin_transaction(qh, ());
+anim.set_duration(0.8);
+anim.set_timing_function(&timing);
+surface_style.set_size(w, h);
+surface_style.set_position(x, y);
+surface_style.set_corner_radius(radius);
+surface_style.set_opacity(1.0);
+anim.commit();  // compositor animates from current → target
+```
+
+> **Note:** The surface style protocol is Otto-specific and experimental. Otto Islands only works with the Otto compositor.
 
 ## Architecture
 
-### Subsurface Model (CALayer-style)
+### Subsurface Model
 
 Every visual element is its own **Wayland subsurface**, composed like Core Animation layers. The parent layer shell surface is a transparent container — all rendering happens in child subsurfaces.
 
 ```
-Layer shell surface (480x400, transparent, Overlay layer)
-  |
-  +-- pill subsurface (group tab: icon + app name + count + chevron)
-  +-- pill subsurface (another group)
-  +-- card subsurface (notification 1)
-  +-- card subsurface (notification 2)
-  +-- ...
+Layer shell surface (480×400, transparent, Overlay layer)
+  ├── pill subsurface (group: icon + app name + count)
+  ├── pill subsurface (another group)
+  ├── card subsurface (notification 1)
+  ├── card subsurface (notification 2)
+  └── ...
 ```
 
-Each subsurface is a `SubsurfaceSurface` from otto-kit with:
-- Its own Skia buffer for content rendering (460x100 logical pixels, 2x HiDPI)
-- Independent size, position, corner radius, opacity via `otto-surface-style-v1`
+Each subsurface has:
+- A Skia buffer for content (460×100 logical, 2× HiDPI)
+- Compositor-managed size, position, corner radius, opacity via surface style
 - Spring-animated transitions on all properties
-- Center anchor point (`set_anchor_point(0.5, 0.5)`) so all coordinates are center-based
+- Center anchor point — all coordinates are center-based
+
+### Surface Style Setup
+
+```rust
+// Island pill
+ss.set_background_color(0.03, 0.03, 0.03, 1.0);  // near-black
+ss.set_corner_radius(radius);
+ss.set_masks_to_bounds(ClipMode::Enabled);         // clip to rounded rect
+ss.set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0);
+ss.set_blend_mode(BlendMode::BackgroundBlur);      // frosted glass
+ss.set_contents_gravity(ContentsGravity::Center);  // buffer centered in bounds
+ss.set_anchor_point(0.5, 0.5);                     // transform origin at center
+```
+
+The app draws flat content. The compositor adds shape, blur, shadow, and animates between states.
+
+### Content Gravity
+
+The buffer is larger than the visible content (460×100 vs the actual pill/card size). `ContentsGravity::Center` tells the compositor to center the buffer within the animated bounds. As the compositor spring-animates the size, more or less of the pre-drawn buffer is revealed — no client-side redraw needed.
 
 ### Surface Lifecycle
 
 **Pill surfaces** are created when a notification group first appears and destroyed (deferred) when the group is dismissed.
 
-**Card surfaces** are created lazily when the stack opens and **reused across open/close cycles**:
-- On close: cards animate out (fade + slide up) but surfaces stay alive
-- On reopen: same surfaces are repositioned and faded back in
-- On notification dismiss: that card surface is deferred-destroyed (0.8s delay for animation)
-
-### Surface Style Protocol
-
-All visual chrome is handled by the compositor via `otto-surface-style-v1`:
-
-```rust
-// Island pill style
-ss.set_background_color(0.03, 0.03, 0.03, 1.0);  // near-black
-ss.set_corner_radius(radius * BUFFER_SCALE);
-ss.set_masks_to_bounds(ClipMode::Enabled);
-ss.set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0);
-ss.set_blend_mode(BlendMode::BackgroundBlur);      // frosted glass
-ss.set_contents_gravity(ContentsGravity::Center);
-ss.set_anchor_point(0.5, 0.5);                     // center anchor
-
-// Card style uses theme material colors
-ss.set_background_color(r, g, b, a);  // from theme.material_medium
-```
-
-The app draws flat content with Skia. The compositor handles shape, blur, shadow, and spring animations.
-
-### Animations
-
-All animations use spring-animated transactions:
-
-```rust
-// Example: animate to new position + size
-let timing = scene.create_timing_function(qh, ());
-timing.set_spring(0.25, 0.0);  // damping, stiffness
-let anim = scene.begin_transaction(qh, ());
-anim.set_duration(0.6);
-anim.set_delay(delay);
-anim.set_timing_function(&timing);
-scene_surface.set_size(w, h);
-scene_surface.set_position(x, y);  // center coords with anchor 0.5,0.5
-anim.commit();
-```
-
-Key animation helpers in `renderer.rs`:
-- `animate_to()` — spring position + size + corner radius
-- `animate_position_opacity()` — spring position + opacity only (size set instantly)
-- `animate_pulse()` — instantly grow, spring back to target (bump effect)
-- `animate_dismiss()` — scale up 1.2x + fade out (card dismiss)
-
-### Content Rendering
-
-Content is drawn with Skia into the subsurface buffer using `draw_centered()`:
-
-```rust
-draw_centered(&surface, content_w, content_h, |canvas| {
-    // Draw at (0,0). draw_centered translates to center in the buffer.
-    renderer::draw_pill(canvas, app_id, icon, count, expanded, w, h);
-});
-```
-
-The buffer is larger than the content (460x100) so content can be pre-drawn at full size. The compositor reveals it via spring-animated bounds.
+**Card surfaces** are created lazily when the stack opens and reused across open/close cycles. On dismiss, the card surface is deferred-destroyed (0.8s delay for animation completion).
 
 ### Input Region
 
-The Wayland input region controls which areas receive pointer events. It must be updated on every layout change:
+The Wayland input region controls pointer events. Updated on every layout change:
 
 ```rust
 // Per-island rect (exact size/position per mode)
-region.add(x, y, w, h);  // top-left coords, not center
+region.add(x, y, w, h);
 
-// Card stack: one continuous rect covering all cards + gaps
+// Expanded card stack: one continuous rect
 region.add(card_x, stack_top, card_w, stack_h);
 ```
 
-The region uses **top-left coordinates** (standard Wayland), not center coords. The layer surface is fixed at 480x400 so the region is never clipped by surface bounds.
-
-### Z-Order
-
-Subsurface stacking is controlled by `place_above`/`place_below`:
-
-```rust
-card.surface.place_below(pill.surface.wl_surface());
-```
-
-Cards are placed below the pill so the pill always renders on top of the stack.
-
-### Hit Testing
-
-`hit_test(px, py)` mirrors the layout math to determine what's under the pointer:
-- Returns `(app_id, None)` for pill/circle hits
-- Returns `(app_id, Some(activity_id))` for card hits
-- `island.cards` vec is kept sorted to match layout order
-
-The hit test uses **top-left coordinates** (Wayland pointer position), while layout uses center coords for animations. The hit test computes top-left bounds from the centered layout.
-
 ## Island Modes
 
-Each island cycles through three modes:
+Each island cycles through three display modes:
 
 | Mode | Visual | Size |
 |------|--------|------|
-| **Mini** | Small pill with icon + count | 44x28 (MINI_W x MINI_H) |
-| **Compact** | Full pill with icon + name + count + chevron | dynamic width x 36 |
-| **Expanded** | Compact pill + card stack below | max(pill_width, 300) x 36 |
+| **Mini** | Small pill with icon (+ count if > 1) | 28×28 or 44×28 |
+| **Compact** | Full pill with icon, app name, title | dynamic width × 36 |
+| **Expanded** | Compact pill + notification card stack | max(pill, 300) × 36 + cards |
 
-Click cycle: **Mini -> Expanded -> Compact -> Expanded -> ...**
+Click cycle: **Mini → Expanded → Compact → Expanded → ...**
 
-### Focus Rules
+### Focus & Timing
 
-- Only 1 island can be Compact/Expanded at a time
-- New notifications auto-focus their island
-- After 2s of no interaction, focused island shrinks to Mini
-- Focus loss (keyboard leave) closes expanded stack with 0.5s delay to Mini
+- Only one island can be Expanded at a time
+- Compact and Expanded islands coexist (e.g. a peeking notification alongside an open stack)
+- After 4s of inactivity, focused island shrinks to Mini
+- Pointer hover pauses the focus timer; it restarts on leave
+- Focus loss closes expanded cards (0.3s slide-up), then Compact → Mini after 2s
 
 ### Peek Animation
 
 When a new notification arrives in a Mini group:
 1. Pulse (bump +6px, spring back)
-2. Animate to Compact size (show content)
+2. Animate to Compact (show title preview)
 3. After 3s, spring back to Mini
+
+New notifications arriving while an island is Expanded or Compact refresh the content without changing mode.
 
 ## File Structure
 
 - `main.rs` — IslandApp, Island/CardSurface structs, layout, hit testing, pointer events
 - `renderer.rs` — Skia drawing (pills, cards, badges), animation helpers, surface style setup
-- `activity.rs` — Activity data model, PresentationMode enum
+- `activity.rs` — Activity data model
 - `state.rs` — SharedState with notification grouping, CRUD operations
 - `notifications.rs` — org.freedesktop.Notifications D-Bus daemon
 - `dbus_service.rs` — org.otto.Island1 custom D-Bus API
-- `music.rs` — MPRIS/PipeWire music integration
 
 ## Running
 
 ```sh
-# Run otto compositor first
+# Run Otto compositor first
 cargo run -- --winit &
 
 # Then run islands

--- a/components/otto-islands/README.md
+++ b/components/otto-islands/README.md
@@ -1,0 +1,173 @@
+# Otto Islands
+
+A standalone otto-kit application that renders notification groups and live activities (music, timers) as a morphing pill-shaped UI anchored to the top-center of the screen.
+
+## Architecture
+
+### Subsurface Model (CALayer-style)
+
+Every visual element is its own **Wayland subsurface**, composed like Core Animation layers. The parent layer shell surface is a transparent container — all rendering happens in child subsurfaces.
+
+```
+Layer shell surface (480x400, transparent, Overlay layer)
+  |
+  +-- pill subsurface (group tab: icon + app name + count + chevron)
+  +-- pill subsurface (another group)
+  +-- card subsurface (notification 1)
+  +-- card subsurface (notification 2)
+  +-- ...
+```
+
+Each subsurface is a `SubsurfaceSurface` from otto-kit with:
+- Its own Skia buffer for content rendering (460x100 logical pixels, 2x HiDPI)
+- Independent size, position, corner radius, opacity via `otto-surface-style-v1`
+- Spring-animated transitions on all properties
+- Center anchor point (`set_anchor_point(0.5, 0.5)`) so all coordinates are center-based
+
+### Surface Lifecycle
+
+**Pill surfaces** are created when a notification group first appears and destroyed (deferred) when the group is dismissed.
+
+**Card surfaces** are created lazily when the stack opens and **reused across open/close cycles**:
+- On close: cards animate out (fade + slide up) but surfaces stay alive
+- On reopen: same surfaces are repositioned and faded back in
+- On notification dismiss: that card surface is deferred-destroyed (0.8s delay for animation)
+
+### Surface Style Protocol
+
+All visual chrome is handled by the compositor via `otto-surface-style-v1`:
+
+```rust
+// Island pill style
+ss.set_background_color(0.03, 0.03, 0.03, 1.0);  // near-black
+ss.set_corner_radius(radius * BUFFER_SCALE);
+ss.set_masks_to_bounds(ClipMode::Enabled);
+ss.set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0);
+ss.set_blend_mode(BlendMode::BackgroundBlur);      // frosted glass
+ss.set_contents_gravity(ContentsGravity::Center);
+ss.set_anchor_point(0.5, 0.5);                     // center anchor
+
+// Card style uses theme material colors
+ss.set_background_color(r, g, b, a);  // from theme.material_medium
+```
+
+The app draws flat content with Skia. The compositor handles shape, blur, shadow, and spring animations.
+
+### Animations
+
+All animations use spring-animated transactions:
+
+```rust
+// Example: animate to new position + size
+let timing = scene.create_timing_function(qh, ());
+timing.set_spring(0.25, 0.0);  // damping, stiffness
+let anim = scene.begin_transaction(qh, ());
+anim.set_duration(0.6);
+anim.set_delay(delay);
+anim.set_timing_function(&timing);
+scene_surface.set_size(w, h);
+scene_surface.set_position(x, y);  // center coords with anchor 0.5,0.5
+anim.commit();
+```
+
+Key animation helpers in `renderer.rs`:
+- `animate_to()` — spring position + size + corner radius
+- `animate_position_opacity()` — spring position + opacity only (size set instantly)
+- `animate_pulse()` — instantly grow, spring back to target (bump effect)
+- `animate_dismiss()` — scale up 1.2x + fade out (card dismiss)
+
+### Content Rendering
+
+Content is drawn with Skia into the subsurface buffer using `draw_centered()`:
+
+```rust
+draw_centered(&surface, content_w, content_h, |canvas| {
+    // Draw at (0,0). draw_centered translates to center in the buffer.
+    renderer::draw_pill(canvas, app_id, icon, count, expanded, w, h);
+});
+```
+
+The buffer is larger than the content (460x100) so content can be pre-drawn at full size. The compositor reveals it via spring-animated bounds.
+
+### Input Region
+
+The Wayland input region controls which areas receive pointer events. It must be updated on every layout change:
+
+```rust
+// Per-island rect (exact size/position per mode)
+region.add(x, y, w, h);  // top-left coords, not center
+
+// Card stack: one continuous rect covering all cards + gaps
+region.add(card_x, stack_top, card_w, stack_h);
+```
+
+The region uses **top-left coordinates** (standard Wayland), not center coords. The layer surface is fixed at 480x400 so the region is never clipped by surface bounds.
+
+### Z-Order
+
+Subsurface stacking is controlled by `place_above`/`place_below`:
+
+```rust
+card.surface.place_below(pill.surface.wl_surface());
+```
+
+Cards are placed below the pill so the pill always renders on top of the stack.
+
+### Hit Testing
+
+`hit_test(px, py)` mirrors the layout math to determine what's under the pointer:
+- Returns `(app_id, None)` for pill/circle hits
+- Returns `(app_id, Some(activity_id))` for card hits
+- `island.cards` vec is kept sorted to match layout order
+
+The hit test uses **top-left coordinates** (Wayland pointer position), while layout uses center coords for animations. The hit test computes top-left bounds from the centered layout.
+
+## Island Modes
+
+Each island cycles through three modes:
+
+| Mode | Visual | Size |
+|------|--------|------|
+| **Mini** | Small pill with icon + count | 44x28 (MINI_W x MINI_H) |
+| **Compact** | Full pill with icon + name + count + chevron | dynamic width x 36 |
+| **Expanded** | Compact pill + card stack below | max(pill_width, 300) x 36 |
+
+Click cycle: **Mini -> Expanded -> Compact -> Expanded -> ...**
+
+### Focus Rules
+
+- Only 1 island can be Compact/Expanded at a time
+- New notifications auto-focus their island
+- After 2s of no interaction, focused island shrinks to Mini
+- Focus loss (keyboard leave) closes expanded stack with 0.5s delay to Mini
+
+### Peek Animation
+
+When a new notification arrives in a Mini group:
+1. Pulse (bump +6px, spring back)
+2. Animate to Compact size (show content)
+3. After 3s, spring back to Mini
+
+## File Structure
+
+- `main.rs` — IslandApp, Island/CardSurface structs, layout, hit testing, pointer events
+- `renderer.rs` — Skia drawing (pills, cards, badges), animation helpers, surface style setup
+- `activity.rs` — Activity data model, PresentationMode enum
+- `state.rs` — SharedState with notification grouping, CRUD operations
+- `notifications.rs` — org.freedesktop.Notifications D-Bus daemon
+- `dbus_service.rs` — org.otto.Island1 custom D-Bus API
+- `music.rs` — MPRIS/PipeWire music integration
+
+## Running
+
+```sh
+# Run otto compositor first
+cargo run -- --winit &
+
+# Then run islands
+WAYLAND_DISPLAY=wayland-1 cargo run -p otto-islands
+
+# Send test notifications
+notify-send -a "Firefox" "New Tab" "You opened a new tab"
+notify-send -a "Firefox" "Download" "file.zip completed"
+```

--- a/components/otto-islands/README.md
+++ b/components/otto-islands/README.md
@@ -2,6 +2,8 @@
 
 An experimental notification manager for Otto, inspired by the iOS dynamic island. It renders notification groups as morphing pill-shaped surfaces anchored to the top-center of the screen.
 
+![Otto Islands demo](https://private-user-images.githubusercontent.com/31436893/573857630-9fec43ac-3b17-49c5-8a3b-f0f52cc395a2.gif)
+
 Otto Islands is a standalone Wayland app that takes advantage of Otto's **experimental surface style protocol** (`otto-surface-style-v1`). This protocol gives clients direct access to the compositor's animated scene graph — similar to Core Animation on iOS/macOS. The app draws flat content once with Skia, and the compositor handles all animation, clipping, shadows, and blur at display refresh rate.
 
 ## Surface Style Protocol

--- a/components/otto-islands/src/activity.rs
+++ b/components/otto-islands/src/activity.rs
@@ -1,0 +1,104 @@
+use std::time::Instant;
+
+pub type ActivityId = u64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Priority {
+    Low,
+    Normal,
+    High,
+    Critical,
+}
+
+impl Priority {
+    pub fn rank(&self) -> u8 {
+        match self {
+            Priority::Low => 0,
+            Priority::Normal => 1,
+            Priority::High => 2,
+            Priority::Critical => 3,
+        }
+    }
+}
+
+impl TryFrom<&str> for Priority {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "low" => Ok(Priority::Low),
+            "normal" => Ok(Priority::Normal),
+            "high" => Ok(Priority::High),
+            "critical" | "urgent" => Ok(Priority::Critical),
+            other => Err(format!("unknown priority: {other}")),
+        }
+    }
+}
+
+impl From<u8> for Priority {
+    fn from(urgency: u8) -> Self {
+        match urgency {
+            0 => Priority::Low,
+            2 => Priority::Critical,
+            _ => Priority::Normal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresentationMode {
+    Idle,
+    Compact,
+    Minimal,
+    Expanded,
+    Banner,
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationAction {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivitySource {
+    DBus,
+    Notification,
+    Portal,
+    Internal,
+}
+
+#[derive(Debug, Clone)]
+pub struct Activity {
+    pub id: ActivityId,
+    pub app_id: String,
+    pub title: String,
+    pub body: String,
+    pub icon: String,
+    pub progress: Option<f64>,
+    pub timeout_ms: u32,
+    pub priority: Priority,
+    pub live: bool,
+    pub created_at: Instant,
+    pub expired: bool,
+    pub actions: Vec<NotificationAction>,
+    pub default_action: Option<String>,
+    pub category: Option<String>,
+    pub image_path: Option<String>,
+    pub transient: bool,
+    pub resident: bool,
+    pub notification_id: Option<u32>,
+    pub source: ActivitySource,
+}
+
+/// Trait for rendering activity content at different presentation sizes.
+///
+/// Each activity type (generic, media, timer, etc.) implements this to
+/// draw itself appropriately for the given mode.
+pub trait ActivityRenderer {
+    /// Preferred surface size (width, height) for this mode.
+    fn size(&self, mode: PresentationMode) -> (f32, f32);
+
+    /// Draw content into the canvas at the given dimensions.
+    fn draw(&self, canvas: &skia_safe::Canvas, mode: PresentationMode, w: f32, h: f32);
+}

--- a/components/otto-islands/src/dbus_service.rs
+++ b/components/otto-islands/src/dbus_service.rs
@@ -1,0 +1,95 @@
+use otto_kit::AppContext;
+use zbus::interface;
+
+use crate::activity::Priority;
+use crate::state::SharedState;
+
+pub const DBUS_NAME: &str = "org.otto.Island";
+pub const DBUS_PATH: &str = "/org/otto/Island";
+
+pub struct IslandService {
+    state: SharedState,
+}
+
+impl IslandService {
+    pub fn new(state: SharedState) -> Self {
+        Self { state }
+    }
+}
+
+#[interface(name = "org.otto.Island1")]
+impl IslandService {
+    /// Create a new activity in the island.
+    ///
+    /// Returns the activity ID on success.
+    /// `progress`: 0.0–1.0 for a progress bar, negative for no progress.
+    /// `priority`: "low", "normal", "high", or "critical".
+    async fn create_activity(
+        &self,
+        app_id: &str,
+        title: &str,
+        icon: &str,
+        progress: f64,
+        timeout_ms: u32,
+        priority: &str,
+        live: bool,
+    ) -> zbus::fdo::Result<u64> {
+        let priority =
+            Priority::try_from(priority).map_err(|e| zbus::fdo::Error::InvalidArgs(e))?;
+
+        let progress = if progress < 0.0 {
+            None
+        } else {
+            Some(progress.clamp(0.0, 1.0))
+        };
+
+        let mut state = self.state.lock().unwrap();
+        let id = state.create_activity(
+            app_id.to_string(),
+            title.to_string(),
+            icon.to_string(),
+            progress,
+            timeout_ms,
+            priority,
+            live,
+        );
+        drop(state);
+
+        AppContext::request_wakeup();
+        tracing::info!(id, app_id, title, "activity created");
+        Ok(id)
+    }
+
+    /// Update an existing activity's title and/or progress.
+    ///
+    /// Pass an empty string for title to leave it unchanged.
+    /// Pass a negative value for progress to clear it.
+    async fn update_activity(
+        &self,
+        id: u64,
+        title: &str,
+        progress: f64,
+    ) -> zbus::fdo::Result<bool> {
+        let mut state = self.state.lock().unwrap();
+        let ok = state.update_activity(id, title, progress);
+        drop(state);
+
+        if ok {
+            AppContext::request_wakeup();
+        }
+        Ok(ok)
+    }
+
+    /// Dismiss an activity by ID.
+    async fn dismiss_activity(&self, id: u64) -> zbus::fdo::Result<bool> {
+        let mut state = self.state.lock().unwrap();
+        let ok = state.dismiss_activity(id);
+        drop(state);
+
+        if ok {
+            AppContext::request_wakeup();
+            tracing::info!(id, "activity dismissed");
+        }
+        Ok(ok)
+    }
+}

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1,0 +1,1204 @@
+mod activity;
+mod dbus_service;
+mod notifications;
+mod renderer;
+mod state;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use otto_kit::protocols::otto_surface_style_v1::{ClipMode, ContentsGravity};
+use otto_kit::surfaces::{LayerShellSurface, SubsurfaceSurface};
+use otto_kit::{App, AppContext, AppRunner};
+use smithay_client_toolkit::compositor::Region;
+use smithay_client_toolkit::seat::pointer::{PointerEvent, PointerEventKind};
+use wayland_protocols_wlr::layer_shell::v1::client::{
+    zwlr_layer_shell_v1::Layer, zwlr_layer_surface_v1::Anchor,
+};
+
+use crate::activity::Activity;
+use crate::dbus_service::{IslandService, DBUS_NAME};
+use crate::renderer::{
+    animate_to, apply_island_style, draw_centered, set_size_and_position, COMPACT_H, MINI_H, MINI_W,
+};
+use crate::state::{IslandState, SharedState};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LAYER_W: u32 = 480;
+const LAYER_H: u32 = 400; // Tall enough for pill + MAX_VISIBLE_CARDS cards.
+const BAR_HEIGHT: f32 = 36.0;
+const GAP: f32 = 6.0;
+/// Seconds of inactivity before the focused island shrinks to Mini.
+const FOCUS_TIMEOUT_SECS: f64 = 2.0;
+
+// ---------------------------------------------------------------------------
+// Island — one notification group or music activity
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IslandMode {
+    Mini,
+    Compact,
+    Expanded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IslandKind {
+    Notification,
+}
+
+/// An island represents one group (notification app_id or music).
+/// It owns a pill/circle subsurface and optionally card subsurfaces.
+struct Island {
+    /// The group key (app_id for notifications, "org.otto.music" for music).
+    app_id: String,
+    kind: IslandKind,
+    /// The icon for this group (resolved once, used consistently in all modes).
+    icon: String,
+    /// The pill/circle subsurface.
+    surface: SubsurfaceSurface,
+    /// Lazily-created card subsurfaces (only when Expanded, notifications only).
+    cards: Vec<CardSurface>,
+    /// Current mode.
+    mode: IslandMode,
+    /// When set, the island is closing its stack and will switch to Compact at this instant.
+    closing_at: Option<std::time::Instant>,
+    /// When this group first appeared.
+    created_at: std::time::Instant,
+    /// Last known notification count (for pulse detection).
+    last_count: usize,
+    /// Last seen activity ID (to detect new notifications even when count doesn't change).
+    last_activity_id: u64,
+    /// When set, the island temporarily shows as Compact until this instant.
+    peek_until: Option<std::time::Instant>,
+    /// Last layout target (w, h, x, y) — skip animation when unchanged.
+    last_layout: (f32, f32, f32, f32),
+}
+
+struct CardSurface {
+    surface: SubsurfaceSurface,
+    activity_id: u64,
+}
+
+// ---------------------------------------------------------------------------
+// IslandApp
+// ---------------------------------------------------------------------------
+
+struct IslandApp {
+    state: SharedState,
+    layer_surface: Option<LayerShellSurface>,
+    islands: Vec<Island>,
+    surfaces_ready: bool,
+    /// Which island (by app_id) is currently focused (Compact/Expanded).
+    focused_app: Option<String>,
+    /// Which island (by app_id) the pointer is currently hovering over.
+    hovered_app: Option<String>,
+    /// Surfaces pending destruction (kept alive for animations, destroyed next cycle).
+    pending_destroy: Vec<(SubsurfaceSurface, std::time::Instant)>,
+    /// Last time the user interacted (pointer event). Used for focus timeout.
+    last_interaction: std::time::Instant,
+}
+
+impl IslandApp {
+    fn new(state: SharedState) -> Self {
+        Self {
+            state,
+            layer_surface: None,
+            islands: Vec::new(),
+            surfaces_ready: false,
+            focused_app: None,
+            hovered_app: None,
+            pending_destroy: Vec::new(),
+            last_interaction: std::time::Instant::now(),
+        }
+    }
+
+    /// Get the parent wl_surface for creating subsurfaces.
+    fn wl_surface(&self) -> Option<wayland_client::protocol::wl_surface::WlSurface> {
+        self.layer_surface
+            .as_ref()
+            .map(|l| l.base_surface().wl_surface().clone())
+    }
+
+    /// Create a new subsurface for an island pill.
+    /// Starts at Mini pill size so it doesn't flash as a big black rect.
+    fn create_pill_subsurface(&self) -> Option<SubsurfaceSurface> {
+        let wl = self.wl_surface()?;
+        let surface =
+            SubsurfaceSurface::new(&wl, 0, 0, renderer::SLOT_BUF_W, renderer::SLOT_BUF_H).ok()?;
+        apply_island_style(&surface, MINI_H as f64 / 2.0, ContentsGravity::Center);
+        // Center coordinates (anchor point is 0.5, 0.5).
+        let cx = LAYER_W as f32 / 2.0;
+        let cy = BAR_HEIGHT / 2.0;
+        set_size_and_position(&surface, MINI_W, MINI_H, cx, cy);
+        surface.draw(|canvas| {
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+        });
+        Some(surface)
+    }
+
+    /// Queue a surface for destruction after animations have time to play.
+    fn defer_destroy(&mut self, surface: SubsurfaceSurface) {
+        self.pending_destroy
+            .push((surface, std::time::Instant::now()));
+    }
+
+    /// Destroy surfaces whose animations have had time to complete (>0.8s).
+    fn flush_pending_destroy(&mut self) {
+        let cutoff = std::time::Instant::now() - Duration::from_secs_f64(0.8);
+        self.pending_destroy.retain_mut(|(surface, queued_at)| {
+            if *queued_at <= cutoff {
+                surface.destroy();
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Sync: reconcile islands with the current state
+    // -----------------------------------------------------------------------
+
+    fn sync(&mut self) {
+        let state = self.state.lock().unwrap();
+        let grouped = state.grouped_activities();
+        drop(state);
+
+        // Build the set of app_ids that should exist as islands.
+        let mut desired: Vec<(String, IslandKind, String)> = Vec::new(); // (app_id, kind, icon)
+        for (activity, _count) in &grouped {
+            let kind = IslandKind::Notification;
+            if !desired.iter().any(|(id, _, _)| id == &activity.app_id) {
+                desired.push((activity.app_id.clone(), kind, activity.icon.clone()));
+            }
+        }
+
+        // Remove islands whose app_id is no longer present.
+        let mut i = 0;
+        while i < self.islands.len() {
+            if desired
+                .iter()
+                .any(|(app_id, _, _)| app_id == &self.islands[i].app_id)
+            {
+                i += 1;
+            } else {
+                let mut island = self.islands.remove(i);
+                tracing::info!(app_id = %island.app_id, "island removed");
+                let cx = LAYER_W as f32 / 2.0;
+                let cy = BAR_HEIGHT / 2.0;
+                let h = COMPACT_H;
+                renderer::animate_to_with_opacity(
+                    &island.surface,
+                    0.0,
+                    h,
+                    cx,
+                    cy,
+                    h as f64 / 2.0,
+                    Some(0.0),
+                    0.3,
+                );
+                for card in &island.cards {
+                    renderer::animate_dismiss(&card.surface, 1.2);
+                }
+                // Defer destruction of all surfaces.
+                for card in island.cards.drain(..) {
+                    self.defer_destroy(card.surface);
+                }
+                self.defer_destroy(island.surface);
+            }
+        }
+
+        // Add islands for new app_ids.
+        for (app_id, kind, icon) in &desired {
+            if !self.islands.iter().any(|i| i.app_id == *app_id) {
+                if let Some(surface) = self.create_pill_subsurface() {
+                    tracing::info!(%app_id, ?kind, %icon, "island created");
+                    self.islands.push(Island {
+                        app_id: app_id.clone(),
+                        kind: *kind,
+                        icon: icon.clone(),
+                        surface,
+                        cards: Vec::new(),
+                        mode: IslandMode::Mini,
+                        closing_at: None,
+                        created_at: std::time::Instant::now(),
+                        last_count: 0,
+                        last_activity_id: 0,
+                        peek_until: None,
+                        last_layout: (0.0, 0.0, 0.0, 0.0),
+                    });
+                    // Auto-focus newly arrived island + reset interaction timer.
+                    self.focused_app = Some(app_id.clone());
+                    self.last_interaction = std::time::Instant::now();
+                }
+            }
+        }
+
+        // Sort islands by creation time (oldest left).
+        self.islands.sort_by_key(|i| i.created_at);
+
+        // If focused app no longer exists, clear focus.
+        if let Some(ref focused) = self.focused_app {
+            if !self.islands.iter().any(|i| i.app_id == *focused) {
+                self.focused_app = None;
+            }
+        }
+
+        // Assign modes: focused gets Compact/Expanded, peeking stays Compact, rest → Mini.
+        for island in &mut self.islands {
+            if Some(&island.app_id) == self.focused_app.as_ref() {
+                if island.mode == IslandMode::Mini {
+                    island.mode = IslandMode::Compact;
+                    tracing::debug!(app_id = %island.app_id, "Mini → Compact (focused)");
+                }
+            } else if island.peek_until.is_some() {
+                // Peeking — stay Compact until peek expires.
+            } else if island.mode == IslandMode::Expanded {
+                // Non-focused expanded → close and shrink.
+                Self::close_cards_for(island);
+                island.mode = IslandMode::Mini;
+            } else {
+                // Non-focused, non-peeking → Mini.
+                if island.mode != IslandMode::Mini {
+                    tracing::debug!(app_id = %island.app_id, from = ?island.mode, "→ Mini");
+                }
+                island.mode = IslandMode::Mini;
+            }
+        }
+
+        self.layout(&grouped);
+    }
+
+    /// Close the card stack — animate out but keep surfaces alive for reuse.
+    fn close_cards_for(island: &mut Island) {
+        tracing::info!(app_id = %island.app_id, cards = island.cards.len(), "stack closed");
+        // Slide up to pill center y, keep current x. Fade out.
+        let pill_cy = BAR_HEIGHT / 2.0;
+        let pill_cx = island.last_layout.2; // cx from last layout
+        for card in &island.cards {
+            renderer::animate_position_opacity(
+                &card.surface,
+                renderer::CARD_W,
+                renderer::CARD_H,
+                pill_cx,
+                pill_cy,
+                0.0,
+                0.0,
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Layout: position all islands and their cards
+    // -----------------------------------------------------------------------
+
+    fn layout(&mut self, grouped: &[(Activity, usize)]) {
+        if self.islands.is_empty() {
+            self.update_layer_size();
+            self.update_input_region();
+            return;
+        }
+
+        // Compute element sizes for layout.
+        let island_size = |island: &Island, mode: IslandMode| -> (f32, f32) {
+            let entry = grouped.iter().find(|(a, _)| a.app_id == island.app_id);
+            let count = entry.map(|(_, c)| *c).unwrap_or(1);
+            let title = entry.map(|(a, _)| a.title.as_str()).unwrap_or("");
+            match mode {
+                IslandMode::Mini => (MINI_W, MINI_H),
+                IslandMode::Compact => {
+                    let w = renderer::pill_width(&island.app_id, title, count);
+                    (w, COMPACT_H)
+                }
+                IslandMode::Expanded => {
+                    let w =
+                        renderer::pill_width(&island.app_id, title, count).max(renderer::CARD_W);
+                    (w, COMPACT_H)
+                }
+            }
+        };
+
+        // Compute total row width.
+        let total_w: f32 = self
+            .islands
+            .iter()
+            .map(|i| island_size(i, i.mode).0)
+            .sum::<f32>()
+            + (self.islands.len() - 1) as f32 * GAP;
+
+        let mut x = (LAYER_W as f32 - total_w) / 2.0;
+
+        // Collect positions for expanded islands, pulse targets, and layout targets.
+        let mut expanded_layouts: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
+        let mut pulse_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
+        let mut layout_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new(); // (idx, w, h, x, y)
+
+        for (idx, island) in self.islands.iter().enumerate() {
+            let count = grouped
+                .iter()
+                .find(|(a, _)| a.app_id == island.app_id)
+                .map(|(_, c)| *c)
+                .unwrap_or(0);
+            let icon = island.icon.as_str();
+
+            let (base_w, base_h) = island_size(island, island.mode);
+            let is_hovered = self.hovered_app.as_ref() == Some(&island.app_id);
+            let grow = if is_hovered
+                && (island.mode == IslandMode::Mini || island.mode == IslandMode::Compact)
+            {
+                renderer::HOVER_GROW
+            } else {
+                0.0
+            };
+            let w = base_w + grow;
+            let h = base_h + grow;
+            // Center coordinates for anchor_point(0.5, 0.5).
+            let cx = x + w / 2.0;
+            let cy = BAR_HEIGHT / 2.0;
+
+            // Detect new notification: count increased or representative activity changed.
+            let current_activity_id = grouped
+                .iter()
+                .find(|(a, _)| a.app_id == island.app_id)
+                .map(|(a, _)| a.id)
+                .unwrap_or(0);
+            let count_increased = count > island.last_count;
+            let activity_changed =
+                current_activity_id != island.last_activity_id && island.last_activity_id > 0;
+            // Only pulse on new notifications (count went up), not on dismissals.
+            let should_pulse = island.kind == IslandKind::Notification && count_increased;
+            if island.kind == IslandKind::Notification {
+                tracing::debug!(
+                    app_id = %island.app_id,
+                    mode = ?island.mode,
+                    count,
+                    last_count = island.last_count,
+                    current_activity_id,
+                    last_activity_id = island.last_activity_id,
+                    count_increased,
+                    activity_changed,
+                    should_pulse,
+                    "notification pulse check"
+                );
+            }
+
+            match island.mode {
+                IslandMode::Mini => {
+                    draw_centered(&island.surface, w, h, |canvas| {
+                        renderer::draw_mini(canvas, icon, count, w, h);
+                    });
+                    if should_pulse {
+                        pulse_targets.push((idx, w, h, cx, cy));
+                    } else {
+                        layout_targets.push((idx, w, h, cx, cy));
+                    }
+                }
+                IslandMode::Compact | IslandMode::Expanded => {
+                    let title = grouped
+                        .iter()
+                        .find(|(a, _)| a.app_id == island.app_id)
+                        .map(|(a, _)| a.title.as_str())
+                        .unwrap_or("");
+                    let expanded = island.mode == IslandMode::Expanded;
+                    draw_centered(&island.surface, w, h, |canvas| {
+                        renderer::draw_pill(
+                            canvas,
+                            &island.app_id,
+                            icon,
+                            title,
+                            count,
+                            expanded,
+                            w,
+                            h,
+                        );
+                    });
+                    if should_pulse {
+                        pulse_targets.push((idx, w, h, cx, cy));
+                    } else {
+                        layout_targets.push((idx, w, h, cx, cy));
+                    }
+
+                    if island.mode == IslandMode::Expanded && island.closing_at.is_none() {
+                        // Store top-left x for card positioning.
+                        expanded_layouts.push((idx, x, cx, cy, w));
+                    }
+                }
+            }
+
+            x += w + GAP;
+        }
+
+        // Apply layout animations only when target changed.
+        for (idx, w, h, x, y) in layout_targets {
+            let target = (w, h, x, y);
+            if self.islands[idx].last_layout != target {
+                let radius = h as f64 / 2.0;
+                animate_to(&self.islands[idx].surface, w, h, x, y, radius, 0.0);
+                self.islands[idx].last_layout = target;
+            }
+        }
+
+        // Apply pulse and peek as Compact for new notifications.
+        for (idx, w, h, cx, cy) in pulse_targets {
+            tracing::info!(
+                app_id = %self.islands[idx].app_id,
+                from = ?self.islands[idx].mode,
+                "pulse → peek Compact for 3s"
+            );
+            renderer::animate_pulse(
+                &self.islands[idx].surface,
+                w,
+                h,
+                cx,
+                cy,
+                h as f64 / 2.0,
+                6.0,
+            );
+            self.islands[idx].last_layout = (w, h, cx, cy);
+            self.islands[idx].peek_until = Some(std::time::Instant::now() + Duration::from_secs(3));
+            self.islands[idx].mode = IslandMode::Compact;
+            self.islands[idx].last_layout = (0.0, 0.0, 0.0, 0.0);
+            // Update tracking now so the next sync doesn't re-trigger.
+            let app_id = &self.islands[idx].app_id;
+            if let Some((a, c)) = grouped.iter().find(|(a, _)| &a.app_id == app_id) {
+                self.islands[idx].last_count = *c;
+                self.islands[idx].last_activity_id = a.id;
+            }
+            // Mark dirty so the next tick re-layouts at Compact size.
+            // Safe from loops because last_count/last_activity_id are now current.
+            let mut st = self.state.lock().unwrap();
+            st.dirty = true;
+        }
+        for island in &mut self.islands {
+            let entry = grouped.iter().find(|(a, _)| a.app_id == island.app_id);
+            island.last_count = entry.map(|(_, c)| *c).unwrap_or(0);
+            island.last_activity_id = entry.map(|(a, _)| a.id).unwrap_or(0);
+        }
+
+        // Now lay out cards for expanded islands (separate pass to avoid borrow conflict).
+        // Collect (notifs, group_icon) per app_id.
+        let state = self.state.lock().unwrap();
+        let all_notifs: std::collections::HashMap<String, (Vec<Activity>, String)> = {
+            let mut map = std::collections::HashMap::new();
+            for (idx, _, _, _, _) in &expanded_layouts {
+                let app_id = &self.islands[*idx].app_id;
+                let notifs: Vec<Activity> = state
+                    .notifications_for_app(app_id)
+                    .into_iter()
+                    .cloned()
+                    .collect();
+                // Group icon: from grouped_activities representative.
+                let group_icon = grouped
+                    .iter()
+                    .find(|(a, _)| a.app_id == *app_id)
+                    .map(|(a, _)| a.icon.clone())
+                    .unwrap_or_default();
+                map.insert(app_id.clone(), (notifs, group_icon));
+            }
+            map
+        };
+        drop(state);
+
+        let mut dismissed_card_surfaces: Vec<SubsurfaceSurface> = Vec::new();
+
+        // Capture wl_surface before mutable borrow of islands.
+        let wl = self.wl_surface();
+
+        for (idx, pill_left_x, _pill_cx, _pill_cy, pill_w) in expanded_layouts {
+            let island = &mut self.islands[idx];
+            let Some((notifs, group_icon)) = all_notifs.get(&island.app_id) else {
+                continue;
+            };
+            let pill_h = COMPACT_H;
+
+            let card_w = renderer::CARD_W;
+            let card_h = renderer::CARD_H;
+            let card_gap = renderer::CARD_GAP;
+            // Center x for cards (centered under pill).
+            let card_cx = pill_left_x + pill_w / 2.0;
+            // Pill bottom edge in top-left coords.
+            let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
+            let max_cards = 5;
+
+            for (i, notif) in notifs.iter().take(max_cards).enumerate() {
+                // Card center y.
+                let card_top = pill_bottom + card_gap + (i as f32) * (card_h + card_gap);
+                let card_cy = card_top + card_h / 2.0;
+                // Start position: center of card at pill bottom.
+                let start_cy = pill_bottom + card_h / 2.0;
+
+                let existing = island.cards.iter().position(|c| c.activity_id == notif.id);
+                let is_new = existing.is_none();
+                let cidx = if let Some(ci) = existing {
+                    ci
+                } else {
+                    let Some(ref wl) = wl else { continue };
+                    let Ok(surface) = SubsurfaceSurface::new(
+                        wl,
+                        0,
+                        0,
+                        renderer::SLOT_BUF_W,
+                        renderer::SLOT_BUF_H,
+                    ) else {
+                        continue;
+                    };
+                    renderer::apply_card_style(&surface);
+                    // Wayland subsurface stacking is parent-relative, not screen-relative.
+                    // For a top-anchored layer shell, "above" in the stack means further
+                    // from the screen edge — i.e. visually behind the pill. So place_above
+                    // makes cards render behind the title surface.
+                    surface.place_above(island.surface.wl_surface());
+                    // Pre-render content before making the surface visible.
+                    draw_centered(&surface, card_w, card_h, |canvas| {
+                        renderer::draw_card(canvas, notif, group_icon, card_w, card_h);
+                    });
+                    set_size_and_position(&surface, card_w, card_h, card_cx, start_cy);
+                    island.cards.push(CardSurface {
+                        surface,
+                        activity_id: notif.id,
+                    });
+                    island.cards.len() - 1
+                };
+
+                // Redraw content for existing cards (count/time may have changed).
+                draw_centered(&island.cards[cidx].surface, card_w, card_h, |canvas| {
+                    renderer::draw_card(canvas, notif, group_icon, card_w, card_h);
+                });
+
+                if is_new {
+                    // New card: start at pill bottom, invisible, slide down + fade in.
+                    set_size_and_position(
+                        &island.cards[cidx].surface,
+                        card_w,
+                        card_h,
+                        card_cx,
+                        start_cy,
+                    );
+                    if let Some(ss) = island.cards[cidx].surface.base_surface().surface_style() {
+                        ss.set_opacity(0.0);
+                    }
+                    renderer::animate_position_opacity(
+                        &island.cards[cidx].surface,
+                        card_w,
+                        card_h,
+                        card_cx,
+                        card_cy,
+                        1.0,
+                        i as f64 * 0.05,
+                    );
+                } else {
+                    // Existing card: animate to position + ensure visible.
+                    renderer::animate_position_opacity(
+                        &island.cards[cidx].surface,
+                        card_w,
+                        card_h,
+                        card_cx,
+                        card_cy,
+                        1.0,
+                        i as f64 * 0.05,
+                    );
+                }
+            }
+
+            // Remove dismissed cards and reorder to match notification order.
+            let notif_ids: Vec<u64> = notifs.iter().take(max_cards).map(|n| n.id).collect();
+            let mut i = 0;
+            while i < island.cards.len() {
+                if notif_ids.contains(&island.cards[i].activity_id) {
+                    i += 1;
+                } else {
+                    let card = island.cards.remove(i);
+                    dismissed_card_surfaces.push(card.surface);
+                }
+            }
+            // Sort cards to match layout order (same as notif_ids).
+            island.cards.sort_by_key(|c| {
+                notif_ids
+                    .iter()
+                    .position(|&id| id == c.activity_id)
+                    .unwrap_or(usize::MAX)
+            });
+        }
+        for s in dismissed_card_surfaces {
+            self.defer_destroy(s);
+        }
+
+        self.update_layer_size();
+        self.update_input_region();
+    }
+
+    // -----------------------------------------------------------------------
+    // Layer size & input region
+    // -----------------------------------------------------------------------
+
+    fn update_layer_size(&self) {
+        let Some(layer) = &self.layer_surface else {
+            return;
+        };
+
+        // Compute the minimum height needed for current layout.
+        let mut max_h = BAR_HEIGHT;
+
+        for island in &self.islands {
+            if island.mode == IslandMode::Expanded {
+                let card_count = island.cards.len().min(5) as f32;
+                let pill_h = COMPACT_H;
+                let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
+                let stack_h = pill_bottom
+                    + renderer::CARD_GAP
+                    + card_count * renderer::CARD_H
+                    + (card_count - 1.0).max(0.0) * renderer::CARD_GAP;
+                max_h = max_h.max(stack_h + 4.0);
+            }
+        }
+
+        layer.set_size(LAYER_W, max_h.ceil() as u32);
+    }
+
+    fn update_input_region(&self) {
+        let Some(layer) = &self.layer_surface else {
+            return;
+        };
+        let cs = AppContext::compositor_state();
+        let Ok(region) = Region::new(cs) else { return };
+
+        // Add input rects when there are visible islands.
+        // Empty region = zero input area (clicks pass through).
+        if !self.islands.is_empty() {
+            // One rect per island, positioned to match layout exactly.
+            let island_size_for_input = |island: &Island| -> (f32, f32) {
+                match island.mode {
+                    IslandMode::Mini => (MINI_W, MINI_H),
+                    IslandMode::Compact => {
+                        let w = island.last_layout.0.max(MINI_W);
+                        (w, COMPACT_H)
+                    }
+                    IslandMode::Expanded => {
+                        let w = island.last_layout.0.max(renderer::CARD_W);
+                        (w, COMPACT_H)
+                    }
+                }
+            };
+            let total_w: f32 = self
+                .islands
+                .iter()
+                .map(|i| island_size_for_input(i).0)
+                .sum::<f32>()
+                + (self.islands.len() - 1) as f32 * GAP;
+
+            let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
+            for island in &self.islands {
+                let (w, h) = island_size_for_input(island);
+                let y = (BAR_HEIGHT - h) / 2.0;
+                region.add(x as i32, y as i32, w.ceil() as i32, h.ceil() as i32);
+                x += w + GAP;
+            }
+
+            // Card stack region — one continuous rect covering all cards + gaps.
+            for island in &self.islands {
+                if island.mode != IslandMode::Expanded || island.cards.is_empty() {
+                    continue;
+                }
+                let pill_h = COMPACT_H;
+                let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
+                let card_w = renderer::CARD_W;
+                let card_h = renderer::CARD_H;
+                let card_gap = renderer::CARD_GAP;
+                let card_count = island.cards.len() as f32;
+                let stack_top = pill_bottom + card_gap;
+                let stack_h = card_count * card_h + (card_count - 1.0) * card_gap;
+                let card_region_x = ((LAYER_W as f32 - card_w) / 2.0).max(0.0);
+                region.add(
+                    card_region_x as i32,
+                    stack_top as i32,
+                    card_w.ceil() as i32,
+                    stack_h.ceil() as i32,
+                );
+            }
+        }
+
+        let wl_surface = layer.base_surface().wl_surface();
+        wl_surface.set_input_region(Some(region.wl_region()));
+        wl_surface.commit();
+    }
+
+    // -----------------------------------------------------------------------
+    // Hit testing
+    // -----------------------------------------------------------------------
+
+    /// Returns (app_id, Option<activity_id>) for what's at (px, py).
+    /// activity_id is Some when a card is hit.
+    fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>)> {
+        let get_size = |island: &Island| -> (f32, f32) {
+            match island.mode {
+                IslandMode::Mini => (MINI_W, MINI_H),
+                IslandMode::Compact => {
+                    let w = island.last_layout.0.max(MINI_W);
+                    (w, COMPACT_H)
+                }
+                IslandMode::Expanded => {
+                    let w = island.last_layout.0.max(renderer::CARD_W);
+                    (w, COMPACT_H)
+                }
+            }
+        };
+
+        let total_w: f32 = self.islands.iter().map(|i| get_size(i).0).sum::<f32>()
+            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
+
+        let mut x = (LAYER_W as f32 - total_w) / 2.0;
+
+        for island in &self.islands {
+            let (w, h) = get_size(island);
+            let y = (BAR_HEIGHT - h) / 2.0;
+
+            // Hit test cards first (they sit below the pill).
+            if island.mode == IslandMode::Expanded {
+                let card_w = renderer::CARD_W;
+                let card_h = renderer::CARD_H;
+                let card_gap = renderer::CARD_GAP;
+                let card_x = x + (w - card_w) / 2.0;
+
+                for (i, card) in island.cards.iter().enumerate() {
+                    let card_y = y + h + card_gap + (i as f32) * (card_h + card_gap);
+                    if px >= card_x
+                        && px <= card_x + card_w
+                        && py >= card_y
+                        && py <= card_y + card_h
+                    {
+                        return Some((island.app_id.clone(), Some(card.activity_id)));
+                    }
+                }
+            }
+
+            // Hit test pill/circle.
+            if px >= x && px <= x + w && py >= y && py <= y + h {
+                return Some((island.app_id.clone(), None));
+            }
+
+            x += w + GAP;
+        }
+
+        None
+    }
+
+    // -----------------------------------------------------------------------
+    // Click handling
+    // -----------------------------------------------------------------------
+
+    fn handle_click(&mut self, px: f32, py: f32) {
+        let Some((app_id, card_id)) = self.hit_test(px, py) else {
+            return;
+        };
+
+        if let Some(activity_id) = card_id {
+            // Clicked a card — animate dismiss (scale up + fade out), then remove.
+            if let Some(island) = self.islands.iter().find(|i| i.app_id == app_id) {
+                if let Some(card) = island.cards.iter().find(|c| c.activity_id == activity_id) {
+                    renderer::animate_dismiss(&card.surface, 1.2);
+                }
+            }
+
+            let mut state = self.state.lock().unwrap();
+            let notification_id = state
+                .activities
+                .iter()
+                .find(|a| a.id == activity_id)
+                .and_then(|a| a.notification_id);
+            let default_action = state
+                .activities
+                .iter()
+                .find(|a| a.id == activity_id)
+                .and_then(|a| a.default_action.clone());
+            if let Some(activity) = state.activities.iter().find(|a| a.id == activity_id) {
+                tracing::info!(
+                    activity_id,
+                    %app_id,
+                    action = ?activity.default_action,
+                    "notification action invoked"
+                );
+            }
+
+            state.dismiss_activity(activity_id);
+            drop(state);
+
+            // Focus the app that sent the notification.
+            request_focus_app(app_id.clone());
+
+            // Emit ActionInvoked D-Bus signal for the notification spec.
+            if let Some(nid) = notification_id {
+                let action_key = default_action.as_deref().unwrap_or("default").to_string();
+                emit_action_invoked(nid, action_key);
+            }
+        } else {
+            // Clicked a pill/circle.
+            let island = self.islands.iter_mut().find(|i| i.app_id == app_id);
+            if let Some(island) = island {
+                match island.mode {
+                    IslandMode::Mini | IslandMode::Compact => {
+                        tracing::info!(%app_id, from = ?island.mode, "click: → Expanded");
+                        self.focused_app = Some(app_id.clone());
+                        self.last_interaction = std::time::Instant::now();
+                        island.mode = IslandMode::Expanded;
+                        island.peek_until = None;
+                    }
+                    IslandMode::Expanded => {
+                        tracing::info!(%app_id, "click: Expanded → Compact");
+                        Self::close_cards_for(island);
+                        island.closing_at =
+                            Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
+                        // Keep focus so timeout governs Mini transition.
+                        self.focused_app = Some(app_id.clone());
+                        self.last_interaction = std::time::Instant::now();
+                    }
+                }
+            }
+            // Mark dirty so sync() runs.
+            let mut state = self.state.lock().unwrap();
+            state.dirty = true;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// App trait implementation
+// ---------------------------------------------------------------------------
+
+impl App for IslandApp {
+    fn on_app_ready(&mut self, _ctx: &AppContext) -> Result<(), Box<dyn std::error::Error>> {
+        let layer_surface =
+            LayerShellSurface::new(Layer::Overlay, "otto-islands", LAYER_W, LAYER_H)?;
+        layer_surface.set_anchor(Anchor::Top);
+        layer_surface.set_margin(2, 0, 0, 0);
+        layer_surface.set_exclusive_zone(0);
+        layer_surface.set_keyboard_interactivity(
+            wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::KeyboardInteractivity::OnDemand,
+        );
+
+        if let Some(style) = layer_surface.base_surface().surface_style() {
+            style.set_masks_to_bounds(ClipMode::Enabled);
+        }
+
+        self.layer_surface = Some(layer_surface);
+        Ok(())
+    }
+
+    fn on_configure_layer(&mut self, _ctx: &AppContext, _w: i32, _h: i32, _serial: u32) {
+        if !self.surfaces_ready {
+            // Clear the parent surface.
+            if let Some(layer) = &self.layer_surface {
+                layer.draw(|canvas| {
+                    canvas.clear(skia_safe::Color::TRANSPARENT);
+                });
+                layer.base_surface().on_frame(|| {});
+            }
+            self.surfaces_ready = true;
+            // Set empty input region so clicks pass through until islands appear.
+            self.update_input_region();
+        }
+    }
+
+    fn on_update(&mut self, _ctx: &AppContext) {
+        if !self.surfaces_ready {
+            return;
+        }
+
+        // Destroy surfaces whose animations have completed.
+        self.flush_pending_destroy();
+
+        // Focus timeout: shrink Compact → Mini after inactivity.
+        let elapsed = self.last_interaction.elapsed().as_secs_f64();
+        if elapsed >= FOCUS_TIMEOUT_SECS && self.focused_app.is_some() {
+            let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
+            if !any_expanded {
+                tracing::info!(
+                    focused = ?self.focused_app,
+                    elapsed_secs = format!("{:.1}", elapsed),
+                    "focus timeout → all Mini"
+                );
+                self.focused_app = None;
+                let mut state = self.state.lock().unwrap();
+                state.dirty = true;
+                drop(state);
+            }
+        }
+
+        // Closing timeout: cards faded out, now shrink pill to Compact.
+        let now = std::time::Instant::now();
+        for island in &mut self.islands {
+            if let Some(at) = island.closing_at {
+                if now >= at {
+                    island.closing_at = None;
+                    island.mode = IslandMode::Compact;
+                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
+                    let mut state = self.state.lock().unwrap();
+                    state.dirty = true;
+                    drop(state);
+                }
+            }
+        }
+
+        // Peek timeout: revert Compact peek back to Mini.
+        for island in &mut self.islands {
+            if let Some(until) = island.peek_until {
+                if now >= until {
+                    tracing::info!(app_id = %island.app_id, "peek expired → Mini");
+                    island.peek_until = None;
+                    island.mode = IslandMode::Mini;
+                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
+                    // Snapshot current state so the next sync doesn't re-trigger peek.
+                    let state = self.state.lock().unwrap();
+                    let grouped = state.grouped_activities();
+                    drop(state);
+                    if let Some((a, c)) = grouped.iter().find(|(a, _)| a.app_id == island.app_id) {
+                        island.last_count = *c;
+                        island.last_activity_id = a.id;
+                    }
+                    let mut state = self.state.lock().unwrap();
+                    state.dirty = true;
+                    drop(state);
+                }
+            }
+        }
+
+        let mut state = self.state.lock().unwrap();
+        state.check_expired_refocus();
+
+        let dirty = state.dirty;
+        if dirty {
+            state.dirty = false;
+        }
+        drop(state);
+
+        if dirty {
+            self.sync();
+        }
+    }
+
+    fn idle_timeout(&self) -> Option<Duration> {
+        Some(Duration::from_millis(200))
+    }
+
+    fn on_keyboard_leave(
+        &mut self,
+        _ctx: &AppContext,
+        _surface: &wayland_client::protocol::wl_surface::WlSurface,
+    ) {
+        // Close expanded stack on focus loss.
+        let mut changed = false;
+        for island in &mut self.islands {
+            if island.mode == IslandMode::Expanded {
+                Self::close_cards_for(island);
+                island.mode = IslandMode::Compact;
+                changed = true;
+            }
+        }
+        // Shorten the focus timeout — go to Mini after 0.5s instead of full 2s.
+        let fast_timeout = Duration::from_secs_f64(FOCUS_TIMEOUT_SECS - 0.5);
+        self.last_interaction = std::time::Instant::now() - fast_timeout;
+        if changed {
+            let mut state = self.state.lock().unwrap();
+            state.dirty = true;
+        }
+    }
+
+    fn on_pointer_event(&mut self, _ctx: &AppContext, events: &[PointerEvent]) {
+        self.last_interaction = std::time::Instant::now();
+        for event in events {
+            match event.kind {
+                PointerEventKind::Enter { .. } | PointerEventKind::Motion { .. } => {
+                    let (px, py) = event.position;
+                    let hit = self.hit_test(px as f32, py as f32);
+                    let new_hovered = hit.as_ref().map(|(app_id, _)| app_id.clone());
+                    if new_hovered != self.hovered_app {
+                        let old = &self.hovered_app;
+                        // Relayout when a Mini or Compact island gains/loses hover (for grow effect).
+                        let has_hover_grow = |app: &Option<String>| -> bool {
+                            app.as_ref()
+                                .and_then(|a| self.islands.iter().find(|i| i.app_id == *a))
+                                .is_some_and(|i| {
+                                    i.mode == IslandMode::Mini || i.mode == IslandMode::Compact
+                                })
+                        };
+                        let needs_relayout = has_hover_grow(old) || has_hover_grow(&new_hovered);
+                        self.hovered_app = new_hovered;
+                        if needs_relayout {
+                            let mut state = self.state.lock().unwrap();
+                            state.dirty = true;
+                        }
+                    }
+                    if hit.is_some() {
+                        AppContext::set_cursor_shape(otto_kit::CursorShape::Pointer);
+                    } else {
+                        AppContext::set_cursor_shape(otto_kit::CursorShape::Default);
+                    }
+                }
+                PointerEventKind::Leave { .. } => {
+                    if self.hovered_app.is_some() {
+                        self.hovered_app = None;
+                        let mut state = self.state.lock().unwrap();
+                        state.dirty = true;
+                    }
+                    AppContext::set_cursor_shape(otto_kit::CursorShape::Default);
+                }
+                PointerEventKind::Press { button: 0x110, .. } => {
+                    let (px, py) = event.position;
+                    self.handle_click(px as f32, py as f32);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// D-Bus helpers
+// ---------------------------------------------------------------------------
+
+/// The D-Bus connection that owns the org.otto.Island bus name.
+/// Signals must be emitted from this connection so receivers matching on
+/// sender="org.otto.Island" can see them.
+static ISLAND_DBUS_CONNECTION: std::sync::OnceLock<zbus::Connection> = std::sync::OnceLock::new();
+
+/// Ask the compositor to focus the given app's window via D-Bus.
+fn request_focus_app(app_id: String) {
+    tokio::spawn(async move {
+        let connection = match zbus::Connection::session().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("failed to connect to session bus for focus_app: {e}");
+                return;
+            }
+        };
+        let reply = connection
+            .call_method(
+                Some("org.otto.Compositor"),
+                "/org/otto/Compositor",
+                Some("org.otto.Compositor"),
+                "FocusApp",
+                &(app_id.as_str(),),
+            )
+            .await;
+        if let Err(e) = reply {
+            tracing::warn!(app_id, "focus_app D-Bus call failed: {e}");
+        }
+    });
+}
+
+/// Emit the org.freedesktop.Notifications ActionInvoked signal.
+fn emit_action_invoked(notification_id: u32, action_key: String) {
+    tokio::spawn(async move {
+        let connection = match zbus::Connection::session().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("failed to connect to session bus for ActionInvoked: {e}");
+                return;
+            }
+        };
+        let result = connection
+            .emit_signal(
+                None::<&str>,
+                "/org/freedesktop/Notifications",
+                "org.freedesktop.Notifications",
+                "ActionInvoked",
+                &(notification_id, action_key.as_str()),
+            )
+            .await;
+        if let Err(e) = result {
+            tracing::warn!(notification_id, "ActionInvoked signal failed: {e}");
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let state: SharedState = Arc::new(Mutex::new(IslandState::new()));
+
+    // Spawn org.otto.Island1 D-Bus service
+    let dbus_state = state.clone();
+    tokio::spawn(async move {
+        let service = IslandService::new(dbus_state);
+
+        let connection = match zbus::ConnectionBuilder::session()
+            .expect("session bus")
+            .name(DBUS_NAME)
+            .expect("claim D-Bus name")
+            .build()
+            .await
+        {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::error!("Failed to build D-Bus connection: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = connection
+            .object_server()
+            .at(dbus_service::DBUS_PATH, service)
+            .await
+        {
+            tracing::error!("Failed to register D-Bus object: {e}");
+            return;
+        }
+
+        let _ = ISLAND_DBUS_CONNECTION.set(connection);
+        tracing::info!("D-Bus service running on {DBUS_NAME}");
+        std::future::pending::<()>().await;
+    });
+
+    // Spawn org.freedesktop.Notifications daemon
+    let notif_state = state.clone();
+    tokio::spawn(async move {
+        let daemon = notifications::NotificationDaemon::new(notif_state);
+
+        let connection = match zbus::ConnectionBuilder::session()
+            .expect("session bus")
+            .name(notifications::NOTIFICATIONS_DBUS_NAME)
+            .expect("claim notifications name")
+            .build()
+            .await
+        {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::error!("Failed to build notifications D-Bus connection: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = connection
+            .object_server()
+            .at(notifications::NOTIFICATIONS_DBUS_PATH, daemon)
+            .await
+        {
+            tracing::error!("Failed to register notifications object: {e}");
+            return;
+        }
+
+        tracing::info!(
+            "Notifications daemon running on {}",
+            notifications::NOTIFICATIONS_DBUS_NAME
+        );
+        std::future::pending::<()>().await;
+    });
+
+    let app = IslandApp::new(state);
+    AppRunner::new(app).run()?;
+
+    Ok(())
+}

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1008,8 +1008,7 @@ impl App for IslandApp {
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
                 Self::close_cards_for(island);
-                island.closing_at =
-                    Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
+                island.closing_at = Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
                 changed = true;
             }
         }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -997,8 +997,8 @@ impl App for IslandApp {
                 changed = true;
             }
         }
-        // Shorten the focus timeout — go to Mini after 0.5s instead of full timeout.
-        let fast_timeout = Duration::from_secs_f64(FOCUS_TIMEOUT_SECS - 0.5);
+        // Shorten the focus timeout — go to Mini after 2s instead of full timeout.
+        let fast_timeout = Duration::from_secs_f64(FOCUS_TIMEOUT_SECS - 2.0);
         self.last_interaction = std::time::Instant::now() - fast_timeout;
         if changed {
             let mut state = self.state.lock().unwrap();

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -911,6 +911,10 @@ impl App for IslandApp {
         self.flush_pending_destroy();
 
         // Focus timeout: shrink Compact → Mini after inactivity.
+        // Pause the timer while the pointer is hovering over any island.
+        if self.hovered_app.is_some() {
+            self.last_interaction = std::time::Instant::now();
+        }
         let elapsed = self.last_interaction.elapsed().as_secs_f64();
         if elapsed >= FOCUS_TIMEOUT_SECS && self.focused_app.is_some() {
             let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
@@ -988,18 +992,18 @@ impl App for IslandApp {
         _ctx: &AppContext,
         _surface: &wayland_client::protocol::wl_surface::WlSurface,
     ) {
-        // Close expanded stack on focus loss.
+        // Close expanded stack on focus loss — animate cards out first.
         let mut changed = false;
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
                 Self::close_cards_for(island);
-                island.mode = IslandMode::Compact;
+                island.closing_at =
+                    Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
                 changed = true;
             }
         }
-        // Shorten the focus timeout — go to Mini after 2s instead of full timeout.
-        let fast_timeout = Duration::from_secs_f64(FOCUS_TIMEOUT_SECS - 2.0);
-        self.last_interaction = std::time::Instant::now() - fast_timeout;
+        // Restart the focus timeout from now.
+        self.last_interaction = std::time::Instant::now();
         if changed {
             let mut state = self.state.lock().unwrap();
             state.dirty = true;

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -32,7 +32,7 @@ const LAYER_H: u32 = 400; // Tall enough for pill + MAX_VISIBLE_CARDS cards.
 const BAR_HEIGHT: f32 = 36.0;
 const GAP: f32 = 6.0;
 /// Seconds of inactivity before the focused island shrinks to Mini.
-const FOCUS_TIMEOUT_SECS: f64 = 2.0;
+const FOCUS_TIMEOUT_SECS: f64 = 4.0;
 
 // ---------------------------------------------------------------------------
 // Island — one notification group or music activity
@@ -997,7 +997,7 @@ impl App for IslandApp {
                 changed = true;
             }
         }
-        // Shorten the focus timeout — go to Mini after 0.5s instead of full 2s.
+        // Shorten the focus timeout — go to Mini after 0.5s instead of full timeout.
         let fast_timeout = Duration::from_secs_f64(FOCUS_TIMEOUT_SECS - 0.5);
         self.last_interaction = std::time::Instant::now() - fast_timeout;
         if changed {

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -444,23 +444,34 @@ impl IslandApp {
 
         // Apply pulse and peek as Compact for new notifications.
         for (idx, w, h, cx, cy) in pulse_targets {
-            tracing::info!(
-                app_id = %self.islands[idx].app_id,
-                from = ?self.islands[idx].mode,
-                "pulse → peek Compact for 3s"
-            );
-            renderer::animate_pulse(
-                &self.islands[idx].surface,
-                w,
-                h,
-                cx,
-                cy,
-                h as f64 / 2.0,
-                6.0,
-            );
-            self.islands[idx].last_layout = (w, h, cx, cy);
-            self.islands[idx].peek_until = Some(std::time::Instant::now() + Duration::from_secs(3));
-            self.islands[idx].mode = IslandMode::Compact;
+            let current_mode = self.islands[idx].mode;
+            // If already Compact or Expanded, don't downgrade — just refresh content.
+            if current_mode == IslandMode::Expanded || current_mode == IslandMode::Compact {
+                tracing::info!(
+                    app_id = %self.islands[idx].app_id,
+                    mode = ?current_mode,
+                    "new notification while open — refresh only"
+                );
+            } else {
+                tracing::info!(
+                    app_id = %self.islands[idx].app_id,
+                    from = ?current_mode,
+                    "pulse → peek Compact for 3s"
+                );
+                renderer::animate_pulse(
+                    &self.islands[idx].surface,
+                    w,
+                    h,
+                    cx,
+                    cy,
+                    h as f64 / 2.0,
+                    6.0,
+                );
+                self.islands[idx].last_layout = (w, h, cx, cy);
+                self.islands[idx].peek_until =
+                    Some(std::time::Instant::now() + Duration::from_secs(3));
+                self.islands[idx].mode = IslandMode::Compact;
+            }
             self.islands[idx].last_layout = (0.0, 0.0, 0.0, 0.0);
             // Update tracking now so the next sync doesn't re-trigger.
             let app_id = &self.islands[idx].app_id;

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -27,7 +27,7 @@ use crate::state::{IslandState, SharedState};
 // Constants
 // ---------------------------------------------------------------------------
 
-const LAYER_W: u32 = 480;
+const LAYER_W: u32 = 800;
 const LAYER_H: u32 = 400; // Tall enough for pill + MAX_VISIBLE_CARDS cards.
 const BAR_HEIGHT: f32 = 36.0;
 const GAP: f32 = 6.0;
@@ -114,6 +114,17 @@ impl IslandApp {
         }
     }
 
+    /// Compute the current effective layer width based on island layout.
+    fn layer_width(&self) -> f32 {
+        let total_w: f32 = self
+            .islands
+            .iter()
+            .map(|i| i.last_layout.0.max(MINI_H))
+            .sum::<f32>()
+            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
+        (total_w + 40.0).max(LAYER_W as f32)
+    }
+
     /// Get the parent wl_surface for creating subsurfaces.
     fn wl_surface(&self) -> Option<wayland_client::protocol::wl_surface::WlSurface> {
         self.layer_surface
@@ -129,7 +140,7 @@ impl IslandApp {
             SubsurfaceSurface::new(&wl, 0, 0, renderer::SLOT_BUF_W, renderer::SLOT_BUF_H).ok()?;
         apply_island_style(&surface, MINI_H as f64 / 2.0, ContentsGravity::Center);
         // Center coordinates (anchor point is 0.5, 0.5).
-        let cx = LAYER_W as f32 / 2.0;
+        let cx = self.layer_width() / 2.0;
         let cy = BAR_HEIGHT / 2.0;
         set_size_and_position(&surface, MINI_W, MINI_H, cx, cy);
         surface.draw(|canvas| {
@@ -187,7 +198,7 @@ impl IslandApp {
             } else {
                 let mut island = self.islands.remove(i);
                 tracing::info!(app_id = %island.app_id, "island removed");
-                let cx = LAYER_W as f32 / 2.0;
+                let cx = self.layer_width() / 2.0;
                 let cy = BAR_HEIGHT / 2.0;
                 let h = COMPACT_H;
                 renderer::animate_to_with_opacity(
@@ -331,7 +342,7 @@ impl IslandApp {
             .sum::<f32>()
             + (self.islands.len() - 1) as f32 * GAP;
 
-        let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
+        let mut x = ((self.layer_width() - total_w) / 2.0).max(0.0);
 
         // Collect positions for expanded islands, pulse targets, and layout targets.
         let mut expanded_layouts: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
@@ -474,7 +485,6 @@ impl IslandApp {
                     Some(std::time::Instant::now() + Duration::from_secs(3));
                 self.islands[idx].mode = IslandMode::Compact;
             }
-            self.islands[idx].last_layout = (0.0, 0.0, 0.0, 0.0);
             // Update tracking now so the next sync doesn't re-trigger.
             let app_id = &self.islands[idx].app_id;
             if let Some((a, c)) = grouped.iter().find(|(a, _)| &a.app_id == app_id) {
@@ -669,7 +679,16 @@ impl IslandApp {
             }
         }
 
-        layer.set_size(LAYER_W, max_h.ceil() as u32);
+        // Compute the minimum width needed for all islands.
+        let total_w: f32 = self
+            .islands
+            .iter()
+            .map(|i| i.last_layout.0.max(MINI_H))
+            .sum::<f32>()
+            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
+        let needed_w = (total_w + 40.0).max(LAYER_W as f32); // padding + minimum
+
+        layer.set_size(needed_w.ceil() as u32, max_h.ceil() as u32);
     }
 
     fn update_input_region(&self) {
@@ -682,43 +701,35 @@ impl IslandApp {
         // Add input rects when there are visible islands.
         // Empty region = zero input area (clicks pass through).
         if !self.islands.is_empty() {
-            // One rect per island, positioned to match layout exactly.
-            let island_size_for_input = |island: &Island| -> (f32, f32) {
-                match island.mode {
-                    IslandMode::Mini => {
-                        let w = island.last_layout.0.max(MINI_H);
-                        (w, MINI_H)
-                    }
-                    IslandMode::Compact => {
-                        let w = island.last_layout.0.max(MINI_H);
-                        (w, COMPACT_H)
-                    }
-                    IslandMode::Expanded => {
-                        let w = island.last_layout.0.max(renderer::CARD_W);
-                        (w, COMPACT_H)
-                    }
-                }
-            };
-            let total_w: f32 = self
-                .islands
-                .iter()
-                .map(|i| island_size_for_input(i).0)
-                .sum::<f32>()
-                + (self.islands.len() - 1) as f32 * GAP;
-
-            let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
+            // One rect per island, derived from last_layout (center coords).
             for island in &self.islands {
-                let (w, h) = island_size_for_input(island);
-                let y = (BAR_HEIGHT - h) / 2.0;
-                region.add(x as i32, y as i32, w.ceil() as i32, h.ceil() as i32);
-                x += w + GAP;
+                let (w, _h, cx, _cy) = island.last_layout;
+                let pill_h = match island.mode {
+                    IslandMode::Mini => MINI_H,
+                    IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+                };
+                let pill_w = match island.mode {
+                    IslandMode::Expanded => w.max(renderer::CARD_W),
+                    _ => w.max(MINI_H),
+                };
+                let x = cx - pill_w / 2.0;
+                let y = (BAR_HEIGHT - pill_h) / 2.0;
+                region.add(
+                    x.max(0.0) as i32,
+                    y as i32,
+                    pill_w.ceil() as i32,
+                    pill_h.ceil() as i32,
+                );
             }
 
-            // Card stack region — one continuous rect covering all cards + gaps.
+            // Card stack region — one rect per expanded island, positioned under its pill.
             for island in &self.islands {
                 if island.mode != IslandMode::Expanded || island.cards.is_empty() {
                     continue;
                 }
+                let pill_w = island.last_layout.0;
+                let pill_cx = island.last_layout.2;
+                let pill_left = pill_cx - pill_w / 2.0;
                 let pill_h = COMPACT_H;
                 let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
                 let card_w = renderer::CARD_W;
@@ -727,9 +738,9 @@ impl IslandApp {
                 let card_count = island.cards.len() as f32;
                 let stack_top = pill_bottom + card_gap;
                 let stack_h = card_count * card_h + (card_count - 1.0) * card_gap;
-                let card_region_x = ((LAYER_W as f32 - card_w) / 2.0).max(0.0);
+                let card_region_x = pill_left + (pill_w - card_w) / 2.0;
                 region.add(
-                    card_region_x as i32,
+                    card_region_x.max(0.0) as i32,
                     stack_top as i32,
                     card_w.ceil() as i32,
                     stack_h.ceil() as i32,
@@ -749,41 +760,28 @@ impl IslandApp {
     /// Returns (app_id, Option<activity_id>) for what's at (px, py).
     /// activity_id is Some when a card is hit.
     fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>)> {
-        let get_size = |island: &Island| -> (f32, f32) {
-            match island.mode {
-                IslandMode::Mini => {
-                    let w = island.last_layout.0.max(MINI_H);
-                    (w, MINI_H)
-                }
-                IslandMode::Compact => {
-                    let w = island.last_layout.0.max(MINI_H);
-                    (w, COMPACT_H)
-                }
-                IslandMode::Expanded => {
-                    let w = island.last_layout.0.max(renderer::CARD_W);
-                    (w, COMPACT_H)
-                }
-            }
-        };
-
-        let total_w: f32 = self.islands.iter().map(|i| get_size(i).0).sum::<f32>()
-            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
-
-        let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
-
         for island in &self.islands {
-            let (w, h) = get_size(island);
-            let y = (BAR_HEIGHT - h) / 2.0;
+            let (w, _h, cx, _cy) = island.last_layout;
+            let pill_h = match island.mode {
+                IslandMode::Mini => MINI_H,
+                IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+            };
+            let pill_w = match island.mode {
+                IslandMode::Expanded => w.max(renderer::CARD_W),
+                _ => w.max(MINI_H),
+            };
+            let x = cx - pill_w / 2.0;
+            let y = (BAR_HEIGHT - pill_h) / 2.0;
 
             // Hit test cards first (they sit below the pill).
             if island.mode == IslandMode::Expanded {
                 let card_w = renderer::CARD_W;
                 let card_h = renderer::CARD_H;
                 let card_gap = renderer::CARD_GAP;
-                let card_x = x + (w - card_w) / 2.0;
+                let card_x = x + (pill_w - card_w) / 2.0;
 
                 for (i, card) in island.cards.iter().enumerate() {
-                    let card_y = y + h + card_gap + (i as f32) * (card_h + card_gap);
+                    let card_y = y + pill_h + card_gap + (i as f32) * (card_h + card_gap);
                     if px >= card_x
                         && px <= card_x + card_w
                         && py >= card_y
@@ -795,11 +793,9 @@ impl IslandApp {
             }
 
             // Hit test pill/circle.
-            if px >= x && px <= x + w && py >= y && py <= y + h {
+            if px >= x && px <= x + pill_w && py >= y && py <= y + pill_h {
                 return Some((island.app_id.clone(), None));
             }
-
-            x += w + GAP;
         }
 
         None

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -64,8 +64,6 @@ struct Island {
     cards: Vec<CardSurface>,
     /// Current mode.
     mode: IslandMode,
-    /// When set, the island is closing its stack and will switch to Compact at this instant.
-    closing_at: Option<std::time::Instant>,
     /// When this group first appeared.
     created_at: std::time::Instant,
     /// Last known notification count (for pulse detection).
@@ -178,6 +176,7 @@ impl IslandApp {
         }
 
         // Remove islands whose app_id is no longer present.
+        let mut removed_island = false;
         let mut i = 0;
         while i < self.islands.len() {
             if desired
@@ -209,6 +208,7 @@ impl IslandApp {
                     self.defer_destroy(card.surface);
                 }
                 self.defer_destroy(island.surface);
+                removed_island = true;
             }
         }
 
@@ -224,15 +224,17 @@ impl IslandApp {
                         surface,
                         cards: Vec::new(),
                         mode: IslandMode::Mini,
-                        closing_at: None,
                         created_at: std::time::Instant::now(),
                         last_count: 0,
                         last_activity_id: 0,
                         peek_until: None,
                         last_layout: (0.0, 0.0, 0.0, 0.0),
                     });
-                    // Auto-focus newly arrived island + reset interaction timer.
-                    self.focused_app = Some(app_id.clone());
+                    // Auto-focus only if no island is currently Expanded.
+                    let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
+                    if !any_expanded {
+                        self.focused_app = Some(app_id.clone());
+                    }
                     self.last_interaction = std::time::Instant::now();
                 }
             }
@@ -249,20 +251,19 @@ impl IslandApp {
         }
 
         // Assign modes: focused gets Compact/Expanded, peeking stays Compact, rest → Mini.
+        // Expanded islands are preserved — they coexist with Compact (peeking) islands.
         for island in &mut self.islands {
-            if Some(&island.app_id) == self.focused_app.as_ref() {
+            if island.mode == IslandMode::Expanded {
+                // Expanded stays Expanded — only user interaction (click/focus loss) closes it.
+            } else if Some(&island.app_id) == self.focused_app.as_ref() {
                 if island.mode == IslandMode::Mini {
                     island.mode = IslandMode::Compact;
                     tracing::debug!(app_id = %island.app_id, "Mini → Compact (focused)");
                 }
             } else if island.peek_until.is_some() {
                 // Peeking — stay Compact until peek expires.
-            } else if island.mode == IslandMode::Expanded {
-                // Non-focused expanded → close and shrink.
-                Self::close_cards_for(island);
-                island.mode = IslandMode::Mini;
             } else {
-                // Non-focused, non-peeking → Mini.
+                // Non-focused, non-peeking, non-expanded → Mini.
                 if island.mode != IslandMode::Mini {
                     tracing::debug!(app_id = %island.app_id, from = ?island.mode, "→ Mini");
                 }
@@ -270,7 +271,7 @@ impl IslandApp {
             }
         }
 
-        self.layout(&grouped);
+        self.layout(&grouped, removed_island);
     }
 
     /// Close the card stack — animate out but keep surfaces alive for reuse.
@@ -296,7 +297,7 @@ impl IslandApp {
     // Layout: position all islands and their cards
     // -----------------------------------------------------------------------
 
-    fn layout(&mut self, grouped: &[(Activity, usize)]) {
+    fn layout(&mut self, grouped: &[(Activity, usize)], reposition_delay: bool) {
         if self.islands.is_empty() {
             self.update_layer_size();
             self.update_input_region();
@@ -309,7 +310,7 @@ impl IslandApp {
             let count = entry.map(|(_, c)| *c).unwrap_or(1);
             let title = entry.map(|(a, _)| a.title.as_str()).unwrap_or("");
             match mode {
-                IslandMode::Mini => (MINI_W, MINI_H),
+                IslandMode::Mini => (renderer::mini_width(count), MINI_H),
                 IslandMode::Compact => {
                     let w = renderer::pill_width(&island.app_id, title, count);
                     (w, COMPACT_H)
@@ -422,7 +423,7 @@ impl IslandApp {
                         layout_targets.push((idx, w, h, cx, cy));
                     }
 
-                    if island.mode == IslandMode::Expanded && island.closing_at.is_none() {
+                    if island.mode == IslandMode::Expanded {
                         // Store top-left x for card positioning.
                         expanded_layouts.push((idx, x, cx, cy, w));
                     }
@@ -433,11 +434,12 @@ impl IslandApp {
         }
 
         // Apply layout animations only when target changed.
+        let layout_delay = if reposition_delay { 0.4 } else { 0.0 };
         for (idx, w, h, x, y) in layout_targets {
             let target = (w, h, x, y);
             if self.islands[idx].last_layout != target {
                 let radius = h as f64 / 2.0;
-                animate_to(&self.islands[idx].surface, w, h, x, y, radius, 0.0);
+                animate_to(&self.islands[idx].surface, w, h, x, y, radius, layout_delay);
                 self.islands[idx].last_layout = target;
             }
         }
@@ -592,7 +594,7 @@ impl IslandApp {
                     if let Some(ss) = island.cards[cidx].surface.base_surface().surface_style() {
                         ss.set_opacity(0.0);
                     }
-                    renderer::animate_position_opacity(
+                    renderer::animate_position_opacity_slow(
                         &island.cards[cidx].surface,
                         card_w,
                         card_h,
@@ -603,7 +605,7 @@ impl IslandApp {
                     );
                 } else {
                     // Existing card: animate to position + ensure visible.
-                    renderer::animate_position_opacity(
+                    renderer::animate_position_opacity_slow(
                         &island.cards[cidx].surface,
                         card_w,
                         card_h,
@@ -683,9 +685,12 @@ impl IslandApp {
             // One rect per island, positioned to match layout exactly.
             let island_size_for_input = |island: &Island| -> (f32, f32) {
                 match island.mode {
-                    IslandMode::Mini => (MINI_W, MINI_H),
+                    IslandMode::Mini => {
+                        let w = island.last_layout.0.max(MINI_H);
+                        (w, MINI_H)
+                    }
                     IslandMode::Compact => {
-                        let w = island.last_layout.0.max(MINI_W);
+                        let w = island.last_layout.0.max(MINI_H);
                         (w, COMPACT_H)
                     }
                     IslandMode::Expanded => {
@@ -746,9 +751,12 @@ impl IslandApp {
     fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>)> {
         let get_size = |island: &Island| -> (f32, f32) {
             match island.mode {
-                IslandMode::Mini => (MINI_W, MINI_H),
+                IslandMode::Mini => {
+                    let w = island.last_layout.0.max(MINI_H);
+                    (w, MINI_H)
+                }
                 IslandMode::Compact => {
-                    let w = island.last_layout.0.max(MINI_W);
+                    let w = island.last_layout.0.max(MINI_H);
                     (w, COMPACT_H)
                 }
                 IslandMode::Expanded => {
@@ -807,6 +815,22 @@ impl IslandApp {
         };
 
         if let Some(activity_id) = card_id {
+            // Determine if the click is in the close zone (right 40px of card).
+            let close_zone = 40.0_f32;
+            let is_close = self
+                .islands
+                .iter()
+                .find(|i| i.app_id == app_id)
+                .map(|island| {
+                    let pill_w = island.last_layout.0;
+                    let pill_cx = island.last_layout.2;
+                    let card_w = renderer::CARD_W;
+                    let pill_x = pill_cx - pill_w / 2.0;
+                    let card_x = pill_x + (pill_w - card_w) / 2.0;
+                    px - card_x > card_w - close_zone
+                })
+                .unwrap_or(false);
+
             // Clicked a card — animate dismiss (scale up + fade out), then remove.
             if let Some(island) = self.islands.iter().find(|i| i.app_id == app_id) {
                 if let Some(card) = island.cards.iter().find(|c| c.activity_id == activity_id) {
@@ -829,24 +853,34 @@ impl IslandApp {
                 tracing::info!(
                     activity_id,
                     %app_id,
+                    close = is_close,
                     action = ?activity.default_action,
-                    "notification action invoked"
+                    "card clicked"
                 );
             }
 
             state.dismiss_activity(activity_id);
             drop(state);
 
-            // Focus the app that sent the notification.
-            request_focus_app(app_id.clone());
+            if !is_close {
+                // Action click — focus the app and emit ActionInvoked.
+                request_focus_app(app_id.clone());
 
-            // Emit ActionInvoked D-Bus signal for the notification spec.
-            if let Some(nid) = notification_id {
-                let action_key = default_action.as_deref().unwrap_or("default").to_string();
-                emit_action_invoked(nid, action_key);
+                if let Some(nid) = notification_id {
+                    let action_key = default_action.as_deref().unwrap_or("default").to_string();
+                    emit_action_invoked(nid, action_key);
+                }
             }
         } else {
             // Clicked a pill/circle.
+            // Close any other expanded island first — only one can be expanded at a time.
+            for island in self.islands.iter_mut().filter(|i| i.app_id != app_id) {
+                if island.mode == IslandMode::Expanded {
+                    Self::close_cards_for(island);
+                    island.mode = IslandMode::Compact;
+                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
+                }
+            }
             let island = self.islands.iter_mut().find(|i| i.app_id == app_id);
             if let Some(island) = island {
                 match island.mode {
@@ -860,8 +894,8 @@ impl IslandApp {
                     IslandMode::Expanded => {
                         tracing::info!(%app_id, "click: Expanded → Compact");
                         Self::close_cards_for(island);
-                        island.closing_at =
-                            Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
+                        island.mode = IslandMode::Compact;
+                        island.last_layout = (0.0, 0.0, 0.0, 0.0);
                         // Keep focus so timeout governs Mini transition.
                         self.focused_app = Some(app_id.clone());
                         self.last_interaction = std::time::Instant::now();
@@ -942,20 +976,7 @@ impl App for IslandApp {
             }
         }
 
-        // Closing timeout: cards faded out, now shrink pill to Compact.
         let now = std::time::Instant::now();
-        for island in &mut self.islands {
-            if let Some(at) = island.closing_at {
-                if now >= at {
-                    island.closing_at = None;
-                    island.mode = IslandMode::Compact;
-                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
-                    let mut state = self.state.lock().unwrap();
-                    state.dirty = true;
-                    drop(state);
-                }
-            }
-        }
 
         // Peek timeout: revert Compact peek back to Mini.
         for island in &mut self.islands {
@@ -1008,7 +1029,8 @@ impl App for IslandApp {
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
                 Self::close_cards_for(island);
-                island.closing_at = Some(std::time::Instant::now() + Duration::from_secs_f64(0.4));
+                island.mode = IslandMode::Compact;
+                island.last_layout = (0.0, 0.0, 0.0, 0.0);
                 changed = true;
             }
         }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -330,7 +330,7 @@ impl IslandApp {
             .sum::<f32>()
             + (self.islands.len() - 1) as f32 * GAP;
 
-        let mut x = (LAYER_W as f32 - total_w) / 2.0;
+        let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
 
         // Collect positions for expanded islands, pulse targets, and layout targets.
         let mut expanded_layouts: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
@@ -750,7 +750,7 @@ impl IslandApp {
         let total_w: f32 = self.islands.iter().map(|i| get_size(i).0).sum::<f32>()
             + (self.islands.len().saturating_sub(1)) as f32 * GAP;
 
-        let mut x = (LAYER_W as f32 - total_w) / 2.0;
+        let mut x = ((LAYER_W as f32 - total_w) / 2.0).max(0.0);
 
         for island in &self.islands {
             let (w, h) = get_size(island);

--- a/components/otto-islands/src/notifications.rs
+++ b/components/otto-islands/src/notifications.rs
@@ -1,0 +1,182 @@
+//! org.freedesktop.Notifications daemon implementation.
+//!
+//! Implements the Desktop Notifications Specification (1.2) so that
+//! native apps (notify-send, Firefox, Thunderbird, etc.) can send
+//! notifications that appear as island activities.
+
+use otto_kit::AppContext;
+use std::collections::HashMap;
+use zbus::interface;
+use zbus::zvariant::Value;
+
+use crate::activity::{NotificationAction, Priority};
+use crate::state::SharedState;
+
+pub const NOTIFICATIONS_DBUS_NAME: &str = "org.freedesktop.Notifications";
+pub const NOTIFICATIONS_DBUS_PATH: &str = "/org/freedesktop/Notifications";
+
+const DEFAULT_TIMEOUT_MS: u32 = 5000;
+
+pub struct NotificationDaemon {
+    state: SharedState,
+}
+
+impl NotificationDaemon {
+    pub fn new(state: SharedState) -> Self {
+        Self { state }
+    }
+}
+
+#[interface(name = "org.freedesktop.Notifications")]
+impl NotificationDaemon {
+    /// Returns the capabilities of this notification server.
+    async fn get_capabilities(&self) -> Vec<String> {
+        vec![
+            "body".into(),
+            "body-markup".into(),
+            "actions".into(),
+            "persistence".into(),
+            "icon-static".into(),
+            "action-icons".into(),
+        ]
+    }
+
+    /// Send a notification. Returns a unique notification ID.
+    async fn notify(
+        &self,
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: Vec<String>,
+        hints: HashMap<String, Value<'_>>,
+        expire_timeout: i32,
+    ) -> zbus::fdo::Result<u32> {
+        // Parse hints
+        let priority = parse_urgency(&hints);
+        let category = parse_string_hint(&hints, "category");
+        let image_path = parse_string_hint(&hints, "image-path");
+        let desktop_entry = parse_string_hint(&hints, "desktop-entry");
+        let transient = parse_bool_hint(&hints, "transient");
+        let resident = parse_bool_hint(&hints, "resident");
+
+        // Determine app_id: prefer desktop-entry hint, fall back to app_name
+        let app_id = desktop_entry.unwrap_or_else(|| app_name.to_string());
+
+        // Resolve icon: prefer app_icon param, then image-path hint, then app_id
+        let icon = if !app_icon.is_empty() {
+            app_icon.to_string()
+        } else if let Some(ref path) = image_path {
+            path.clone()
+        } else {
+            // Fall back to app_id as icon name (works for desktop entries like com.mitchellh.ghostty)
+            app_id.clone()
+        };
+
+        // Parse timeout
+        let timeout_ms = match expire_timeout {
+            -1 => DEFAULT_TIMEOUT_MS,
+            0 => 0, // persistent
+            t if t > 0 => t as u32,
+            _ => DEFAULT_TIMEOUT_MS,
+        };
+
+        // Parse actions: alternating [id, label, id, label, ...]
+        let mut parsed_actions = Vec::new();
+        let mut default_action = None;
+        let mut iter = actions.iter();
+        while let Some(id) = iter.next() {
+            if let Some(label) = iter.next() {
+                if id == "default" {
+                    default_action = Some(label.clone());
+                } else {
+                    parsed_actions.push(NotificationAction {
+                        id: id.clone(),
+                        label: label.clone(),
+                    });
+                }
+            }
+        }
+
+        let mut state = self.state.lock().unwrap();
+        let (activity_id, notification_id) = state.create_notification(
+            app_id,
+            replaces_id,
+            icon,
+            summary.to_string(),
+            body.to_string(),
+            parsed_actions,
+            priority,
+            timeout_ms,
+            category,
+            image_path,
+            transient,
+            resident,
+            default_action,
+        );
+        drop(state);
+
+        AppContext::request_wakeup();
+        tracing::info!(
+            notification_id,
+            activity_id,
+            app_name,
+            app_icon,
+            summary,
+            body,
+            "notification created"
+        );
+
+        Ok(notification_id)
+    }
+
+    /// Close a notification by ID.
+    async fn close_notification(&self, id: u32) -> zbus::fdo::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        let dismissed = state.dismiss_notification(id);
+        drop(state);
+
+        if dismissed {
+            AppContext::request_wakeup();
+            tracing::info!(id, "notification closed");
+        }
+        Ok(())
+    }
+
+    /// Return server information.
+    async fn get_server_information(&self) -> (String, String, String, String) {
+        (
+            "Otto Islands".into(),
+            "otto-compositor".into(),
+            "0.1.0".into(),
+            "1.2".into(),
+        )
+    }
+
+    // TODO: Signals — these require zbus SignalContext
+    // NotificationClosed(id: u32, reason: u32)
+    // ActionInvoked(id: u32, action_key: String)
+}
+
+fn parse_urgency(hints: &HashMap<String, Value>) -> Priority {
+    if let Some(Value::U8(u)) = hints.get("urgency") {
+        Priority::from(*u)
+    } else {
+        Priority::Normal
+    }
+}
+
+fn parse_string_hint(hints: &HashMap<String, Value>, key: &str) -> Option<String> {
+    match hints.get(key) {
+        Some(Value::Str(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_bool_hint(hints: &HashMap<String, Value>, key: &str) -> bool {
+    match hints.get(key) {
+        Some(Value::Bool(b)) => *b,
+        _ => false,
+    }
+}

--- a/components/otto-islands/src/notifications.rs
+++ b/components/otto-islands/src/notifications.rs
@@ -89,7 +89,7 @@ impl NotificationDaemon {
         while let Some(id) = iter.next() {
             if let Some(label) = iter.next() {
                 if id == "default" {
-                    default_action = Some(label.clone());
+                    default_action = Some(id.clone());
                 } else {
                     parsed_actions.push(NotificationAction {
                         id: id.clone(),

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -55,7 +55,7 @@ pub fn pill_width(app_id: &str, title: &str, count: usize) -> f32 {
     .font();
     let (text_w, _) = font.measure_str(&label, None);
 
-    (text_x + text_w + badge_w + pad).clamp(MINI_W, 300.0)
+    (text_x + text_w + badge_w + pad).clamp(MINI_W, 340.0)
 }
 
 pub fn draw_pill(

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -1,0 +1,528 @@
+use crate::activity::Activity;
+use otto_kit::desktop_entry::lookup_app;
+use otto_kit::icons::named_icon_sized;
+use otto_kit::protocols::otto_surface_style_v1::{BlendMode, ClipMode, ContentsGravity};
+use otto_kit::typography::TextStyle;
+use otto_kit::AppContext;
+use skia_safe::{Canvas, Color, Paint, RRect, Rect};
+
+// ---------------------------------------------------------------------------
+// Constants (from spec)
+// ---------------------------------------------------------------------------
+
+pub const MINI_W: f32 = 44.0;
+pub const MINI_H: f32 = 28.0;
+pub const COMPACT_W: f32 = 240.0;
+pub const COMPACT_H: f32 = 36.0;
+pub const CARD_W: f32 = 300.0;
+pub const CARD_H: f32 = 60.0;
+pub const CARD_GAP: f32 = 4.0;
+pub const CARD_RADIUS: f32 = 10.0;
+pub const HOVER_GROW: f32 = 4.0;
+
+pub const BUFFER_SCALE: f64 = 2.0;
+pub const SLOT_BUF_W: i32 = 460;
+pub const SLOT_BUF_H: i32 = 140;
+
+// ---------------------------------------------------------------------------
+// Drawing: group pill (Compact mode)
+// ---------------------------------------------------------------------------
+
+/// Resolve an app_id to a human-readable display name via XDG desktop entries.
+fn app_display_name(app_id: &str) -> String {
+    lookup_app(app_id)
+        .map(|info| info.name)
+        .unwrap_or_else(|| app_id.to_string())
+}
+
+/// Compute the width needed for a notification pill based on its content.
+pub fn pill_width(app_id: &str, title: &str, count: usize) -> f32 {
+    let pad = 8.0;
+    let icon_size = COMPACT_H - pad * 2.0;
+    let text_x = pad + icon_size + 6.0;
+    let badge_w = if count > 1 { 8.0 + 18.0 } else { 0.0 };
+
+    let label = if title.is_empty() {
+        app_display_name(app_id)
+    } else {
+        title.to_string()
+    };
+    let font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 12.0,
+    }
+    .font();
+    let (text_w, _) = font.measure_str(&label, None);
+
+    (text_x + text_w + badge_w + pad).clamp(MINI_W, 300.0)
+}
+
+pub fn draw_pill(
+    canvas: &Canvas,
+    app_id: &str,
+    icon: &str,
+    title: &str,
+    count: usize,
+    _expanded: bool,
+    w: f32,
+    h: f32,
+) {
+    let pad = 8.0;
+    let icon_size = h - pad * 2.0;
+    let icon_x = pad;
+    let icon_y = (h - icon_size) / 2.0;
+    draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
+
+    let text_x = icon_x + icon_size + 6.0;
+    let badge_w = if count > 1 { 8.0 + 18.0 } else { 0.0 };
+    let max_w = w - text_x - badge_w - pad;
+
+    // Top row: app name (small, dimmer)
+    let name = app_display_name(app_id);
+    let app_font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 9.0,
+    }
+    .font();
+    let mut app_paint = Paint::default();
+    app_paint.set_anti_alias(true);
+    app_paint.set_color(Color::from_argb(140, 255, 255, 255));
+    let app_label = truncate_text(&name, &app_font, max_w);
+    canvas.draw_str(&app_label, (text_x, h / 2.0 - 3.0), &app_font, &app_paint);
+
+    // Bottom row: notification title (bold, white)
+    let title_font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 11.0,
+    }
+    .font();
+    let mut title_paint = Paint::default();
+    title_paint.set_anti_alias(true);
+    title_paint.set_color(Color::WHITE);
+    let display_title = if title.is_empty() { &name } else { title };
+    let title_label = truncate_text(display_title, &title_font, max_w);
+    canvas.draw_str(
+        &title_label,
+        (text_x, h / 2.0 + 9.0),
+        &title_font,
+        &title_paint,
+    );
+
+    // Count badge
+    if count > 1 {
+        draw_count_badge(canvas, w - pad - 18.0, (h - 14.0) / 2.0, count);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Drawing: peek pill (two-line: app name + notification title)
+// ---------------------------------------------------------------------------
+// Drawing: group circle (Mini mode)
+// ---------------------------------------------------------------------------
+
+pub fn draw_mini(canvas: &Canvas, icon: &str, count: usize, _w: f32, h: f32) {
+    let pad = 6.0;
+    let icon_size = h - pad * 2.0;
+    let icon_x = pad;
+    let icon_y = (h - icon_size) / 2.0;
+    draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
+
+    // Count text to the right of the icon
+    let count_text = format!("{count}");
+    let font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 11.0,
+    }
+    .font();
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::WHITE);
+    canvas.draw_str(
+        &count_text,
+        (icon_x + icon_size + 4.0, h / 2.0 + 4.0),
+        &font,
+        &paint,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Drawing: notification card
+// ---------------------------------------------------------------------------
+
+pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32, h: f32) {
+    let theme = AppContext::current_theme();
+    let pad = 10.0;
+
+    // Use the activity icon if available, otherwise fall back to group icon.
+    let icon = if activity.icon.is_empty() {
+        group_icon
+    } else {
+        &activity.icon
+    };
+
+    // Background — uses theme material
+    let mut bg = Paint::default();
+    bg.set_anti_alias(true);
+    bg.set_color(theme.material_medium);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(Rect::from_xywh(0.0, 0.0, w, h), CARD_RADIUS, CARD_RADIUS),
+        &bg,
+    );
+
+    // Icon
+    let icon_size = 24.0;
+    let icon_x = pad;
+    let icon_y = pad;
+    draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
+
+    // Title
+    let title_font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 12.0,
+    }
+    .font();
+    let mut title_paint = Paint::default();
+    title_paint.set_anti_alias(true);
+    title_paint.set_color(theme.text_primary);
+    let text_x = icon_x + icon_size + 8.0;
+    let max_w = w - text_x - pad;
+    let title = truncate_text(&activity.title, &title_font, max_w);
+    canvas.draw_str(&title, (text_x, pad + 13.0), &title_font, &title_paint);
+
+    // Body
+    if !activity.body.is_empty() {
+        let body_font = TextStyle {
+            family: "Inter",
+            weight: 400,
+            size: 11.0,
+        }
+        .font();
+        let mut body_paint = Paint::default();
+        body_paint.set_anti_alias(true);
+        body_paint.set_color(theme.text_secondary);
+        let body = truncate_text(&activity.body, &body_font, max_w);
+        canvas.draw_str(&body, (text_x, pad + 28.0), &body_font, &body_paint);
+    }
+
+    // Elapsed time
+    let hint_font = TextStyle {
+        family: "Inter",
+        weight: 400,
+        size: 9.0,
+    }
+    .font();
+    let mut hint_paint = Paint::default();
+    hint_paint.set_anti_alias(true);
+    hint_paint.set_color(theme.text_tertiary);
+    let elapsed = activity.created_at.elapsed().as_secs();
+    let time_str = if elapsed < 60 {
+        "just now".to_string()
+    } else if elapsed < 3600 {
+        format!("{}m ago", elapsed / 60)
+    } else {
+        format!("{}h ago", elapsed / 3600)
+    };
+    let (tw, _) = hint_font.measure_str(&time_str, None);
+    canvas.draw_str(
+        &time_str,
+        (w - pad - tw, h - pad + 2.0),
+        &hint_font,
+        &hint_paint,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: icons, badges, text
+// ---------------------------------------------------------------------------
+// (dialog and fingerprint rendering will be added in separate PRs)
+
+// ---------------------------------------------------------------------------
+
+fn draw_app_icon(canvas: &Canvas, icon_name: &str, x: f32, y: f32, size: f32) {
+    if !icon_name.is_empty() {
+        if let Some(icon) = named_icon_sized(icon_name, size as i32) {
+            let dst = Rect::from_xywh(x, y, size, size);
+            let r = size * 0.18;
+            canvas.save();
+            canvas.clip_rrect(
+                RRect::new_rect_xy(dst, r, r),
+                skia_safe::ClipOp::Intersect,
+                true,
+            );
+            let src = Rect::from_xywh(0.0, 0.0, icon.width() as f32, icon.height() as f32);
+            canvas.draw_image_rect(
+                &icon,
+                Some((&src, skia_safe::canvas::SrcRectConstraint::Strict)),
+                dst,
+                &Paint::default(),
+            );
+            canvas.restore();
+            return;
+        }
+    }
+    draw_envelope(canvas, x, y, size);
+}
+
+fn draw_envelope(canvas: &Canvas, x: f32, y: f32, size: f32) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::from_argb(200, 255, 255, 255));
+    paint.set_style(skia_safe::paint::Style::Stroke);
+    paint.set_stroke_width(1.2);
+
+    let w = size;
+    let h = size * 0.7;
+    let oy = y + (size - h) / 2.0;
+    canvas.draw_rect(Rect::from_xywh(x, oy, w, h), &paint);
+
+    let mut b = skia_safe::PathBuilder::new();
+    b.move_to((x, oy));
+    b.line_to((x + w / 2.0, oy + h * 0.55));
+    b.line_to((x + w, oy));
+    canvas.draw_path(&b.detach(), &paint);
+}
+
+fn draw_count_badge(canvas: &Canvas, x: f32, y: f32, count: usize) {
+    let badge_w = 18.0_f32;
+    let badge_h = 14.0_f32;
+    let badge_r = 7.0_f32;
+
+    let mut bg = Paint::default();
+    bg.set_anti_alias(true);
+    bg.set_color(Color::from_argb(80, 255, 255, 255));
+    canvas.draw_rrect(
+        RRect::new_rect_xy(Rect::from_xywh(x, y, badge_w, badge_h), badge_r, badge_r),
+        &bg,
+    );
+
+    let text = format!("{count}");
+    let font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 10.0,
+    }
+    .font();
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::WHITE);
+    let (cw, _) = font.measure_str(&text, None);
+    canvas.draw_str(&text, (x + (badge_w - cw) / 2.0, y + 11.0), &font, &paint);
+}
+
+fn truncate_text(text: &str, font: &skia_safe::Font, max_width: f32) -> String {
+    let (width, _) = font.measure_str(text, None);
+    if width <= max_width {
+        return text.to_string();
+    }
+    let ellipsis = "…";
+    let (ew, _) = font.measure_str(ellipsis, None);
+    let available = max_width - ew;
+
+    let mut result = String::new();
+    for ch in text.chars() {
+        result.push(ch);
+        let (w, _) = font.measure_str(&result, None);
+        if w > available {
+            result.pop();
+            break;
+        }
+    }
+    result.push_str(ellipsis);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Surface style helpers
+// ---------------------------------------------------------------------------
+
+pub fn apply_island_style(
+    surface: &otto_kit::SubsurfaceSurface,
+    radius: f64,
+    gravity: ContentsGravity,
+) {
+    if let Some(ss) = surface.base_surface().surface_style() {
+        ss.set_background_color(0.03, 0.03, 0.03, 1.0);
+        ss.set_corner_radius(radius * BUFFER_SCALE);
+        ss.set_masks_to_bounds(ClipMode::Enabled);
+        ss.set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0);
+        ss.set_blend_mode(BlendMode::BackgroundBlur);
+        ss.set_contents_gravity(gravity);
+        ss.set_anchor_point(0.5, 0.5);
+    }
+}
+
+/// Style for notification cards — theme material background with blur.
+pub fn apply_card_style(surface: &otto_kit::SubsurfaceSurface) {
+    let theme = AppContext::current_theme();
+    let c = theme.material_medium;
+    if let Some(ss) = surface.base_surface().surface_style() {
+        ss.set_background_color(
+            c.r() as f64 / 255.0,
+            c.g() as f64 / 255.0,
+            c.b() as f64 / 255.0,
+            c.a() as f64 / 255.0,
+        );
+        ss.set_corner_radius(CARD_RADIUS as f64 * BUFFER_SCALE);
+        ss.set_masks_to_bounds(ClipMode::Enabled);
+        ss.set_blend_mode(BlendMode::BackgroundBlur);
+        ss.set_contents_gravity(ContentsGravity::Center);
+        ss.set_anchor_point(0.5, 0.5);
+    }
+}
+
+pub fn set_size_and_position(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+) {
+    if let Some(ss) = surface.base_surface().surface_style() {
+        ss.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
+        ss.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
+    }
+}
+
+pub fn animate_to(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+    radius: f64,
+    delay: f64,
+) {
+    animate_to_with_opacity(surface, w, h, x, y, radius, None, delay);
+}
+
+pub fn animate_to_with_opacity(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+    radius: f64,
+    opacity: Option<f64>,
+    delay: f64,
+) {
+    if let Some(scene_surface) = surface.base_surface().surface_style() {
+        if let Some(scene) = AppContext::surface_style_manager() {
+            let qh = AppContext::queue_handle();
+
+            let timing = scene.create_timing_function(qh, ());
+            timing.set_spring(0.25, 0.0);
+
+            let anim = scene.begin_transaction(qh, ());
+            anim.set_duration(0.6);
+            if delay > 0.0 {
+                anim.set_delay(delay);
+            }
+            anim.set_timing_function(&timing);
+
+            scene_surface.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
+            scene_surface.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
+            scene_surface.set_corner_radius(radius * BUFFER_SCALE);
+            if let Some(o) = opacity {
+                scene_surface.set_opacity(o);
+            }
+
+            anim.commit();
+        }
+    }
+}
+
+/// Animate only position and opacity (size is set instantly, not animated).
+pub fn animate_position_opacity(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+    opacity: f64,
+    delay: f64,
+) {
+    if let Some(scene_surface) = surface.base_surface().surface_style() {
+        // Set size immediately (outside any transaction).
+        scene_surface.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
+
+        if let Some(scene) = AppContext::surface_style_manager() {
+            let qh = AppContext::queue_handle();
+
+            let timing = scene.create_timing_function(qh, ());
+            timing.set_spring(0.25, 0.0);
+
+            let anim = scene.begin_transaction(qh, ());
+            anim.set_duration(0.6);
+            if delay > 0.0 {
+                anim.set_delay(delay);
+            }
+            anim.set_timing_function(&timing);
+
+            scene_surface.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
+            scene_surface.set_opacity(opacity);
+
+            anim.commit();
+        }
+    }
+}
+
+/// Dismiss animation: scale up to `scale` while fading out to opacity 0.
+pub fn animate_dismiss(surface: &otto_kit::SubsurfaceSurface, scale: f64) {
+    if let Some(scene_surface) = surface.base_surface().surface_style() {
+        if let Some(scene) = AppContext::surface_style_manager() {
+            let qh = AppContext::queue_handle();
+
+            let timing = scene.create_timing_function(qh, ());
+            timing.set_spring(0.25, 0.0);
+
+            let anim = scene.begin_transaction(qh, ());
+            anim.set_duration(0.4);
+            anim.set_timing_function(&timing);
+
+            scene_surface.set_scale(scale, scale);
+            scene_surface.set_opacity(0.0);
+
+            anim.commit();
+        }
+    }
+}
+
+/// Pulse animation: instantly grow by `grow` pixels, then spring back to target size.
+/// With center anchor, position stays the same — only size changes.
+pub fn animate_pulse(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    cx: f32,
+    cy: f32,
+    radius: f64,
+    grow: f32,
+) {
+    // Step 1: instantly set to enlarged size (center anchor keeps it centered).
+    set_size_and_position(surface, w + grow, h + grow, cx, cy);
+
+    // Step 2: spring back to target size.
+    animate_to(surface, w, h, cx, cy, radius, 0.0);
+}
+
+/// Draw content centered in the subsurface buffer.
+pub fn draw_centered(
+    surface: &otto_kit::SubsurfaceSurface,
+    content_w: f32,
+    content_h: f32,
+    draw_fn: impl FnOnce(&Canvas),
+) {
+    surface.draw(|canvas| {
+        let tx = (SLOT_BUF_W as f32 - content_w) / 2.0;
+        let ty = (SLOT_BUF_H as f32 - content_h) / 2.0;
+        canvas.save();
+        canvas.translate((tx, ty));
+        draw_fn(canvas);
+        canvas.restore();
+    });
+}

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -132,6 +132,15 @@ pub fn draw_pill(
 // Drawing: group circle (Mini mode)
 // ---------------------------------------------------------------------------
 
+/// Width for a mini pill: smaller when just one notification.
+pub fn mini_width(count: usize) -> f32 {
+    if count > 1 {
+        MINI_W
+    } else {
+        MINI_H // square pill (icon only)
+    }
+}
+
 pub fn draw_mini(canvas: &Canvas, icon: &str, count: usize, _w: f32, h: f32) {
     let pad = 6.0;
     let icon_size = h - pad * 2.0;
@@ -139,23 +148,24 @@ pub fn draw_mini(canvas: &Canvas, icon: &str, count: usize, _w: f32, h: f32) {
     let icon_y = (h - icon_size) / 2.0;
     draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
 
-    // Count text to the right of the icon
-    let count_text = format!("{count}");
-    let font = TextStyle {
-        family: "Inter",
-        weight: 600,
-        size: 11.0,
+    if count > 1 {
+        let count_text = format!("{count}");
+        let font = TextStyle {
+            family: "Inter",
+            weight: 600,
+            size: 11.0,
+        }
+        .font();
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::WHITE);
+        canvas.draw_str(
+            &count_text,
+            (icon_x + icon_size + 4.0, h / 2.0 + 4.0),
+            &font,
+            &paint,
+        );
     }
-    .font();
-    let mut paint = Paint::default();
-    paint.set_anti_alias(true);
-    paint.set_color(Color::WHITE);
-    canvas.draw_str(
-        &count_text,
-        (icon_x + icon_size + 4.0, h / 2.0 + 4.0),
-        &font,
-        &paint,
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -198,8 +208,9 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     let mut title_paint = Paint::default();
     title_paint.set_anti_alias(true);
     title_paint.set_color(theme.text_primary);
+    let close_zone = 40.0;
     let text_x = icon_x + icon_size + 8.0;
-    let max_w = w - text_x - pad;
+    let max_w = w - text_x - close_zone;
     let title = truncate_text(&activity.title, &title_font, max_w);
     canvas.draw_str(&title, (text_x, pad + 13.0), &title_font, &title_paint);
 
@@ -239,9 +250,35 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     let (tw, _) = hint_font.measure_str(&time_str, None);
     canvas.draw_str(
         &time_str,
-        (w - pad - tw, h - pad + 2.0),
+        (w - close_zone - tw - 8.0, h - pad + 2.0),
         &hint_font,
         &hint_paint,
+    );
+
+    // Separator line before close zone
+    let mut sep_paint = Paint::default();
+    sep_paint.set_anti_alias(true);
+    sep_paint.set_color(Color::from_argb(20, 0, 0, 0));
+    sep_paint.set_stroke_width(1.0);
+    let sep_x = w - close_zone;
+    canvas.draw_line((sep_x, 0.0), (sep_x, h), &sep_paint);
+
+    // Close button — right zone
+    let close_font = TextStyle {
+        family: "Inter",
+        weight: 500,
+        size: 9.0,
+    }
+    .font();
+    let mut close_paint = Paint::default();
+    close_paint.set_anti_alias(true);
+    close_paint.set_color(theme.text_secondary);
+    let (cw, _) = close_font.measure_str("Close", None);
+    canvas.draw_str(
+        "Close",
+        (w - close_zone / 2.0 - cw / 2.0, h / 2.0 + 3.0),
+        &close_font,
+        &close_paint,
     );
 }
 
@@ -424,10 +461,10 @@ pub fn animate_to_with_opacity(
             let qh = AppContext::queue_handle();
 
             let timing = scene.create_timing_function(qh, ());
-            timing.set_spring(0.25, 0.0);
+            timing.set_spring(0.15, 0.0);
 
             let anim = scene.begin_transaction(qh, ());
-            anim.set_duration(0.6);
+            anim.set_duration(0.8);
             if delay > 0.0 {
                 anim.set_delay(delay);
             }
@@ -455,6 +492,31 @@ pub fn animate_position_opacity(
     opacity: f64,
     delay: f64,
 ) {
+    animate_position_opacity_duration(surface, w, h, x, y, opacity, delay, 0.3);
+}
+
+pub fn animate_position_opacity_slow(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+    opacity: f64,
+    delay: f64,
+) {
+    animate_position_opacity_duration(surface, w, h, x, y, opacity, delay, 0.8);
+}
+
+fn animate_position_opacity_duration(
+    surface: &otto_kit::SubsurfaceSurface,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
+    opacity: f64,
+    delay: f64,
+    duration: f64,
+) {
     if let Some(scene_surface) = surface.base_surface().surface_style() {
         // Set size immediately (outside any transaction).
         scene_surface.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
@@ -463,10 +525,10 @@ pub fn animate_position_opacity(
             let qh = AppContext::queue_handle();
 
             let timing = scene.create_timing_function(qh, ());
-            timing.set_spring(0.25, 0.0);
+            timing.set_spring(0.0, 0.0);
 
             let anim = scene.begin_transaction(qh, ());
-            anim.set_duration(0.6);
+            anim.set_duration(duration);
             if delay > 0.0 {
                 anim.set_delay(delay);
             }

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -36,25 +36,34 @@ fn app_display_name(app_id: &str) -> String {
 }
 
 /// Compute the width needed for a notification pill based on its content.
+/// Measures both rows (app name + title) and uses the wider one.
 pub fn pill_width(app_id: &str, title: &str, count: usize) -> f32 {
     let pad = 8.0;
     let icon_size = COMPACT_H - pad * 2.0;
     let text_x = pad + icon_size + 6.0;
     let badge_w = if count > 1 { 8.0 + 18.0 } else { 0.0 };
 
-    let label = if title.is_empty() {
-        app_display_name(app_id)
-    } else {
-        title.to_string()
-    };
-    let font = TextStyle {
+    // Top row: app name (9px)
+    let name = app_display_name(app_id);
+    let app_font = TextStyle {
         family: "Inter",
         weight: 600,
-        size: 12.0,
+        size: 9.0,
     }
     .font();
-    let (text_w, _) = font.measure_str(&label, None);
+    let (name_w, _) = app_font.measure_str(&name, None);
 
+    // Bottom row: notification title (11px)
+    let display_title = if title.is_empty() { &name } else { title };
+    let title_font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 11.0,
+    }
+    .font();
+    let (title_w, _) = title_font.measure_str(display_title, None);
+
+    let text_w = name_w.max(title_w);
     (text_x + text_w + badge_w + pad).clamp(MINI_W, 340.0)
 }
 

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -415,6 +415,7 @@ pub fn apply_card_style(surface: &otto_kit::SubsurfaceSurface) {
         );
         ss.set_corner_radius(CARD_RADIUS as f64 * BUFFER_SCALE);
         ss.set_masks_to_bounds(ClipMode::Enabled);
+        ss.set_shadow(0.25, 16.0, 0.0, 1.0, 0.0, 0.0, 0.0);
         ss.set_blend_mode(BlendMode::BackgroundBlur);
         ss.set_contents_gravity(ContentsGravity::Center);
         ss.set_anchor_point(0.5, 0.5);

--- a/components/otto-islands/src/state.rs
+++ b/components/otto-islands/src/state.rs
@@ -1,0 +1,282 @@
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::activity::{Activity, ActivityId, ActivitySource, NotificationAction, Priority};
+
+pub type SharedState = Arc<Mutex<IslandState>>;
+
+/// Counter for generating unique org.freedesktop.Notifications IDs.
+static NEXT_NOTIFICATION_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+
+pub struct IslandState {
+    next_id: ActivityId,
+    pub activities: Vec<Activity>,
+    pub dirty: bool,
+}
+
+impl IslandState {
+    pub fn new() -> Self {
+        Self {
+            next_id: 1,
+            activities: Vec::new(),
+            dirty: false,
+        }
+    }
+
+    fn next_activity_id(&mut self) -> ActivityId {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    pub fn create_activity(
+        &mut self,
+        app_id: String,
+        title: String,
+        icon: String,
+        progress: Option<f64>,
+        timeout_ms: u32,
+        priority: Priority,
+        live: bool,
+    ) -> ActivityId {
+        let id = self.next_activity_id();
+        self.activities.push(Activity {
+            id,
+            app_id,
+            title,
+            body: String::new(),
+            icon,
+            progress,
+            timeout_ms,
+            priority,
+            live,
+            created_at: Instant::now(),
+            expired: false,
+            actions: Vec::new(),
+            default_action: None,
+            category: None,
+            image_path: None,
+            transient: false,
+            resident: false,
+            notification_id: None,
+            source: ActivitySource::DBus,
+        });
+        self.dirty = true;
+        id
+    }
+
+    /// Create an activity from an org.freedesktop.Notifications Notify call.
+    /// Returns (activity_id, notification_id).
+    pub fn create_notification(
+        &mut self,
+        app_id: String,
+        replaces_id: u32,
+        icon: String,
+        title: String,
+        body: String,
+        actions: Vec<NotificationAction>,
+        priority: Priority,
+        timeout_ms: u32,
+        category: Option<String>,
+        image_path: Option<String>,
+        transient: bool,
+        resident: bool,
+        default_action: Option<String>,
+    ) -> (ActivityId, u32) {
+        // If replaces_id > 0, update existing notification
+        if replaces_id > 0 {
+            if let Some(activity) = self
+                .activities
+                .iter_mut()
+                .find(|a| a.notification_id == Some(replaces_id))
+            {
+                activity.title = title;
+                activity.body = body;
+                activity.icon = icon;
+                activity.actions = actions;
+                activity.priority = priority;
+                activity.category = category;
+                activity.image_path = image_path;
+                activity.default_action = default_action;
+                if timeout_ms > 0 {
+                    activity.timeout_ms = timeout_ms;
+                    activity.created_at = Instant::now();
+                    activity.expired = false;
+                }
+                self.dirty = true;
+                return (activity.id, replaces_id);
+            }
+        }
+
+        let notification_id =
+            NEXT_NOTIFICATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let id = self.next_activity_id();
+        self.activities.push(Activity {
+            id,
+            app_id,
+            title,
+            body,
+            icon,
+            progress: None,
+            timeout_ms,
+            priority,
+            live: false,
+            created_at: Instant::now(),
+            expired: false,
+            actions,
+            default_action,
+            category,
+            image_path,
+            transient,
+            resident,
+            notification_id: Some(notification_id),
+            source: ActivitySource::Notification,
+        });
+        self.dirty = true;
+        (id, notification_id)
+    }
+
+    /// Dismiss a notification by its org.freedesktop.Notifications ID.
+    pub fn dismiss_notification(&mut self, notification_id: u32) -> bool {
+        let len_before = self.activities.len();
+        self.activities
+            .retain(|a| a.notification_id != Some(notification_id));
+        if self.activities.len() != len_before {
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn update_activity(&mut self, id: ActivityId, title: &str, progress: f64) -> bool {
+        if let Some(activity) = self.activities.iter_mut().find(|a| a.id == id) {
+            let mut changed = false;
+            if !title.is_empty() && activity.title != title {
+                activity.title = title.to_string();
+                changed = true;
+            }
+            let new_progress = if progress < 0.0 {
+                None
+            } else {
+                Some(progress.clamp(0.0, 1.0))
+            };
+            if activity.progress != new_progress {
+                activity.progress = new_progress;
+                changed = true;
+            }
+            if changed {
+                self.dirty = true;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn dismiss_activity(&mut self, id: ActivityId) -> bool {
+        let len_before = self.activities.len();
+        self.activities.retain(|a| a.id != id);
+        if self.activities.len() != len_before {
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Mark expired activities instead of removing them.
+    /// This triggers a refocus: the expired activity shrinks and the
+    /// previous one expands.
+    pub fn check_expired_refocus(&mut self) {
+        let now = Instant::now();
+        for activity in &mut self.activities {
+            if activity.timeout_ms > 0
+                && !activity.expired
+                && now.duration_since(activity.created_at).as_millis()
+                    >= activity.timeout_ms as u128
+            {
+                activity.expired = true;
+                self.dirty = true;
+            }
+        }
+    }
+
+    /// Returns activities grouped for layout purposes.
+    /// Notifications from the same app_id are grouped — only the most recent
+    /// is returned as the representative, with a count of how many are in the group.
+    /// Non-notification activities (music, D-Bus, internal) are returned as-is.
+    pub fn grouped_activities(&self) -> Vec<(Activity, usize)> {
+        use std::collections::HashMap;
+
+        let mut notification_groups: HashMap<&str, Vec<&Activity>> = HashMap::new();
+        let mut result: Vec<(Activity, usize)> = Vec::new();
+
+        // Separate notifications from other activities
+        for activity in &self.activities {
+            if activity.source == ActivitySource::Notification {
+                notification_groups
+                    .entry(&activity.app_id)
+                    .or_default()
+                    .push(activity);
+            } else {
+                result.push((activity.clone(), 1));
+            }
+        }
+
+        // For each notification group, take the most recent as representative
+        for (_app_id, mut group) in notification_groups {
+            group.sort_by_key(|a| a.created_at);
+            let count = group.len();
+            if let Some(latest) = group.last() {
+                result.push(((*latest).clone(), count));
+            }
+        }
+
+        // Sort by creation time so layout order is stable
+        result.sort_by_key(|(a, _)| a.created_at);
+        result
+    }
+
+    /// Get all notifications for a given app_id, ordered by creation time (newest first).
+    pub fn notifications_for_app(&self, app_id: &str) -> Vec<&Activity> {
+        let mut result: Vec<_> = self
+            .activities
+            .iter()
+            .filter(|a| a.source == ActivitySource::Notification && a.app_id == app_id)
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result
+    }
+
+    /// Remove all activities whose timeout has expired.
+    pub fn expire_timeouts(&mut self) {
+        let now = Instant::now();
+        let len_before = self.activities.len();
+        self.activities.retain(|a| {
+            a.timeout_ms == 0 || now.duration_since(a.created_at).as_millis() < a.timeout_ms as u128
+        });
+        if self.activities.len() != len_before {
+            self.dirty = true;
+        }
+    }
+
+    /// The highest-priority, most-recent activity (for the left "O" surface).
+    pub fn top_activity(&self) -> Option<&Activity> {
+        self.activities
+            .iter()
+            .max_by_key(|a| (a.priority.rank(), a.created_at))
+    }
+
+    /// The second activity (for the right "o" surface).
+    pub fn second_activity(&self) -> Option<&Activity> {
+        if self.activities.len() < 2 {
+            return None;
+        }
+        let top_id = self.top_activity().map(|a| a.id);
+        self.activities
+            .iter()
+            .filter(|a| Some(a.id) != top_id)
+            .max_by_key(|a| (a.priority.rank(), a.created_at))
+    }
+}

--- a/components/otto-kit/src/app_runner/context.rs
+++ b/components/otto-kit/src/app_runner/context.rs
@@ -47,6 +47,13 @@ thread_local! {
     static TRANSACTION_COMPLETION_CALLBACKS: RefCell<HashMap<ObjectId, Box<dyn FnOnce()>>> = RefCell::new(HashMap::new());
 }
 
+// -- Cursor shape state --
+
+thread_local! {
+    static CURSOR_SHAPE_DEVICE: RefCell<Option<wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>> = const { RefCell::new(None) };
+    static LAST_POINTER_ENTER_SERIAL: RefCell<u32> = const { RefCell::new(0) };
+}
+
 // -- Rendering state --
 
 thread_local! {
@@ -110,6 +117,7 @@ pub struct AppContextData {
     pub wlr_layer_shell: Option<ZwlrLayerShellV1>,
     pub subcompositor: Option<wayland_client::protocol::wl_subcompositor::WlSubcompositor>,
     pub otto_dock_manager: Option<crate::protocols::otto_dock_manager_v1::OttoDockManagerV1>,
+    pub cursor_shape_manager: Option<wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1>,
     pub display_ptr: *mut std::ffi::c_void,
 }
 
@@ -397,6 +405,45 @@ impl<'a> AppContext<'a> {
     pub fn current_theme() -> crate::theme::Theme {
         use crate::theme::Theme;
         Theme::for_scheme(crate::color_scheme::current_color_scheme())
+    }
+
+    // ========================================================================
+    // Cursor shape (wp_cursor_shape_v1)
+    // ========================================================================
+
+    pub(crate) fn set_last_pointer_enter_serial(serial: u32) {
+        LAST_POINTER_ENTER_SERIAL.with(|s| *s.borrow_mut() = serial);
+    }
+
+    pub(crate) fn ensure_cursor_shape_device<A: super::App + 'static>(
+        context_data: &AppContextData,
+        pointer: &wayland_client::protocol::wl_pointer::WlPointer,
+        qh: &QueueHandle<super::AppData<A>>,
+    ) {
+        CURSOR_SHAPE_DEVICE.with(|d| {
+            if d.borrow().is_some() {
+                return;
+            }
+            if let Some(ref manager) = context_data.cursor_shape_manager {
+                let device = manager.get_pointer(pointer, qh, ());
+                *d.borrow_mut() = Some(device);
+            }
+        });
+    }
+
+    /// Set the cursor shape for the current pointer.
+    ///
+    /// Uses `wp_cursor_shape_v1` — no bitmap loading needed.
+    /// Call this from `on_pointer_event` on Enter/Motion events.
+    pub fn set_cursor_shape(
+        shape: wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape,
+    ) {
+        let serial = LAST_POINTER_ENTER_SERIAL.with(|s| *s.borrow());
+        CURSOR_SHAPE_DEVICE.with(|d| {
+            if let Some(ref device) = *d.borrow() {
+                device.set_shape(serial, shape);
+            }
+        });
     }
 
     // ========================================================================

--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -276,6 +276,8 @@ impl<A: App + 'static> AppRunnerWithType<A> {
         let wlr_layer_shell: Option<ZwlrLayerShellV1> = globals.bind(&qh, 1..=4, ()).ok();
         let otto_dock_manager = globals.bind(&qh, 1..=1, ()).ok();
         let subcompositor = globals.bind(&qh, 1..=1, ()).ok();
+        let cursor_shape_manager: Option<wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1> =
+            globals.bind(&qh, 1..=2, ()).ok();
 
         // Get display pointer for creating surfaces
         let display_ptr = conn.backend().display_ptr() as *mut std::ffi::c_void;
@@ -293,6 +295,7 @@ impl<A: App + 'static> AppRunnerWithType<A> {
             wlr_layer_shell,
             subcompositor,
             otto_dock_manager,
+            cursor_shape_manager,
             display_ptr,
         });
 
@@ -675,10 +678,22 @@ impl<A: App + 'static> PointerHandler for AppData<A> {
     fn pointer_frame(
         &mut self,
         _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
+        qh: &QueueHandle<Self>,
+        pointer: &wl_pointer::WlPointer,
         events: &[PointerEvent],
     ) {
+        use smithay_client_toolkit::seat::pointer::PointerEventKind;
+
+        // Track enter serial and lazily create cursor shape device.
+        for event in events {
+            if let PointerEventKind::Enter { serial, .. } = event.kind {
+                AppContext::set_last_pointer_enter_serial(serial);
+
+                // Create cursor shape device if we have the manager but no device yet.
+                AppContext::ensure_cursor_shape_device(&self.context_data, pointer, qh);
+            }
+        }
+
         AppContext::dispatch_pointer_callbacks(events);
         let ctx = AppContext::new(&self.context_data);
         self.app.on_pointer_event(&ctx, events);
@@ -874,3 +889,5 @@ impl<A: App + 'static> Dispatch<otto_dock_item_v1::OttoDockItemV1, ()> for AppDa
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_client::protocol::wl_subcompositor::WlSubcompositor);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_client::protocol::wl_subsurface::WlSubsurface);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore ZwlrLayerShellV1);
+wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1);
+wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1);

--- a/components/otto-kit/src/lib.rs
+++ b/components/otto-kit/src/lib.rs
@@ -34,6 +34,9 @@ pub use surfaces::{
 // Re-export app framework
 pub use app_runner::{App, AppContext, AppRunner, AppRunnerWithType};
 
+// Re-export cursor shape type for apps
+pub use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape as CursorShape;
+
 /// Convenience prelude for application development
 pub mod prelude {
     pub use crate::app_runner::{App, AppContext, AppRunner, AppRunnerWithType};

--- a/components/otto-kit/src/surfaces/subsurface.rs
+++ b/components/otto-kit/src/surfaces/subsurface.rs
@@ -19,6 +19,7 @@ use super::common::{
 /// to be part of a window but managed separately.
 pub struct SubsurfaceSurface {
     base_surface: BaseWaylandSurface,
+    subsurface: Option<wl_subsurface::WlSubsurface>,
 }
 
 impl SubsurfaceSurface {
@@ -124,7 +125,10 @@ impl SubsurfaceSurface {
         core.surface_style = sc_layer;
         core.create_skia_surface()?;
 
-        Ok(Self { base_surface: core })
+        Ok(Self {
+            base_surface: core,
+            subsurface: Some(subsurface),
+        })
     }
 
     /// Resize the subsurface
@@ -134,8 +138,21 @@ impl SubsurfaceSurface {
 
     /// Set position relative to parent surface
     pub fn set_position(&self, _x: i32, _y: i32) {
-        // Note: subsurface handle is not stored, position must be set during creation
-        // This method is kept for API compatibility but does nothing
+        // Note: position is managed via surface style, not wl_subsurface.
+    }
+
+    /// Place this subsurface above a sibling surface in the stacking order.
+    pub fn place_above(&self, sibling: &wayland_client::protocol::wl_surface::WlSurface) {
+        if let Some(ref sub) = self.subsurface {
+            sub.place_above(sibling);
+        }
+    }
+
+    /// Place this subsurface below a sibling surface in the stacking order.
+    pub fn place_below(&self, sibling: &wayland_client::protocol::wl_surface::WlSurface) {
+        if let Some(ref sub) = self.subsurface {
+            sub.place_below(sibling);
+        }
     }
 
     /// Commit changes to the subsurface
@@ -160,6 +177,14 @@ impl SubsurfaceSurface {
 }
 
 impl SubsurfaceSurface {
+    /// Destroy the subsurface and its underlying wl_surface.
+    pub fn destroy(&mut self) {
+        if let Some(subsurface) = self.subsurface.take() {
+            subsurface.destroy();
+        }
+        self.base_surface.wl_surface().destroy();
+    }
+
     /// Get reference to the base surface
     pub fn base_surface(&self) -> &BaseWaylandSurface {
         &self.base_surface

--- a/specs/dynamic-island-milestones.md
+++ b/specs/dynamic-island-milestones.md
@@ -1,0 +1,147 @@
+# Dynamic Island — Implementation Milestones
+
+**Status:** draft
+**Related specs:** dynamic-island, notification-daemon
+
+## Summary
+
+Incremental implementation plan for the Dynamic Island. Each milestone is self-contained and demoable.
+
+---
+
+## Milestone 1 — End-to-End Activity Lifecycle (DONE)
+
+**Goal:** D-Bus client submits an activity, the island renders it, and it auto-dismisses after timeout.
+
+**Delivered:**
+- Standalone `otto-islands` component with D-Bus interface (`org.otto.Island1`)
+- Two subsurfaces with surface style chrome (blur, shadow, rounded corners)
+- Spring-animated transitions between idle circles and compact pill
+- `GenericActivityRenderer` for basic data-driven activities
+- `MusicActivityRenderer` with MPRIS (playerctl) + PipeWire audio levels
+- Pointer hover (Compact → Expanded) and click (Expanded → Banner) interaction
+- Wayland input region support (compositor fix: honouring `surface_under` for layer shells)
+- Right circle repositions with spring animation when left expands
+
+---
+
+## Milestone 2 — Notification Integration
+
+**Goal:** Notifications from desktop apps appear as island activities.
+
+**Scope:**
+- `xdg-desktop-portal-otto` implements `org.freedesktop.impl.portal.Notification`
+- Portal forwards notifications to island via `CreateActivity` D-Bus call
+- Map notification urgency to island priority (low/normal/critical)
+- Map notification timeout to island timeout
+- Notification actions mapped to island actions (future: clickable buttons)
+- Optionally: island claims `org.freedesktop.Notifications` directly for non-portal apps
+
+**Delivers:** Desktop notifications appear in the island instead of a separate notification daemon.
+
+---
+
+## Milestone 3 — Multiple Activities & Dismissed Stack
+
+**Goal:** Multiple activities coexist, dismissed ones are recoverable.
+
+**Scope:**
+- Support more than 2 concurrent activities (stack model)
+- Dismissed transient activities enter a stack with a badge counter
+- Click badge → island expands vertically showing dismissed activities
+- User can dismiss individual items or clear all
+- Same-`app_id` transient activities replace each other (notification grouping)
+
+**Delivers:** Notifications don't get lost. Badge shows unread count.
+
+---
+
+## Milestone 4 — Playback Controls
+
+**Goal:** Music player controls are interactive.
+
+**Scope:**
+- Click prev/play-pause/next buttons in Banner mode sends `playerctl` commands
+- Hit-test buttons within the Banner surface
+- Scrub the progress bar (drag to seek)
+- Album art click opens the player app
+
+**Delivers:** Full media control from the island without switching to the player app.
+
+---
+
+## Milestone 5 — Timer & Recording Activities
+
+**Goal:** Built-in activity types for common use cases.
+
+**Scope:**
+- `TimerActivityRenderer` — countdown display, pause/resume/cancel actions
+- `RecordingActivityRenderer` — duration counter, recording indicator, stop button
+- D-Bus methods: `CreateTimer(duration_ms)`, `CreateRecording(label)`
+- Screen recording integration with the screenshare system
+
+**Delivers:** Timer and recording indicators in the island.
+
+---
+
+## Milestone 6 — Permissions & Configuration
+
+**Goal:** Per-app control over island access.
+
+**Scope:**
+- Configuration in `otto_config.toml`:
+  ```toml
+  [island]
+  enabled = true
+  max_visible_activities = 3
+
+  [island.permissions]
+  default_policy = "allow"  # allow | deny | prompt
+  ```
+- Per-app overrides for priority limits, timeout minimums
+- D-Bus introspection for permission queries
+
+**Delivers:** Users control which apps can use the island and how.
+
+---
+
+## Milestone 7 — Exclusive Mode
+
+**Goal:** An activity can lock the island for focused UI.
+
+**Scope:**
+- `exclusive` flag on `CreateActivity`
+- When exclusive: all other activities hidden, incoming ones queued
+- On dismiss: previous layout restores, queued banners play
+- Only one exclusive activity at a time
+- Use case: fingerprint auth, voice assistant listening
+
+**Delivers:** Security-sensitive and high-focus activities work.
+
+---
+
+## Milestone 8 — Multi-Output & Draggable Position
+
+**Goal:** Island works across outputs and can be repositioned.
+
+**Scope:**
+- Island follows focused output (animated transition)
+- Drag gesture on idle circles repositions the island horizontally
+- Position persists across sessions
+- Configuration: `draggable = "horizontal" | "free" | "none"`
+
+**Delivers:** Multi-monitor users and custom placement.
+
+---
+
+## Future (not scoped)
+
+- Voice/AI agent activity with waveform visualization
+- Clipboard peek activity
+- Calendar/reminder activity
+- System alerts (low battery, disk full, updates)
+- VPN/network status activity
+- Volume/brightness OSD replacement
+- Theming integration
+- Keyboard navigation
+- Animation polish (morph curves, spring tuning)

--- a/specs/dynamic-island.md
+++ b/specs/dynamic-island.md
@@ -1,0 +1,302 @@
+# Dynamic Island (Otto Islands)
+
+**Status:** draft
+**Related specs:** notification-daemon, topbar
+
+## Summary
+
+Otto Islands is a persistent, morphing UI element anchored to the top-center of the screen. It provides a unified surface for live status, notifications, and contextual controls. Activities are submitted by any process via a D-Bus API (`org.otto.Island1`); the island app owns all rendering. It runs as a standalone otto-kit application using a layer shell surface.
+
+## Terminology
+
+| Term | Definition |
+|------|-----------|
+| **Island** | The otto-kit app that renders the pill-shaped UI element with background blur, rounded corners, and drop shadow. |
+| **Activity** | A data-driven unit of content displayed in the island. Activities have a title, icon, priority, optional progress, and optional timeout. |
+| **Live** | An activity attribute. Live activities are actively updating (e.g., elapsed time, audio levels). The island may show an animated indicator. |
+| **Presentation Mode** | The visual size of an activity: Idle, Compact, Expanded, or Banner. |
+
+### Presentation Modes
+
+| Mode | Description |
+|------|-------------|
+| **Idle** | No activity. Two small circles ("O o") displayed at top-center within the topbar area. |
+| **Compact** | Default active state. Small pill with content (e.g., album art + title + equalizer). Vertically centered in the topbar area. |
+| **Expanded** | Hover state. Taller pill showing more detail (e.g., bigger art, progress bar). Pinned to top, grows downward. |
+| **Banner** | Click/open state. Full card with interactive controls (e.g., playback controls, action buttons). Pinned to top, grows downward. |
+
+## Architecture
+
+### Standalone App
+
+The island is **not** compositor-internal. It is a separate binary (`otto-islands`) that:
+- Uses a `Layer::Overlay` layer shell surface anchored to the top-center of the screen.
+- Creates two subsurfaces for the two activity slots (left "O" and right "o").
+- Controls visual appearance (size, position, corner radius, background, blur, shadow) via the `otto-surface-style-v1` protocol with spring-animated transactions.
+- Draws content with Skia via otto-kit.
+- Accepts activities over D-Bus.
+
+The compositor has zero knowledge of the island beyond treating it as a regular layer shell client.
+
+### Two-Surface Layout
+
+The island has two Wayland subsurfaces side by side:
+
+- **Left ("O")** — the **active** activity. Larger circle at idle, morphs to a pill when hosting an activity.
+- **Right ("o")** — the **previous/secondary** activity. Smaller circle, renders in minimal mode (e.g., 3-bar equalizer for music, first letter for generic).
+
+When idle, the two circles resemble the Otto logo: a larger "O" and a smaller "o" side by side.
+
+When a single activity arrives:
+1. The left surface morphs from circle to compact pill.
+2. The right "o" circle slides behind the left pill and hides (overlaps, becoming invisible behind the larger surface).
+
+When a second activity arrives:
+1. The first activity shifts to the right surface (shrinks to minimal, slides out from behind).
+2. The new activity takes the left surface.
+
+When the active activity is dismissed:
+1. If there is a previous activity in the right surface, it moves left and morphs to compact. The right "o" hides behind again.
+2. If nothing remains, both surfaces return to idle circles ("O o").
+
+### Surface Style Rendering
+
+The island does **not** draw its own pill shape with Skia. Instead, it uses the `otto-surface-style-v1` protocol:
+- `set_background_color` — dark fill (near-black, 0.03 alpha)
+- `set_corner_radius` — circle when idle (radius = half size), pill when active
+- `set_masks_to_bounds` — clips content to the rounded shape
+- `set_shadow` — drop shadow
+- `set_blend_mode(BackgroundBlur)` — frosted glass effect
+- `set_contents_gravity(TopLeft)` — content pinned to top-left; visual size reveals/hides content
+
+All size and position transitions use **spring-animated transactions**:
+```
+timing = create_timing_function()
+timing.set_spring(damping, stiffness)
+animation = begin_transaction()
+animation.set_duration(duration)
+animation.set_timing_function(timing)
+style.set_size(w, h)
+style.set_position(x, y)
+style.set_corner_radius(r)
+animation.commit()
+```
+
+Content is drawn at the target size **before** the animation starts. The compositor reveals the pre-drawn content as the spring animation expands the visual bounds.
+
+### D-Bus API
+
+Interface: `org.otto.Island1` at path `/org/otto/Island`
+
+#### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `CreateActivity` | `(s app_id, s title, s icon, d progress, u timeout_ms, s priority, b live) -> t` | Create a new activity. Returns the activity ID. `progress`: 0.0-1.0 for a progress bar, negative for none. `priority`: "low", "normal", "high", "critical". `timeout_ms`: 0 for persistent, >0 for auto-dismiss. |
+| `UpdateActivity` | `(t id, s title, d progress) -> b` | Update an existing activity's title and/or progress. Empty title = no change. Negative progress = clear. |
+| `DismissActivity` | `(t id) -> b` | Dismiss an activity by ID. |
+
+Any process can call these methods. The island wakes its event loop via `AppContext::request_wakeup()` on each mutation.
+
+### ActivityRenderer Trait
+
+Each activity type knows how to draw itself at each presentation size:
+
+```rust
+pub trait ActivityRenderer {
+    fn size(&self, mode: PresentationMode) -> (f32, f32);
+    fn draw(&self, canvas: &Canvas, mode: PresentationMode, w: f32, h: f32);
+}
+```
+
+Built-in renderers:
+- **GenericActivityRenderer** — title text + optional progress bar + optional live dot. Used for notifications, timers, downloads.
+- **MusicActivityRenderer** — album art + title/artist + equalizer bars + progress bar + playback controls. Uses MPRIS (playerctl) for metadata and PipeWire for audio levels.
+
+Future renderers: TimerRenderer (countdown), RecordingRenderer (duration + stop), VoiceRenderer (waveform).
+
+## Behavior
+
+### Idle State
+
+When no activities are present, the island shows two small circles ("O o") vertically centered within the topbar area (30px height, matching topbar dimensions). The circles have dark background, blur, shadow, and rounded corners via surface style.
+
+### Activity Lifecycle
+
+1. A client calls `CreateActivity` over D-Bus with app_id, title, icon, priority, timeout, and live flag.
+2. The island assigns the activity to the left surface. If an activity was already there, it shifts to the right surface.
+3. The left surface animates from its current state to the compact pill size (spring animation on size, position, corner radius).
+4. The right surface animates to reposition next to the left pill.
+5. If `timeout_ms > 0`, a timer starts. When it fires, the activity is dismissed.
+6. The client can call `UpdateActivity` to change title/progress at any time.
+7. The client calls `DismissActivity` or the timeout fires. The activity is removed. Layout adjusts.
+
+### Activity Priority
+
+Activities are sorted by priority (critical > high > normal > low), then by recency (most recent first). The top activity gets the left surface. The second gets the right surface.
+
+### Pointer Interaction
+
+| Interaction | Behavior |
+|-------------|----------|
+| **Hover** | Left surface expands from Compact to Expanded mode (spring animation). Shows more detail. |
+| **Click** | Left surface expands from Expanded to Banner mode (spring animation). Shows full controls. |
+| **Click outside / Leave** | Returns to Compact mode. |
+
+The island sets a Wayland input region matching the visible pill and circle bounds. The compositor respects this region for pointer hit testing (via `surface_under` checking input regions).
+
+### Hover background
+
+On hover, the surface style background color animates from dark (0.03) to slightly lighter (0.10) with a spring transition. On leave, it animates back.
+
+### Music Activity
+
+When music is playing (detected via `playerctl`), the island automatically creates a persistent live activity:
+- **Compact**: album art + title + artist + 8-bar equalizer (PipeWire audio levels)
+- **Expanded**: larger art + title/artist + equalizer + progress bar
+- **Banner**: full card with art + title/artist + prev/play-pause/next controls + progress bar
+- **Minimal** (right surface): 3-bar mini equalizer with accent color
+
+Album art accent color is extracted and used for equalizer bars and progress fill.
+
+### Positioning
+
+- The layer shell surface is anchored to `Top` with a small margin (matching topbar).
+- In Idle/Compact mode, content is vertically centered within the topbar bar height (30px).
+- In Expanded/Banner mode, content is pinned to top (y=0) and grows downward below the bar area.
+- The left surface is horizontally centered in the layer.
+- The right surface positions itself to the right of the left surface with a gap.
+
+## Integration
+
+### Portal Notifications (future)
+
+`xdg-desktop-portal-otto` will implement `org.freedesktop.impl.portal.Notification` and forward notifications to the island by calling `org.otto.Island1.CreateActivity` over D-Bus. This keeps the island as the single rendering surface and the portal as the bridge to the freedesktop notification spec.
+
+### Direct Notifications (future)
+
+The island may also claim `org.freedesktop.Notifications` directly for non-sandboxed apps that bypass the portal.
+
+## Constraints & Edge Cases
+
+- **Multi-output:** The island appears on the primary output. Multi-output support is a future milestone.
+- **Fullscreen windows:** The island is on the Overlay layer. Behavior with fullscreen windows is TBD (may need compositor cooperation to hide).
+- **Scaling:** All dimensions are in logical pixels. The surface style uses physical pixels (2x buffer scale for HiDPI).
+- **Activity limit:** Maximum concurrent activities per client (default 5) and globally (default 20).
+- **D-Bus name collision:** If started twice, the second instance fails to claim `org.otto.Island` — single instance by design.
+- **PipeWire sink changes:** The audio level monitor connects to the default sink at startup. If the user changes audio output, the equalizer may go flat until restart.
+
+## Rationale
+
+- **Standalone app vs compositor-internal:** Faster iteration, cleaner separation of concerns. The compositor doesn't need island-specific code. Layer shell provides correct z-ordering.
+- **D-Bus vs Wayland protocol:** A data-driven D-Bus API covers all identified use cases (music, notifications, timers, recordings, downloads, system alerts). No client needs to render its own surface inside the island. D-Bus is language-agnostic and simple to use from any process.
+- **Surface style for chrome:** The compositor handles the pill shape, blur, shadow, and spring animations. The island app only draws flat content. This gives smooth compositor-level animations without client-side rendering of the chrome.
+- **Two surfaces:** Allows showing the active + previous activity simultaneously, with independent animations. The right circle provides continuity when activities change.
+- **ActivityRenderer trait:** Extensible pattern for different activity types. Each type defines its own rendering for all presentation modes. New renderers can be added without changing the core layout logic.
+
+## Experiment: Activity Stack Model
+
+**Status:** proposed — replaces the two-surface swap model
+
+### Concept
+
+Activities are arranged as a **horizontal stack** of circles/pills. Only **N** activities are expanded at a time (default N=1). New activities always enter from the right. The stack shifts left to make room.
+
+The key rules:
+
+1. **New activity arrives** → slides in from the right as a circle, then expands to compact pill. The currently expanded activity shrinks to a circle and shifts left.
+2. **When an activity expands** → all others shrink to circles.
+3. **When an activity shrinks/dismisses** → the previous activity (next in the stack to the left) expands.
+4. **N=1** means at most one pill at a time. The rest are minimal circles.
+
+### Idle
+
+Two circles side by side: "O" (30px) and "o" (20px), vertically centered in the topbar area. The Otto logo mark.
+
+### Activity Arrives
+
+1. Current pill **shrinks** in place to a circle and **slides left**.
+2. New activity **slides in from the right** as a circle, then **expands** to compact pill.
+3. The stack is now: `[old circle] [new pill]`
+
+### Activity Dismissed
+
+1. The dismissed activity **shrinks** to a circle and **slides out right** (fades out).
+2. The next activity in the stack (to the left) **expands** from circle to compact pill.
+3. If no activities remain, both circles return to idle "O o" positions.
+
+### Example: Music + Notification
+
+```
+State 0: Music playing
+  [===music pill===]  (o hidden behind)
+
+State 1: Notification arrives
+  [o music] [===notification pill===]
+
+State 2: Notification dismissed (5s timeout)
+  [===music pill===]  (o hidden behind)
+```
+
+### Example: Music + Two Notifications
+
+```
+State 0: Music pill
+  [===music pill===]
+
+State 1: Notification A arrives
+  [o music] [===notif A pill===]
+
+State 2: Notification B arrives (different app)
+  [o music] [o notif A] [===notif B pill===]
+
+State 3: Notification B dismissed
+  [o music] [===notif A pill===]
+
+State 4: Notification A dismissed
+  [===music pill===]
+```
+
+### Stack Rules
+
+- The **rightmost** activity is always the expanded one (the most recent arrival).
+- Activities to the left are minimal circles, ordered by arrival time (oldest on the left).
+- When the expanded activity is dismissed, the one immediately to its left expands.
+- `max_visible_activities` (config) limits how many circles + pill are shown. Overflow activities are hidden with a badge counter.
+
+### Animation Choreography
+
+All transitions use spring-animated surface style transactions.
+
+**New arrival:**
+1. Current pill shrinks (size only, in place) → completion callback
+2. Current circle slides left + new circle slides in from right (simultaneous)
+3. New circle expands to pill
+
+**Dismissal:**
+1. Dismissed pill shrinks to circle → slides right + fades out → completion callback
+2. Previous circle expands to pill
+
+### Implementation Change
+
+This model requires **N+1 subsurfaces** instead of exactly 2 — one for each visible activity slot plus one for arrivals/departures. Each activity is assigned a surface and keeps it for its lifetime. Surfaces are recycled when activities are dismissed.
+
+Alternatively, keep 2 surfaces but treat them as "expanded slot" and "circle slot" — on arrival, the circle slot shows the old activity shrinking while the expanded slot shows the new one. This matches the current architecture.
+
+### Open Questions
+
+- Should N be configurable or always 1?
+- When N>1, how should the expanded activities be arranged? Side by side as pills?
+- Should clicking a circle expand it (and shrink the current pill)?
+- Should the stack scroll/wrap when there are many activities?
+
+---
+
+## Open Questions
+
+1. **Keyboard navigation:** Should there be a global shortcut to focus the island?
+2. **Theming:** Should the island inherit from a global theme, or have its own style overrides?
+3. **Drag-and-drop:** Should files be droppable onto island activities?
+4. **Multi-output:** How should the island behave across multiple outputs?
+5. **Persistence:** Should activity state survive compositor/island restarts?
+6. **Notification grouping:** Should multiple notifications from the same app_id be grouped/replaced or stacked?

--- a/specs/notification-island.md
+++ b/specs/notification-island.md
@@ -1,0 +1,175 @@
+# Notification Island — Spec
+
+**Status:** draft
+**Parent:** dynamic-island
+
+## Summary
+
+A notification island is a group of subsurfaces that represents all notifications from one `app_id`. Multiple islands (notification groups + music) coexist side by side as a centered horizontal row. Only one island at a time can be in **Compact** (focused) mode; the rest are **Mini** circles.
+
+## Core Concepts
+
+### Every element is a subsurface
+
+The island follows a Core Animation-like model: each visual element is its own Wayland subsurface with independent size, position, corner radius, and spring animations via `otto-surface-style-v1`. The parent layer shell surface is just a transparent container.
+
+Elements:
+- **Group pill** — one subsurface per notification group (the tab header)
+- **Notification card** — one subsurface per notification in the stack
+- **Music pill** — one subsurface for the music activity
+
+### Presentation Modes
+
+Each island (group) cycles through three modes via click:
+
+| Mode | Visual | Trigger |
+|------|--------|---------|
+| **Mini** | Small circle (~28px). App icon + count badge (when count > 1). | Default for unfocused islands. |
+| **Compact** | Pill (~240x36). App icon + app name + count badge + chevron. | Click a Mini circle. |
+| **Expanded** | Compact pill stays visible. Notification cards slide down below it as a stack. | Click the Compact pill. |
+
+Click cycles: **Mini → Compact → Expanded → Compact** (clicking the pill toggles the stack).
+
+Only **1** island can be Compact/Expanded at a time (configurable, default 1). When one island becomes Compact, the previously focused one shrinks to Mini.
+
+### Hover
+
+Hover causes a subtle size increase on any island element (pill or circle) to invite interaction. No mode change on hover.
+
+## Layout
+
+All islands are arranged as a **centered horizontal row** at the top of the screen:
+
+```
+Layer surface (480px wide, anchored top-center):
+
+    [o] [o] [===compact pill===]
+    ←────── centered as group ──────→
+```
+
+- Elements are ordered left-to-right by arrival time (oldest left, newest right).
+- The focused (Compact/Expanded) island is the rightmost non-mini, or whichever was last clicked.
+- Gap between elements: 6px.
+- Vertically centered within the bar height (30px) for Mini/Compact.
+
+When a stack is open (Expanded mode), cards appear below the pill:
+
+```
+    [o] [o] [===compact pill===]
+              [  card 1        ]
+              [  card 2        ]
+              [  card 3        ]
+```
+
+Cards are centered under the pill.
+
+## Notification Group Behavior
+
+### One group = one `app_id`
+
+All notifications from the same `app_id` are grouped into one island. The group pill shows the app icon, app name, and count.
+
+### Notification lifecycle
+
+1. First notification from an app → group created, island appears as Mini (or Compact if no other island is focused).
+2. More notifications from same app → count increments, pill/circle redraws.
+3. Notification times out → stays in the group (not removed). Only dismissed by user action.
+4. User clicks a card → invokes default action + dismisses that notification.
+5. All notifications dismissed → group disappears, island removed from row.
+6. `replaces_id` → updates the notification in place (no reorder).
+
+### Stack (Expanded mode)
+
+- Default max visible cards: **5** (configurable).
+- If more than max: show a "+N more" indicator at the bottom.
+- Cards are created as subsurfaces **lazily** when the stack opens.
+- Cards are destroyed when the stack closes.
+
+### Stack open animation
+
+1. Each card starts at zero height, positioned at the pill bottom.
+2. Cards slide down to their final position with staggered delay (0.05s per card).
+3. Spring animation (same parameters as all other transitions).
+
+### Stack close animation
+
+1. Cards collapse height to zero, sliding up toward the pill.
+2. Card subsurfaces are destroyed after animation.
+
+### Closing the stack
+
+The stack closes when:
+- The pill is clicked again (toggle).
+- The user clicks outside the island.
+- The island loses focus (e.g., user focuses another app/window).
+
+## Subsurface Style
+
+All subsurfaces use `otto-surface-style-v1`:
+
+- `set_background_color(0.03, 0.03, 0.03, 1.0)` — near-black
+- `set_corner_radius(r)` — circle for Mini, pill radius for Compact, card radius for cards
+- `set_masks_to_bounds(Enabled)` — clip content
+- `set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0)` — drop shadow
+- `set_blend_mode(BackgroundBlur)` — frosted glass
+- `set_contents_gravity(Center)` — content anchored center
+
+No opacity manipulation. All elements are always fully visible.
+
+## Rendering
+
+Content is drawn with Skia into each subsurface's buffer. The buffer is larger than needed (460x100) so content can be drawn at target size before the compositor spring-animates the visual bounds.
+
+### Group pill (Compact)
+
+- App icon (rounded, left)
+- App name text (bold, 12pt)
+- Count badge (when > 1): semi-transparent pill with white count text
+- Chevron indicator (right edge)
+
+### Group circle (Mini)
+
+- App icon centered (60% of circle size)
+- Count badge overlay (bottom-right, when > 1)
+
+### Notification card
+
+- Card background: semi-transparent white (alpha 40), rounded corners (10px)
+- App icon (24px, left)
+- Title (bold, 12pt, white)
+- Body (regular, 11pt, dimmed)
+- Elapsed time (9pt, bottom-right)
+- Card dimensions: 300x60px, gap between cards: 4px
+
+## Coexistence with Music
+
+Music is another island in the same row. It follows the same Mini/Compact/Expanded rules:
+- When music is Compact, notification groups are Mini circles.
+- When a notification group is clicked to Compact, music shrinks to Mini.
+- Music Mini: 3-bar equalizer in a circle.
+- Music Compact: album art + title + artist + equalizer.
+
+## D-Bus Integration
+
+- `org.otto.Island1` — custom API for creating arbitrary activities.
+- `org.freedesktop.Notifications` — standard notification daemon. Notifications come in here and are grouped by `app_id`.
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| LAYER_W | 480 | Layer surface width |
+| BAR_HEIGHT | 30 | Topbar area height |
+| GAP | 6 | Space between islands |
+| MINI_SIZE | 28 | Mini circle diameter |
+| COMPACT_W | 240 | Compact pill width |
+| COMPACT_H | 36 | Compact pill height |
+| CARD_W | 300 | Notification card width |
+| CARD_H | 60 | Notification card height |
+| CARD_GAP | 4 | Gap between cards |
+| CARD_RADIUS | 10 | Card corner radius |
+| MAX_VISIBLE_CARDS | 5 | Default max cards in stack |
+| MAX_FOCUSED | 1 | Max islands in Compact mode |
+| SLOT_BUF_W | 460 | Subsurface buffer width |
+| SLOT_BUF_H | 100 | Subsurface buffer height |
+| BUFFER_SCALE | 2.0 | HiDPI scale factor |

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -12,6 +12,30 @@ use smithay::{
     wayland::{input_method::InputMethodSeat, shell::wlr_layer::Layer as WlrLayer},
 };
 
+/// Check if a point (in surface-local logical coordinates) falls within the
+/// parent surface's input region.  Returns `true` when the region allows input
+/// at that point (or when no explicit region is set, which means "accept all").
+///
+/// This is used as an additional gate for layer-shell hit testing: Wayland
+/// subsurfaces have their own input regions and are not clipped by the parent's
+/// region, but for compositor UI (layer shells with subsurfaces) we want the
+/// parent's input region to act as the authoritative clickable area.
+fn point_in_surface_input_region(
+    surface: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
+    point: Point<f64, Logical>,
+) -> bool {
+    smithay::wayland::compositor::with_states(surface, |states| {
+        let mut attrs = states
+            .cached_state
+            .get::<smithay::wayland::compositor::SurfaceAttributes>();
+        let attrs = attrs.current();
+        match &attrs.input_region {
+            Some(region) => region.contains(point.to_i32_round()),
+            None => true, // no region set = accept all
+        }
+    })
+}
+
 #[cfg(any(feature = "winit", feature = "x11", feature = "udev"))]
 use smithay::backend::input::AbsolutePositionEvent;
 
@@ -129,6 +153,21 @@ impl<BackendData: Backend> Otto<BackendData> {
                     let lay_layer = &layer_shell_surf.layer;
                     if lay_layer.cointains_point((phys.x as f32, phys.y as f32)) {
                         let ls = layer_shell_surf.layer_surface();
+                        let render_pos = lay_layer.render_position();
+                        let layer_abs_pos: Point<f64, Logical> =
+                            Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
+                        let relative_pos = self.pointer.current_location() - layer_abs_pos;
+                        // Gate on the parent surface's input region so that
+                        // subsurfaces outside it don't intercept events.
+                        if !point_in_surface_input_region(ls.wl_surface(), relative_pos) {
+                            continue;
+                        }
+                        if ls
+                            .surface_under(relative_pos, WindowSurfaceType::ALL)
+                            .is_none()
+                        {
+                            continue;
+                        }
                         if ls.can_receive_keyboard_focus() {
                             keyboard.set_focus(self, Some(ls.clone().into()), serial);
                             found_layer_focus = true;
@@ -191,6 +230,19 @@ impl<BackendData: Backend> Otto<BackendData> {
                     let lay_layer = &layer_shell_surf.layer;
                     if lay_layer.cointains_point((phys.x as f32, phys.y as f32)) {
                         let ls = layer_shell_surf.layer_surface();
+                        let render_pos = lay_layer.render_position();
+                        let layer_abs_pos: Point<f64, Logical> =
+                            Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
+                        let relative_pos = self.pointer.current_location() - layer_abs_pos;
+                        if !point_in_surface_input_region(ls.wl_surface(), relative_pos) {
+                            continue;
+                        }
+                        if ls
+                            .surface_under(relative_pos, WindowSurfaceType::ALL)
+                            .is_none()
+                        {
+                            continue;
+                        }
                         if ls.can_receive_keyboard_focus() {
                             keyboard.set_focus(self, Some(ls.clone().into()), serial);
                         }
@@ -321,6 +373,11 @@ impl<BackendData: Backend> Otto<BackendData> {
                         Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
                     let ls = layer_shell_surf.layer_surface().clone();
                     let relative_pos = pos - layer_abs_pos;
+                    // Gate on the parent surface's input region so that
+                    // subsurfaces outside it don't intercept events.
+                    if !point_in_surface_input_region(ls.wl_surface(), relative_pos) {
+                        continue;
+                    }
                     if let Some((surface, surface_loc)) =
                         ls.surface_under(relative_pos, WindowSurfaceType::ALL)
                     {
@@ -328,10 +385,10 @@ impl<BackendData: Backend> Otto<BackendData> {
                             PointerFocusTarget::WlSurface(surface),
                             layer_abs_pos + surface_loc.to_f64(),
                         ));
-                    } else {
-                        under = Some((ls.into(), layer_abs_pos));
+                        break;
                     }
-                    break;
+                    // surface_under returned None — the point is outside the
+                    // input region. Continue checking other layers / windows.
                 }
             }
         }
@@ -384,6 +441,9 @@ impl<BackendData: Backend> Otto<BackendData> {
                         Point::from((render_pos.x as f64 / scale, render_pos.y as f64 / scale));
                     let ls = layer_shell_surf.layer_surface().clone();
                     let relative_pos = pos - layer_abs_pos;
+                    if !point_in_surface_input_region(ls.wl_surface(), relative_pos) {
+                        continue;
+                    }
                     if let Some((surface, surface_loc)) =
                         ls.surface_under(relative_pos, WindowSurfaceType::ALL)
                     {
@@ -747,5 +807,106 @@ impl crate::Otto<crate::udev::UdevData> {
         } else {
             (clamped_x, pos_y).into()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smithay::utils::{Logical, Point, Rectangle};
+    use smithay::wayland::compositor::RegionAttributes;
+
+    /// Simulates the input-region gate used in layer-shell hit testing.
+    /// When a region is set, only points inside it should pass.
+    /// When no region is set (None), all points pass.
+    fn region_contains(region: &Option<RegionAttributes>, point: Point<i32, Logical>) -> bool {
+        match region {
+            Some(r) => r.contains(point),
+            None => true,
+        }
+    }
+
+    #[test]
+    fn no_region_accepts_all_points() {
+        let region: Option<RegionAttributes> = None;
+        assert!(region_contains(&region, (0, 0).into()));
+        assert!(region_contains(&region, (500, 500).into()));
+        assert!(region_contains(&region, (-10, -10).into()));
+    }
+
+    #[test]
+    fn empty_region_rejects_all_points() {
+        let region = Some(RegionAttributes { rects: vec![] });
+        assert!(!region_contains(&region, (0, 0).into()));
+        assert!(!region_contains(&region, (100, 15).into()));
+    }
+
+    #[test]
+    fn single_rect_region_clips_subsurface_area() {
+        // Simulates a compact music pill: 220x30 centered in a 480px-wide layer
+        // that has subsurfaces extending to 460x140.  Without the input-region
+        // gate the subsurface area (y > 30) would still intercept pointer events.
+        let x = 130; // (480 - 220) / 2
+        let region = Some(RegionAttributes {
+            rects: vec![(
+                smithay::wayland::compositor::RectangleKind::Add,
+                Rectangle::new((x, 0).into(), (220, 30).into()),
+            )],
+        });
+
+        // Inside the pill — should pass
+        assert!(region_contains(&region, (200, 15).into()));
+        assert!(region_contains(&region, (130, 0).into()));
+        assert!(region_contains(&region, (349, 29).into()));
+
+        // Outside the pill — should be rejected so subsurfaces don't intercept
+        assert!(!region_contains(&region, (0, 15).into())); // left of pill
+        assert!(!region_contains(&region, (400, 15).into())); // right of pill
+        assert!(!region_contains(&region, (200, 50).into())); // below pill
+        assert!(!region_contains(&region, (200, 200).into())); // far below (subsurface buffer)
+    }
+
+    #[test]
+    fn expanded_region_covers_pill_and_cards() {
+        // Simulates expanded notification island: pill + card stack
+        let pill = (
+            smithay::wayland::compositor::RectangleKind::Add,
+            Rectangle::new((130, 0).into(), (220, 30).into()),
+        );
+        let cards = (
+            smithay::wayland::compositor::RectangleKind::Add,
+            Rectangle::new((90, 34).into(), (300, 200).into()),
+        );
+        let region = Some(RegionAttributes {
+            rects: vec![pill, cards],
+        });
+
+        // In pill
+        assert!(region_contains(&region, (200, 15).into()));
+        // In cards
+        assert!(region_contains(&region, (200, 100).into()));
+        // Gap between pill and cards
+        assert!(!region_contains(&region, (200, 32).into()));
+        // Outside both
+        assert!(!region_contains(&region, (50, 15).into()));
+    }
+
+    #[test]
+    fn region_with_subtract_creates_hole() {
+        let region = Some(RegionAttributes {
+            rects: vec![
+                (
+                    smithay::wayland::compositor::RectangleKind::Add,
+                    Rectangle::new((0, 0).into(), (480, 400).into()),
+                ),
+                (
+                    smithay::wayland::compositor::RectangleKind::Subtract,
+                    Rectangle::new((100, 100).into(), (100, 100).into()),
+                ),
+            ],
+        });
+
+        assert!(region_contains(&region, (50, 50).into()));
+        assert!(!region_contains(&region, (150, 150).into())); // in the hole
+        assert!(region_contains(&region, (250, 250).into()));
     }
 }

--- a/src/screenshare/dbus_service.rs
+++ b/src/screenshare/dbus_service.rs
@@ -538,8 +538,8 @@ impl CompositorInterface {
 
     /// Focus an application window by app_id.
     ///
-    /// Raises the most recent window belonging to the given app_id and
-    /// gives it keyboard focus. Returns true if a matching window was found.
+    /// Sends a focus command to the compositor for the given app_id.
+    /// Returns true if the command was dispatched (not whether a window was found).
     async fn focus_app(&self, app_id: &str) -> zbus::fdo::Result<bool> {
         info!(app_id, "focus_app requested via D-Bus");
         self.compositor_tx

--- a/src/screenshare/dbus_service.rs
+++ b/src/screenshare/dbus_service.rs
@@ -515,19 +515,39 @@ impl StreamInterface {
     }
 }
 
-/// Compositor health monitoring interface.
-///
-/// Provides a simple ping/pong mechanism for watchdog health checks.
-pub struct CompositorHealthInterface;
+/// Compositor D-Bus interface for health checks and app management.
+pub struct CompositorInterface {
+    compositor_tx: Sender<CompositorCommand>,
+}
+
+impl CompositorInterface {
+    fn new(compositor_tx: Sender<CompositorCommand>) -> Self {
+        Self { compositor_tx }
+    }
+}
 
 #[interface(name = "org.otto.Compositor")]
-impl CompositorHealthInterface {
+impl CompositorInterface {
     /// Ping method for watchdog health checks.
     ///
     /// Returns "pong" if the compositor is responsive.
     async fn ping(&self) -> zbus::fdo::Result<String> {
         debug!("Ping received from watchdog");
         Ok("pong".to_string())
+    }
+
+    /// Focus an application window by app_id.
+    ///
+    /// Raises the most recent window belonging to the given app_id and
+    /// gives it keyboard focus. Returns true if a matching window was found.
+    async fn focus_app(&self, app_id: &str) -> zbus::fdo::Result<bool> {
+        info!(app_id, "focus_app requested via D-Bus");
+        self.compositor_tx
+            .send(CompositorCommand::FocusApp {
+                app_id: app_id.to_string(),
+            })
+            .map_err(|e| zbus::fdo::Error::Failed(format!("channel send failed: {e}")))?;
+        Ok(true)
     }
 }
 
@@ -544,11 +564,11 @@ pub async fn run_dbus_service(compositor_tx: Sender<CompositorCommand>) -> zbus:
 
     connection.request_name("org.otto.ScreenCast").await?;
 
-    // Register the health interface for watchdog
-    let health = CompositorHealthInterface;
+    // Register the compositor interface (health + app management)
+    let compositor = CompositorInterface::new(compositor_tx);
     connection
         .object_server()
-        .at("/org/otto/Compositor", health)
+        .at("/org/otto/Compositor", compositor)
         .await?;
 
     connection.request_name("org.otto.Compositor").await?;

--- a/src/screenshare/mod.rs
+++ b/src/screenshare/mod.rs
@@ -103,6 +103,8 @@ pub enum CompositorCommand {
     },
     /// Destroy a session.
     DestroySession { session_id: String },
+    /// Focus an application by app_id (e.g. from notification click).
+    FocusApp { app_id: String },
 }
 
 /// Information about an available output.
@@ -406,6 +408,10 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             } else {
                 tracing::warn!("Session not found for destruction: {}", session_id);
             }
+        }
+        CompositorCommand::FocusApp { app_id } => {
+            tracing::info!("FocusApp: {}", app_id);
+            state.focus_app(&app_id);
         }
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -392,6 +392,14 @@ impl<BackendData: Backend> Otto<BackendData> {
             ),
         > = std::collections::HashMap::new();
 
+        // Track per-parent child ordering as Smithay delivers it
+        // (respects wl_subsurface.place_above / place_below reordering)
+        #[allow(clippy::mutable_key_type)]
+        let mut children_order: std::collections::HashMap<
+            smithay::reexports::wayland_server::backend::ObjectId,
+            Vec<smithay::reexports::wayland_server::backend::ObjectId>,
+        > = std::collections::HashMap::new();
+
         smithay::wayland::compositor::with_surface_tree_downward(
             &wl_surface,
             initial_context,
@@ -439,10 +447,13 @@ impl<BackendData: Backend> Otto<BackendData> {
                     parent_id.clone(),
                 ) {
                     render_elements.push_front(wvs.clone());
-                    surface_info.insert(
-                        surface.id(),
-                        (surface.clone(), *location, parent_id.clone()),
-                    );
+                    let sid = surface.id();
+                    surface_info
+                        .insert(sid.clone(), (surface.clone(), *location, parent_id.clone()));
+                    // Record child ordering per parent for subsurface reordering
+                    if let Some(pid) = parent_id {
+                        children_order.entry(pid.clone()).or_default().push(sid);
+                    }
                 } else {
                     // Null buffer — hide the layer so unmapped subsurfaces don't linger
                     if let Some(layer) = self.surface_layers.get(&surface.id()) {
@@ -488,6 +499,19 @@ impl<BackendData: Backend> Otto<BackendData> {
                                 .layers_engine
                                 .append_layer(&surface_layer, parent_layer.id());
                         }
+                    }
+                }
+            }
+        }
+
+        // Re-append children in Smithay's subsurface order so that
+        // place_above / place_below reordering is reflected in lay-rs.
+        for (parent_id, child_ids) in children_order.iter() {
+            if let Some(parent_layer) = self.surface_layers.get(parent_id) {
+                let parent_node = parent_layer.id();
+                for child_id in child_ids {
+                    if let Some(child_layer) = self.surface_layers.get(child_id) {
+                        let _ = self.layers_engine.append_layer(child_layer, parent_node);
                     }
                 }
             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1004,6 +1004,11 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 (WlSurface, Option<ObjectId>),
             > = std::collections::HashMap::new();
 
+            // Track per-parent child ordering for subsurface reordering
+            #[allow(clippy::mutable_key_type)]
+            let mut children_order: std::collections::HashMap<ObjectId, Vec<ObjectId>> =
+                std::collections::HashMap::new();
+
             let initial_location: smithay::utils::Point<f64, smithay::utils::Physical> =
                 (0.0, 0.0).into();
             let initial_context = (initial_location, initial_location, None);
@@ -1046,7 +1051,11 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                         parent_id.clone(),
                     ) {
                         render_elements.push_front(wvs);
-                        surface_info.insert(surface.id(), (surface.clone(), parent_id.clone()));
+                        let sid = surface.id();
+                        surface_info.insert(sid.clone(), (surface.clone(), parent_id.clone()));
+                        if let Some(pid) = parent_id {
+                            children_order.entry(pid.clone()).or_default().push(sid);
+                        }
                     }
                 },
                 |_, _, _| true,
@@ -1080,6 +1089,18 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                         let _ = self
                             .layers_engine
                             .append_layer(&layer, self.workspaces.dnd_view.content_layer.id());
+                    }
+                }
+            }
+
+            // Re-append children in Smithay's subsurface order
+            for (parent_id, child_ids) in children_order.iter() {
+                if let Some(parent_layer) = self.surface_layers.get(parent_id) {
+                    let parent_node = parent_layer.id();
+                    for child_id in child_ids {
+                        if let Some(child_layer) = self.surface_layers.get(child_id) {
+                            let _ = self.layers_engine.append_layer(child_layer, parent_node);
+                        }
                     }
                 }
             }
@@ -1271,6 +1292,12 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 ),
             > = std::collections::HashMap::new();
 
+            // Track per-parent child ordering as Smithay delivers it
+            // (respects wl_subsurface.place_above / place_below reordering)
+            #[allow(clippy::mutable_key_type)]
+            let mut children_order: std::collections::HashMap<ObjectId, Vec<ObjectId>> =
+                std::collections::HashMap::new();
+
             smithay::wayland::compositor::with_surface_tree_downward(
                 &window_surface,
                 initial_context,
@@ -1311,10 +1338,13 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                         parent_id.clone(),
                     ) {
                         render_elements.push_front(window_view.clone());
-                        surface_info.insert(
-                            surface.id(),
-                            (surface.clone(), *location, parent_id.clone()),
-                        );
+                        let sid = surface.id();
+                        surface_info
+                            .insert(sid.clone(), (surface.clone(), *location, parent_id.clone()));
+                        // Record child ordering per parent for subsurface reordering
+                        if let Some(pid) = parent_id {
+                            children_order.entry(pid.clone()).or_default().push(sid);
+                        }
                     } else {
                         // Surface committed a null buffer (unmapped subsurface) — hide its layer
                         if let Some(layer) = self.surface_layers.get(&surface.id()) {
@@ -1348,6 +1378,21 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     if let Some(parent_id) = parent_id {
                         if let Some(parent_layer) = self.surface_layers.get(parent_id) {
                             let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
+                        }
+                    }
+                }
+            }
+
+            // Re-append children in Smithay's subsurface order so that
+            // place_above / place_below reordering is reflected in lay-rs.
+            // append_layer detaches and re-appends as the last child, so
+            // iterating in order produces the correct sibling sequence.
+            for (parent_id, child_ids) in children_order.iter() {
+                if let Some(parent_layer) = self.surface_layers.get(parent_id) {
+                    let parent_node = parent_layer.id();
+                    for child_id in child_ids {
+                        if let Some(child_layer) = self.surface_layers.get(child_id) {
+                            let _ = self.layers_engine.append_layer(child_layer, parent_node);
                         }
                     }
                 }

--- a/test-notifications.sh
+++ b/test-notifications.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Random notification generator for testing otto-islands
+# Uses -a to set app_name so notifications group by app
+
+notifications=(
+  "thunar|File Manager|Your downloads folder has 847 files. At this point it's an archaeological dig."
+  "thunar|File Manager|Move complete. 3 files had the same name. Good luck."
+  "firefox|Firefox|Tab 47 is using 2GB of RAM. It's been open since March."
+  "firefox|Firefox|Password breach detected. It was 'password123'. Again."
+  "firefox|Firefox|A website wants to send you notifications. The audacity."
+  "thunderbird|Thunderbird|You have 3 unread emails and 12,000 you're pretending don't exist."
+  "thunderbird|Thunderbird|Reply All was clicked. Prayers up."
+  "spotify|Spotify|Your Discover Weekly is ready. It's still mostly lo-fi hip hop."
+  "spotify|Spotify|Your friend started a listening session. It's country."
+  "vlc|VLC|Playback finished. Time to stare at the traffic cone in silence."
+  "steam|Steam|Your friend is playing Elden Ring. They started 6 hours ago. They haven't moved."
+  "steam|Steam|Sale: 90% off a game you already own. You're tempted anyway."
+  "telegram|Telegram|Mom sent a photo. It's the dog again. 10/10 would notify."
+  "telegram|Telegram|5 unread messages in the family group chat. All forwarded memes."
+  "discord|Discord|Someone @everyone'd in #general. Chaos ensues."
+  "discord|Discord|You were pinged 14 times while you were away. None were urgent."
+  "gimp|GIMP|Export complete. The file is 4 pixels wider than you wanted."
+  "nautilus|Files|Trash has 23GB of files you'll never restore but refuse to empty."
+  "gnome-terminal|Terminal|Build succeeded on the 14th attempt. We don't talk about the other 13."
+  "gnome-terminal|Terminal|Segfault. But hey, it compiled."
+  "chromium|Chromium|A tab crashed. Honestly, it lived a good life."
+  "libreoffice|LibreOffice|Document recovered. The formatting did not survive."
+  "obs-studio|OBS Studio|Recording stopped. You forgot to unmute. Classic."
+  "code|VS Code|Extension wants to reload. Again. For the 5th time today."
+  "evolution|Calendar|Meeting in 5 minutes. You are not prepared."
+  "blender|Blender|Render complete: 4 hours for a donut. Worth it."
+)
+
+echo "Sending random notifications every 5-15 seconds. Ctrl+C to stop."
+
+while true; do
+  idx=$((RANDOM % ${#notifications[@]}))
+  IFS='|' read -r app_id title body <<< "${notifications[$idx]}"
+  notify-send -a "$app_id" -i "$app_id" "$title" "$body"
+  echo "[$app_id] $title: $body"
+  sleep $((5 + RANDOM % 11))
+done


### PR DESCRIPTION
## Summary

Adds **otto-islands**, an experimental notification manager for Otto inspired by the iOS dynamic island.

Otto Islands is a standalone Wayland app that uses Otto's **experimental surface style protocol** — giving clients direct access to the compositor's animated scene graph, similar to Core Animation on iOS/macOS. The app draws flat content once with Skia; the compositor handles all animation (springs, easing), clipping, shadows, background blur, and content gravity at display refresh rate. No client-side render loop needed.

![otto-islands](https://github.com/user-attachments/assets/9fec43ac-3b17-49c5-8a3b-f0f52cc395a2)

### Surface style protocol highlights
- **Animated properties**: position, size, corner radius, opacity — with springs and easing, batched in transactions
- **Graphical properties**: background color, shadow, background blur (frosted glass), masks-to-bounds
- **Content gravity**: how the buffer maps to surface bounds (resize, aspect fit, center) — like `contentsGravity` in Core Animation

### Notification features
- `org.freedesktop.Notifications` D-Bus daemon with XDG icon resolution
- Notification grouping by app_id with stacked card rendering
- Three display modes: Mini pill, Compact with title/body, Expanded cards
- Card close button (dismiss without triggering action)
- Smooth spring animations between modes
- Peek-to-Compact on new notification, auto-dismiss with timeout
- Click notification to focus the originating app window
- Expanded islands coexist with Compact (peeking) — new notifications don't disrupt interaction

### Compositor-side changes
- Subsurface z-order control (place_above/place_below) in shell
- Layer-shell input region hit testing for pointer events
- FocusApp compositor command for click-to-focus from islands

## Try it out

```sh
# Terminal 1: run Otto
cargo run -- --winit

# Terminal 2: run otto-islands
WAYLAND_DISPLAY=wayland-1 cargo run -p otto-islands

# Terminal 3: send notifications
notify-send -a "Firefox" "New Tab" "You opened a new tab"
notify-send -a "Firefox" "Download" "file.zip completed"
notify-send -a "Telegram" "Mom" "Sent a photo"
```

Music, screenshare dialog, and fingerprint auth islands will follow in separate PRs.

## Test plan

- [x] `cargo build` and `cargo clippy --features default -- -D warnings` pass
- [x] Run otto-islands alongside Otto in winit mode
- [x] Send notifications with `notify-send` — verify they appear as islands
- [x] Multiple notifications from same app group into one island
- [x] Click left side of card → app focuses, card dismisses
- [x] Click "Close" on right side of card → card dismisses only
- [x] Islands auto-dismiss after timeout
- [x] Expanded island stays open when new notification from different app arrives