### PR TITLE
fix: send output_enter in wlr-foreign-toplevel protocol

### DIFF
--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -147,9 +147,9 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                 .map(|o| o.name()),
             target_output.as_ref().map(|o| o.name()),
         );
-        if let Some(output) = target_output {
+        if let Some(ref output) = target_output {
             self.workspaces
-                .map_window_for_output(&output, &window_element, location, true, None);
+                .map_window_for_output(output, &window_element, location, true, None);
         } else {
             self.workspaces
                 .map_window(&window_element, location, true, None);
@@ -168,23 +168,12 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             &app_id,
             &title,
             surface_id.clone(),
+            target_output.as_ref(),
         );
 
         let handles = crate::state::foreign_toplevel_shared::ForeignToplevelHandles::new(
-            ext_handle, wlr_handle,
+            ext_handle, wlr_handle, target_output,
         );
-
-        // Tell taskbars (e.g. Waybar) which output this toplevel is on
-        if let Some(output) = self
-            .workspaces
-            .output_under(pointer_location)
-            .next()
-            .cloned()
-            .or_else(|| self.workspaces.primary_output().cloned())
-        {
-            handles.send_output_enter(&output);
-        }
-
         self.foreign_toplevels.insert(surface_id.clone(), handles);
 
         // Create the rendering layer for sc_layers to find

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -173,6 +173,18 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
         let handles = crate::state::foreign_toplevel_shared::ForeignToplevelHandles::new(
             ext_handle, wlr_handle,
         );
+
+        // Tell taskbars (e.g. Waybar) which output this toplevel is on
+        if let Some(output) = self
+            .workspaces
+            .output_under(pointer_location)
+            .next()
+            .cloned()
+            .or_else(|| self.workspaces.primary_output().cloned())
+        {
+            handles.send_output_enter(&output);
+        }
+
         self.foreign_toplevels.insert(surface_id.clone(), handles);
 
         // Create the rendering layer for sc_layers to find

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -172,7 +172,9 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
         );
 
         let handles = crate::state::foreign_toplevel_shared::ForeignToplevelHandles::new(
-            ext_handle, wlr_handle, target_output,
+            ext_handle,
+            wlr_handle,
+            target_output,
         );
         self.foreign_toplevels.insert(surface_id.clone(), handles);
 

--- a/src/state/foreign_toplevel_shared.rs
+++ b/src/state/foreign_toplevel_shared.rs
@@ -3,6 +3,7 @@
 /// This module provides a unified interface for both:
 /// - ext-foreign-toplevel-list-v1 (newer, Smithay built-in)
 /// - wlr-foreign-toplevel-management-unstable-v1 (older, wlroots protocol)
+use smithay::output::Output;
 use smithay::wayland::foreign_toplevel_list::ForeignToplevelHandle as ExtHandle;
 
 use super::wlr_foreign_toplevel::WlrForeignToplevelHandle;
@@ -54,6 +55,20 @@ impl ForeignToplevelHandles {
         }
         if let Some(wlr) = &self.wlr {
             wlr.send_closed();
+        }
+    }
+
+    /// Notify that this toplevel is visible on the given output.
+    pub fn send_output_enter(&self, output: &Output) {
+        if let Some(wlr) = &self.wlr {
+            wlr.send_output_enter(output);
+        }
+    }
+
+    /// Notify that this toplevel is no longer visible on the given output.
+    pub fn send_output_leave(&self, output: &Output) {
+        if let Some(wlr) = &self.wlr {
+            wlr.send_output_leave(output);
         }
     }
 

