### PR TITLE
fix: popup crash and subsurface rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ otto-kit = { path = "components/otto-kit" }
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-tag = "v1.9.0"
+tag = "v1.10.0"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,8 @@ mpris = "2.0"
 otto-kit = { path = "components/otto-kit" }
 
 [dependencies.laye-rs]
-# path = "../layers"
 git = "https://github.com/nongio/layers"
-tag = "v1.8.0"
+tag = "v1.9.0"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -33,7 +33,7 @@ debugger = ["laye-rs/debugger"]
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-tag = "v1.9.0"
+tag = "v1.10.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -33,7 +33,7 @@ debugger = ["laye-rs/debugger"]
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-tag = "v1.8.0"
+tag = "v1.9.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]

--- a/src/render_elements/scene_element.rs
+++ b/src/render_elements/scene_element.rs
@@ -168,7 +168,7 @@ impl ScenePerfStats {
         let delta_no_change = delta_updates.saturating_sub(delta_changes);
 
         tracing::info!(
-            target: "screen_composer::perf.scene",
+            target: "otto::perf.scene",
             total_updates = self.total_updates,
             updates_per_sec = delta_updates,
             updates_with_scene_changes = delta_changes,

--- a/src/render_elements/scene_element.rs
+++ b/src/render_elements/scene_element.rs
@@ -167,13 +167,13 @@ impl ScenePerfStats {
         let delta_damage = self.updates_with_damage - self.prev_logged_damage;
         let delta_no_change = delta_updates.saturating_sub(delta_changes);
 
-        tracing::info!(
-            target: "otto::perf.scene",
+        tracing::debug!(
             total_updates = self.total_updates,
             updates_per_sec = delta_updates,
             updates_with_scene_changes = delta_changes,
             updates_with_damage = delta_damage,
             updates_without_changes = delta_no_change,
+            "scene perf counters",
         );
 
         self.prev_logged_updates = self.total_updates;

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -298,11 +298,14 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
         // Use cached root lookup - O(1) instead of traversing popup tree
         let popup_id = popup_surface.wl_surface().id();
 
-        // Remove from popup overlay layer
-        self.workspaces.popup_overlay.remove_popup(&popup_id);
+        // Remove from popup overlay layer and get subsurface IDs for cleanup
+        let popup_surface_ids = self.workspaces.popup_overlay.remove_popup(&popup_id);
 
-        // Clean up layers for this popup surface
+        // Clean up layers for this popup surface and all its subsurfaces
         self.destroy_layer_for_surface(&popup_id);
+        for surface_id in &popup_surface_ids {
+            self.destroy_layer_for_surface(surface_id);
+        }
         // Also clean up any sc-layers attached to these surfaces
         self.surfaces_style.remove(&popup_id);
 
@@ -1384,6 +1387,7 @@ impl<BackendData: Backend> Otto<BackendData> {
         if let Some(layer) = self.surface_layers.remove(surface_id) {
             self.layers_engine.mark_for_delete(layer.id);
         }
+        self.surface_layer_parents.remove(surface_id);
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -77,10 +77,7 @@ use smithay::{
         },
         shell::{
             wlr_layer::WlrLayerShellState,
-            xdg::{
-                decoration::XdgDecorationState, SurfaceCachedState, XdgPopupSurfaceData,
-                XdgShellState,
-            },
+            xdg::{decoration::XdgDecorationState, SurfaceCachedState, XdgShellState},
         },
         shm::{ShmHandler, ShmState},
         socket::ListeningSocketSource,
@@ -285,6 +282,9 @@ pub struct Otto<BackendData: Backend + 'static> {
     pub style_transactions: HashMap<ObjectId, crate::surface_style::StyleTransaction>,
     // Map from surface ID to its rendering layer in the scene graph
     pub surface_layers: HashMap<ObjectId, layers::prelude::Layer>,
+    /// Tracks which parent ObjectId each surface layer was last appended to,
+    /// so we can skip redundant append_layer calls that cause flicker.
+    pub surface_layer_parents: HashMap<ObjectId, ObjectId>,
     // Pre-warmed View caches: surface_id -> (layer_key -> NodeRef)
     // Built during surface creation, moved into Views when they're created
     pub view_warm_cache:
@@ -744,6 +744,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             // Surface style protocol
             surfaces_style: HashMap::new(),
             style_transactions: HashMap::new(),
+            surface_layer_parents: HashMap::new(),
             surface_layers: HashMap::new(),
             view_warm_cache: HashMap::new(),
 
@@ -1256,23 +1257,6 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 );
 
                 self.surface_layers.extend(popup_layers);
-
-                // Show the popup only after the initial configure has been sent and
-                // the client has committed at the correct position. Until then the
-                // layer stays hidden (as initialised in get_or_create_popup_layer).
-                let initial_configure_sent =
-                    smithay::wayland::compositor::with_states(popup_surface, |states| {
-                        states
-                            .data_map
-                            .get::<XdgPopupSurfaceData>()
-                            .map(|d: &std::sync::Mutex<_>| d.lock().unwrap().initial_configure_sent)
-                            .unwrap_or(false)
-                    });
-                if initial_configure_sent {
-                    if let Some(popup_layer) = self.workspaces.popup_overlay.get_popup(&popup_id) {
-                        popup_layer.layer.set_hidden(false);
-                    }
-                }
             });
 
             let initial_location: smithay::utils::Point<f64, smithay::utils::Physical> =
@@ -1291,12 +1275,6 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     Option<ObjectId>,
                 ),
             > = std::collections::HashMap::new();
-
-            // Track per-parent child ordering as Smithay delivers it
-            // (respects wl_subsurface.place_above / place_below reordering)
-            #[allow(clippy::mutable_key_type)]
-            let mut children_order: std::collections::HashMap<ObjectId, Vec<ObjectId>> =
-                std::collections::HashMap::new();
 
             smithay::wayland::compositor::with_surface_tree_downward(
                 &window_surface,
@@ -1338,13 +1316,10 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                         parent_id.clone(),
                     ) {
                         render_elements.push_front(window_view.clone());
-                        let sid = surface.id();
-                        surface_info
-                            .insert(sid.clone(), (surface.clone(), *location, parent_id.clone()));
-                        // Record child ordering per parent for subsurface reordering
-                        if let Some(pid) = parent_id {
-                            children_order.entry(pid.clone()).or_default().push(sid);
-                        }
+                        surface_info.insert(
+                            surface.id(),
+                            (surface.clone(), *location, parent_id.clone()),
+                        );
                     } else {
                         // Surface committed a null buffer (unmapped subsurface) — hide its layer
                         if let Some(layer) = self.surface_layers.get(&surface.id()) {
@@ -1374,25 +1349,19 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                         shared_gravity,
                     );
 
-                    // Set up parent-child relationship using layers_engine
+                    // Set up parent-child relationship using layers_engine.
+                    // Only re-parent if the parent changed — re-appending on
+                    // every commit detaches and re-attaches the node, which
+                    // causes flicker.
                     if let Some(parent_id) = parent_id {
-                        if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                            let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
-                        }
-                    }
-                }
-            }
-
-            // Re-append children in Smithay's subsurface order so that
-            // place_above / place_below reordering is reflected in lay-rs.
-            // append_layer detaches and re-appends as the last child, so
-            // iterating in order produces the correct sibling sequence.
-            for (parent_id, child_ids) in children_order.iter() {
-                if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                    let parent_node = parent_layer.id();
-                    for child_id in child_ids {
-                        if let Some(child_layer) = self.surface_layers.get(child_id) {
-                            let _ = self.layers_engine.append_layer(child_layer, parent_node);
+                        let needs_reparent =
+                            self.surface_layer_parents.get(surface_id) != Some(parent_id);
+                        if needs_reparent {
+                            if let Some(parent_layer) = self.surface_layers.get(parent_id) {
+                                let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
+                                self.surface_layer_parents
+                                    .insert(surface_id.clone(), parent_id.clone());
+                            }
                         }
                     }
                 }

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -661,7 +661,11 @@ pub fn run_udev() {
                     .all(|s| s.idle_countdown == 0);
                 for device in state.backend_data.backends.values_mut() {
                     for surface in device.surfaces.values_mut() {
-                        surface.idle_countdown = 30;
+                        // Short tail after the last input/commit — enough to absorb
+                        // one missed event gap without flapping fast/slow dispatch.
+                        // (Was 30 ≈ 500 ms which kept the 1 kHz poll loop hot
+                        // through entire animations with no benefit.)
+                        surface.idle_countdown = 3;
                     }
                 }
                 if was_idle {

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -618,8 +618,9 @@ impl Otto<UdevData> {
                     surface.avg_render_time_us * 0.9 + render_time_us * 0.1;
                 // Reset countdown on any activity: animations, actual frame
                 // submitted, or a render triggered by input/client commit.
+                // Short tail — see commentary in init.rs dispatch loop.
                 if has_animations || was_rendered {
-                    surface.idle_countdown = 30; // ~0.5s at 60Hz
+                    surface.idle_countdown = 3;
                 }
             }
         }

--- a/src/workspaces/popup_overlay.rs
+++ b/src/workspaces/popup_overlay.rs
@@ -14,6 +14,9 @@ pub struct PopupLayer {
     pub root_window_id: ObjectId,
     pub layer: Layer,
     pub content_layer: Layer,
+    /// Surface IDs whose layers live under this popup's content_layer.
+    /// Used to clean up `surface_layers` when the popup is destroyed.
+    surface_ids: Vec<ObjectId>,
 }
 
 /// View for rendering popups on top of all windows
@@ -75,10 +78,6 @@ impl PopupOverlayView {
                 content_layer.set_pointer_events(false);
                 content_layer.set_picture_cached(true);
 
-                // Start hidden — only show after the initial configure has been
-                // acknowledged and the popup has committed at its correct position.
-                layer.set_hidden(true);
-
                 let _ = self.layers_engine.append_layer(&layer, self.layer.id());
                 let _ = self.layers_engine.append_layer(&content_layer, layer.id());
 
@@ -87,6 +86,7 @@ impl PopupOverlayView {
                     root_window_id,
                     layer,
                     content_layer,
+                    surface_ids: Vec::new(),
                 }
             })
     }
