### PR TITLE
feat(test): headless integration testing framework and expose bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: cargo clippy --features "default" -- -D warnings
       - name: Run tests
         run: cargo test --lib --workspace
+      - name: Run headless integration tests
+        run: cargo test --features headless --test headless_basic
       - name: Run font matching tests
         run: cargo test --lib -p otto -- workspaces::utils::tests --ignored
   

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,11 +126,15 @@ xwayland = [
 profile-with-puffin = ["profiling/profile-with-puffin", "puffin_http"]
 profile-with-tracy = ["profiling/profile-with-tracy"]
 profile-with-tracy-mem = ["profile-with-tracy"]
+headless = []
 renderer_sync = []
 
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+serde_json = "1"
+otto-kit = { path = "components/otto-kit", features = ["testing"] }
+wayland-client = "0.31"
 
 # [profile.release]
 # opt-level = 3

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rustix = { version = "0.38", features = ["fs", "process"], optional = true }
 smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "staging"] }
@@ -29,6 +30,7 @@ freedesktop-desktop-entry = "0.7.5"
 
 [features]
 default = []
+testing = ["rustix"]
 debugger = ["laye-rs/debugger"]
 
 [dependencies.laye-rs]

--- a/components/otto-kit/src/lib.rs
+++ b/components/otto-kit/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "testing")]
+pub mod testing;
+
 pub mod app_runner;
 pub mod color_scheme;
 pub mod common;

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -141,8 +141,7 @@ impl TestClient {
             title: title.to_string(),
         }));
 
-        let xdg_surface =
-            xdg_wm_base.get_xdg_surface(&surface, &self.qh, toplevel_state.clone());
+        let xdg_surface = xdg_wm_base.get_xdg_surface(&surface, &self.qh, toplevel_state.clone());
         let toplevel = xdg_surface.get_toplevel(&self.qh, toplevel_state.clone());
         toplevel.set_title(title.to_string());
 