--- a/src/state/foreign_toplevel_shared.rs
+++ b/src/state/foreign_toplevel_shared.rs
@@ -14,13 +14,16 @@ pub struct ForeignToplevelHandles {
     pub ext: Option<ExtHandle>,
     /// wlr-foreign-toplevel-management handle (older wlroots protocol)
     pub wlr: Option<WlrForeignToplevelHandle>,
+    /// The output this toplevel is on (for late-joining managers)
+    pub output: Option<Output>,
 }
 
 impl ForeignToplevelHandles {
-    pub fn new(ext: ExtHandle, wlr: WlrForeignToplevelHandle) -> Self {
+    pub fn new(ext: ExtHandle, wlr: WlrForeignToplevelHandle, output: Option<Output>) -> Self {
         Self {
             ext: Some(ext),
             wlr: Some(wlr),
+            output,
         }
     }
 

--- a/src/state/wlr_foreign_toplevel.rs
+++ b/src/state/wlr_foreign_toplevel.rs
@@ -42,6 +42,7 @@ impl WlrForeignToplevelManagerState {
         app_id: &str,
         title: &str,
         window_id: ObjectId,
+        output: Option<&Output>,
     ) -> WlrForeignToplevelHandle
     where
         D: Dispatch<ZwlrForeignToplevelHandleV1, Arc<Mutex<WlrToplevelData>>> + 'static,
@@ -68,9 +69,14 @@ impl WlrForeignToplevelManagerState {
                 if let Some(handle) = handle {
                     manager.toplevel(&handle);
 
-                    // Send initial state
+                    // Send initial properties + output in one batch before done
                     handle.app_id(app_id.to_string());
                     handle.title(title.to_string());
+                    if let Some(output) = output {
+                        for wl_output in output.client_outputs(&client) {
+                            handle.output_enter(&wl_output);
+                        }
+                    }
                     handle.done();
 
                     handle_data.lock().unwrap().resources.push(handle);
@@ -238,8 +244,7 @@ impl<BackendData: Backend> GlobalDispatch<ZwlrForeignToplevelManagerV1, (), Otto
                         handle.app_id(data.app_id.clone());
                         handle.title(data.title.clone());
                         handle.state(data.current_state.clone());
-                        // Send output_enter for all outputs so taskbars display the toplevel
-                        for output in state.workspaces.outputs() {
+                        if let Some(output) = &handles.output {
                             for wl_output in output.client_outputs(&client) {
                                 handle.output_enter(&wl_output);
                             }

--- a/src/state/wlr_foreign_toplevel.rs
+++ b/src/state/wlr_foreign_toplevel.rs
@@ -4,6 +4,7 @@
 /// Used by rofi, waybar, and other wlroots-based tools.
 use std::sync::{Arc, Mutex};
 
+use smithay::output::Output;
 use wayland_server::{
     backend::ObjectId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
@@ -130,6 +131,30 @@ impl WlrForeignToplevelHandle {
         }
     }
 
+    pub fn send_output_enter(&self, output: &Output) {
+        let data = self.data.lock().unwrap();
+        for resource in &data.resources {
+            if let Some(client) = resource.client() {
+                for wl_output in output.client_outputs(&client) {
+                    resource.output_enter(&wl_output);
+                }
+                resource.done();
+            }
+        }
+    }
+
+    pub fn send_output_leave(&self, output: &Output) {
+        let data = self.data.lock().unwrap();
+        for resource in &data.resources {
+            if let Some(client) = resource.client() {
+                for wl_output in output.client_outputs(&client) {
+                    resource.output_leave(&wl_output);
+                }
+                resource.done();
+            }
+        }
+    }
+
     pub fn send_closed(&self) {
         let data = self.data.lock().unwrap();
         for resource in &data.resources {
@@ -213,6 +238,12 @@ impl<BackendData: Backend> GlobalDispatch<ZwlrForeignToplevelManagerV1, (), Otto
                         handle.app_id(data.app_id.clone());
                         handle.title(data.title.clone());
                         handle.state(data.current_state.clone());
+                        // Send output_enter for all outputs so taskbars display the toplevel
+                        for output in state.workspaces.outputs() {
+                            for wl_output in output.client_outputs(&client) {
+                                handle.output_enter(&wl_output);
+                            }
+                        }
                         handle.done();
 
                         // Store handle reference


### PR DESCRIPTION
## Summary
- Waybar's `wlr/taskbar` module filters toplevels by output — without `output_enter` events, no windows are displayed
- Send `output_enter` when a toplevel is first mapped (resolves the correct `wl_output` per-client)
- Send `output_enter` for existing toplevels when a new manager binds (late-joining Waybar)
- Add `send_output_enter` / `send_output_leave` to both `WlrForeignToplevelHandle` and `ForeignToplevelHandles`

fixes #88 

## Test plan
- [x] Run Otto, launch Waybar with `wlr/taskbar` module, open windows — they should appear in the taskbar
- [x] Start Waybar after windows are already open — existing windows should appear
- [ ] Multi-output: verify windows show on the correct output's taskbar