@@ -107,10 +107,6 @@ impl PopupOverlayView {
         let popup =
             self.get_or_create_popup_layer(popup_id.clone(), root_window_id.clone(), warm_cache);
 
-        // Account for the layer's size and anchor point when positioning
-        // The position parameter represents where we want the top-left corner to be,
-        // but set_position places the layer's anchor point at that position.
-        // So we need to offset by (size * anchor_point) to get the correct visual position.
         let anchor_point = popup.layer.anchor_point();
         let size = popup.layer.render_size();
         let adjusted_position = Point {
@@ -119,17 +115,24 @@ impl PopupOverlayView {
         };
         popup.layer.set_position(adjusted_position, None);
 
-        // Map surface IDs to their layers
         let mut surface_layers: HashMap<ObjectId, Layer> = HashMap::new();
+        let mut new_surface_ids: Vec<ObjectId> = Vec::new();
 
         for wvs in surfaces.iter() {
             if wvs.phy_dst_w <= 0.0 || wvs.phy_dst_h <= 0.0 {
                 continue;
             }
 
-            // Reuse layer from cache if it exists, otherwise create new one
+            // Reuse layer from cache if it exists and alive, otherwise create new one
             let layer = if let Some(cached_layer) = existing_surface_layers.get(&wvs.id) {
-                cached_layer.clone()
+                if layers_engine.is_layer_alive(&cached_layer.id()) {
+                    cached_layer.clone()
+                } else {
+                    let new_layer = layers_engine.new_layer();
+                    let key = format!("surface_{:?}", wvs.id);
+                    new_layer.set_key(&key);
+                    new_layer
+                }
             } else {
                 let new_layer = layers_engine.new_layer();
                 let key = format!("surface_{:?}", wvs.id);
@@ -137,42 +140,45 @@ impl PopupOverlayView {
                 new_layer
             };
 
-            // Configure layer with all properties and draw callback
             crate::workspaces::utils::configure_surface_layer(
                 &layer,
                 wvs,
-                crate::surface_style::ContentsGravity::TopLeft,
+                crate::surface_style::ContentsGravity::Resize,
                 false,
                 None,
             );
 
-            // Set up parent-child relationship
             if let Some(ref parent_id) = wvs.parent_id {
                 if let Some(parent_layer) = surface_layers.get(parent_id) {
                     let _ = layers_engine.append_layer(&layer, parent_layer.id());
                 } else {
-                    // Parent not yet created, append to content layer
                     let _ = layers_engine.append_layer(&layer, popup.content_layer.id());
                 }
             } else {
-                // Root surface, append to content layer
                 let _ = layers_engine.append_layer(&layer, popup.content_layer.id());
             }
 
+            new_surface_ids.push(wvs.id.clone());
             surface_layers.insert(wvs.id.clone(), layer);
         }
+
+        popup.surface_ids = new_surface_ids;
 
         surface_layers
     }
 
-    /// Remove a popup layer
-    pub fn remove_popup(&mut self, popup_id: &ObjectId) {
+    /// Remove a popup layer, returning surface IDs that need cleanup from surface_layers
+    pub fn remove_popup(&mut self, popup_id: &ObjectId) -> Vec<ObjectId> {
         if let Some(popup) = self.popup_layers.remove(popup_id) {
             popup.layer.remove();
+            popup.surface_ids
+        } else {
+            Vec::new()
         }
     }
 
     /// Remove all popups belonging to a specific root window
+    /// Returns all surface IDs (popup + subsurface) that need cleanup
     pub fn remove_popups_for_window(&mut self, root_window_id: &ObjectId) -> Vec<ObjectId> {
         let to_remove: Vec<ObjectId> = self
             .popup_layers
@@ -181,11 +187,13 @@ impl PopupOverlayView {
             .map(|(id, _)| id.clone())
             .collect();
 
+        let mut all_surface_ids = Vec::new();
         for id in to_remove.iter() {
-            self.remove_popup(id);
+            let surface_ids = self.remove_popup(id);
+            all_surface_ids.extend(surface_ids);
         }
 
-        to_remove
+        all_surface_ids
     }
 
     /// Clear all popup layers

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -252,13 +252,12 @@ pub fn configure_surface_layer(
     }
 
     layer.set_pointer_events(false);
-    // Picture caching is enabled so opacity/transform animations on the layer
-    // (e.g. popup fade-in) can composite the cached bitmap without re-rasterizing.
-    // The draw closure still reads live state from textures_storage, but lay-rs
-    // invalidates the cache when set_draw_content marks the layer dirty on commit.
+    // Picture caching keeps opacity/transform animations cheap — the cached
+    // bitmap is composited without re-rasterising the draw closure.
+    // Re-installing set_draw_content below on every commit does NOT clear
+    // the cache (lay-rs only swaps the closure); the closure's returned
+    // damage rect is the source of truth for partial repaint.
     layer.set_picture_cached(true);
-    // The draw_content callback fills the entire bounds with the surface texture,
-    // so this layer can act as an occluder in occlusion culling.
     layer.set_content_opaque(true);
 
     let draw_wvs = wvs.clone();


### PR DESCRIPTION
## Summary
- Track popup subsurface IDs and clean them from `surface_layers` on popup destroy, preventing stale cached layers from causing panics when Wayland reuses ObjectIDs
- Check `is_layer_alive` before reusing cached popup surface layers (defense in depth)
- Remove `children_order` re-append loop that broke subsurface z-order and caused menu flicker
- Only re-parent subsurface layers when parent actually changes
- Remove `set_hidden(true)` / `initial_configure_sent` gating on popup layers that left some popup types permanently invisible
- Bump laye-rs to v1.9.0 (includes safe `scene_remove_layer` subtree removal)

## Test plan
- [x] Open/close Firefox right-click context menus — no crash
- [x] Open/close Firefox hamburger menu — renders correctly, no flicker
- [x] Rapidly open/close popups — no deadlock or freeze
- [x] GTK app popups (Ghostty context menu) work correctly