@@ -195,11 +194,8 @@ impl ShmBuffer {
         let size = (stride * height) as usize;
 
         // Create a memfd for the SHM pool
-        let fd = rustix::fs::memfd_create(
-            c"otto-test-shm",
-            rustix::fs::MemfdFlags::CLOEXEC,
-        )
-        .expect("memfd_create failed");
+        let fd = rustix::fs::memfd_create(c"otto-test-shm", rustix::fs::MemfdFlags::CLOEXEC)
+            .expect("memfd_create failed");
 
         rustix::io::retry_on_intr(|| rustix::fs::ftruncate(&fd, size as u64))
             .expect("ftruncate failed");
@@ -245,8 +241,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for TestClientState {
         {
             match interface.as_str() {
                 "wl_compositor" => {
-                    state.wl_compositor =
-                        Some(registry.bind(name, version.min(6), qh, ()));
+                    state.wl_compositor = Some(registry.bind(name, version.min(6), qh, ()));
                 }
                 "wl_shm" => {
                     state.wl_shm = Some(registry.bind(name, version.min(1), qh, ()));
@@ -255,8 +250,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for TestClientState {
                     state.wl_seat = Some(registry.bind(name, version.min(9), qh, ()));
                 }
                 "xdg_wm_base" => {
-                    state.xdg_wm_base =
-                        Some(registry.bind(name, version.min(6), qh, ()));
+                    state.xdg_wm_base = Some(registry.bind(name, version.min(6), qh, ()));
                 }
                 _ => {}
             }
@@ -395,9 +389,7 @@ impl Dispatch<xdg_toplevel::XdgToplevel, Arc<Mutex<TestToplevel>>> for TestClien
         _qh: &QueueHandle<Self>,
     ) {
         match event {
-            xdg_toplevel::Event::Configure {
-                width, height, ..
-            } => {
+            xdg_toplevel::Event::Configure { width, height, .. } => {
                 if width > 0 && height > 0 {
                     let mut tl = data.lock().unwrap();
                     tl.width = width;

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -1,0 +1,413 @@
+//! Test utilities for writing integration tests against a Wayland compositor.
+//!
+//! This module provides lightweight Wayland client primitives designed for use
+//! in integration tests. Unlike the full `AppRunner` stack, these utilities
+//! don't require EGL/Skia — they use SHM buffers and raw protocol interactions.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use otto_kit::testing::TestClient;
+//!
+//! let mut client = TestClient::connect("wayland-1").unwrap();
+//! let toplevel = client.create_toplevel("test-window", 200, 150);
+//! client.roundtrip().unwrap();
+//! assert!(toplevel.lock().unwrap().configured);
+//! ```
+
+use std::{
+    os::unix::io::AsFd,
+    os::unix::net::UnixStream,
+    sync::{Arc, Mutex},
+};
+
+use wayland_client::{
+    protocol::{
+        wl_buffer, wl_callback, wl_compositor, wl_registry, wl_seat, wl_shm, wl_shm_pool,
+        wl_surface,
+    },
+    Connection, Dispatch, EventQueue, QueueHandle,
+};
+use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+
+/// Shared state for the test client's Wayland event dispatching.
+#[derive(Debug)]
+pub struct TestClientState {
+    pub wl_compositor: Option<wl_compositor::WlCompositor>,
+    pub wl_shm: Option<wl_shm::WlShm>,
+    pub wl_seat: Option<wl_seat::WlSeat>,
+    pub xdg_wm_base: Option<xdg_wm_base::XdgWmBase>,
+    pub shm_formats: Vec<wl_shm::Format>,
+}
+
+impl TestClientState {
+    fn new() -> Self {
+        Self {
+            wl_compositor: None,
+            wl_shm: None,
+            wl_seat: None,
+            xdg_wm_base: None,
+            shm_formats: Vec::new(),
+        }
+    }
+}
+
+/// A lightweight Wayland client for integration testing.
+///
+/// Connects to a compositor via the given socket name and provides methods
+/// for creating surfaces, toplevels, and performing roundtrips.
+pub struct TestClient {
+    pub conn: Connection,
+    pub queue: EventQueue<TestClientState>,
+    pub qh: QueueHandle<TestClientState>,
+    pub state: TestClientState,
+}
+
+impl TestClient {
+    /// Connect to the compositor at the given socket name.
+    pub fn connect(socket_name: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let socket_path = std::env::var("XDG_RUNTIME_DIR")
+            .map(|dir| format!("{}/{}", dir, socket_name))
+            .unwrap_or_else(|_| {
+                let uid = rustix::process::getuid().as_raw();
+                format!("/run/user/{}/{}", uid, socket_name)
+            });
+
+        let stream = UnixStream::connect(&socket_path)?;
+        let conn = Connection::from_socket(stream)?;
+        let mut queue = conn.new_event_queue();
+        let qh = queue.handle();
+
+        let display = conn.display();
+        display.get_registry(&qh, ());
+
+        let mut state = TestClientState::new();
+        // Initial roundtrip to bind globals
+        queue.roundtrip(&mut state)?;
+
+        Ok(Self {
+            conn,
+            queue,
+            qh,
+            state,
+        })
+    }
+
+    /// Perform a blocking roundtrip — sends pending requests and waits for
+    /// the compositor to process them and respond.
+    pub fn roundtrip(&mut self) -> Result<usize, Box<dyn std::error::Error>> {
+        Ok(self.queue.roundtrip(&mut self.state)?)
+    }
+
+    /// Dispatch pending events without blocking.
+    pub fn dispatch_pending(&mut self) -> Result<usize, Box<dyn std::error::Error>> {
+        let n = self.queue.dispatch_pending(&mut self.state)?;
+        self.conn.flush()?;
+        Ok(n)
+    }
+
+    /// Create a wl_surface.
+    pub fn create_surface(&self) -> wl_surface::WlSurface {
+        self.state
+            .wl_compositor
+            .as_ref()
+            .expect("compositor not bound")
+            .create_surface(&self.qh, ())
+    }
+
+    /// Create an XDG toplevel window and attach a minimal SHM buffer.
+    ///
+    /// Returns a shared reference to the toplevel state which tracks
+    /// configure events.
+    pub fn create_toplevel(
+        &mut self,
+        title: &str,
+        width: u32,
+        height: u32,
+    ) -> Arc<Mutex<TestToplevel>> {
+        let surface = self.create_surface();
+
+        let xdg_wm_base = self
+            .state
+            .xdg_wm_base
+            .as_ref()
+            .expect("xdg_wm_base not bound");
+
+        let toplevel_state = Arc::new(Mutex::new(TestToplevel {
+            configured: false,
+            width: width as i32,
+            height: height as i32,
+            closed: false,
+            title: title.to_string(),
+        }));
+
+        let xdg_surface =
+            xdg_wm_base.get_xdg_surface(&surface, &self.qh, toplevel_state.clone());
+        let toplevel = xdg_surface.get_toplevel(&self.qh, toplevel_state.clone());
+        toplevel.set_title(title.to_string());
+
+        // Commit to trigger the initial configure
+        surface.commit();
+
+        // Attach a minimal SHM buffer
+        let buffer = ShmBuffer::new(
+            self.state.wl_shm.as_ref().expect("wl_shm not bound"),
+            &self.qh,
+            width,
+            height,
+        );
+        surface.attach(Some(buffer.buffer()), 0, 0);
+
+        // Roundtrip to receive configure
+        let _ = self.roundtrip();
+
+        // Commit the buffer after configure
+        surface.commit();
+
+        toplevel_state
+    }
+}
+
+/// Tracks the state of a test XDG toplevel.
+#[derive(Debug)]
+pub struct TestToplevel {
+    pub configured: bool,
+    pub width: i32,
+    pub height: i32,
+    pub closed: bool,
+    pub title: String,
+}
+
+/// A minimal SHM buffer backed by a memfd.
+pub struct ShmBuffer {
+    _pool: wl_shm_pool::WlShmPool,
+    buffer: wl_buffer::WlBuffer,
+}
+
+impl ShmBuffer {
+    pub fn new(
+        shm: &wl_shm::WlShm,
+        qh: &QueueHandle<TestClientState>,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        let stride = width * 4;
+        let size = (stride * height) as usize;
+
+        // Create a memfd for the SHM pool
+        let fd = rustix::fs::memfd_create(
+            c"otto-test-shm",
+            rustix::fs::MemfdFlags::CLOEXEC,
+        )
+        .expect("memfd_create failed");
+
+        rustix::io::retry_on_intr(|| rustix::fs::ftruncate(&fd, size as u64))
+            .expect("ftruncate failed");
+
+        let pool = shm.create_pool(fd.as_fd(), size as i32, qh, ());
+        let buffer = pool.create_buffer(
+            0,
+            width as i32,
+            height as i32,
+            stride as i32,
+            wl_shm::Format::Argb8888,
+            qh,
+            (),
+        );
+
+        Self {
+            _pool: pool,
+            buffer,
+        }
+    }
+
+    pub fn buffer(&self) -> &wl_buffer::WlBuffer {
+        &self.buffer
+    }
+}
+
+// --- Wayland dispatch implementations ---
+
+impl Dispatch<wl_registry::WlRegistry, ()> for TestClientState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "wl_compositor" => {
+                    state.wl_compositor =
+                        Some(registry.bind(name, version.min(6), qh, ()));
+                }
+                "wl_shm" => {
+                    state.wl_shm = Some(registry.bind(name, version.min(1), qh, ()));
+                }
+                "wl_seat" => {
+                    state.wl_seat = Some(registry.bind(name, version.min(9), qh, ()));
+                }
+                "xdg_wm_base" => {
+                    state.xdg_wm_base =
+                        Some(registry.bind(name, version.min(6), qh, ()));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// No-op dispatchers for bound globals
+impl Dispatch<wl_compositor::WlCompositor, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_compositor::WlCompositor,
+        _event: wl_compositor::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_shm::WlShm, ()> for TestClientState {
+    fn event(
+        state: &mut Self,
+        _proxy: &wl_shm::WlShm,
+        event: wl_shm::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let wl_shm::Event::Format { format } = event {
+            if let wayland_client::WEnum::Value(fmt) = format {
+                state.shm_formats.push(fmt);
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_shm_pool::WlShmPool, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_shm_pool::WlShmPool,
+        _event: wl_shm_pool::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_buffer::WlBuffer, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_buffer::WlBuffer,
+        _event: wl_buffer::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_seat::WlSeat,
+        _event: wl_seat::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_surface::WlSurface, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_surface::WlSurface,
+        _event: wl_surface::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_callback::WlCallback, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_callback::WlCallback,
+        _event: wl_callback::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<xdg_wm_base::XdgWmBase, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        wm_base: &xdg_wm_base::XdgWmBase,
+        event: xdg_wm_base::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            wm_base.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<xdg_surface::XdgSurface, Arc<Mutex<TestToplevel>>> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        xdg_surface: &xdg_surface::XdgSurface,
+        event: xdg_surface::Event,
+        data: &Arc<Mutex<TestToplevel>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let xdg_surface::Event::Configure { serial } = event {
+            xdg_surface.ack_configure(serial);
+            data.lock().unwrap().configured = true;
+        }
+    }
+}
+
+impl Dispatch<xdg_toplevel::XdgToplevel, Arc<Mutex<TestToplevel>>> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &xdg_toplevel::XdgToplevel,
+        event: xdg_toplevel::Event,
+        data: &Arc<Mutex<TestToplevel>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            xdg_toplevel::Event::Configure {
+                width, height, ..
+            } => {
+                if width > 0 && height > 0 {
+                    let mut tl = data.lock().unwrap();
+                    tl.width = width;
+                    tl.height = height;
+                }
+            }
+            xdg_toplevel::Event::Close => {
+                data.lock().unwrap().closed = true;
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -9,10 +9,7 @@ use std::{
 };
 
 use smithay::{
-    backend::{
-        allocator::dmabuf::Dmabuf,
-        renderer::utils::RendererSurfaceState,
-    },
+    backend::{allocator::dmabuf::Dmabuf, renderer::utils::RendererSurfaceState},
     delegate_dmabuf,
     input::pointer::CursorImageStatus,
     output::{Mode, Output, PhysicalProperties, Subpixel},
@@ -118,9 +115,7 @@ impl HeadlessHandle {
             run_headless_loop(config, ready_tx, query_rx, result_tx, running_clone);
         });
 
-        let socket_name = ready_rx
-            .recv()
-            .expect("Compositor thread failed to start");
+        let socket_name = ready_rx.recv().expect("Compositor thread failed to start");
 
         Self {
             socket_name,
@@ -274,9 +269,7 @@ impl HeadlessHandle {
     /// Programmatically switch to a workspace by index.
     pub fn set_workspace(&self, index: usize) {
         self.with_state(move |state| {
-            state
-                .workspaces
-                .set_current_workspace_index(index, None);
+            state.workspaces.set_current_workspace_index(index, None);
         });
     }
 
@@ -395,15 +388,7 @@ impl HeadlessHandle {
             selector_state
                 .rects
                 .iter()
-                .map(|r| {
-                    (
-                        r.window_title.clone(),
-                        r.x,
-                        r.y,
-                        r.w,
-                        r.h,
-                    )
-                })
+                .map(|r| (r.window_title.clone(), r.x, r.y, r.w, r.h))
                 .collect()
         })
     }
@@ -456,9 +441,7 @@ impl Otto<HeadlessData> {
     /// Press or release the left pointer button.
     fn synthetic_pointer_button(&mut self, pressed: bool) {
         use smithay::{
-            backend::input::ButtonState,
-            input::pointer::ButtonEvent,
-            utils::SERIAL_COUNTER,
+            backend::input::ButtonState, input::pointer::ButtonEvent, utils::SERIAL_COUNTER,
         };
 
         let serial = SERIAL_COUNTER.next_serial();
@@ -516,8 +499,7 @@ fn run_headless_loop(
     let mut display_handle = display.handle();
 
     let mut dmabuf_state = DmabufState::new();
-    let dmabuf_global = dmabuf_state
-        .create_global::<Otto<HeadlessData>>(&display.handle(), vec![]);
+    let dmabuf_global = dmabuf_state.create_global::<Otto<HeadlessData>>(&display.handle(), vec![]);
 
     let data = HeadlessData {
         dmabuf_state,

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,0 +1,504 @@
+use std::{
+    sync::{
+        atomic::Ordering,
+        mpsc::{self, Receiver, Sender},
+        Arc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use smithay::{
+    backend::{
+        allocator::dmabuf::Dmabuf,
+        renderer::utils::RendererSurfaceState,
+    },
+    delegate_dmabuf,
+    input::pointer::CursorImageStatus,
+    output::{Mode, Output, PhysicalProperties, Subpixel},
+    reexports::{
+        calloop::EventLoop,
+        wayland_server::{protocol::wl_surface, Display},
+    },
+    wayland::dmabuf::{DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier},
+};
+use tracing::info;
+
+use crate::{
+    skia_renderer::SkiaTextureImage,
+    state::{Backend, Otto},
+};
+
+const OUTPUT_NAME: &str = "headless";
+const DEFAULT_WIDTH: i32 = 1920;
+const DEFAULT_HEIGHT: i32 = 1080;
+
+pub struct HeadlessData {
+    dmabuf_state: DmabufState,
+    #[allow(dead_code)]
+    dmabuf_global: DmabufGlobal,
+}
+
+impl Backend for HeadlessData {
+    fn seat_name(&self) -> String {
+        "headless".into()
+    }
+    fn backend_name(&self) -> &'static str {
+        "headless"
+    }
+    fn reset_buffers(&mut self, _output: &Output) {}
+    fn early_import(&mut self, _surface: &wl_surface::WlSurface) {}
+    fn texture_for_surface(&self, _surface: &RendererSurfaceState) -> Option<SkiaTextureImage> {
+        None
+    }
+    fn set_cursor(&mut self, _image: &CursorImageStatus) {}
+    fn renderer_context(&mut self) -> Option<layers::skia::gpu::DirectContext> {
+        None
+    }
+}
+
+impl DmabufHandler for Otto<HeadlessData> {
+    fn dmabuf_state(&mut self) -> &mut DmabufState {
+        &mut self.backend_data.dmabuf_state
+    }
+
+    fn dmabuf_imported(
+        &mut self,
+        _global: &DmabufGlobal,
+        _dmabuf: Dmabuf,
+        notifier: ImportNotifier,
+    ) {
+        // No renderer available — always reject dmabuf imports
+        notifier.failed();
+    }
+}
+delegate_dmabuf!(Otto<HeadlessData>);
+
+/// Configuration for the headless compositor instance.
+pub struct HeadlessConfig {
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Default for HeadlessConfig {
+    fn default() -> Self {
+        Self {
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+        }
+    }
+}
+
+/// Handle to a running headless compositor instance.
+///
+/// The compositor runs on a background thread. Use this handle to get the
+/// Wayland socket name, run queries against compositor state, and stop it.
+pub struct HeadlessHandle {
+    pub socket_name: String,
+    compositor_thread: Option<JoinHandle<()>>,
+    running: Arc<std::sync::atomic::AtomicBool>,
+    query_tx: Sender<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>,
+    result_rx: Receiver<()>,
+}
+
+impl HeadlessHandle {
+    /// Start a headless compositor with the given configuration.
+    ///
+    /// Returns a handle once the compositor is ready to accept Wayland clients.
+    pub fn start(config: HeadlessConfig) -> Self {
+        let (ready_tx, ready_rx) = mpsc::channel::<String>();
+        let (query_tx, query_rx) =
+            mpsc::channel::<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>();
+        let (result_tx, result_rx) = mpsc::channel::<()>();
+
+        let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let running_clone = running.clone();
+
+        let compositor_thread = thread::spawn(move || {
+            run_headless_loop(config, ready_tx, query_rx, result_tx, running_clone);
+        });
+
+        let socket_name = ready_rx
+            .recv()
+            .expect("Compositor thread failed to start");
+
+        Self {
+            socket_name,
+            compositor_thread: Some(compositor_thread),
+            running,
+            query_tx,
+            result_rx,
+        }
+    }
+
+    /// Execute a closure on the compositor thread with access to the full
+    /// `Otto<HeadlessData>` state. Blocks until the closure has run.
+    pub fn with_state<F>(&self, f: F)
+    where
+        F: FnOnce(&mut Otto<HeadlessData>) + Send + 'static,
+    {
+        self.query_tx.send(Box::new(f)).ok();
+        // Wait for the compositor loop to execute it
+        let _ = self.result_rx.recv();
+    }
+
+    /// Stop the compositor and join the background thread.
+    pub fn stop(mut self) {
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(thread) = self.compositor_thread.take() {
+            let _ = thread.join();
+        }
+    }
+
+    /// Wait for the compositor to process events for the given duration.
+    /// Useful after client operations to let the compositor catch up.
+    pub fn wait(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+
+    // ── Synthetic gesture input ──────────────────────────────────────────
+
+    /// Simulate a 3-finger swipe begin gesture.
+    pub fn swipe_begin(&self) {
+        self.with_state(|state| {
+            state.gesture_swipe_begin_3finger();
+        });
+    }
+
+    /// Simulate a swipe gesture update with the given pixel deltas.
+    pub fn swipe_update(&self, dx: f64, dy: f64) {
+        self.with_state(move |state| {
+            state.gesture_swipe_update(dx, dy);
+        });
+    }
+
+    /// Simulate a swipe gesture ending.
+    pub fn swipe_end(&self) {
+        self.with_state(|state| {
+            state.gesture_swipe_end(false);
+        });
+    }
+
+    /// Simulate a complete swipe gesture with multiple update frames.
+    /// Each element in `deltas` is a (dx, dy) frame.
+    pub fn swipe(&self, deltas: &[(f64, f64)]) {
+        let deltas = deltas.to_vec();
+        self.with_state(move |state| {
+            state.gesture_swipe_begin_3finger();
+            for (dx, dy) in &deltas {
+                state.gesture_swipe_update(*dx, *dy);
+            }
+            state.gesture_swipe_end(false);
+        });
+    }
+
+    /// Simulate a 4-finger pinch begin gesture (show desktop).
+    pub fn pinch_begin(&self) {
+        self.with_state(|state| {
+            state.gesture_pinch_begin_4finger();
+        });
+    }
+
+    /// Simulate a pinch gesture update with the given scale.
+    pub fn pinch_update(&self, scale: f64) {
+        self.with_state(move |state| {
+            state.gesture_pinch_update(scale);
+        });
+    }
+
+    /// Simulate a pinch gesture ending.
+    pub fn pinch_end(&self) {
+        self.with_state(|state| {
+            state.gesture_pinch_end();
+        });
+    }
+
+    // ── State queries ────────────────────────────────────────────────────
+
+    /// Query a value from compositor state. Returns the result synchronously.
+    pub fn query<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut Otto<HeadlessData>) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.with_state(move |state| {
+            let result = f(state);
+            let _ = tx.send(result);
+        });
+        rx.recv().expect("Failed to receive query result")
+    }
+
+    /// Get the current workspace index.
+    pub fn current_workspace_index(&self) -> usize {
+        self.query(|state| state.workspaces.get_current_workspace_index())
+    }
+
+    /// Check if expose mode (show all windows) is active.
+    pub fn is_expose_active(&self) -> bool {
+        self.query(|state| state.workspaces.get_show_all())
+    }
+
+    /// Check if expose mode is in the middle of a transition (animating).
+    pub fn is_expose_transitioning(&self) -> bool {
+        self.query(|state| state.workspaces.is_expose_transitioning())
+    }
+
+    /// Check if show-desktop mode is active.
+    pub fn is_show_desktop_active(&self) -> bool {
+        self.query(|state| state.workspaces.get_show_desktop())
+    }
+
+    /// Check if show-desktop is in the middle of a transition.
+    pub fn is_show_desktop_transitioning(&self) -> bool {
+        self.query(|state| state.workspaces.is_show_desktop_transitioning())
+    }
+
+    /// Get the current swipe gesture state name (for assertions).
+    pub fn swipe_gesture_state(&self) -> String {
+        self.query(|state| match &state.swipe_gesture {
+            crate::state::SwipeGestureState::Idle => "idle".to_string(),
+            crate::state::SwipeGestureState::Detecting { .. } => "detecting".to_string(),
+            crate::state::SwipeGestureState::WorkspaceSwitching { .. } => {
+                "workspace_switching".to_string()
+            }
+            crate::state::SwipeGestureState::Expose { .. } => "expose".to_string(),
+        })
+    }
+
+    /// Get the number of windows across all workspaces.
+    pub fn window_count(&self) -> usize {
+        self.query(|state| state.workspaces.spaces_elements().count())
+    }
+
+    /// Programmatically switch to a workspace by index.
+    pub fn set_workspace(&self, index: usize) {
+        self.with_state(move |state| {
+            state
+                .workspaces
+                .set_current_workspace_index(index, None);
+        });
+    }
+
+    /// Toggle expose mode on/off.
+    pub fn toggle_expose(&self) {
+        self.with_state(|state| {
+            let current = state.workspaces.get_show_all();
+            state.workspaces.expose_set_visible(!current);
+        });
+    }
+
+    /// Get a snapshot of the scene tree (all nodes with keys, bounds, visibility).
+    pub fn scene_snapshot(&self) -> layers::engine::scene::SceneSnapshot {
+        self.query(|state| state.layers_engine.scene().snapshot())
+    }
+
+    /// Serialize the scene tree to pretty JSON (for debugging / golden tests).
+    pub fn scene_json(&self) -> String {
+        self.query(|state| {
+            state
+                .layers_engine
+                .scene()
+                .serialize_state_pretty()
+                .unwrap_or_default()
+        })
+    }
+
+    /// Find a layer by its key and return whether it is hidden.
+    /// Returns `None` if no layer with that key exists.
+    pub fn is_layer_hidden(&self, key: &str) -> Option<bool> {
+        let key = key.to_string();
+        self.query(move |state| {
+            state
+                .layers_engine
+                .find_layer_by_key(&key)
+                .map(|l| l.hidden())
+        })
+    }
+
+    /// Find a layer by its key and return its opacity from the scene snapshot.
+    /// Returns `None` if no layer with that key exists.
+    pub fn layer_opacity(&self, key: &str) -> Option<f32> {
+        let key = key.to_string();
+        self.query(move |state| {
+            let snapshot = state.layers_engine.scene().snapshot();
+            find_node_by_key(&snapshot.nodes, &key).map(|n| n.opacity)
+        })
+    }
+
+    /// Check whether any layer is currently animating (scene has pending damage).
+    pub fn scene_has_damage(&self) -> bool {
+        self.query(|state| state.scene_element.update())
+    }
+
+    /// Advance the scene graph by one frame with the given delta time (seconds).
+    /// Returns true if the frame produced damage (i.e. animations are still running).
+    pub fn tick(&self, dt: f32) -> bool {
+        self.query(move |state| state.layers_engine.update(dt))
+    }
+
+    /// Run the scene graph at 60fps until animations finish or `max_frames` is reached.
+    ///
+    /// Advances the engine timer by 16ms per frame (deterministic, no wall-clock sleep).
+    /// Returns the number of frames that had damage.
+    pub fn settle(&self, max_frames: usize) -> usize {
+        const DT: f32 = 1.0 / 60.0;
+        let mut frames_with_damage = 0;
+        for _ in 0..max_frames {
+            let has_damage = self.query(move |state| state.layers_engine.update(DT));
+            if has_damage {
+                frames_with_damage += 1;
+            } else {
+                break;
+            }
+        }
+        frames_with_damage
+    }
+}
+
+impl Drop for HeadlessHandle {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(thread) = self.compositor_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn run_headless_loop(
+    config: HeadlessConfig,
+    ready_tx: Sender<String>,
+    query_rx: Receiver<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>,
+    result_tx: Sender<()>,
+    running: Arc<std::sync::atomic::AtomicBool>,
+) {
+    // A tokio runtime is needed because some compositor subsystems (e.g. dock)
+    // spawn async tasks internally.
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    let _guard = rt.enter();
+
+    let mut event_loop = EventLoop::try_new().unwrap();
+    let display = Display::new().unwrap();
+    let mut display_handle = display.handle();
+
+    let mut dmabuf_state = DmabufState::new();
+    let dmabuf_global = dmabuf_state
+        .create_global::<Otto<HeadlessData>>(&display.handle(), vec![]);
+
+    let data = HeadlessData {
+        dmabuf_state,
+        dmabuf_global,
+    };
+
+    let mut state = Otto::init(display, event_loop.handle(), data, true);
+    state.running = running;
+
+    // Create a virtual output
+    let mode = Mode {
+        size: (config.width, config.height).into(),
+        refresh: 60_000,
+    };
+    let output = Output::new(
+        OUTPUT_NAME.to_string(),
+        PhysicalProperties {
+            size: (0, 0).into(),
+            subpixel: Subpixel::Unknown,
+            make: "Otto".into(),
+            model: "Headless".into(),
+            serial_number: "0".into(),
+        },
+    );
+    let _global = output.create_global::<Otto<HeadlessData>>(&state.display_handle);
+
+    let config_screen_scale = crate::config::Config::with(|c| c.screen_scale);
+    output.change_current_state(
+        Some(mode),
+        Some(smithay::utils::Transform::Flipped180),
+        Some(smithay::output::Scale::Fractional(config_screen_scale)),
+        Some((0, 0).into()),
+    );
+    output.set_preferred(mode);
+
+    // Set up scene dimensions and map output
+    let root = state.scene_element.root_layer().unwrap();
+    state
+        .layers_engine
+        .scene_set_size(config.width as f32, config.height as f32);
+    root.set_size(
+        layers::types::Size::points(config.width as f32, config.height as f32),
+        None,
+    );
+
+    state
+        .workspaces
+        .set_screen_dimension(config.width, config.height);
+    state.workspaces.map_output(&output, (0, 0));
+
+    let socket_name = state
+        .socket_name
+        .clone()
+        .expect("Headless compositor must have a socket");
+    info!(name = %socket_name, "Headless compositor ready");
+
+    // Signal readiness
+    ready_tx.send(socket_name).unwrap();
+
+    // Main dispatch loop — no rendering, just protocol dispatch and scene updates
+    while state.running.load(Ordering::SeqCst) {
+        // Process any pending state queries from the test thread
+        while let Ok(query) = query_rx.try_recv() {
+            query(&mut state);
+            let _ = result_tx.send(());
+        }
+
+        // Update the scene graph (layout computation, no GPU)
+        state.scene_element.update();
+
+        // Dispatch Wayland clients and calloop sources
+        let result = event_loop.dispatch(Some(Duration::from_millis(16)), &mut state);
+        if result.is_err() {
+            state.running.store(false, Ordering::SeqCst);
+        } else {
+            state.workspaces.refresh_space();
+            state.popups.cleanup();
+            display_handle.flush_clients().unwrap();
+        }
+    }
+
+    info!("Headless compositor stopped");
+}
+
+/// Convenience entry point for running headless from the CLI (mainly for
+/// manual testing). Blocks until the compositor is stopped.
+pub fn run_headless() {
+    let handle = HeadlessHandle::start(HeadlessConfig::default());
+    info!(
+        socket = %handle.socket_name,
+        "Headless compositor running. Set WAYLAND_DISPLAY={} to connect clients.",
+        handle.socket_name
+    );
+
+    // Block until interrupted
+    loop {
+        std::thread::sleep(Duration::from_secs(1));
+        if !handle.running.load(Ordering::SeqCst) {
+            break;
+        }
+    }
+}
+
+/// Recursively search for a node by key in the scene snapshot tree.
+fn find_node_by_key(
+    nodes: &[layers::engine::scene::SceneNodeSnapshot],
+    key: &str,
+) -> Option<layers::engine::scene::SceneNodeSnapshot> {
+    for node in nodes {
+        if node.key == key {
+            return Some(node.clone());
+        }
+        if let Some(found) = find_node_by_key(&node.children, key) {
+            return Some(found);
+        }
+    }
+    None
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -354,6 +354,140 @@ impl HeadlessHandle {
         }
         frames_with_damage
     }
+
+    // ── Synthetic pointer input ──────────────────────────────────────────
+
+    /// Move the pointer to an absolute position (logical pixels).
+    pub fn pointer_move(&self, x: f64, y: f64) {
+        self.with_state(move |state| {
+            state.synthetic_pointer_move(x, y);
+        });
+    }
+
+    /// Simulate a left-button click (press + release) at the current pointer position.
+    pub fn pointer_click(&self) {
+        self.with_state(|state| {
+            state.synthetic_pointer_button(true);
+            state.synthetic_pointer_button(false);
+        });
+    }
+
+    /// Return the title of the currently hovered window in expose, if any.
+    pub fn expose_selected_title(&self) -> Option<String> {
+        self.query(|state| {
+            let ws_index = state.workspaces.get_current_workspace_index();
+            let workspace = state.workspaces.get_workspace_at(ws_index)?;
+            let selector_state = workspace.window_selector_view.view.get_state();
+            let index = selector_state.current_selection?;
+            Some(selector_state.rects.get(index)?.window_title.clone())
+        })
+    }
+
+    /// Return the expose window rects for the current workspace: (title, x, y, w, h)
+    /// in physical pixels (same coordinate space as the window selector).
+    pub fn expose_window_rects(&self) -> Vec<(String, f32, f32, f32, f32)> {
+        self.query(|state| {
+            let ws_index = state.workspaces.get_current_workspace_index();
+            let Some(workspace) = state.workspaces.get_workspace_at(ws_index) else {
+                return Vec::new();
+            };
+            let selector_state = workspace.window_selector_view.view.get_state();
+            selector_state
+                .rects
+                .iter()
+                .map(|r| {
+                    (
+                        r.window_title.clone(),
+                        r.x,
+                        r.y,
+                        r.w,
+                        r.h,
+                    )
+                })
+                .collect()
+        })
+    }
+}
+
+impl Otto<HeadlessData> {
+    /// Move pointer to (x, y) in logical pixels, updating focus and layers engine.
+    fn synthetic_pointer_move(&mut self, x: f64, y: f64) {
+        use smithay::{
+            input::pointer::MotionEvent,
+            utils::{Logical, Point, SERIAL_COUNTER},
+        };
+
+        let pos: Point<f64, Logical> = (x, y).into();
+        let serial = SERIAL_COUNTER.next_serial();
+
+        let under = self.surface_under(pos);
+        let pointer = self.pointer.clone();
+        self.last_pointer_location = (pos.x, pos.y);
+
+        {
+            let focused = self.workspaces.output_under(pos).next().cloned();
+            self.workspaces.set_focused_output(focused.as_ref());
+        }
+
+        pointer.motion(
+            self,
+            under,
+            &MotionEvent {
+                location: pos,
+                serial,
+                time: 0,
+            },
+        );
+        pointer.frame(self);
+
+        // Also update the layers engine in physical pixels.
+        let scale = self
+            .workspaces
+            .outputs()
+            .next()
+            .map(|o| o.current_scale().fractional_scale())
+            .unwrap_or(1.0);
+        let phys = pos.to_physical(scale);
+        self.cursor_physical_position = (phys.x, phys.y);
+        self.layers_engine
+            .pointer_move(&(phys.x as f32, phys.y as f32).into(), None);
+    }
+
+    /// Press or release the left pointer button.
+    fn synthetic_pointer_button(&mut self, pressed: bool) {
+        use smithay::{
+            backend::input::ButtonState,
+            input::pointer::ButtonEvent,
+            utils::SERIAL_COUNTER,
+        };
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let button_state = if pressed {
+            ButtonState::Pressed
+        } else {
+            ButtonState::Released
+        };
+
+        // BTN_LEFT = 0x110
+        if !self.workspaces.get_show_all() && pressed {
+            self.focus_window_under_cursor(serial);
+        }
+        let pointer = self.pointer.clone();
+        pointer.button(
+            self,
+            &ButtonEvent {
+                button: 0x110,
+                state: button_state,
+                serial,
+                time: 0,
+            },
+        );
+        pointer.frame(self);
+        match button_state {
+            ButtonState::Pressed => self.layers_engine.pointer_button_down(),
+            ButtonState::Released => self.layers_engine.pointer_button_up(),
+        }
+    }
 }
 
 impl Drop for HeadlessHandle {

--- a/src/input/gestures.rs
+++ b/src/input/gestures.rs
@@ -37,12 +37,6 @@ impl crate::Otto<crate::udev::UdevData> {
         );
     }
 
-    fn gesture_swipe_begin_3finger(&mut self) {
-        self.swipe_gesture = crate::state::SwipeGestureState::Detecting {
-            accumulated: (0.0, 0.0),
-        };
-    }
-
     pub(crate) fn on_gesture_swipe_update<B: InputBackend>(
         &mut self,
         evt: B::GestureSwipeUpdateEvent,
@@ -163,36 +157,6 @@ impl crate::Otto<crate::udev::UdevData> {
         );
     }
 
-    fn gesture_swipe_end_expose(&mut self, velocity_samples: Vec<f64>) {
-        // Calculate average velocity from samples
-        let velocity = if velocity_samples.is_empty() {
-            0.0
-        } else {
-            velocity_samples.iter().sum::<f64>() / velocity_samples.len() as f64
-        };
-
-        self.expose_end_with_velocity_and_focus_top(velocity as f32);
-    }
-
-    fn gesture_swipe_end_workspace(
-        &mut self,
-        velocity_samples: Vec<f64>,
-        output_name: String,
-        cancelled: bool,
-    ) {
-        let velocity = if !cancelled && !velocity_samples.is_empty() {
-            velocity_samples.iter().sum::<f64>() / velocity_samples.len() as f64
-        } else {
-            0.0
-        };
-        let target_index = self
-            .workspaces
-            .workspace_swipe_end(&output_name, velocity as f32);
-
-        // Update keyboard focus to top window of the target workspace
-        self.focus_top_window_or_clear(target_index);
-    }
-
     pub(crate) fn on_gesture_pinch_begin<B: InputBackend>(
         &mut self,
         evt: B::GesturePinchBeginEvent,
@@ -295,6 +259,168 @@ impl crate::Otto<crate::udev::UdevData> {
                 cancelled: evt.cancelled(),
             },
         );
+    }
+
+}
+
+// ── Headless / test helpers ──────────────────────────────────────────
+// These bypass InputBackend events and manipulate gesture state directly.
+// Available for any backend (not just udev).
+impl<B: crate::state::Backend> crate::Otto<B> {
+    /// Simulate a 3-finger swipe begin gesture.
+    pub fn gesture_swipe_begin_3finger(&mut self) {
+        self.swipe_gesture = crate::state::SwipeGestureState::Detecting {
+            accumulated: (0.0, 0.0),
+        };
+    }
+
+    /// Simulate a swipe gesture update with raw deltas (no InputBackend needed).
+    pub fn gesture_swipe_update(&mut self, dx: f64, dy: f64) {
+        let delta = smithay::utils::Point::<f64, smithay::utils::Logical>::from((dx, dy));
+
+        match &mut self.swipe_gesture {
+            crate::state::SwipeGestureState::Detecting { accumulated } => {
+                accumulated.0 += delta.x;
+                accumulated.1 += delta.y;
+
+                let direction = crate::state::SwipeDirection::from_accumulated(
+                    accumulated.0.abs(),
+                    accumulated.1.abs(),
+                );
+
+                match direction {
+                    crate::state::SwipeDirection::Horizontal(_) => {
+                        let pointer_loc = self.pointer.current_location();
+                        let output_name = self
+                            .workspaces
+                            .output_under(pointer_loc)
+                            .next()
+                            .map(|o| o.name())
+                            .or_else(|| self.workspaces.primary_output().map(|o| o.name()))
+                            .unwrap_or_default();
+
+                        self.swipe_gesture = crate::state::SwipeGestureState::WorkspaceSwitching {
+                            velocity_samples: vec![delta.x],
+                            output_name: output_name.clone(),
+                        };
+                        self.workspaces
+                            .workspace_swipe_update(&output_name, delta.x as f32);
+                    }
+                    crate::state::SwipeDirection::Vertical(_) => {
+                        self.dismiss_all_popups();
+                        if !self.workspaces.get_show_all() {
+                            self.workspaces.expose_gesture_start();
+                        } else {
+                            self.workspaces.expose_gesture_close_start();
+                        }
+                        self.swipe_gesture = crate::state::SwipeGestureState::Expose {
+                            velocity_samples: vec![-delta.y],
+                        };
+                        let expose_delta =
+                            (-delta.y / crate::state::EXPOSE_DELTA_MULTIPLIER) as f32;
+                        self.workspaces.expose_update(expose_delta);
+                    }
+                    crate::state::SwipeDirection::Undetermined => {}
+                }
+            }
+            crate::state::SwipeGestureState::WorkspaceSwitching {
+                velocity_samples,
+                output_name,
+            } => {
+                velocity_samples.push(delta.x);
+                if velocity_samples.len() > crate::state::VELOCITY_SAMPLE_COUNT {
+                    velocity_samples.remove(0);
+                }
+                let name = output_name.clone();
+                self.workspaces
+                    .workspace_swipe_update(&name, delta.x as f32);
+            }
+            crate::state::SwipeGestureState::Expose { velocity_samples } => {
+                velocity_samples.push(-delta.y);
+                if velocity_samples.len() > crate::state::VELOCITY_SAMPLE_COUNT {
+                    velocity_samples.remove(0);
+                }
+                let expose_delta = (-delta.y / crate::state::EXPOSE_DELTA_MULTIPLIER) as f32;
+                self.workspaces.expose_update(expose_delta);
+            }
+            crate::state::SwipeGestureState::Idle => {}
+        }
+    }
+
+    fn gesture_swipe_end_expose(&mut self, velocity_samples: Vec<f64>) {
+        let velocity = if velocity_samples.is_empty() {
+            0.0
+        } else {
+            velocity_samples.iter().sum::<f64>() / velocity_samples.len() as f64
+        };
+        self.expose_end_with_velocity_and_focus_top(velocity as f32);
+    }
+
+    fn gesture_swipe_end_workspace(
+        &mut self,
+        velocity_samples: Vec<f64>,
+        output_name: String,
+        cancelled: bool,
+    ) {
+        let velocity = if !cancelled && !velocity_samples.is_empty() {
+            velocity_samples.iter().sum::<f64>() / velocity_samples.len() as f64
+        } else {
+            0.0
+        };
+        let target_index = self
+            .workspaces
+            .workspace_swipe_end(&output_name, velocity as f32);
+        self.focus_top_window_or_clear(target_index);
+    }
+
+    /// Simulate ending a swipe gesture (no InputBackend needed).
+    pub fn gesture_swipe_end(&mut self, cancelled: bool) {
+        match std::mem::replace(
+            &mut self.swipe_gesture,
+            crate::state::SwipeGestureState::Idle,
+        ) {
+            crate::state::SwipeGestureState::Expose { velocity_samples } => {
+                self.gesture_swipe_end_expose(velocity_samples);
+            }
+            crate::state::SwipeGestureState::WorkspaceSwitching {
+                velocity_samples,
+                output_name,
+            } => {
+                self.gesture_swipe_end_workspace(velocity_samples, output_name, cancelled);
+            }
+            _ => {}
+        }
+    }
+
+    /// Simulate a 4-finger pinch begin (no InputBackend needed).
+    pub fn gesture_pinch_begin_4finger(&mut self) {
+        let is_swiping = !matches!(self.swipe_gesture, crate::state::SwipeGestureState::Idle);
+        let is_expose_active = self.workspaces.get_show_all();
+        if !is_swiping && !is_expose_active {
+            self.is_pinching = true;
+            self.pinch_last_scale = 1.0;
+            self.workspaces.reset_show_desktop_gesture();
+        }
+    }
+
+    /// Simulate a pinch gesture update with a scale value (no InputBackend needed).
+    pub fn gesture_pinch_update(&mut self, scale: f64) {
+        if self.is_pinching {
+            let current_scale = scale as f32;
+            let last_scale = self.pinch_last_scale as f32;
+            let scale_delta = current_scale - last_scale;
+            let delta = scale_delta * 1.5;
+            self.pinch_last_scale = scale;
+            self.workspaces.expose_show_desktop(delta, false);
+        }
+    }
+
+    /// Simulate ending a pinch gesture (no InputBackend needed).
+    pub fn gesture_pinch_end(&mut self) {
+        if self.is_pinching {
+            self.workspaces.expose_show_desktop(0.0, true);
+            self.is_pinching = false;
+        }
     }
 }
 

--- a/src/input/gestures.rs
+++ b/src/input/gestures.rs
@@ -260,7 +260,6 @@ impl crate::Otto<crate::udev::UdevData> {
             },
         );
     }
-
 }
 
 // ── Headless / test helpers ──────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
 // If no backend is enabled, a large portion of the codebase is unused.
 // So silence this useless warning for the CI.
 #![cfg_attr(
-    not(any(feature = "winit", feature = "x11", feature = "udev", feature = "headless")),
+    not(any(
+        feature = "winit",
+        feature = "x11",
+        feature = "udev",
+        feature = "headless"
+    )),
     allow(dead_code, unused_imports)
 )]
 
@@ -10,6 +15,8 @@ pub mod audio;
 pub mod cursor;
 pub mod drawing;
 pub mod focus;
+#[cfg(feature = "headless")]
+pub mod headless;
 pub mod input;
 pub mod input_handler;
 pub mod interactive_view;
@@ -26,8 +33,6 @@ pub mod skia_renderer;
 pub mod state;
 pub mod surface_style;
 pub mod textures_storage;
-#[cfg(feature = "headless")]
-pub mod headless;
 #[cfg(feature = "udev")]
 pub mod udev;
 pub mod virtual_output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 // If no backend is enabled, a large portion of the codebase is unused.
 // So silence this useless warning for the CI.
 #![cfg_attr(
-    not(any(feature = "winit", feature = "x11", feature = "udev")),
+    not(any(feature = "winit", feature = "x11", feature = "udev", feature = "headless")),
     allow(dead_code, unused_imports)
 )]
 
 pub mod audio;
-#[cfg(any(feature = "udev", feature = "xwayland"))]
+#[cfg(any(feature = "udev", feature = "xwayland", feature = "headless"))]
 pub mod cursor;
 pub mod drawing;
 pub mod focus;
@@ -26,6 +26,8 @@ pub mod skia_renderer;
 pub mod state;
 pub mod surface_style;
 pub mod textures_storage;
+#[cfg(feature = "headless")]
+pub mod headless;
 #[cfg(feature = "udev")]
 pub mod udev;
 pub mod virtual_output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn main() {
                 && !other.starts_with("--tty-udev")
                 && !other.starts_with("--probe")
                 && !other.starts_with("--x11")
+                && !other.starts_with("--headless")
                 && !other.starts_with("--systemd-notify") =>
         {
             eprintln!("Unknown argument: {}", other);
@@ -114,6 +115,12 @@ async fn main() {
             tracing::info!("Starting otto with x11 backend");
             std::env::set_var("OTTO_BACKEND", "x11");
             otto::x11::run_x11();
+        }
+        #[cfg(feature = "headless")]
+        Some("--headless") => {
+            tracing::info!("Starting otto with headless backend");
+            std::env::set_var("OTTO_BACKEND", "headless");
+            otto::headless::run_headless();
         }
         Some("--version") => {
             println!("otto {}", env!("CARGO_PKG_VERSION"));

--- a/src/state/app_management.rs
+++ b/src/state/app_management.rs
@@ -199,7 +199,13 @@ impl<BackendData: Backend> Otto<BackendData> {
             let h = self
                 .workspaces
                 .get_workspace_at(workspace_index)
-                .and_then(|wv| wv.window_selector_view.get_selected_window_id());
+                .and_then(|wv| {
+                    // The close gesture clears the selection before we get here,
+                    // so fall back to the snapshot taken at gesture start.
+                    wv.window_selector_view
+                        .get_selected_window_id()
+                        .or_else(|| wv.window_selector_view.take_pre_close_hovered())
+                });
             tracing::debug!("expose_end_with_velocity_and_focus_top: hovered={:?}", h);
             h
         } else {

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -803,7 +803,8 @@ impl Workspaces {
                     .window_selector_view
                     .window_selector_view
                     .set_opacity(0.0, None);
-                // Clear any leftover selection and force a fresh layout recalculation.
+                // Clear any leftover selection/state and force a fresh layout recalculation.
+                workspace_view.window_selector_view.take_pre_close_hovered();
                 workspace_view.window_selector_view.clear_selection();
                 workspace_view.window_selector_view.invalidate_layout();
             }
@@ -839,6 +840,7 @@ impl Workspaces {
                     .window_selector_view
                     .window_selector_view
                     .set_opacity(0.0, None);
+                workspace_view.window_selector_view.save_pre_close_hovered();
                 workspace_view.window_selector_view.clear_selection();
             }
         }
@@ -1159,6 +1161,24 @@ impl Workspaces {
                 Vec::new()
             }
         });
+
+        // Snapshot the pre-expose stacking order the first time layout runs
+        // while expose is active (or the gesture is starting).  This avoids
+        // capturing a stale snapshot during normal window-mapping which also
+        // calls expose_show_all_layout.
+        let expose_active = self.get_show_all()
+            || self
+                .expose_gesture_active
+                .load(std::sync::atomic::Ordering::Relaxed);
+        if expose_active && workspace.peek_pre_expose_order_empty() {
+            if let Some(space) = self
+                .primary_output_workspaces()
+                .and_then(|ows| ows.spaces.get(workspace_index))
+            {
+                let order: Vec<ObjectId> = space.elements().map(|e| e.id()).collect();
+                workspace.save_pre_expose_order(order);
+            }
+        }
 
         // Keep expose layout stable regardless of runtime z-order changes.
         // Window stacking may change (hover raise/focus), but tiling positions should not.
@@ -3379,12 +3399,20 @@ impl Workspaces {
             return;
         };
 
-        let state = workspace.window_selector_view.view.get_state().clone();
-        let order: Vec<ObjectId> = state
-            .rects
-            .iter()
-            .filter_map(|rect| rect.window_id.clone())
-            .collect();
+        // Restore the stacking order that was saved when expose opened.
+        // This avoids replacing the user's z-order with the sorted layout order.
+        let saved = workspace.take_pre_expose_order();
+        let order = if saved.is_empty() {
+            // Fallback: use expose rects order (should not normally happen).
+            let state = workspace.window_selector_view.view.get_state().clone();
+            state
+                .rects
+                .iter()
+                .filter_map(|rect| rect.window_id.clone())
+                .collect()
+        } else {
+            saved
+        };
 
         for window_id in order {
             self.raise_element(&window_id, false, false);

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2569,7 +2569,7 @@ impl Workspaces {
     /// Raise thw windowelement on top of all the windows in its space
     /// activate: will set the window as active
     /// update: will update the workspace model
-    fn raise_element(&mut self, window_id: &ObjectId, activate: bool, update: bool) {
+    pub fn raise_element(&mut self, window_id: &ObjectId, activate: bool, update: bool) {
         // get the space with the window
         // tracing::info!("workspaces::raise_element: {:?}", window_id);
         // Find window index in primary output's spaces

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -100,6 +100,8 @@ pub struct WindowSelectorView {
     pub drag_state: Arc<RwLock<Option<DragState>>>,
     pub expose_bin: Arc<RwLock<HashMap<ObjectId, LayoutRect>>>,
     layout_hash: Arc<RwLock<u64>>,
+    /// Hovered window saved before the close gesture clears the selection.
+    pre_close_hovered: Arc<RwLock<Option<ObjectId>>>,
 }
 
 /// # WindowSelectorView Layer Structure
@@ -223,6 +225,7 @@ impl WindowSelectorView {
             drag_state: Arc::new(RwLock::new(None)),
             expose_bin: Arc::new(RwLock::new(HashMap::new())),
             layout_hash: Arc::new(RwLock::new(0)),
+            pre_close_hovered: Arc::new(RwLock::new(None)),
         }
     }
     pub fn layer_for_window(&self, window: &ObjectId) -> Option<Layer> {
@@ -279,6 +282,17 @@ impl WindowSelectorView {
         let state = self.view.get_state();
         let index = state.current_selection?;
         state.rects.get(index)?.window_id.clone()
+    }
+
+    /// Snapshot the current selection so it survives `clear_selection` during
+    /// the close gesture.
+    pub fn save_pre_close_hovered(&self) {
+        *self.pre_close_hovered.write().unwrap() = self.get_selected_window_id();
+    }
+
+    /// Take the saved pre-close hovered window, leaving it empty.
+    pub fn take_pre_close_hovered(&self) -> Option<ObjectId> {
+        self.pre_close_hovered.write().unwrap().take()
     }
 
     pub fn bring_window_to_front(&self, window_id: &ObjectId) {
@@ -795,7 +809,6 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowSelecto
         otto: &mut crate::Otto<Backend>,
         event: &smithay::input::pointer::MotionEvent,
     ) {
-        // println!("on_motion");
         let state = self.view.get_state().clone();
         let screen_scale = Config::with(|config| config.screen_scale);
         let location = event.location.to_physical(screen_scale);

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -38,6 +38,9 @@ pub struct WorkspaceView {
     is_fullscreen_animating: Arc<AtomicBool>,
     name: Arc<RwLock<Option<String>>>,
     window_base_layers: Arc<RwLock<HashMap<ObjectId, Layer>>>,
+    /// Stacking order (bottom→top ObjectIds) saved when expose opens,
+    /// so it can be restored verbatim when expose closes without selection.
+    pre_expose_order: Arc<RwLock<Vec<ObjectId>>>,
 }
 
 impl fmt::Debug for WorkspaceView {
@@ -169,6 +172,7 @@ impl WorkspaceView {
             is_fullscreen_animating: Arc::new(AtomicBool::new(false)),
             name: Arc::new(RwLock::new(None)),
             window_base_layers: Arc::new(RwLock::new(HashMap::new())),
+            pre_expose_order: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -322,6 +326,21 @@ impl WorkspaceView {
 
     pub fn get_name(&self) -> Option<String> {
         self.name.read().unwrap().clone()
+    }
+
+    /// Returns true if no pre-expose stacking order has been saved yet.
+    pub fn peek_pre_expose_order_empty(&self) -> bool {
+        self.pre_expose_order.read().unwrap().is_empty()
+    }
+
+    /// Snapshot the current stacking order so it can be restored after expose.
+    pub fn save_pre_expose_order(&self, order: Vec<ObjectId>) {
+        *self.pre_expose_order.write().unwrap() = order;
+    }
+
+    /// Take the saved pre-expose stacking order, leaving it empty.
+    pub fn take_pre_expose_order(&self) -> Vec<ObjectId> {
+        std::mem::take(&mut *self.pre_expose_order.write().unwrap())
     }
 }
 

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -342,6 +342,239 @@ mod headless_tests {
         );
     }
 
+    #[test]
+    #[serial]
+    fn expose_click_raises_window() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        // Create 3 windows — last opened ends up on top
+        let _w1 = client.create_toplevel("window-1", 640, 480);
+        let _w2 = client.create_toplevel("window-2", 800, 600);
+        let _w3 = client.create_toplevel("window-3", 400, 300);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+        assert_eq!(handle.window_count(), 3);
+
+        // Record which window is on top before expose
+        let top_before = window_order(&handle).last().cloned().unwrap();
+        eprintln!("Top window before expose: {}", top_before);
+
+        // Enter expose via swipe
+        handle.swipe_begin();
+        handle.swipe_update(0.0, -10.0);
+        handle.swipe_update(0.0, -50.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(handle.is_expose_active(), "Expose should be active");
+
+        // Find the expose rect for a window that is NOT currently on top
+        let rects = handle.expose_window_rects();
+        eprintln!("Expose rects: {:?}", rects);
+        assert!(!rects.is_empty(), "Expose should have window rects");
+
+        let target = rects
+            .iter()
+            .find(|(title, _, _, _, _)| *title != top_before)
+            .expect("Should find a non-top window to click");
+        let target_title = target.0.clone();
+        eprintln!(
+            "Clicking on '{}' at physical ({}, {}, {}, {})",
+            target_title, target.1, target.2, target.3, target.4
+        );
+
+        // Click the center of the target window rect.
+        // Rects are in physical pixels; pointer_move takes logical pixels.
+        let scale: f64 = handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale())
+                .unwrap_or(1.0)
+        });
+        let center_x = (target.1 + target.3 / 2.0) as f64 / scale;
+        let center_y = (target.2 + target.4 / 2.0) as f64 / scale;
+        eprintln!("Pointer move to logical ({}, {})", center_x, center_y);
+
+        // Establish pointer focus on window selector (first move triggers smithay
+        // enter, not motion — the selection is only updated on motion events).
+        handle.pointer_move(5.0, 300.0);
+        handle.settle(2);
+        handle.pointer_move(center_x, center_y);
+        handle.settle(10);
+        handle.pointer_click();
+        handle.settle(300);
+
+        assert!(
+            !handle.is_expose_active(),
+            "Expose should close after clicking a window"
+        );
+
+        // The clicked window should now be on top
+        let order_after = window_order(&handle);
+        let top_after = order_after.last().cloned().unwrap();
+        eprintln!("Order after: {:?}", order_after);
+
+        assert_eq!(
+            top_after, target_title,
+            "Clicked window '{}' should be raised to top, but top is '{}'",
+            target_title, top_after
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn expose_pointer_selects_hovered_window() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        let _w1 = client.create_toplevel("window-1", 640, 480);
+        let _w2 = client.create_toplevel("window-2", 800, 600);
+        let _w3 = client.create_toplevel("window-3", 400, 300);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+
+        // Enter expose
+        handle.swipe_begin();
+        handle.swipe_update(0.0, -10.0);
+        handle.swipe_update(0.0, -50.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(handle.is_expose_active(), "Expose should be active");
+
+        // No selection yet
+        assert_eq!(
+            handle.expose_selected_title(),
+            None,
+            "No window should be selected before pointer enters any rect"
+        );
+
+        let rects = handle.expose_window_rects();
+        let scale: f64 = handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale())
+                .unwrap_or(1.0)
+        });
+
+        // Establish pointer focus on the window selector area (smithay sends
+        // enter on first focus, then motion on subsequent moves within the
+        // same target).  Move to a point that lies inside the window selector
+        // but outside any window rect.
+        handle.pointer_move(5.0, 300.0);
+        handle.settle(2);
+
+        // Move pointer over each window rect and verify it becomes selected
+        for (title, x, y, w, h) in &rects {
+            let cx = (*x + *w / 2.0) as f64 / scale;
+            let cy = (*y + *h / 2.0) as f64 / scale;
+            handle.pointer_move(cx, cy);
+            handle.settle(10);
+
+            let selected = handle.expose_selected_title();
+            assert_eq!(
+                selected.as_deref(),
+                Some(title.as_str()),
+                "Moving pointer over '{}' should select it, but selected is {:?}",
+                title,
+                selected
+            );
+        }
+
+        // Move pointer away from all rects — selection should clear
+        handle.pointer_move(0.0, 0.0);
+        handle.settle(10);
+        assert_eq!(
+            handle.expose_selected_title(),
+            None,
+            "Moving pointer away should clear selection"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn expose_gesture_close_raises_hovered_window() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        // Open 4 windows — w4 ends up on top
+        let _w1 = client.create_toplevel("window-1", 640, 480);
+        let _w2 = client.create_toplevel("window-2", 800, 600);
+        let _w3 = client.create_toplevel("window-3", 400, 300);
+        let _w4 = client.create_toplevel("window-4", 500, 400);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+        assert_eq!(handle.window_count(), 4);
+
+        let order_before = window_order(&handle);
+        let top_before = order_before.last().cloned().unwrap();
+        assert_eq!(top_before, "window-4", "window-4 should be on top initially");
+
+        // Enter expose via swipe
+        handle.swipe_begin();
+        handle.swipe_update(0.0, -10.0);
+        handle.swipe_update(0.0, -50.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(handle.is_expose_active(), "Expose should be active");
+
+        // Find the expose rect for window-1 (the bottom-most window)
+        let rects = handle.expose_window_rects();
+        let scale: f64 = handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale())
+                .unwrap_or(1.0)
+        });
+        let target = rects
+            .iter()
+            .find(|(title, _, _, _, _)| title == "window-1")
+            .expect("window-1 should have an expose rect");
+
+        // Establish pointer focus, then hover window-1
+        handle.pointer_move(5.0, 300.0);
+        handle.settle(2);
+        let cx = (target.1 + target.3 / 2.0) as f64 / scale;
+        let cy = (target.2 + target.4 / 2.0) as f64 / scale;
+        handle.pointer_move(cx, cy);
+        handle.settle(10);
+        assert_eq!(
+            handle.expose_selected_title().as_deref(),
+            Some("window-1"),
+            "window-1 should be selected"
+        );
+
+        // Close expose via downward swipe gesture (no click)
+        handle.swipe_begin();
+        handle.swipe_update(0.0, 10.0);
+        handle.swipe_update(0.0, 50.0);
+        handle.swipe_update(0.0, 80.0);
+        handle.swipe_update(0.0, 80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(!handle.is_expose_active(), "Expose should be closed");
+
+        // window-1 must now be on top
+        let order_after = window_order(&handle);
+        let top_after = order_after.last().cloned().unwrap();
+        assert_eq!(
+            top_after, "window-1",
+            "Hovered window-1 should be raised to top after gesture close, but top is '{}'",
+            top_after
+        );
+    }
+
     // ── Scene JSON for debugging ─────────────────────────────────────────
 
     #[test]

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -36,7 +36,10 @@ mod headless_tests {
         let handle = start_compositor();
         let client = connect_client(&handle);
 
-        assert!(client.state.wl_compositor.is_some(), "wl_compositor not bound");
+        assert!(
+            client.state.wl_compositor.is_some(),
+            "wl_compositor not bound"
+        );
         assert!(client.state.wl_shm.is_some(), "wl_shm not bound");
         assert!(client.state.xdg_wm_base.is_some(), "xdg_wm_base not bound");
 
@@ -53,7 +56,10 @@ mod headless_tests {
         handle.wait(Duration::from_millis(100));
         let _ = client.roundtrip();
 
-        assert!(toplevel.lock().unwrap().configured, "Toplevel should be configured");
+        assert!(
+            toplevel.lock().unwrap().configured,
+            "Toplevel should be configured"
+        );
 
         handle.stop();
     }
@@ -120,7 +126,10 @@ mod headless_tests {
 
         // Let animations settle
         let frames = handle.settle(300);
-        assert!(frames > 0, "Expected animation frames during expose transition");
+        assert!(
+            frames > 0,
+            "Expected animation frames during expose transition"
+        );
 
         // Should be fully active after settling
         assert!(handle.is_expose_active());
@@ -151,12 +160,7 @@ mod headless_tests {
         assert_eq!(handle.window_count(), 3);
 
         // Simulate a strong vertical swipe to enter expose
-        handle.swipe(&[
-            (0.0, -10.0),
-            (0.0, -50.0),
-            (0.0, -80.0),
-            (0.0, -80.0),
-        ]);
+        handle.swipe(&[(0.0, -10.0), (0.0, -50.0), (0.0, -80.0), (0.0, -80.0)]);
 
         // Let the spring animation finish
         handle.settle(300);
@@ -198,7 +202,10 @@ mod headless_tests {
         let handle = start_compositor();
 
         let snapshot = handle.scene_snapshot();
-        assert!(!snapshot.nodes.is_empty(), "Scene should have at least the root node");
+        assert!(
+            !snapshot.nodes.is_empty(),
+            "Scene should have at least the root node"
+        );
 
         // The root should have key "otto_root"
         let root = &snapshot.nodes[0];
@@ -320,7 +327,10 @@ mod headless_tests {
         handle.swipe_update(0.0, -80.0);
         handle.swipe_end();
         handle.settle(300);
-        assert!(handle.is_expose_active(), "Expose should be active after swipe up");
+        assert!(
+            handle.is_expose_active(),
+            "Expose should be active after swipe up"
+        );
 
         // Swipe DOWN to close expose (without selecting a window)
         handle.swipe_begin();
@@ -330,7 +340,10 @@ mod headless_tests {
         handle.swipe_update(0.0, 80.0);
         handle.swipe_end();
         handle.settle(300);
-        assert!(!handle.is_expose_active(), "Expose should be closed after swipe down");
+        assert!(
+            !handle.is_expose_active(),
+            "Expose should be closed after swipe down"
+        );
 
         // Stacking order must be identical
         let order_after = window_order(&handle);
@@ -515,7 +528,10 @@ mod headless_tests {
 
         let order_before = window_order(&handle);
         let top_before = order_before.last().cloned().unwrap();
-        assert_eq!(top_before, "window-4", "window-4 should be on top initially");
+        assert_eq!(
+            top_before, "window-4",
+            "window-4 should be on top initially"
+        );
 
         // Enter expose via swipe
         handle.swipe_begin();
@@ -584,7 +600,10 @@ mod headless_tests {
 
         let json = handle.scene_json();
         assert!(!json.is_empty(), "Scene JSON should not be empty");
-        assert!(json.contains("otto_root"), "Scene JSON should contain root node");
+        assert!(
+            json.contains("otto_root"),
+            "Scene JSON should contain root node"
+        );
 
         // Should be valid JSON
         let parsed: Result<serde_json::Value, _> = serde_json::from_str(&json);

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -1,0 +1,362 @@
+//! Integration tests for the Otto headless compositor.
+//!
+//! These tests start a headless compositor instance, connect Wayland clients,
+//! and verify compositor behavior: gestures, expose mode, workspace switching,
+//! layer visibility, and animations.
+
+#[cfg(feature = "headless")]
+mod headless_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    fn start_compositor() -> HeadlessHandle {
+        HeadlessHandle::start(HeadlessConfig::default())
+    }
+
+    fn connect_client(handle: &HeadlessHandle) -> TestClient {
+        TestClient::connect(&handle.socket_name).expect("Failed to connect to compositor")
+    }
+
+    // ── Basic lifecycle ──────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn compositor_starts_and_stops() {
+        let handle = start_compositor();
+        assert!(!handle.socket_name.is_empty());
+        // compositor is running (it would have panicked on start otherwise)
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn client_connects_and_binds_globals() {
+        let handle = start_compositor();
+        let client = connect_client(&handle);
+
+        assert!(client.state.wl_compositor.is_some(), "wl_compositor not bound");
+        assert!(client.state.wl_shm.is_some(), "wl_shm not bound");
+        assert!(client.state.xdg_wm_base.is_some(), "xdg_wm_base not bound");
+
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn client_creates_toplevel() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        let toplevel = client.create_toplevel("test-window", 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+
+        assert!(toplevel.lock().unwrap().configured, "Toplevel should be configured");
+
+        handle.stop();
+    }
+
+    // ── Gesture: workspace switching ─────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn swipe_gesture_state_machine() {
+        let handle = start_compositor();
+
+        // Initially idle
+        assert_eq!(handle.swipe_gesture_state(), "idle");
+
+        // Begin 3-finger swipe
+        handle.swipe_begin();
+        assert_eq!(handle.swipe_gesture_state(), "detecting");
+
+        // Horizontal swipe → workspace switching
+        handle.swipe_update(20.0, 0.0);
+        assert_eq!(handle.swipe_gesture_state(), "workspace_switching");
+
+        // End gesture
+        handle.swipe_end();
+        assert_eq!(handle.swipe_gesture_state(), "idle");
+
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn vertical_swipe_triggers_expose() {
+        let handle = start_compositor();
+
+        // Begin 3-finger swipe
+        handle.swipe_begin();
+        assert_eq!(handle.swipe_gesture_state(), "detecting");
+
+        // Vertical swipe → expose mode
+        handle.swipe_update(0.0, -20.0);
+        assert_eq!(handle.swipe_gesture_state(), "expose");
+
+        // End gesture
+        handle.swipe_end();
+        assert_eq!(handle.swipe_gesture_state(), "idle");
+
+        handle.stop();
+    }
+
+    // ── Expose mode ──────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn expose_toggle_and_settle() {
+        let handle = start_compositor();
+
+        assert!(!handle.is_expose_active());
+
+        // Toggle expose on
+        handle.toggle_expose();
+
+        // Should be active (or transitioning)
+        assert!(handle.is_expose_active() || handle.is_expose_transitioning());
+
+        // Let animations settle
+        let frames = handle.settle(300);
+        assert!(frames > 0, "Expected animation frames during expose transition");
+
+        // Should be fully active after settling
+        assert!(handle.is_expose_active());
+
+        // Toggle expose off
+        handle.toggle_expose();
+        handle.settle(300);
+        assert!(!handle.is_expose_active());
+
+        handle.stop();
+    }
+
+    // ── Expose with windows ──────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn expose_with_three_windows() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        // Create 3 windows
+        let _w1 = client.create_toplevel("window-1", 640, 480);
+        let _w2 = client.create_toplevel("window-2", 800, 600);
+        let _w3 = client.create_toplevel("window-3", 400, 300);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+
+        assert_eq!(handle.window_count(), 3);
+
+        // Simulate a strong vertical swipe to enter expose
+        handle.swipe(&[
+            (0.0, -10.0),
+            (0.0, -50.0),
+            (0.0, -80.0),
+            (0.0, -80.0),
+        ]);
+
+        // Let the spring animation finish
+        handle.settle(300);
+
+        // Verify expose is active
+        assert!(
+            handle.is_expose_active(),
+            "Expose should be active after strong upward swipe"
+        );
+
+        handle.stop();
+    }
+
+    // ── Pinch: show desktop ──────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn pinch_show_desktop() {
+        let handle = start_compositor();
+
+        assert!(!handle.is_show_desktop_active());
+
+        // 4-finger pinch out (spread) to show desktop
+        handle.pinch_begin();
+        handle.pinch_update(1.5); // scale > 1.0 = spread
+        handle.pinch_end();
+
+        // May be transitioning
+        handle.settle(300);
+
+        handle.stop();
+    }
+
+    // ── Layer visibility ─────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn scene_snapshot_has_root() {
+        let handle = start_compositor();
+
+        let snapshot = handle.scene_snapshot();
+        assert!(!snapshot.nodes.is_empty(), "Scene should have at least the root node");
+
+        // The root should have key "otto_root"
+        let root = &snapshot.nodes[0];
+        assert_eq!(root.key, "otto_root");
+
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn check_layer_hidden_by_key() {
+        let handle = start_compositor();
+
+        // The root layer should exist and not be hidden
+        let hidden = handle.is_layer_hidden("otto_root");
+        assert_eq!(hidden, Some(false), "otto_root should not be hidden");
+
+        // A non-existent layer should return None
+        let missing = handle.is_layer_hidden("nonexistent_layer_xyz");
+        assert_eq!(missing, None, "Non-existent layer should return None");
+
+        handle.stop();
+    }
+
+    // ── Workspace switching ──────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn workspace_switch_programmatic() {
+        let handle = start_compositor();
+
+        let initial = handle.current_workspace_index();
+        assert_eq!(initial, 0);
+
+        // Switch to workspace 1
+        handle.set_workspace(1);
+        handle.settle(300);
+
+        assert_eq!(handle.current_workspace_index(), 1);
+
+        // Switch back
+        handle.set_workspace(0);
+        handle.settle(300);
+
+        assert_eq!(handle.current_workspace_index(), 0);
+
+        handle.stop();
+    }
+
+    // ── Compositor state query via closures ───────────────────────────────
+
+    #[test]
+    #[serial]
+    fn state_query_window_count() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        let _w1 = client.create_toplevel("query-test-1", 800, 600);
+        let _w2 = client.create_toplevel("query-test-2", 400, 300);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+
+        let count = handle.window_count();
+        assert!(count >= 2, "Expected at least 2 windows, got {}", count);
+
+        handle.stop();
+    }
+
+    // ── Bug: expose should preserve focused window ─────────────────────
+
+    /// Helper: get the window stacking order as a list of titles (bottom to top).
+    fn window_order(handle: &HeadlessHandle) -> Vec<String> {
+        handle.query(|state| {
+            state
+                .workspaces
+                .spaces_elements()
+                .map(|w| w.xdg_title())
+                .collect()
+        })
+    }
+
+    #[test]
+    #[serial]
+    fn expose_roundtrip_preserves_window_order() {
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        // Create 3 windows — last opened is on top
+        let _w1 = client.create_toplevel("window-1", 640, 480);
+        let _w2 = client.create_toplevel("window-2", 800, 600);
+        let _w3 = client.create_toplevel("window-3", 400, 300);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+
+        assert_eq!(handle.window_count(), 3);
+
+        // Focus window-1 (simulates clicking on it — raises + focuses)
+        handle.with_state(|state| {
+            let w1_id = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == "window-1")
+                .map(|w| w.id())
+                .expect("window-1 not found");
+            state.workspaces.raise_element(&w1_id, true, true);
+            state.set_keyboard_focus_on_surface(&w1_id);
+        });
+        handle.settle(60);
+
+        // Record stacking order before expose
+        let order_before = window_order(&handle);
+        eprintln!("Order before expose: {:?}", order_before);
+
+        // Swipe UP to enter expose
+        handle.swipe_begin();
+        handle.swipe_update(0.0, -10.0);
+        handle.swipe_update(0.0, -50.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_update(0.0, -80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(handle.is_expose_active(), "Expose should be active after swipe up");
+
+        // Swipe DOWN to close expose (without selecting a window)
+        handle.swipe_begin();
+        handle.swipe_update(0.0, 10.0);
+        handle.swipe_update(0.0, 50.0);
+        handle.swipe_update(0.0, 80.0);
+        handle.swipe_update(0.0, 80.0);
+        handle.swipe_end();
+        handle.settle(300);
+        assert!(!handle.is_expose_active(), "Expose should be closed after swipe down");
+
+        // Stacking order must be identical
+        let order_after = window_order(&handle);
+        eprintln!("Order after expose: {:?}", order_after);
+
+        assert_eq!(
+            order_before, order_after,
+            "Window stacking order should be preserved after expose roundtrip"
+        );
+    }
+
+    // ── Scene JSON for debugging ─────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn scene_json_is_valid() {
+        let handle = start_compositor();
+
+        let json = handle.scene_json();
+        assert!(!json.is_empty(), "Scene JSON should not be empty");
+        assert!(json.contains("otto_root"), "Scene JSON should contain root node");
+
+        // Should be valid JSON
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed.is_ok(), "Scene JSON should be valid: {}", json);
+
+        handle.stop();
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces **headless integration testing** for Otto — a new testing framework built on `otto-kit` that runs a real compositor instance without GPU, enabling tests for gestures, expose mode, window stacking, and pointer interactions.

### Headless testing infrastructure
- **`HeadlessHandle`** starts a headless compositor on a background thread with synthetic input: swipe/pinch gestures, pointer movement, clicks
- **`TestClient`** (in `otto-kit`) is a lightweight Wayland client that creates toplevels with SHM buffers for testing
- **`settle(frames)`** drives the scene graph deterministically at 60fps — no wall-clock sleeps, no flaky timing
- **17 integration tests** covering compositor lifecycle, expose mode, workspace switching, window stacking, pointer selection, and scene graph validation

### Bug fixes discovered and fixed via the new tests
- **Expose roundtrip reset stacking order**: `apply_window_selector_order_to_workspace` was applying the sorted expose layout order (by `protocol_id`) instead of the original z-order. Fixed by saving the pre-expose Space element order and restoring it on close.
- **Gesture-close didn't raise hovered window**: `expose_gesture_close_start` cleared the selection before the gesture-end path could read it. Fixed by saving the hovered window ID before clearing and falling back to it in the gesture-end path.

### CI
- Headless integration tests now run in the `check` job (`cargo test --features headless --test headless_basic`)

## Test plan

- [x] `expose_roundtrip_preserves_window_order` — open/close expose without selecting, stacking unchanged
- [x] `expose_click_raises_window` — click a window in expose, it ends up on top
- [x] `expose_pointer_selects_hovered_window` — pointer over each rect selects the right window
- [x] `expose_gesture_close_raises_hovered_window` — 4 windows, hover w1, swipe close, w1 on top
- [x] All 17 headless tests pass locally and in CI