### PR TITLE
feat(scanout): promote eligible windows to KMS overlay planes

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -106,7 +106,24 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
 
     fn new_surface(&mut self, surface: &WlSurface) {
         add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+            // Explicit-sync (wp_linux_drm_syncobj) acquire point, if the client
+            // committed one. smithay only validates these points in its own
+            // commit_hook — the compositor must add the blocker so the surface
+            // transaction waits until the client's GPU render completes. Without
+            // it, KMS plane scanout flips a half-rendered buffer (tearing),
+            // because smithay assumes a blocker already waited. udev-only:
+            // DrmSyncobjCachedState lives behind smithay's backend_drm feature.
+            #[cfg(feature = "udev")]
+            let mut acquire_point = None;
             let maybe_dmabuf = with_states(surface, |surface_data| {
+                #[cfg(feature = "udev")]
+                acquire_point.clone_from(
+                    &surface_data
+                        .cached_state
+                        .get::<smithay::wayland::drm_syncobj::DrmSyncobjCachedState>()
+                        .pending()
+                        .acquire_point,
+                );
                 surface_data
                     .cached_state
                     .get::<SurfaceAttributes>()
@@ -119,6 +136,25 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
                     })
             });
             if let Some(dmabuf) = maybe_dmabuf {
+                // Prefer the explicit acquire fence when the client provided one.
+                #[cfg(feature = "udev")]
+                if let Some(acquire_point) = acquire_point {
+                    if let Ok((blocker, source)) = acquire_point.generate_blocker() {
+                        if let Some(client) = surface.client() {
+                            let res = state.handle.insert_source(source, move |_, _, data| {
+                                let dh = data.display_handle.clone();
+                                data.client_compositor_state(&client)
+                                    .blocker_cleared(data, &dh);
+                                Ok(())
+                            });
+                            if res.is_ok() {
+                                add_blocker(surface, blocker);
+                                // Don't also add the implicit blocker for this commit.
+                                return;
+                            }
+                        }
+                    }
+                }
                 if let Ok((blocker, source)) = dmabuf.generate_blocker(Interest::READ) {
                     if let Some(client) = surface.client() {
                         let res = state.handle.insert_source(source, move |_, _, data| {

--- a/src/skia_renderer.rs
+++ b/src/skia_renderer.rs
@@ -778,6 +778,14 @@ impl SkiaRenderer {
             self.gl.DeleteFramebuffers(1, &dst_fbo);
             self.gl.BindRenderbuffer(ffi::RENDERBUFFER, 0);
             self.gl.DeleteRenderbuffers(1, &src_rbo);
+
+            // GPU sync: the source EGLImage is the client's just-written buffer
+            // (mpv video) and the blit result is sampled by Skia immediately
+            // after. Without a sync the blit can read a half-written client
+            // buffer (no implicit fence under explicit-sync clients) and Skia can
+            // sample a partial texture — seen as "texture not fully mapped /
+            // black tearing". Finish ensures the read+blit complete before use.
+            self.gl.Finish();
         }
         Ok(())
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -876,6 +876,12 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         self.exclusive_zones.insert(output_name.clone(), zones);
     }
 
+    /// The usable area of `output` in logical pixels: the output geometry minus
+    /// tracked exclusive zones (layer-shell reservations) and, when the dock is
+    /// not in autohide, minus the dock. Used by maximize and window tiling.
+    ///
+    /// Reads the cached exclusive zones; call [`Self::recalculate_exclusive_zones`]
+    /// first when fresh data is required.
     pub fn usable_zone(&self, output: &Output) -> utils::Rectangle<i32, utils::Logical> {
         let output_geom = self.workspaces.output_geometry(output).unwrap();
         let zones = self
@@ -1279,182 +1285,217 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             let title = window.xdg_title();
             let fullscreen = window.is_fullscreen();
 
-            let mut render_elements = VecDeque::new();
+            // While a window is promoted to KMS plane scanout its content_layer
+            // is hidden and its buffer is scanned out directly. Skip importing
+            // the surface tree into lay-rs entirely so a buffer commit pushes no
+            // scene transaction (the primary is not redrawn for content
+            // updates). The shadow model is still kept current (size-gated)
+            // below. See docs/developer/window-scanout-promotion.md.
+            let content_hidden = self
+                .workspaces
+                .get_window_view(&id)
+                .map(|v| v.is_content_hidden())
+                .unwrap_or(false);
 
-            // Collect popup surfaces and send them to the popup overlay layer
-            PopupManager::popups_for_surface(&window_surface).for_each(|(popup, popup_offset)| {
-                let offset: smithay::utils::Point<f64, smithay::utils::Physical> =
-                    popup_offset.to_physical_precise_round(scale_factor);
-                let popup_surface = popup.wl_surface();
-                let popup_id = popup_surface.id();
+            if !content_hidden {
+                let mut render_elements = VecDeque::new();
 
-                // Calculate absolute popup position (window position + popup offset)
-                let popup_position = layers::types::Point {
-                    x: location.x as f32 + offset.x as f32,
-                    y: location.y as f32 + offset.y as f32,
-                };
+                // Collect popup surfaces and send them to the popup overlay layer
+                PopupManager::popups_for_surface(&window_surface).for_each(
+                    |(popup, popup_offset)| {
+                        let offset: smithay::utils::Point<f64, smithay::utils::Physical> =
+                            popup_offset.to_physical_precise_round(scale_factor);
+                        let popup_surface = popup.wl_surface();
+                        let popup_id = popup_surface.id();
 
-                // Collect surfaces for this popup
-                let mut popup_surfaces = Vec::new();
-                let popup_origin: smithay::utils::Point<f64, smithay::utils::Physical> =
-                    (0.0, 0.0).into();
-                with_surfaces_surface_tree(popup_surface, |surface, states| {
-                    // For popups, parent tracking is simpler - just use None for root
-                    // The popup itself is the root of its own surface tree
-                    if let Some(window_view) = self.window_view_for_surface(
-                        surface,
-                        states,
-                        &popup_origin,
-                        scale_factor,
-                        None,
-                    ) {
-                        popup_surfaces.push(window_view);
-                    }
-                });
+                        // Calculate absolute popup position (window position + popup offset)
+                        let popup_position = layers::types::Point {
+                            x: location.x as f32 + offset.x as f32,
+                            y: location.y as f32 + offset.y as f32,
+                        };
 
-                // Send popup to the overlay layer and register its surface layers
-                #[allow(clippy::mutable_key_type)]
-                let popup_layers = self.workspaces.popup_overlay.update_popup(
-                    &popup_id,
-                    &id,
-                    popup_position,
-                    popup_surfaces,
-                    None, // No warm cache needed anymore
-                    &self.layers_engine,
-                    &self.surface_layers,
+                        // Collect surfaces for this popup
+                        let mut popup_surfaces = Vec::new();
+                        let popup_origin: smithay::utils::Point<f64, smithay::utils::Physical> =
+                            (0.0, 0.0).into();
+                        with_surfaces_surface_tree(popup_surface, |surface, states| {
+                            // For popups, parent tracking is simpler - just use None for root
+                            // The popup itself is the root of its own surface tree
+                            if let Some(window_view) = self.window_view_for_surface(
+                                surface,
+                                states,
+                                &popup_origin,
+                                scale_factor,
+                                None,
+                            ) {
+                                popup_surfaces.push(window_view);
+                            }
+                        });
+
+                        // Send popup to the overlay layer and register its surface layers
+                        #[allow(clippy::mutable_key_type)]
+                        let popup_layers = self.workspaces.popup_overlay.update_popup(
+                            &popup_id,
+                            &id,
+                            popup_position,
+                            popup_surfaces,
+                            None, // No warm cache needed anymore
+                            &self.layers_engine,
+                            &self.surface_layers,
+                        );
+
+                        self.surface_layers.extend(popup_layers);
+                    },
                 );
 
-                self.surface_layers.extend(popup_layers);
-            });
+                let initial_location: smithay::utils::Point<f64, smithay::utils::Physical> =
+                    (0.0, 0.0).into();
 
-            let initial_location: smithay::utils::Point<f64, smithay::utils::Physical> =
-                (0.0, 0.0).into();
+                // Track parent through traversal context: (location, parent_location, parent_id)
+                let initial_context = (initial_location, initial_location, None);
 
-            // Track parent through traversal context: (location, parent_location, parent_id)
-            let initial_context = (initial_location, initial_location, None);
+                // Collect all surfaces and build parent-child map
+                #[allow(clippy::mutable_key_type, clippy::type_complexity)]
+                let mut surface_info: std::collections::HashMap<
+                    ObjectId,
+                    (
+                        WlSurface,
+                        smithay::utils::Point<f64, smithay::utils::Physical>,
+                        Option<ObjectId>,
+                    ),
+                > = std::collections::HashMap::new();
 
-            // Collect all surfaces and build parent-child map
-            #[allow(clippy::mutable_key_type, clippy::type_complexity)]
-            let mut surface_info: std::collections::HashMap<
-                ObjectId,
-                (
-                    WlSurface,
-                    smithay::utils::Point<f64, smithay::utils::Physical>,
-                    Option<ObjectId>,
-                ),
-            > = std::collections::HashMap::new();
+                smithay::wayland::compositor::with_surface_tree_downward(
+                    &window_surface,
+                    initial_context,
+                    |surface, states, (location, _parent_location, _parent_id)| {
+                        profiling::scope!("surface_tree_downward");
+                        let mut location = *location;
+                        let data = states.data_map.get::<RendererSurfaceStateUserData>();
+                        let mut cached_state = states.cached_state.get::<SurfaceCachedState>();
+                        let cached_state = cached_state.current();
+                        let surface_geometry = cached_state.geometry.unwrap_or_default();
 
-            smithay::wayland::compositor::with_surface_tree_downward(
-                &window_surface,
-                initial_context,
-                |surface, states, (location, _parent_location, _parent_id)| {
-                    profiling::scope!("surface_tree_downward");
-                    let mut location = *location;
-                    let data = states.data_map.get::<RendererSurfaceStateUserData>();
-                    let mut cached_state = states.cached_state.get::<SurfaceCachedState>();
-                    let cached_state = cached_state.current();
-                    let surface_geometry = cached_state.geometry.unwrap_or_default();
+                        if let Some(data) = data {
+                            let data = data.lock().unwrap();
 
-                    if let Some(data) = data {
-                        let data = data.lock().unwrap();
-
-                        if let Some(view) = data.view() {
-                            location += view.offset.to_f64().to_physical(scale_factor);
-                            location -= surface_geometry.loc.to_f64().to_physical(scale_factor);
-                            TraversalAction::DoChildren((location, location, Some(surface.id())))
+                            if let Some(view) = data.view() {
+                                location += view.offset.to_f64().to_physical(scale_factor);
+                                location -= surface_geometry.loc.to_f64().to_physical(scale_factor);
+                                TraversalAction::DoChildren((
+                                    location,
+                                    location,
+                                    Some(surface.id()),
+                                ))
+                            } else {
+                                TraversalAction::SkipChildren
+                            }
                         } else {
                             TraversalAction::SkipChildren
                         }
-                    } else {
-                        TraversalAction::SkipChildren
-                    }
-                },
-                |surface, states, (location, parent_location, parent_id)| {
-                    let relative_offset = if parent_id.is_some() {
-                        *location - *parent_location
-                    } else {
-                        *location
-                    };
+                    },
+                    |surface, states, (location, parent_location, parent_id)| {
+                        let relative_offset = if parent_id.is_some() {
+                            *location - *parent_location
+                        } else {
+                            *location
+                        };
 
-                    if let Some(window_view) = self.window_view_for_surface(
-                        surface,
-                        states,
-                        &relative_offset,
-                        scale_factor,
-                        parent_id.clone(),
-                    ) {
-                        render_elements.push_front(window_view.clone());
-                        surface_info.insert(
-                            surface.id(),
-                            (surface.clone(), *location, parent_id.clone()),
-                        );
-                    } else {
-                        // Surface committed a null buffer (unmapped subsurface) — hide its layer
-                        if let Some(layer) = self.surface_layers.get(&surface.id()) {
-                            layer.set_hidden(true);
+                        if let Some(window_view) = self.window_view_for_surface(
+                            surface,
+                            states,
+                            &relative_offset,
+                            scale_factor,
+                            parent_id.clone(),
+                        ) {
+                            render_elements.push_front(window_view.clone());
+                            surface_info.insert(
+                                surface.id(),
+                                (surface.clone(), *location, parent_id.clone()),
+                            );
+                        } else {
+                            // Surface committed a null buffer (unmapped subsurface) — hide its layer
+                            if let Some(layer) = self.surface_layers.get(&surface.id()) {
+                                layer.set_hidden(true);
+                            }
                         }
-                    }
-                },
-                |_, _, _| true,
-            );
+                    },
+                    |_, _, _| true,
+                );
 
-            // Now sync the layer hierarchy to match the surface tree
-            for (surface_id, (surface, _pos, parent_id)) in surface_info.iter() {
-                let layer = self.get_or_create_layer_for_surface(surface);
+                // Now sync the layer hierarchy to match the surface tree
+                for (surface_id, (surface, _pos, parent_id)) in surface_info.iter() {
+                    let layer = self.get_or_create_layer_for_surface(surface);
 
-                // Configure layer with all properties and draw callback
-                if let Some(wvs) = render_elements.iter().find(|e| &e.id == surface_id) {
-                    layer.set_hidden(false);
-                    let style = self.surfaces_style.get(surface_id).and_then(|v| v.first());
-                    let gravity = style.map(|s| s.contents_gravity).unwrap_or_default();
-                    let client_owns_size = style.map(|s| s.client_owns_size).unwrap_or(false);
-                    let shared_gravity = style.map(|s| s.shared_gravity.clone());
-                    crate::workspaces::utils::configure_surface_layer(
-                        &layer,
-                        wvs,
-                        gravity,
-                        client_owns_size,
-                        shared_gravity,
-                    );
+                    // Configure layer with all properties and draw callback
+                    if let Some(wvs) = render_elements.iter().find(|e| &e.id == surface_id) {
+                        layer.set_hidden(false);
+                        let style = self.surfaces_style.get(surface_id).and_then(|v| v.first());
+                        let gravity = style.map(|s| s.contents_gravity).unwrap_or_default();
+                        let client_owns_size = style.map(|s| s.client_owns_size).unwrap_or(false);
+                        let shared_gravity = style.map(|s| s.shared_gravity.clone());
+                        crate::workspaces::utils::configure_surface_layer(
+                            &layer,
+                            wvs,
+                            gravity,
+                            client_owns_size,
+                            shared_gravity,
+                        );
 
-                    // Set up parent-child relationship using layers_engine.
-                    // Only re-parent if the parent changed — re-appending on
-                    // every commit detaches and re-attaches the node, which
-                    // causes flicker.
-                    if let Some(parent_id) = parent_id {
-                        let needs_reparent =
-                            self.surface_layer_parents.get(surface_id) != Some(parent_id);
-                        if needs_reparent {
-                            if let Some(parent_layer) = self.surface_layers.get(parent_id) {
-                                let _ = self.layers_engine.append_layer(&layer, parent_layer.id());
-                                self.surface_layer_parents
-                                    .insert(surface_id.clone(), parent_id.clone());
+                        // Set up parent-child relationship using layers_engine.
+                        // Only re-parent if the parent changed — re-appending on
+                        // every commit detaches and re-attaches the node, which
+                        // causes flicker.
+                        if let Some(parent_id) = parent_id {
+                            let needs_reparent =
+                                self.surface_layer_parents.get(surface_id) != Some(parent_id);
+                            if needs_reparent {
+                                if let Some(parent_layer) = self.surface_layers.get(parent_id) {
+                                    let _ =
+                                        self.layers_engine.append_layer(&layer, parent_layer.id());
+                                    self.surface_layer_parents
+                                        .insert(surface_id.clone(), parent_id.clone());
+                                }
                             }
                         }
                     }
                 }
-            }
+            } // end: import surface tree into lay-rs only when not scanned out
 
             if let Some(window_view) = self.workspaces.get_window_view(&id) {
-                let model = WindowViewBaseModel {
-                    x: location.x as f32,
-                    y: location.y as f32,
-                    w: window_geometry.size.w as f32,
-                    h: window_geometry.size.h as f32,
-                    title,
-                    fullscreen,
-                    active: false,
-                };
-                window_view.view_base.update_state(&model);
+                // Re-raster the shadow only when the window SIZE (or title /
+                // fullscreen) changes — never on a pure move — so a promoted
+                // window that only moves doesn't dirty the primary plane.
+                let new_w = window_geometry.size.w as f32;
+                let new_h = window_geometry.size.h as f32;
+                let cur = window_view.view_base.get_state();
+                let needs_shadow_update = cur.w != new_w
+                    || cur.h != new_h
+                    || cur.title != title
+                    || cur.fullscreen != fullscreen;
+                if needs_shadow_update {
+                    let model = WindowViewBaseModel {
+                        x: location.x as f32,
+                        y: location.y as f32,
+                        w: new_w,
+                        h: new_h,
+                        title,
+                        fullscreen,
+                        active: cur.active,
+                    };
+                    window_view.view_base.update_state(&model);
+                }
 
-                // Directly add root surface layer to content layer without using LayerTreeBuilder
-                let content_layer = &window_view.content_layer;
-
-                if let Some(root_layer) = self.surface_layers.get(&id) {
-                    // Use layers_engine to set parent-child relationship
-                    let _ = self
-                        .layers_engine
-                        .append_layer(root_layer, content_layer.id());
+                // Re-parent the root surface layer under content_layer only when
+                // we actually imported it (skipped while scanned out).
+                if !content_hidden {
+                    let content_layer = &window_view.content_layer;
+                    if let Some(root_layer) = self.surface_layers.get(&id) {
+                        // Use layers_engine to set parent-child relationship
+                        let _ = self
+                            .layers_engine
+                            .append_layer(root_layer, content_layer.id());
+                    }
                 }
 
                 self.workspaces.expose_update_if_needed();

--- a/src/state/window_throttle.rs
+++ b/src/state/window_throttle.rs
@@ -93,6 +93,11 @@ pub struct ClassifierContext<'a> {
     /// True when the expose overview is animating or open; all non-minimized
     /// windows get smooth live previews during this period.
     pub expose_active: bool,
+    /// Windows that are tiled (snapped to a half/maximized via the tiling
+    /// feature). Tiled windows sit side-by-side and are all fully visible, so
+    /// they're primary targets and must run at full rate — not the Secondary
+    /// 30 Hz bucket, which judders video in the non-active half.
+    pub tiled_ids: &'a HashSet<ObjectId>,
 }
 
 /// Classify a single window given its own minimized flag and a context
@@ -117,6 +122,12 @@ pub fn classify_one(
         // A fullscreen exists on the current workspace and it's not this
         // window — we're behind it, fully covered.
         return WindowThrottleState::Occluded;
+    }
+    if ctx.tiled_ids.contains(window_id) {
+        // Tiled windows are side-by-side and fully visible — both halves are
+        // primary targets and need full rate (a 30 Hz Secondary bucket judders
+        // video playing in the non-focused half).
+        return WindowThrottleState::Focused;
     }
     if ctx.top_of_current == Some(window_id) {
         // Top of the current workspace = user's primary focus target.
@@ -150,11 +161,25 @@ pub fn classify_windows(
     let current_workspace_index = workspaces.with_model(|m| m.current_workspace);
     let top_of_current = workspaces.get_top_window_of_workspace(current_workspace_index);
 
+    // Windows currently tiled (snapped to a half / maximized): both halves are
+    // fully visible primaries and must run at full rate.
+    let tiled_ids: HashSet<ObjectId> = windows
+        .iter()
+        .map(|w| w.id())
+        .filter(|id| {
+            workspaces
+                .get_window_view(id)
+                .map(|v| v.tiled_zone.is_some())
+                .unwrap_or(false)
+        })
+        .collect();
+
     let ctx = ClassifierContext {
         fullscreen_id: fullscreen_id.as_ref(),
         top_of_current: top_of_current.as_ref(),
         occluded_ids,
         expose_active,
+        tiled_ids: &tiled_ids,
     };
 
     let mut result = HashMap::with_capacity(windows.len());
@@ -205,6 +230,7 @@ mod tests {
             top_of_current: Some(&id),
             occluded_ids: &occ,
             expose_active: true,
+            tiled_ids: &occ,
         };
         assert_eq!(
             classify_one(&id, true, &ctx),
@@ -222,6 +248,7 @@ mod tests {
             top_of_current: None,
             occluded_ids: &occ,
             expose_active: true,
+            tiled_ids: &occ,
         };
         assert_eq!(
             classify_one(&id, false, &ctx),
@@ -239,6 +266,7 @@ mod tests {
             top_of_current: Some(&id),
             occluded_ids: &occ,
             expose_active: false,
+            tiled_ids: &occ,
         };
         assert_eq!(
             classify_one(&id, false, &ctx),

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -448,9 +448,15 @@ pub fn run_udev() {
             .node_with_type(NodeType::Primary)
             .and_then(|x| x.ok())
         {
+            // Set OTTO_NO_EXPLICIT_SYNC=1 to suppress wp_linux_drm_syncobj so
+            // clients fall back to implicit dmabuf fences (which smithay applies
+            // to KMS planes automatically) — used to isolate scanout tearing.
+            let suppress_explicit_sync = std::env::var_os("OTTO_NO_EXPLICIT_SYNC").is_some();
             if let Some(backend) = state.backend_data.backends.get(&primary_node) {
                 let import_device = backend.drm.device_fd().clone();
-                if supports_syncobj_eventfd(&import_device) {
+                if suppress_explicit_sync {
+                    info!("Explicit sync suppressed via OTTO_NO_EXPLICIT_SYNC (implicit fences)");
+                } else if supports_syncobj_eventfd(&import_device) {
                     let syncobj_state =
                         DrmSyncobjState::new::<Otto<UdevData>>(&display_handle, import_device);
                     state.backend_data.syncobj_state = Some(syncobj_state);

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -289,8 +289,55 @@ impl Otto<UdevData> {
             .and_then(|d| d.surfaces.get_mut(&crtc))
             .and_then(|s| s.prefetched_scene_damage.take());
 
-        // Get screenshare sessions before borrowing backend_data
-        // let _has_screenshare = !self.screenshare_sessions.is_empty();
+        // Determine if fullscreen direct scanout should be allowed:
+        // - Current workspace must be in fullscreen mode and not animating
+        // - Disable during expose gesture / workspace swipe gesture
+        let allow_direct_scanout =
+            self.workspaces.is_fullscreen_and_stable() && !self.swipe_gesture.is_active();
+        let fullscreen_window = if allow_direct_scanout {
+            self.workspaces.get_fullscreen_window()
+        } else {
+            None
+        };
+
+        // ---- Topmost-window (non-fullscreen) scanout selection ----
+        // Computed here, BEFORE the `device`/`surface` mutable borrow of
+        // `self.backend_data`, because the demotion re-import below calls
+        // `self.update_window_view` (full `&mut self`), which can't coexist with
+        // a live `surface` borrow. Capture (screenshot via screencopy /
+        // recording via screenshare) must see a fully-composited primary, so it
+        // disables scanout; fullscreen (own path) and the swipe gesture too.
+        let capture_active =
+            !self.pending_screencopy_frames.is_empty() || !self.screenshare_sessions.is_empty();
+        let scanout_windows =
+            if fullscreen_window.is_none() && !self.swipe_gesture.is_active() && !capture_active {
+                self.workspaces.get_scanout_candidates()
+            } else {
+                Vec::new()
+            };
+
+        // Demotion: windows that LEFT the scanout set had their lay-rs content
+        // import skipped while promoted; re-import them now (after the set
+        // update unhides their content_layer) so the first composited frame
+        // shows the current buffer, not a stale one.
+        let new_scanout_ids: std::collections::HashSet<
+            smithay::reexports::wayland_server::backend::ObjectId,
+        > = scanout_windows.iter().map(|(w, _)| w.id()).collect();
+        let prev_scanout_ids = self.workspaces.scanout_window_ids();
+        let departed_windows: Vec<WindowElement> = self
+            .workspaces
+            .spaces_elements()
+            .filter(|w| prev_scanout_ids.contains(&w.id()) && !new_scanout_ids.contains(&w.id()))
+            .cloned()
+            .collect();
+        {
+            let scanout_refs: Vec<&WindowElement> =
+                scanout_windows.iter().map(|(w, _)| w).collect();
+            self.workspaces.set_scanout_windows(&scanout_refs);
+        }
+        for w in &departed_windows {
+            self.update_window_view(w);
+        }
 
         let device = if let Some(device) = self.backend_data.backends.get_mut(&node) {
             device
@@ -358,21 +405,8 @@ impl Otto<UdevData> {
         // `self.backend_data`) is also live.
         let scene_has_damage =
             prefetched_scene_damage.unwrap_or_else(|| self.scene_element.update());
+
         let all_window_elements: Vec<&WindowElement> = self.workspaces.spaces_elements().collect();
-
-        // Determine if direct scanout should be allowed:
-        // - Current workspace must be in fullscreen mode and not animating
-        // - Disable during expose gesture
-        // - Disable during workspace swipe gesture
-        let allow_direct_scanout =
-            self.workspaces.is_fullscreen_and_stable() && !self.swipe_gesture.is_active();
-
-        // Only fetch the fullscreen window if direct scanout is allowed
-        let fullscreen_window = if allow_direct_scanout {
-            self.workspaces.get_fullscreen_window()
-        } else {
-            None
-        };
 
         // Build a per-output scene element that renders from the output's own layer node
         let output_scene_element = self
@@ -408,6 +442,7 @@ impl Otto<UdevData> {
             output_scene_element,
             scene_has_damage,
             fullscreen_window.as_ref(),
+            &scanout_windows,
             &window_throttle_states,
             &mut self.pending_screencopy_frames,
         );
@@ -961,6 +996,7 @@ pub(super) fn render_surface<'a>(
     scene_element: SceneElement,
     scene_has_damage: bool,
     fullscreen_window: Option<&WindowElement>,
+    scanout_windows: &[(WindowElement, Point<i32, Logical>)],
     window_throttle_states: &std::collections::HashMap<
         smithay::reexports::wayland_server::backend::ObjectId,
         crate::state::window_throttle::WindowThrottleState,
@@ -1041,8 +1077,10 @@ pub(super) fn render_surface<'a>(
         workspace_render_elements.push(WorkspaceRenderElements::Fps(element.clone()));
     }
 
-    // Track direct scanout mode transitions
-    let is_direct_scanout = fullscreen_window.is_some();
+    // Track direct scanout mode transitions. Fullscreen scanout (skips the
+    // scene entirely) and topmost-window scanout (keeps the scene for shadow +
+    // chrome) both count — switching either way needs a buffer reset.
+    let is_direct_scanout = fullscreen_window.is_some() || !scanout_windows.is_empty();
     let mode_changed = is_direct_scanout != surface.was_direct_scanout;
     surface.was_direct_scanout = is_direct_scanout;
 
@@ -1078,6 +1116,78 @@ pub(super) fn render_surface<'a>(
 
             // Always render in fullscreen mode since the window surface may have damage
             // Use black clear color - the window fills the screen anyway
+            (elements, CLEAR_COLOR, true)
+        } else if !scanout_windows.is_empty() {
+            // Topmost-window scanout: render the scene (each candidate's
+            // content_layer is hidden, so the scene draws shadows + chrome +
+            // everything not promoted) AND append each candidate's surface tree
+            // ABOVE the scene in top-to-bottom z-order as a Kind::ScanoutCandidate
+            // so smithay's DrmCompositor can promote it to an overlay plane.
+            // Whatever can't fit a plane GPU-composites the same (current)
+            // element above the scene — so a same-frame plane failure is z-correct.
+            use smithay::backend::renderer::element::surface::render_elements_from_surface_tree;
+            use smithay::backend::renderer::element::Wrap;
+
+            let mut elements: Vec<OutputRenderElements<'a, _, WindowRenderElement<_>>> = Vec::new();
+            elements.extend(
+                workspace_render_elements
+                    .into_iter()
+                    .map(OutputRenderElements::from),
+            );
+
+            for (scanout_win, location) in scanout_windows {
+                // Drive the buffer position from the lay-rs scene layer (the
+                // animated visible top-left) rather than the static smithay
+                // Space location, so an unexpected fall-back to compositing
+                // doesn't make the window jump. CSD clients draw shadows past
+                // the visible region — geometry().loc is the buffer→visible
+                // inset, so subtract it to get the buffer top-left.
+                let base_bounds = scanout_win.base_layer().render_bounds_transformed();
+                let geom_phys = scanout_win.geometry().loc.to_f64().to_physical(scale);
+                let layer_ready = base_bounds.x() != 0.0 || base_bounds.y() != 0.0;
+                let physical_loc: Point<i32, Physical> = if layer_ready {
+                    (
+                        (base_bounds.x() as f64 - geom_phys.x).round() as i32,
+                        (base_bounds.y() as f64 - geom_phys.y).round() as i32,
+                    )
+                        .into()
+                } else {
+                    let render_location = *location - scanout_win.geometry().loc;
+                    render_location.to_physical_precise_round(scale)
+                };
+                let window_elements_rendered: Vec<WindowRenderElement<_>> =
+                    if let Some(surface) = scanout_win.wl_surface() {
+                        render_elements_from_surface_tree(
+                            renderer,
+                            &surface,
+                            physical_loc,
+                            scale,
+                            1.0,
+                            Kind::ScanoutCandidate,
+                        )
+                        .into_iter()
+                        .map(WindowRenderElement::Window)
+                        .collect()
+                    } else {
+                        scanout_win.render_elements(renderer, physical_loc, scale, 1.0)
+                    };
+                elements.extend(
+                    window_elements_rendered
+                        .into_iter()
+                        .map(|e| OutputRenderElements::Window(Wrap::from(e))),
+                );
+            }
+
+            // Scene below all scanout windows: shadows + chrome + non-promoted.
+            elements.push(OutputRenderElements::from(WorkspaceRenderElements::Scene(
+                scene_element,
+            )));
+
+            // Must always render: a promoted window's buffer commit produces no
+            // scene damage (its content_layer is hidden and its import skipped),
+            // so gating on scene_has_damage would drop video frames. render_frame
+            // returns is_empty when nothing actually changed, so the idle case
+            // stays cheap (no page flip).
             (elements, CLEAR_COLOR, true)
         } else {
             // Normal mode: render the full scene
@@ -1123,7 +1233,8 @@ pub(super) fn render_surface<'a>(
             &output_elements,
             clear_color,
             smithay::backend::drm::compositor::FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT
-                | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY,
+                | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY
+                | smithay::backend::drm::compositor::FrameFlags::ALLOW_OVERLAY_PLANE_SCANOUT,
         )
         .map_err(|err| match err {
             smithay::backend::drm::compositor::RenderFrameError::PrepareFrame(err) => err.into(),
@@ -1236,7 +1347,8 @@ pub(super) fn initial_render(
             &[],
             CLEAR_COLOR,
             smithay::backend::drm::compositor::FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT
-                | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY,
+                | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY
+                | smithay::backend::drm::compositor::FrameFlags::ALLOW_OVERLAY_PLANE_SCANOUT,
         )
         .map_err(|err| match err {
             smithay::backend::drm::compositor::RenderFrameError::PrepareFrame(err) => err.into(),

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -403,8 +403,18 @@ impl Otto<UdevData> {
         // distinct fields, so field-projection rules allow the mutable borrow
         // of `self.scene_element` here even though `surface` (derived from
         // `self.backend_data`) is also live.
-        let scene_has_damage =
-            prefetched_scene_damage.unwrap_or_else(|| self.scene_element.update());
+        let scene_has_damage = if !departed_windows.is_empty() {
+            // A window was demoted from scanout this frame: its buffer was
+            // re-imported (above) *after* the Phase-1 scene prefetch, so that
+            // content transaction is still unflushed. Re-run the engine update
+            // now to apply it before compositing, and force a draw — otherwise
+            // the first composited frame after demotion shows the stale,
+            // shadow-only scene (a one-frame flicker).
+            self.scene_element.update();
+            true
+        } else {
+            prefetched_scene_damage.unwrap_or_else(|| self.scene_element.update())
+        };
 
         let all_window_elements: Vec<&WindowElement> = self.workspaces.spaces_elements().collect();
 

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -379,6 +379,19 @@ impl DockView {
     pub fn is_autohide_enabled(&self) -> bool {
         self.dock_config.read().unwrap().autohide
     }
+    /// True while the dock is showing a right-click context menu.
+    pub fn is_context_menu_open(&self) -> bool {
+        self.context_menu.read().unwrap().is_some()
+    }
+    /// True while the pointer is over the dock and magnification is active (the
+    /// icons are animating). The rest position is the -500 off-screen sentinel.
+    pub fn is_magnifying(&self) -> bool {
+        *self.magnification_position.read().unwrap() > -100.0
+    }
+    /// Full dock bounds in physical/scene pixels, if the dock has been laid out.
+    pub fn dock_bounds(&self) -> Option<skia::Rect> {
+        *self.cached_dock_bounds.read().unwrap()
+    }
     pub fn set_active_flag(&self, active: bool) {
         self.active
             .store(active, std::sync::atomic::Ordering::Relaxed);

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -154,6 +154,15 @@ pub struct Workspaces {
     observers: Vec<Weak<dyn Observer<WorkspacesModel>>>,
     expose_dragged_window: Arc<std::sync::Mutex<Option<ObjectId>>>,
     remove_workspace_sender: CalloopSender<usize>,
+
+    /// Windows whose client buffer is currently scanned out on a KMS plane.
+    /// Their `content_layer` is hidden in the scene (the shadow keeps drawing)
+    /// and the WindowElement is appended above the SceneElement as a plane
+    /// candidate. See `docs/developer/window-scanout-promotion.md`.
+    scanout_windows: Arc<RwLock<HashSet<ObjectId>>>,
+    /// Popups currently scanned out (content hidden so the scene doesn't
+    /// double-draw them). Tracked separately — popups live in PopupOverlayView.
+    scanout_popups: Arc<RwLock<HashSet<ObjectId>>>,
 }
 
 /// # Workspaces Layer Structure
@@ -361,6 +370,8 @@ impl Workspaces {
             expose_dragged_window: Arc::new(std::sync::Mutex::new(None)),
             remove_workspace_sender,
             display_handle,
+            scanout_windows: Arc::new(RwLock::new(HashSet::new())),
+            scanout_popups: Arc::new(RwLock::new(HashSet::new())),
         };
 
         workspaces.add_listener(dock.clone());
@@ -637,6 +648,185 @@ impl Workspaces {
             .cloned()?;
 
         Some(window)
+    }
+
+    /// Select the regular (non-fullscreen) windows of the current workspace to
+    /// promote to KMS plane scanout, top-to-bottom (front first).
+    ///
+    /// Stable gate (returns empty if any holds): expose/show-all (window &
+    /// workspace selection), expose transitioning, app switcher, OSD, a visible
+    /// layer-shell overlay surface, fullscreen mode/animating. Capture
+    /// (screenshot/recording), the workspace swipe gesture and overlay state
+    /// owned by `Otto` are checked at the call-site.
+    ///
+    /// Overlap rule: a window is promoted only if it is **disjoint from every
+    /// visible window above it** — so the topmost window always promotes and a
+    /// lower one promotes only when nothing overlaps it. Promoted windows are
+    /// therefore mutually disjoint and unoccluded (independent planes).
+    pub fn get_scanout_candidates(
+        &self,
+    ) -> Vec<(
+        WindowElement,
+        smithay::utils::Point<i32, smithay::utils::Logical>,
+    )> {
+        use smithay::utils::Rectangle;
+
+        // TEMP diagnostic: log every gate state each frame to find what blocks scanout.
+        tracing::debug!(target: "otto::scanout",
+            show_all = self.get_show_all(),
+            expose = self.is_expose_transitioning(),
+            switcher = self.app_switcher.alive(),
+            osd = self.osd.is_visible(),
+            overlay = !self.layer_shell_overlay.hidden(),
+            dock_menu = self.dock.is_context_menu_open(),
+            dock_magnify = self.dock.is_magnifying(),
+            "scanout gate states");
+
+        // ---- global stable gate ----
+        if self.get_show_all() || self.is_expose_transitioning() {
+            return Vec::new();
+        }
+        if self.app_switcher.alive() || self.osd.is_visible() {
+            return Vec::new();
+        }
+        // A visible wlr-layer-shell overlay surface draws above everything.
+        if !self.layer_shell_overlay.hidden() {
+            return Vec::new();
+        }
+        // The window-tiling drop-zone overlay is drawn above windows during a
+        // drag — disable scanout while it's visible, like any other overlay.
+        if self.tiling_overlay.is_visible() {
+            return Vec::new();
+        }
+        // Dock interaction composites above windows: a context menu open, or the
+        // hover/magnification animation running, means the scene around the dock
+        // is changing and must keep compositing.
+        if self.dock.is_context_menu_open() || self.dock.is_magnifying() {
+            return Vec::new();
+        }
+        let Some(current_workspace) = self.get_current_workspace() else {
+            return Vec::new();
+        };
+        // Fullscreen has its own dedicated direct-scanout path.
+        if current_workspace.get_fullscreen_mode() || current_workspace.get_fullscreen_animating() {
+            return Vec::new();
+        }
+
+        let current_index = self.get_current_workspace_index();
+        let Some(space) = self
+            .primary_output_workspaces()
+            .and_then(|ows| ows.spaces.get(current_index))
+        else {
+            return Vec::new();
+        };
+
+        // Windows overlapping the visible dock can't be promoted: the dock
+        // composites in the primary plane, above the scanned-out overlay.
+        // `cached_dock_bounds` is already in LOGICAL coords (the dock divides
+        // screen size by scale when computing it), so compare directly — do NOT
+        // divide by scale again.
+        let dock_logical: Option<Rectangle<i32, smithay::utils::Logical>> =
+            if self.dock.is_hidden() {
+                None
+            } else {
+                self.dock.dock_bounds().map(|r| {
+                    Rectangle::new(
+                        (r.left as i32, r.top as i32).into(),
+                        ((r.right - r.left) as i32, (r.bottom - r.top) as i32).into(),
+                    )
+                })
+            };
+
+        // ---- per-window eligibility + top-to-bottom overlap selection ----
+        let mut promoted = Vec::new();
+        // Union of visible-window rects seen so far (everything above current).
+        let mut covered: Vec<Rectangle<i32, smithay::utils::Logical>> = Vec::new();
+        // Space::elements yields bottom-to-top; rev() => top-to-bottom.
+        for window in space.elements().rev() {
+            if window.is_minimised() {
+                continue; // not visible — doesn't occlude
+            }
+            let view = self.get_window_view(&window.id());
+            if view.as_ref().map(|v| v.is_unmapped()).unwrap_or(false) {
+                continue; // gone — doesn't occlude
+            }
+            let Some(location) = space.element_location(window) else {
+                continue;
+            };
+            let rect = Rectangle::new(location, window.geometry().size);
+            let overlaps_above = covered.iter().any(|c| c.overlaps(rect));
+            // This window occupies space for everything below it, whether or
+            // not it ends up promoted.
+            covered.push(rect);
+
+            // A minimizing window is still visible (animating to the dock) so
+            // it occludes, but can't be promoted (it has a live transform).
+            let animating = view.as_ref().map(|v| v.is_minimizing()).unwrap_or(false);
+            // v1 doesn't scan out popups; a window with an open popup must
+            // composite normally or the (scene-drawn) popup would be hidden
+            // under the window's overlay plane.
+            let has_popups = window
+                .wl_surface()
+                .map(|s| {
+                    smithay::desktop::PopupManager::popups_for_surface(&s)
+                        .next()
+                        .is_some()
+                })
+                .unwrap_or(false);
+            let overlaps_dock = dock_logical.map(|d| d.overlaps(rect)).unwrap_or(false);
+            tracing::debug!(target: "otto::scanout",
+                win = ?rect, dock = ?dock_logical, dock_hidden = self.dock.is_hidden(),
+                overlaps_above, animating, has_popups, overlaps_dock,
+                "candidate eval");
+            if !overlaps_above && !animating && !has_popups && !overlaps_dock {
+                promoted.push((window.clone(), location));
+            }
+        }
+        promoted
+    }
+
+    /// Snapshot of the windows currently flagged for scanout (their
+    /// `content_layer` is hidden). The render call-site diffs against this to
+    /// re-import departing windows before they're composited again.
+    pub fn scanout_window_ids(&self) -> HashSet<ObjectId> {
+        self.scanout_windows.read().unwrap().clone()
+    }
+
+    /// Replace the scanout window set: hides `content_layer` for new entrants,
+    /// unhides it for departures. Idempotent. The caller must re-import any
+    /// departing window's buffer (via `update_window_view`) *before* this call
+    /// so the unhidden `content_layer` shows the current frame, not a stale one.
+    pub fn set_scanout_windows(&self, windows: &[&WindowElement]) {
+        let new_ids: HashSet<ObjectId> = windows.iter().map(|w| w.id()).collect();
+        let prev_ids = self.scanout_windows.read().unwrap().clone();
+        if prev_ids == new_ids {
+            return;
+        }
+        tracing::info!(
+            target: "otto::scanout",
+            prev = prev_ids.len(),
+            new = new_ids.len(),
+            "scanout window set changed"
+        );
+        for prev in prev_ids.difference(&new_ids) {
+            if let Some(view) = self.get_window_view(prev) {
+                view.set_content_hidden(false);
+            }
+        }
+        for new in new_ids.difference(&prev_ids) {
+            if let Some(view) = self.get_window_view(new) {
+                view.set_content_hidden(true);
+            }
+        }
+        *self.scanout_windows.write().unwrap() = new_ids;
+    }
+
+    /// Replace the scanout popup set. v1 tracks the set only; popup content
+    /// hiding is a follow-up (windows with open popups are simply not promoted,
+    /// see the call-site), so this currently only records state.
+    pub fn set_scanout_popups(&self, popup_ids: &[ObjectId]) {
+        let new_ids: HashSet<ObjectId> = popup_ids.iter().cloned().collect();
+        *self.scanout_popups.write().unwrap() = new_ids;
     }
 
     /// Return if we are in window selection mode

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -142,6 +142,13 @@ pub struct Workspaces {
     pub is_animating: Arc<AtomicBool>,
     /// True while a 3-finger expose gesture is physically in progress (fingers on trackpad).
     pub expose_gesture_active: Arc<AtomicBool>,
+    /// True for the full duration of an expose open/close *release* animation
+    /// (after the finger lifts / on keyboard toggle), cleared in the spring's
+    /// `on_finish`. Unlike the gesture value — which snaps to its target (0 or
+    /// 1000) the instant the closing animation is scheduled — this stays true
+    /// until the animation actually settles, so scanout promotion waits for the
+    /// expose-exit animation to finish. See [`is_expose_transitioning`].
+    pub expose_animating: Arc<AtomicBool>,
 
     // layers
     pub layers_engine: Arc<Engine>,
@@ -364,6 +371,7 @@ impl Workspaces {
             show_desktop_gesture: Arc::new(AtomicI32::new(0)),
             is_animating: Arc::new(AtomicBool::new(false)),
             expose_gesture_active: Arc::new(AtomicBool::new(false)),
+            expose_animating: Arc::new(AtomicBool::new(false)),
             window_views: Arc::new(RwLock::new(HashMap::new())),
             observers: Vec::new(),
             layers_engine,
@@ -853,9 +861,16 @@ impl Workspaces {
         let is_animating = self.is_animating.load(std::sync::atomic::Ordering::Relaxed);
 
         // We're transitioning if:
+        // 0. A release animation is in flight. The gesture value snaps to its
+        //    target (0 on close) the instant the animation is scheduled, so the
+        //    clauses below can't see a close-in-progress — this flag bridges the
+        //    gap until `on_finish` clears it, keeping scanout disabled until the
+        //    expose-exit animation actually finishes.
         // 1. Gesture value is between 0 and 1000 (not fully closed or fully open), OR
         // 2. Animation is in progress AND we're not at a stable state (0 or 1000)
-        (gesture_value > 0 && gesture_value < 1000)
+        self.expose_animating
+            .load(std::sync::atomic::Ordering::Relaxed)
+            || (gesture_value > 0 && gesture_value < 1000)
             || (is_animating && gesture_value != 0 && gesture_value != 1000)
     }
 
@@ -1498,6 +1513,15 @@ impl Workspaces {
             .clone();
         self.is_animating
             .store(is_starting_animation, std::sync::atomic::Ordering::Relaxed);
+        // A release animation is about to run: mark expose as transitioning so
+        // scanout stays disabled until it settles. Only set (never clear) here —
+        // the loop in `expose_end_with_velocity` calls this for non-current
+        // workspaces with `transition = None`, and those must not clobber the
+        // flag. The clear happens in the spring's `on_finish` below.
+        if is_starting_animation {
+            self.expose_animating
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
 
         window_selector_view.set_opacity(0.0, None);
 
@@ -1613,6 +1637,7 @@ impl Workspaces {
             let show_all_ref = self.show_all.clone();
             let show_all_gesture_ref = self.show_all_gesture.clone();
             let expose_gesture_active_ref = self.expose_gesture_active.clone();
+            let expose_animating_ref = self.expose_animating.clone();
             let expose_dragged_window_ref = self.expose_dragged_window.clone();
             let model_ref = self.model.clone();
 
@@ -1660,6 +1685,12 @@ impl Workspaces {
                 window_selector_view_ref.set_position((0.0, 0.0), None);
                 transaction.on_finish(
                     move |_: &Layer, _: f32| {
+                        // The release animation has settled (this fires only on
+                        // natural completion — a reversal cancels the transaction
+                        // without firing it), so expose is no longer transitioning
+                        // and scanout may resume.
+                        expose_animating_ref
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
                         let is_dragging =
                             expose_dragged_window_ref.lock().unwrap().is_some();
                         // Re-read the current state at finish time — the gesture may have

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -678,12 +678,12 @@ impl Workspaces {
         if self.app_switcher.alive() || self.osd.is_visible() {
             return Vec::new();
         }
-        // A visible wlr-layer-shell overlay surface draws above everything.
-        if !self.layer_shell_overlay.hidden() {
-            return Vec::new();
-        }
-        // The window-tiling drop-zone overlay is drawn above windows during a
-        // drag — disable scanout while it's visible, like any other overlay.
+        // Note: wlr-layer-shell Top/Overlay surfaces (panels, notification
+        // daemons) are handled per-window below via `layer_rects` — a window is
+        // only blocked if a layer surface actually overlaps it, so the
+        // always-present top bar doesn't disable scanout for unrelated windows.
+        // The window-tiling drop-zone overlay is an Otto scene overlay (not a
+        // layer-shell surface), so it still needs its own global gate.
         if self.tiling_overlay.is_visible() {
             return Vec::new();
         }
@@ -726,6 +726,26 @@ impl Workspaces {
                 })
             };
 
+        // Top/Overlay layer-shell surfaces (notification daemons, panels)
+        // composite above windows in the scene, so a window one of them overlaps
+        // would be hidden behind its own scanout plane — don't promote it. This
+        // is overlap-aware (not a blanket gate) so the always-present top bar
+        // only blocks windows it actually covers, not every window.
+        let layer_rects: Vec<Rectangle<i32, smithay::utils::Logical>> = self
+            .primary_output
+            .as_ref()
+            .map(|output| {
+                let map = smithay::desktop::layer_map_for_output(output);
+                map.layers()
+                    .filter(|l| {
+                        use smithay::wayland::shell::wlr_layer::Layer;
+                        matches!(l.layer(), Layer::Top | Layer::Overlay)
+                    })
+                    .filter_map(|l| map.layer_geometry(l))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         // ---- per-window eligibility + top-to-bottom overlap selection ----
         let mut promoted = Vec::new();
         // Union of visible-window rects seen so far (everything above current).
@@ -763,7 +783,9 @@ impl Workspaces {
                 })
                 .unwrap_or(false);
             let overlaps_dock = dock_logical.map(|d| d.overlaps(rect)).unwrap_or(false);
-            if !overlaps_above && !animating && !has_popups && !overlaps_dock {
+            // Behind a notification/panel layer surface → must composite.
+            let overlaps_layer = layer_rects.iter().any(|r| r.overlaps(rect));
+            if !overlaps_above && !animating && !has_popups && !overlaps_dock && !overlaps_layer {
                 promoted.push((window.clone(), location));
             }
         }

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -671,17 +671,6 @@ impl Workspaces {
     )> {
         use smithay::utils::Rectangle;
 
-        // TEMP diagnostic: log every gate state each frame to find what blocks scanout.
-        tracing::debug!(target: "otto::scanout",
-            show_all = self.get_show_all(),
-            expose = self.is_expose_transitioning(),
-            switcher = self.app_switcher.alive(),
-            osd = self.osd.is_visible(),
-            overlay = !self.layer_shell_overlay.hidden(),
-            dock_menu = self.dock.is_context_menu_open(),
-            dock_magnify = self.dock.is_magnifying(),
-            "scanout gate states");
-
         // ---- global stable gate ----
         if self.get_show_all() || self.is_expose_transitioning() {
             return Vec::new();
@@ -774,10 +763,6 @@ impl Workspaces {
                 })
                 .unwrap_or(false);
             let overlaps_dock = dock_logical.map(|d| d.overlaps(rect)).unwrap_or(false);
-            tracing::debug!(target: "otto::scanout",
-                win = ?rect, dock = ?dock_logical, dock_hidden = self.dock.is_hidden(),
-                overlaps_above, animating, has_popups, overlaps_dock,
-                "candidate eval");
             if !overlaps_above && !animating && !has_popups && !overlaps_dock {
                 promoted.push((window.clone(), location));
             }

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -714,17 +714,17 @@ impl Workspaces {
         // `cached_dock_bounds` is already in LOGICAL coords (the dock divides
         // screen size by scale when computing it), so compare directly — do NOT
         // divide by scale again.
-        let dock_logical: Option<Rectangle<i32, smithay::utils::Logical>> =
-            if self.dock.is_hidden() {
-                None
-            } else {
-                self.dock.dock_bounds().map(|r| {
-                    Rectangle::new(
-                        (r.left as i32, r.top as i32).into(),
-                        ((r.right - r.left) as i32, (r.bottom - r.top) as i32).into(),
-                    )
-                })
-            };
+        let dock_logical: Option<Rectangle<i32, smithay::utils::Logical>> = if self.dock.is_hidden()
+        {
+            None
+        } else {
+            self.dock.dock_bounds().map(|r| {
+                Rectangle::new(
+                    (r.left as i32, r.top as i32).into(),
+                    ((r.right - r.left) as i32, (r.bottom - r.top) as i32).into(),
+                )
+            })
+        };
 
         // Top/Overlay layer-shell surfaces (notification daemons, panels)
         // composite above windows in the scene, so a window one of them overlaps
@@ -795,6 +795,7 @@ impl Workspaces {
     /// Snapshot of the windows currently flagged for scanout (their
     /// `content_layer` is hidden). The render call-site diffs against this to
     /// re-import departing windows before they're composited again.
+    #[allow(clippy::mutable_key_type)]
     pub fn scanout_window_ids(&self) -> HashSet<ObjectId> {
         self.scanout_windows.read().unwrap().clone()
     }
@@ -803,6 +804,7 @@ impl Workspaces {
     /// unhides it for departures. Idempotent. The caller must re-import any
     /// departing window's buffer (via `update_window_view`) *before* this call
     /// so the unhidden `content_layer` shows the current frame, not a stale one.
+    #[allow(clippy::mutable_key_type)]
     pub fn set_scanout_windows(&self, windows: &[&WindowElement]) {
         let new_ids: HashSet<ObjectId> = windows.iter().map(|w| w.id()).collect();
         let prev_ids = self.scanout_windows.read().unwrap().clone();
@@ -831,6 +833,7 @@ impl Workspaces {
     /// Replace the scanout popup set. v1 tracks the set only; popup content
     /// hiding is a follow-up (windows with open popups are simply not promoted,
     /// see the call-site), so this currently only records state.
+    #[allow(clippy::mutable_key_type)]
     pub fn set_scanout_popups(&self, popup_ids: &[ObjectId]) {
         let new_ids: HashSet<ObjectId> = popup_ids.iter().cloned().collect();
         *self.scanout_popups.write().unwrap() = new_ids;

--- a/src/workspaces/window_view/view.rs
+++ b/src/workspaces/window_view/view.rs
@@ -27,12 +27,16 @@ pub struct WindowView {
     pub genie_effect: GenieEffect,
 
     pub unmaximised_rect: smithay::utils::Rectangle<i32, Logical>,
-    /// The tiling zone this window is currently snapped into, if any. Set when
-    /// a window is tiled (drag-snap or shortcut), cleared on drag-off or restore.
-    /// `unmaximised_rect` holds the pre-snap geometry.
+    /// The tiling zone this window is currently snapped into, if any. Set when a
+    /// window is tiled (drag-snap or shortcut), cleared when it is dragged off or
+    /// restored. `unmaximised_rect` holds the pre-snap geometry to restore to.
     pub tiled_zone: Option<crate::workspaces::TileZone>,
     pub minimizing_animation: Arc<AtomicBool>,
     pub is_unmapped: Arc<AtomicBool>,
+    /// True when the content_layer is hidden because the window's client buffer
+    /// is being scanned out directly on a KMS plane. The shadow layer stays
+    /// visible so it composites underneath the scanned-out plane.
+    pub content_hidden: Arc<AtomicBool>,
 }
 
 impl WindowView {
@@ -91,7 +95,25 @@ impl WindowView {
             tiled_zone: None,
             minimizing_animation: Arc::new(AtomicBool::new(false)),
             is_unmapped: Arc::new(AtomicBool::new(false)),
+            content_hidden: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Toggle content_layer visibility for direct-scanout: when `hidden` is
+    /// true the scene stops compositing the client surface buffer (the shadow
+    /// keeps drawing) so the buffer can be scanned out on a KMS plane.
+    pub fn set_content_hidden(&self, hidden: bool) {
+        let prev = self
+            .content_hidden
+            .swap(hidden, std::sync::atomic::Ordering::SeqCst);
+        if prev != hidden {
+            self.content_layer.set_hidden(hidden);
+        }
+    }
+
+    pub fn is_content_hidden(&self) -> bool {
+        self.content_hidden
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Update the activation state of the window shadow


### PR DESCRIPTION
## Summary
- Promotes eligible regular windows to KMS overlay planes: hides `content_layer` in the lay-rs scene (keeping the shadow) and appends the client surface as a `ScanoutCandidate` — no GPU compositing while the buffer updates
- Top-to-bottom overlap selection: topmost window always promotes; a lower window promotes only when disjoint from everything above it (mutually disjoint, independent planes)
- Stable gate disables promotion during: expose, app switcher, OSD, layer-shell overlay, tiling drop-zone, screencopy/screenshare capture, dock menu/hover/animation, windows overlapping the dock
- Explicit-sync fix: adds `DrmSyncPointBlocker` from the surface acquire point so the KMS commit waits for the client GPU before the plane flips
- Forces tiled windows to the Focused throttle state so the non-active half keeps full frame-rate
- GPU sync after EGLImage→2D blit so composited buffers aren't sampled mid-upload
- Demotion flicker fix: flushes re-imported buffer before unhiding `content_layer`

## Test plan
- [ ] Single window on screen — should scanout directly (verify with `RUST_LOG=otto::scanout=debug`)
- [ ] Two non-overlapping windows — both promote to separate planes
- [ ] Overlapping windows — only topmost promotes
- [ ] Window overlapping dock — does not promote
- [ ] Open expose / app switcher — scanout gates off
- [ ] Screenshare active — scanout gates off
- [ ] No tearing with explicit-sync enabled
- [ ] Tiled window pair — both run at full frame-rate