### PR TITLE
feat: implement wlr-screencopy-v1 protocol

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -195,6 +195,8 @@ pub struct Otto<BackendData: Backend + 'static> {
     pub wlr_foreign_toplevel_state: wlr_foreign_toplevel::WlrForeignToplevelManagerState,
     pub cursor_shape_manager_state: CursorShapeManagerState,
     pub virtual_keyboard_manager_state: VirtualKeyboardManagerState,
+    pub screencopy_manager_state: screencopy::ScreencopyManagerState,
+    pub pending_screencopy_frames: Vec<screencopy::PendingScreencopy>,
 
     #[cfg(feature = "xwayland")]
     pub xwayland_shell_state: xwayland_shell::XWaylandShellState,
@@ -306,6 +308,7 @@ pub mod foreign_toplevel_shared;
 pub mod fractional_scale_handler;
 pub mod gamma_control;
 pub mod input_method_handler;
+pub mod screencopy;
 pub mod seat_handler;
 pub mod security_context_handler;
 pub mod selection_handler;
@@ -441,6 +444,18 @@ smithay::reexports::wayland_server::delegate_dispatch!(@<BackendData: Backend + 
     crate::otto_dock::protocol::gen::otto_dock_item_v1::OttoDockItemV1: crate::otto_dock::protocol::DockItem
 ] => crate::otto_dock::handlers::OttoDockState);
 
+smithay::reexports::wayland_server::delegate_global_dispatch!(@<BackendData: Backend + 'static> Otto<BackendData>: [
+    smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: ()
+] => screencopy::ScreencopyManagerState);
+
+smithay::reexports::wayland_server::delegate_dispatch!(@<BackendData: Backend + 'static> Otto<BackendData>: [
+    smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: ()
+] => screencopy::ScreencopyManagerState);
+
+smithay::reexports::wayland_server::delegate_dispatch!(@<BackendData: Backend + 'static> Otto<BackendData>: [
+    smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_frame_v1::ZwlrScreencopyFrameV1: screencopy::ScreencopyFrameData
+] => screencopy::ScreencopyManagerState);
+
 impl<BackendData: Backend + 'static> Otto<BackendData> {
     pub fn init(
         display: Display<Otto<BackendData>>,
@@ -554,6 +569,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         InputMethodManagerState::new::<Self, _>(&dh, |_client| true);
         let virtual_keyboard_manager_state =
             VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| true);
+        let screencopy_manager_state = screencopy::ScreencopyManagerState::new::<BackendData>(&dh);
         // Expose global only if backend supports relative motion events
         if BackendData::HAS_RELATIVE_MOTION {
             RelativePointerManagerState::new::<Self>(&dh);
@@ -693,6 +709,8 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             wlr_foreign_toplevel_state,
             cursor_shape_manager_state,
             virtual_keyboard_manager_state,
+            screencopy_manager_state,
+            pending_screencopy_frames: Vec::new(),
             dnd_icon: None,
             suppressed_keys: Vec::new(),
             current_modifiers: ModifiersState::default(),

--- a/src/state/screencopy.rs
+++ b/src/state/screencopy.rs
@@ -1,0 +1,315 @@
+use std::sync::Mutex;
+
+use smithay::{
+    output::Output,
+    reexports::{
+        wayland_protocols_wlr::screencopy::v1::server::{
+            zwlr_screencopy_frame_v1::{self, ZwlrScreencopyFrameV1},
+            zwlr_screencopy_manager_v1::{self, ZwlrScreencopyManagerV1},
+        },
+        wayland_server::{
+            backend::{ClientId, GlobalId},
+            protocol::{wl_buffer::WlBuffer, wl_output::WlOutput, wl_shm},
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+        },
+    },
+    utils::Rectangle,
+    wayland::shm,
+};
+
+use crate::state::{Backend, Otto};
+
+#[derive(Debug)]
+pub struct ScreencopyManagerState {
+    #[allow(dead_code)]
+    global: GlobalId,
+}
+
+impl ScreencopyManagerState {
+    pub fn new<BackendData>(display: &DisplayHandle) -> Self
+    where
+        BackendData: Backend + 'static,
+        Otto<BackendData>: GlobalDispatch<ZwlrScreencopyManagerV1, ()>,
+        Otto<BackendData>: Dispatch<ZwlrScreencopyManagerV1, ()>,
+        Otto<BackendData>: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData>,
+    {
+        let global = display.create_global::<Otto<BackendData>, ZwlrScreencopyManagerV1, ()>(2, ());
+        Self { global }
+    }
+}
+
+#[derive(Debug)]
+pub struct ScreencopyFrameData {
+    pub output: Output,
+    pub overlay_cursor: bool,
+    pub region: Option<Rectangle<i32, smithay::utils::Logical>>,
+    pub width: u32,
+    pub height: u32,
+    pub stride: u32,
+    #[allow(dead_code)]
+    state: Mutex<FrameState>,
+}
+
+#[derive(Debug)]
+enum FrameState {
+    AwaitingCopy,
+    Copying,
+}
+
+/// A pending screencopy frame waiting to be filled during the render loop.
+pub struct PendingScreencopy {
+    pub frame: ZwlrScreencopyFrameV1,
+    pub buffer: WlBuffer,
+    pub output: Output,
+    pub region: Option<Rectangle<i32, smithay::utils::Logical>>,
+    pub width: u32,
+    pub height: u32,
+    pub stride: u32,
+}
+
+fn find_output_for_wl<BackendData: Backend>(
+    state: &Otto<BackendData>,
+    wl_output: &WlOutput,
+) -> Option<Output> {
+    let Some(client) = wl_output.client() else {
+        return None;
+    };
+    state
+        .workspaces
+        .outputs()
+        .find(|o| o.client_outputs(&client).any(|co| co == *wl_output))
+        .cloned()
+}
+
+impl<BackendData> GlobalDispatch<ZwlrScreencopyManagerV1, (), Otto<BackendData>>
+    for ScreencopyManagerState
+where
+    BackendData: Backend + 'static,
+    Otto<BackendData>: Dispatch<ZwlrScreencopyManagerV1, ()>,
+    Otto<BackendData>: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData>,
+{
+    fn bind(
+        _state: &mut Otto<BackendData>,
+        _display: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwlrScreencopyManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Otto<BackendData>>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl<BackendData> Dispatch<ZwlrScreencopyManagerV1, (), Otto<BackendData>>
+    for ScreencopyManagerState
+where
+    BackendData: Backend + 'static,
+    Otto<BackendData>: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData>,
+{
+    fn request(
+        state: &mut Otto<BackendData>,
+        _client: &Client,
+        _resource: &ZwlrScreencopyManagerV1,
+        request: zwlr_screencopy_manager_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, Otto<BackendData>>,
+    ) {
+        match request {
+            zwlr_screencopy_manager_v1::Request::CaptureOutput {
+                frame,
+                overlay_cursor,
+                output: wl_output,
+            } => {
+                let Some(output) = find_output_for_wl(state, &wl_output) else {
+                    return;
+                };
+                init_frame(state, data_init, frame, output, overlay_cursor != 0, None);
+            }
+            zwlr_screencopy_manager_v1::Request::CaptureOutputRegion {
+                frame,
+                overlay_cursor,
+                output: wl_output,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                let Some(output) = find_output_for_wl(state, &wl_output) else {
+                    return;
+                };
+                let region = Rectangle::new((x, y).into(), (width, height).into());
+                init_frame(
+                    state,
+                    data_init,
+                    frame,
+                    output,
+                    overlay_cursor != 0,
+                    Some(region),
+                );
+            }
+            zwlr_screencopy_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+fn init_frame<BackendData: Backend + 'static>(
+    _state: &mut Otto<BackendData>,
+    data_init: &mut DataInit<'_, Otto<BackendData>>,
+    frame_new: New<ZwlrScreencopyFrameV1>,
+    output: Output,
+    overlay_cursor: bool,
+    region: Option<Rectangle<i32, smithay::utils::Logical>>,
+) where
+    Otto<BackendData>: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData>,
+{
+    let mode = output.current_mode().unwrap();
+    let scale = output.current_scale().fractional_scale();
+    let (width, height) = if let Some(region) = region {
+        (
+            (region.size.w as f64 * scale) as u32,
+            (region.size.h as f64 * scale) as u32,
+        )
+    } else {
+        (mode.size.w as u32, mode.size.h as u32)
+    };
+    let stride = width * 4;
+
+    let frame_data = ScreencopyFrameData {
+        output,
+        overlay_cursor,
+        region,
+        width,
+        height,
+        stride,
+        state: Mutex::new(FrameState::AwaitingCopy),
+    };
+    let frame = data_init.init(frame_new, frame_data);
+
+    frame.buffer(wl_shm::Format::Argb8888, width, height, stride);
+    if frame.version() >= 3 {
+        frame.buffer_done();
+    }
+}
+
+impl<BackendData> Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData, Otto<BackendData>>
+    for ScreencopyManagerState
+where
+    BackendData: Backend + 'static,
+{
+    fn request(
+        state: &mut Otto<BackendData>,
+        _client: &Client,
+        resource: &ZwlrScreencopyFrameV1,
+        request: zwlr_screencopy_frame_v1::Request,
+        data: &ScreencopyFrameData,
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Otto<BackendData>>,
+    ) {
+        match request {
+            zwlr_screencopy_frame_v1::Request::Copy { buffer }
+            | zwlr_screencopy_frame_v1::Request::CopyWithDamage { buffer } => {
+                let mut frame_state = data.state.lock().unwrap();
+                if !matches!(*frame_state, FrameState::AwaitingCopy) {
+                    resource.failed();
+                    return;
+                }
+                *frame_state = FrameState::Copying;
+                drop(frame_state);
+
+                state.pending_screencopy_frames.push(PendingScreencopy {
+                    frame: resource.clone(),
+                    buffer,
+                    output: data.output.clone(),
+                    region: data.region,
+                    width: data.width,
+                    height: data.height,
+                    stride: data.stride,
+                });
+            }
+            zwlr_screencopy_frame_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+
+    fn destroyed(
+        _state: &mut Otto<BackendData>,
+        _client: ClientId,
+        _resource: &ZwlrScreencopyFrameV1,
+        _data: &ScreencopyFrameData,
+    ) {
+    }
+}
+
+/// Called from the render loop after the output has been rendered to
+/// a Skia surface. Reads pixels from the Skia surface into pending
+/// screencopy shm buffers for this output.
+pub fn complete_screencopy_for_output(
+    pending: &mut Vec<PendingScreencopy>,
+    output: &Output,
+    skia_surface: &mut layers::skia::Surface,
+) {
+    let indices: Vec<usize> = pending
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.output == *output)
+        .map(|(i, _)| i)
+        .collect();
+
+    for i in indices.into_iter().rev() {
+        let p = pending.remove(i);
+        let result = shm::with_buffer_contents(&p.buffer, |ptr, len, buf_data| {
+            if buf_data.format != wl_shm::Format::Argb8888 {
+                return false;
+            }
+            let expected = p.stride as usize * p.height as usize;
+            if len < expected {
+                return false;
+            }
+
+            let x_off = p
+                .region
+                .map(|r| {
+                    let scale = output.current_scale().fractional_scale();
+                    (r.loc.x as f64 * scale) as i32
+                })
+                .unwrap_or(0);
+            let y_off = p
+                .region
+                .map(|r| {
+                    let scale = output.current_scale().fractional_scale();
+                    (r.loc.y as f64 * scale) as i32
+                })
+                .unwrap_or(0);
+
+            let info = layers::skia::ImageInfo::new(
+                (p.width as i32, p.height as i32),
+                layers::skia::ColorType::BGRA8888,
+                layers::skia::AlphaType::Premul,
+                None,
+            );
+
+            let dst = unsafe { std::slice::from_raw_parts_mut(ptr as *mut u8, expected) };
+
+            skia_surface.read_pixels(&info, dst, p.stride as usize, (x_off, y_off))
+        });
+
+        match result {
+            Ok(true) => {
+                p.frame.flags(zwlr_screencopy_frame_v1::Flags::empty());
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default();
+                p.frame.ready(
+                    (now.as_secs() >> 32) as u32,
+                    now.as_secs() as u32,
+                    now.subsec_nanos(),
+                );
+            }
+            _ => {
+                p.frame.failed();
+            }
+        }
+    }
+}

--- a/src/state/screencopy.rs
+++ b/src/state/screencopy.rs
@@ -71,9 +71,7 @@ fn find_output_for_wl<BackendData: Backend>(
     state: &Otto<BackendData>,
     wl_output: &WlOutput,
 ) -> Option<Output> {
-    let Some(client) = wl_output.client() else {
-        return None;
-    };
+    let client = wl_output.client()?;
     state
         .workspaces
         .outputs()

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -409,6 +409,7 @@ impl Otto<UdevData> {
             scene_has_damage,
             fullscreen_window.as_ref(),
             &window_throttle_states,
+            &mut self.pending_screencopy_frames,
         );
 
         let reschedule = match &result {
@@ -964,6 +965,7 @@ pub(super) fn render_surface<'a>(
         smithay::reexports::wayland_server::backend::ObjectId,
         crate::state::window_throttle::WindowThrottleState,
     >,
+    pending_screencopy: &mut Vec<crate::state::screencopy::PendingScreencopy>,
 ) -> Result<RenderOutcome, SwapBuffersError> {
     // Start frame timing
     #[cfg(feature = "metrics")]
@@ -1051,60 +1053,62 @@ pub(super) fn render_surface<'a>(
     }
 
     // If fullscreen_window is Some, direct scanout is allowed (checked by caller)
-    let (output_elements, clear_color, should_draw) =
-        if let Some(fullscreen_win) = fullscreen_window {
-            // In fullscreen mode: render only the fullscreen window + cursor
-            // Skip the scene element entirely for direct scanout
-            let mut elements: Vec<OutputRenderElements<'a, _, WindowRenderElement<_>>> = Vec::new();
+    let (output_elements, clear_color, should_draw) = if let Some(fullscreen_win) =
+        fullscreen_window
+    {
+        // In fullscreen mode: render only the fullscreen window + cursor
+        // Skip the scene element entirely for direct scanout
+        let mut elements: Vec<OutputRenderElements<'a, _, WindowRenderElement<_>>> = Vec::new();
 
-            // Add pointer elements first (rendered at bottom, but cursor plane may handle separately)
-            elements.extend(
-                workspace_render_elements
-                    .into_iter()
-                    .map(OutputRenderElements::from),
-            );
+        // Add pointer elements first (rendered at bottom, but cursor plane may handle separately)
+        elements.extend(
+            workspace_render_elements
+                .into_iter()
+                .map(OutputRenderElements::from),
+        );
 
-            // Add the fullscreen window's render elements wrapped in Wrap
-            use smithay::backend::renderer::element::Wrap;
-            let window_elements_rendered: Vec<WindowRenderElement<_>> =
-                fullscreen_win.render_elements(renderer, (0, 0).into(), scale, 1.0);
-            elements.extend(
-                window_elements_rendered
-                    .into_iter()
-                    .map(|e| OutputRenderElements::Window(Wrap::from(e))),
-            );
+        // Add the fullscreen window's render elements wrapped in Wrap
+        use smithay::backend::renderer::element::Wrap;
+        let window_elements_rendered: Vec<WindowRenderElement<_>> =
+            fullscreen_win.render_elements(renderer, (0, 0).into(), scale, 1.0);
+        elements.extend(
+            window_elements_rendered
+                .into_iter()
+                .map(|e| OutputRenderElements::Window(Wrap::from(e))),
+        );
 
-            // Always render in fullscreen mode since the window surface may have damage
-            // Use black clear color - the window fills the screen anyway
-            (elements, CLEAR_COLOR, true)
-        } else {
-            // Normal mode: render the full scene
-            workspace_render_elements.push(WorkspaceRenderElements::Scene(scene_element));
+        // Always render in fullscreen mode since the window surface may have damage
+        // Use black clear color - the window fills the screen anyway
+        (elements, CLEAR_COLOR, true)
+    } else {
+        // Normal mode: render the full scene
+        workspace_render_elements.push(WorkspaceRenderElements::Scene(scene_element));
 
-            // We still pass cursor elements to render_frame so the DRM compositor
-            // can manage the hardware cursor plane (ALLOW_CURSOR_PLANE_SCANOUT).
-            // When nothing actually changed, render_frame returns is_empty=true
-            // and no page flip occurs, so this is cheap in the idle case.
-            let cursor_needs_draw = pointer_in_output;
-            let should_draw = scene_has_damage || dnd_needs_draw || cursor_needs_draw;
-            if !should_draw {
-                return Ok(RenderOutcome::skipped());
-            }
+        // We still pass cursor elements to render_frame so the DRM compositor
+        // can manage the hardware cursor plane (ALLOW_CURSOR_PLANE_SCANOUT).
+        // When nothing actually changed, render_frame returns is_empty=true
+        // and no page flip occurs, so this is cheap in the idle case.
+        let cursor_needs_draw = pointer_in_output;
+        let has_screencopy = !pending_screencopy.is_empty();
+        let should_draw = scene_has_damage || dnd_needs_draw || cursor_needs_draw || has_screencopy;
+        if !should_draw {
+            return Ok(RenderOutcome::skipped());
+        }
 
-            let output_render_elements: Vec<OutputRenderElements<'a, _, WindowRenderElement<_>>> =
-                workspace_render_elements
-                    .into_iter()
-                    .map(OutputRenderElements::from)
-                    .collect::<Vec<_>>();
-            let (output_elements, clear_color) = output_elements(
-                output,
-                window_elements.iter().copied(),
-                output_render_elements,
-                dnd_icon,
-                renderer,
-            );
-            (output_elements, clear_color, true)
-        };
+        let output_render_elements: Vec<OutputRenderElements<'a, _, WindowRenderElement<_>>> =
+            workspace_render_elements
+                .into_iter()
+                .map(OutputRenderElements::from)
+                .collect::<Vec<_>>();
+        let (output_elements, clear_color) = output_elements(
+            output,
+            window_elements.iter().copied(),
+            output_render_elements,
+            dnd_icon,
+            renderer,
+        );
+        (output_elements, clear_color, true)
+    };
 
     if !should_draw {
         return Ok(RenderOutcome::skipped());
@@ -1195,6 +1199,15 @@ pub(super) fn render_surface<'a>(
     );
 
     if rendered {
+        if let Some(skia_renderer) = renderer.as_mut().current_skia_renderer() {
+            let mut skia_surface = skia_renderer.surface.clone();
+            crate::state::screencopy::complete_screencopy_for_output(
+                pending_screencopy,
+                output,
+                &mut skia_surface,
+            );
+        }
+
         let output_presentation_feedback =
             take_presentation_feedback(output, &post_repaint_elements, &states);
         surface


### PR DESCRIPTION
## Summary

- Implements `zwlr_screencopy_manager_v1` (v2), enabling screen capture tools like `grim` and `wl-mirror` to work with Otto
- Supports `capture_output` (full output) and `capture_output_region` (sub-region)
- Reads pixels from the Skia surface after each rendered frame and copies into the client's SHM buffer
- Screencopy requests force a render frame even when the scene has no damage, so capture tools always get a fresh frame

## Test plan

- [x] `grim` captures full-screen screenshots
- [x] `grim -g "x,y wxh"` captures a region
- [ ] `wl-mirror` streams the output in real time
- [ ] No performance regression when no screencopy clients are connected