### PR TITLE
feat(xwayland): fullscreen game support on the scanout stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,15 @@ branch = "feat/subtree-buffer-render"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]
-# local checkout: feat/dmabuf-scanout + xwm set_input_focus cherry-pick
-path = "../smithay/smithay-drm-extras"
+git = "https://github.com/nongio/smithay"
+branch = "feat/dmabuf-scanout"
+# local development: path = "../smithay/smithay-drm-extras"
 optional = true
 
 [dependencies.smithay]
-# local checkout: feat/dmabuf-scanout + xwm set_input_focus cherry-pick
-path = "../smithay"
+git = "https://github.com/nongio/smithay"
+branch = "feat/dmabuf-scanout"
+# local development: path = "../smithay"
 default-features = false
 features = [
     "backend_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,15 +57,13 @@ branch = "feat/subtree-buffer-render"
 features = ["export-taffy"]
 
 [dependencies.smithay-drm-extras]
-git = "https://github.com/nongio/smithay"
-branch = "feat/dmabuf-scanout"
-# local development: path = "../smithay/smithay-drm-extras"
+# local checkout: feat/dmabuf-scanout + xwm set_input_focus cherry-pick
+path = "../smithay/smithay-drm-extras"
 optional = true
 
 [dependencies.smithay]
-git = "https://github.com/nongio/smithay"
-branch = "feat/dmabuf-scanout"
-# local development: path = "../smithay"
+# local checkout: feat/dmabuf-scanout + xwm set_input_focus cherry-pick
+path = "../smithay"
 default-features = false
 features = [
     "backend_winit",
@@ -156,6 +154,7 @@ members = [
     "sample-clients/client-rainbow",
     "sample-clients/submenu",
     "sample-clients/submenu-gtk",
+    "sample-clients/deadlock-test",
 ]
 
 [package.metadata.deb]

--- a/XWAYLAND_FULLSCREEN_GAME_FOCUS_PLAN.md
+++ b/XWAYLAND_FULLSCREEN_GAME_FOCUS_PLAN.md
@@ -1,0 +1,180 @@
+# XWayland fullscreen game focus — findings & implementation plan
+
+**Goal:** fullscreen XWayland games (Cuphead via Proton/Steam) that (a) render without stalling,
+(b) survive workspace switches, and (c) **receive keyboard input** — all at once.
+
+**Status:** ALL THREE SOLVED and in the tree (uncommitted), user-confirmed with real keyboard input
+("everything works"). (a) renders, (b) survives workspace switches, (c) keyboard reaches the game via
+gamescope-style `XSetInputFocus`. Remaining work is cleanup + consolidation + commit (sections 6).
+NOTE: the wlrctl *virtual* keyboard is unreliable — it can false-fail on input even when delivery works;
+trust real keyboard / the menu actually advancing, not virtual-keyboard negatives.
+
+Full investigation log: project memory `project_xwayland_fullscreen_black_scanout.md` (UPDATEs 1–20)
+and `project_cuphead_fullscreen_hang.md`.
+
+---
+
+## 1. The three dynamics (root causes)
+
+Cuphead is a **Unity / Proton (DXVK) game**, ICCCM input model **Globally-Active** (`WM_HINTS.input=false`
++ `WM_TAKE_FOCUS`), default **`Run In Background = false`**. Each dynamic was a separate bug:
+
+| # | Symptom | Root cause | Fix |
+|---|---------|-----------|-----|
+| 1 | Black screen at launch | Forcing keyboard/X focus (→ `WM_TAKE_FOCUS`) **at map** stalls the render loop | Don't focus-protocol at map; route keys to the `wl_surface` |
+| 2 | Freeze on workspace switch | Unity (`Run In Background=false`) **pauses on X11 `FocusOut`**; switching focused another window → XWayland sent the game `FocusOut` | Keep focus on the fullscreen game (focus-retention) |
+| 3 | **Keyboard has no effect** (SOLVED) | `wl_keyboard` focus alone does NOT deliver keys — XWayland needs the **WM to set X input focus**. But `WM_TAKE_FOCUS` (the ICCCM way) breaks rendering (dynamic #1, any time) | **gamescope's bare `XSetInputFocus`** (no `WM_TAKE_FOCUS`) — implemented in §4, confirmed working |
+
+Predicate used throughout: **self-managing == `WmInputModel::GloballyActive | None`**
+(helper `WindowElement::x11_self_manages_focus()`).
+
+---
+
+## 2. Reference implementations — the key comparison
+
+When the WM gives focus to a Globally-Active X11 window, there are two strategies:
+
+| Compositor | Globally-Active focus | ICCCM-correct? | Works with Cuphead? |
+|---|---|---|---|
+| **smithay default** (`X11Surface::enter`) | send `WM_TAKE_FOCUS`, no `set_input_focus` | ✅ yes | ❌ **breaks render** |
+| **wlroots/sway** (`offer_focus`) | send `WM_TAKE_FOCUS` only ("it gets focus itself") | ✅ yes | ❌ (Hyprland #7155 = same, closed unsolved) |
+| **gamescope** (`steamcompmgr.cpp:4857`) | **bare `XSetInputFocus(win, RevertToNone, CurrentTime)`, NO `WM_TAKE_FOCUS`** | ❌ deviates | ✅ **works** |
+
+gamescope code (the validated answer):
+```cpp
+// steamcompmgr.cpp ~4857, on map / focus apply. WM_HINTS.input only gates XRaiseWindow above.
+if ( w == ctx->focus.inputFocusWindow || w->xwayland().id == ctx->currentKeyboardFocusWindow )
+    XSetInputFocus(ctx->dpy, w->xwayland().id, RevertToNone, CurrentTime);
+```
+`grep WM_TAKE_FOCUS steamcompmgr.cpp` → **nothing**. gamescope never uses it.
+
+**Insight:** Wine's `WM_TAKE_FOCUS` *handler* (re-asserts fullscreen / mode-set) is what breaks DXVK; a
+plain `FocusIn` from `XSetInputFocus` sets X focus — delivering keys — without invoking that handler.
+For fullscreen games we should follow **gamescope, not ICCCM/wlroots**.
+
+Sources: [gamescope steamcompmgr.cpp](https://github.com/ValveSoftware/gamescope/blob/master/src/steamcompmgr.cpp) ·
+[wlroots xwm.c](https://github.com/swaywm/wlroots/blob/master/xwayland/xwm.c) ·
+[Hyprland #7155](https://github.com/hyprwm/Hyprland/issues/7155) ·
+[smithay #1863 `_NET_ACTIVE_WINDOW`](https://github.com/Smithay/smithay/pull/1863)
+
+---
+
+## 3. Current working build (in the tree, uncommitted)
+
+Renders perfectly (harness: 2145+ frames, rock-steady ~38fps) and survives workspace switches (30s, 3
+swipe cycles) — but **no keyboard** (dynamics #1 & #2 fixed, #3 open). Files:
+
+- **src/shell/element.rs** — `x11_self_manages_focus()` helper; `set_activate` no-op (never toggle
+  `_NET_WM_STATE_FOCUSED`); `output_leave` no-op (never `wl_surface.leave(output)`) — for self-managing X11.
+- **src/focus.rs** — `x11_self_managed_surface(s)` helper; `enter`/`key`/`modifiers` for self-managing X11
+  route to the **`wl_surface`** (gives `wl_keyboard` focus, NO `WM_TAKE_FOCUS`); `leave` is a no-op.
+- **src/state/app_management.rs** — always `keyboard.set_focus`; **focus-retention**: `focus_top_window_or_clear`
+  early-returns and `set_keyboard_focus_on_window` skips when a self-managing game is fullscreen & target≠game;
+  `set_x11_active_window` won't hand `_NET_ACTIVE_WINDOW` to another window while the game is fullscreen.
+- **src/state/xwayland_handler.rs** — `surface_associated` focuses the window at map (routes to wl_surface
+  for self-managing) + `apply_x11_fullscreen` replay.
+
+Evidence it works: harness imported 2145 frames at steady 38fps through 8 keypresses with **zero** freeze/
+unmap; survived multiple swipes in an earlier run. Keyboard confirmed dead by user + harness (no menu advance).
+
+---
+
+## 4. The fix — add gamescope's `XSetInputFocus` (lever-2)
+
+Keep the render-stable `wl_surface` key routing (gives the game `wl_keyboard` focus so XWayland *has* the
+keys) AND additionally set the **X input focus** to the game so XWayland *delivers* them — using
+`XSetInputFocus`, never `WM_TAKE_FOCUS`.
+
+### 4a. smithay patch (`../smithay`, a path dep)
+smithay exposes no way to force `set_input_focus` (only `X11Wm::set_active_window` / `raise_window`). The
+exact call already exists privately in `X11Surface::enter` (surface.rs:1147:
+`conn.set_input_focus(InputFocus::NONE, self.window, x11rb::CURRENT_TIME)`). Add a public method:
+```rust
+// smithay/src/xwayland/xwm/surface.rs, impl X11Surface
+/// Set the X11 input focus to this window directly (RevertToNone), WITHOUT sending
+/// WM_TAKE_FOCUS. Mirrors gamescope: needed to deliver keyboard to Globally-Active
+/// games (Unity/DXVK) whose WM_TAKE_FOCUS handler would otherwise break their render loop.
+pub fn set_input_focus(&self) -> Result<(), ConnectionError> {
+    if let Some(conn) = self.conn.upgrade() {
+        conn.set_input_focus(InputFocus::NONE, self.window, x11rb::CURRENT_TIME)?;
+        let _ = conn.flush();
+    }
+    Ok(())
+}
+```
+Additive, doesn't change existing behavior. (Upstreamable as the smithay analogue of
+`wlr_xwayland_surface_offer_focus` but for the gamescope/force-focus policy.)
+
+### 4b. Otto change
+When a self-managing X11 game gains keyboard focus, call `set_input_focus()` on it. Cleanest seam:
+`src/focus.rs` `KeyboardTarget::enter`, the self-managing branch:
+```rust
+WindowSurface::X11(s) => match x11_self_managed_surface(s) {
+    Some(surface) => {
+        let _ = s.set_input_focus();              // gamescope: X focus, no WM_TAKE_FOCUS -> keys flow
+        KeyboardTarget::enter(&surface, seat, data, keys, serial)  // wl_keyboard focus -> XWayland has keys
+    }
+    None => KeyboardTarget::enter(s, seat, data, keys, serial),
+},
+```
+The game is focused at map (xwayland_handler) and held by focus-retention, so `set_input_focus` fires once
+when it becomes focused and stays. No `WM_TAKE_FOCUS` is ever sent to it.
+
+### 4c. Verify (harness or real input)
+1. Cuphead renders fullscreen continuously (no stall) — must still hold.
+2. **Without clicking**, send menu keys (Enter/Z/arrows) → game **advances past the title attract screen**
+   to save-slot/main menu = keys reached it. Capture AFTER screenshot within ~5s (the game self-exits if
+   left idle — investigate that separately; possibly a key mapping to quit).
+3. Swipe away/back several times → still renders, still takes keys.
+4. A real click into the game → does NOT break rendering (no `WM_TAKE_FOCUS` anywhere now).
+
+---
+
+## 5. Open questions / risks
+
+- **Does `XSetInputFocus` at map stall?** gamescope does it in its map handler and Cuphead works → expected
+  safe. Verify; if it does, defer the `set_input_focus` to the first frame / first interaction.
+- **Scope.** Only call `set_input_focus` for self-managing X11 (`GloballyActive|None`). Passive/Local apps
+  keep the normal smithay `X11Surface::enter` path (`WM_TAKE_FOCUS` + `set_input_focus`) — don't regress them.
+- **Focus stealing.** With focus-retention, X focus stays on the game; confirm a second monitor / dock /
+  un-fullscreen path can still move focus when the game stops being fullscreen.
+- **Self-exit.** Harness saw Cuphead exit ~20s after idle keypresses (PipeWire "Cuphead.exe removed"). Rule
+  out a test key hitting a quit, and confirm Otto's own quit shortcut can't be triggered by game keys.
+- **ICCCM deviation.** This intentionally ignores the Globally-Active "don't set focus" convention for
+  fullscreen games, matching gamescope. Acceptable for a gaming-capable compositor; document it.
+
+---
+
+## 6. Refactor / consolidation (the "proper solution")
+
+Right now the policy is spread across 4 files and several gates. Consolidate into one concept:
+**"a self-managing X11 game is fullscreen → it owns focus + X-input-focus + `_NET_ACTIVE_WINDOW` until it
+unfullscreens, and is focused via `XSetInputFocus` not `WM_TAKE_FOCUS`."**
+
+- Consider a single helper, e.g. `Workspaces::fullscreen_focus_lock() -> Option<&WindowElement>`, and route
+  all focus/activation/visibility decisions through it.
+- Decide the minimal necessary gate set by removing each and testing (focus-retention is THE one for #2;
+  set_activate/output_leave/leave no-ops are defense-in-depth — verify each is actually needed).
+- Verify normal X11 apps (xterm, Passive/Local) focus and take keys correctly.
+
+### Cleanup checklist (before commit)
+- Remove `OTTO_DEBUG_TEX`-gated logs added during debugging: `[set-activate]`, `[x11-active-window]`,
+  `[kbd-focus]`, `[ws-switch]`, and `[tex-import]/[tex-render]/[frame-cb]/[scanout]/[sync]`.
+- Remove experimental env gates: `OTTO_NO_SWIPE_FOCUS` (gestures.rs, redundant), and the older
+  `OTTO_FORCE_PRESENT_FB`, `OTTO_SKIP_FS_ANIM`, `OTTO_ANVIL_FULLSCREEN`, `OTTO_X11_SCANOUT`, `OTTO_BLIT_CCS`,
+  `OTTO_NO_X11_DMABUF_FEEDBACK`, `OTTO_XWAYLAND_WL_DEBUG` (per memory revert list); smithay `OTTO_BUF_DROP`
+  probe + anvil bisect injections in `../smithay`.
+- Keep: the smithay `set_input_focus` method (4a), and `udev/feedback.rs strip_clear_color_modifiers` (a
+  separate correct fix — Otto can't sample CCS_CC; stops grim hanging).
+- spec-sync, then commit smithay + otto together (smithay is a path dep — bump/commit it too).
+
+---
+
+## 7. Diagnostic method (reuse it)
+`RUST_LOG=info OTTO_DEBUG_TEX=1 ./target/release/otto --tty-udev > /tmp/otto.log` (kill the respawning
+`xdg-desktop-portal-otto` watchdog in a loop or it pkills busy Otto). Per-surface by `wl_surface@N`, game =
+2880x1920 dims. `[tex-import]` gap = freeze instant. `frame-cb throttle=` `0ns→33ms` marks the
+workspace-non-current instant. `unmap_window`+`ReparentWindow BadWindow`+dock `running=[...]` = game exit
+vs pause. The `otto-remote-control` skill drives a live Otto (Steam+Cuphead, wlrctl pointer/keyboard, grim)
+for objective verification. Build PLAIN `cargo build --release` (smithay is a path dep; --features dev
+recompiles all of smithay).

--- a/sample-clients/deadlock-test/Cargo.toml
+++ b/sample-clients/deadlock-test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "deadlock-test"
+version = "0.1.0"
+edition = "2021"
+description = "X11 client that reproduces Unity/Proton game deadlock on Otto compositor"
+license = "MIT"
+publish = false
+
+[dependencies]
+x11rb = { version = "0.13", features = ["allow-unsafe-code"] }

--- a/sample-clients/deadlock-test/src/main.rs
+++ b/sample-clients/deadlock-test/src/main.rs
@@ -1,0 +1,385 @@
+//! X11 client that reproduces the Unity/Proton game deadlock on Otto compositor.
+//!
+//! Mimics Cuphead's startup pattern:
+//! 1. Creates a window with WM_HINTS: iconic state + no input focus
+//! 2. Maps the window
+//! 3. Waits for WM_TAKE_FOCUS + _NET_ACTIVE_WINDOW
+//! 4. On Plasma: activated within 1-2 seconds
+//! 5. On Otto:   deadlocked, focus flaps, _NET_ACTIVE_WINDOW never set
+//!
+//! Build:  cargo build -p deadlock-test
+//! Run:    cargo run -p deadlock-test
+
+use std::time::Instant;
+
+use x11rb::atom_manager;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::*;
+use x11rb::protocol::Event;
+use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as _;
+
+atom_manager! {
+    pub AtomCollection: AtomCollectionCookie {
+        WM_PROTOCOLS,
+        WM_TAKE_FOCUS,
+        WM_DELETE_WINDOW,
+        _NET_ACTIVE_WINDOW,
+        _NET_WM_STATE,
+        _NET_WM_STATE_FOCUSED,
+        _NET_WM_STATE_FULLSCREEN,
+        _NET_WM_STATE_HIDDEN,
+        _NET_WM_BYPASS_COMPOSITOR,
+        _NET_WM_NAME,
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (conn, screen_num) = RustConnection::connect(None)?;
+    let screen = &conn.setup().roots[screen_num];
+    let atoms = AtomCollection::new(&conn)?.reply()?;
+
+    let win = conn.generate_id()?;
+    let black = conn.generate_id()?;
+    let white = conn.generate_id()?;
+
+    // Create graphics contexts
+    conn.create_gc(black, screen.root, &CreateGCAux::new().foreground(screen.black_pixel))?;
+    conn.create_gc(white, screen.root, &CreateGCAux::new().foreground(screen.white_pixel))?;
+
+    // Create window
+    let depth = screen.root_depth;
+    conn.create_window(
+        depth,
+        win,
+        screen.root,
+        100,   // x
+        100,   // y
+        800,   // width
+        600,   // height
+        1,     // border
+        WindowClass::INPUT_OUTPUT,
+        0,     // visual
+        &CreateWindowAux::new()
+            .background_pixel(screen.black_pixel)
+            .event_mask(
+                EventMask::EXPOSURE
+                    | EventMask::FOCUS_CHANGE
+                    | EventMask::STRUCTURE_NOTIFY
+                    | EventMask::PROPERTY_CHANGE
+                    | EventMask::KEY_PRESS,
+            ),
+    )?;
+
+    // ---- Set WM_HINTS: iconic state + no input focus ----
+    // This is exactly what Cuphead/Unity does.
+    let hints_data: [u32; 9] = {
+        // XWMHints structure (order: flags, input, initial_state, icon_pixmap,
+        //                        icon_window, icon_x, icon_y, icon_mask, window_group)
+        let flags: u32 = 0x0003; // StateHint | InputHint
+        let input: u32 = 0;      // False = client doesn't accept input focus
+        let initial_state: u32 = 3; // IconicState
+        let icon_pixmap: u32 = 0;
+        let icon_window: u32 = 0;
+        let icon_x: u32 = 0;
+        let icon_y: u32 = 0;
+        let icon_mask: u32 = 0;
+        let window_group: u32 = 0;
+
+        [flags, input, initial_state, icon_pixmap, icon_window, icon_x, icon_y, icon_mask, window_group]
+    };
+    conn.change_property32(
+        PropMode::REPLACE,
+        win,
+        AtomEnum::WM_HINTS,
+        AtomEnum::WM_HINTS,
+        &hints_data,
+    )?;
+
+    // Set window name
+    conn.change_property8(
+        PropMode::REPLACE,
+        win,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
+        b"deadlock-test",
+    )?;
+
+    // Set _NET_WM_NAME (need to intern UTF8_STRING atom)
+    let utf8_string = conn.intern_atom(false, b"UTF8_STRING")?.reply()?.atom;
+    conn.change_property8(
+        PropMode::REPLACE,
+        win,
+        atoms._NET_WM_NAME,
+        utf8_string,
+        b"deadlock-test",
+    )?;
+
+    // Set WM_PROTOCOLS: WM_TAKE_FOCUS, WM_DELETE_WINDOW
+    let protocols = [atoms.WM_TAKE_FOCUS, atoms.WM_DELETE_WINDOW];
+    conn.change_property32(
+        PropMode::REPLACE,
+        win,
+        atoms.WM_PROTOCOLS,
+        AtomEnum::ATOM,
+        &protocols,
+    )?;
+
+    // Map the window first — WM only processes client messages for mapped windows
+    conn.map_window(win)?;
+    conn.flush()?;
+
+    // Now request _NET_WM_BYPASS_COMPOSITOR (like Cuphead/Unity fullscreen games)
+    conn.change_property32(
+        PropMode::REPLACE,
+        win,
+        atoms._NET_WM_BYPASS_COMPOSITOR,
+        AtomEnum::CARDINAL,
+        &[1],
+    )?;
+
+    // Send _NET_WM_STATE client message to request fullscreen.
+    // This is what triggers Plasma to activate the window despite iconic hints.
+    let wm_state = conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom;
+    let mut event = [0u8; 32];
+    event[0] = 33; // ClientMessage
+    event[1] = 32; // format
+    // sequence (bytes 2-3): leave 0
+    // window (bytes 4-7)
+    event[4..8].copy_from_slice(&win.to_ne_bytes());
+    // message_type (bytes 8-11)
+    event[8..12].copy_from_slice(&wm_state.to_ne_bytes());
+    // data[0] = _NET_WM_STATE_ADD (1)
+    event[12..16].copy_from_slice(&1u32.to_ne_bytes());
+    // data[1] = _NET_WM_STATE_FULLSCREEN
+    event[16..20].copy_from_slice(&atoms._NET_WM_STATE_FULLSCREEN.to_ne_bytes());
+    // data[2] = 0 (second property, none)
+    // data[3] = 1 (source indication: 1 = application)
+    event[24..28].copy_from_slice(&1u32.to_ne_bytes());
+    conn.send_event(
+        false,
+        screen.root,
+        EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+        event,
+    )?;
+
+    eprintln!("Window mapped (ID: 0x{:x}). Waiting for activation...", win);
+
+    let start = Instant::now();
+    let mut has_focus = false;
+    let mut activated = false;
+    let mut first_focus_time: Option<Instant> = None;
+
+    loop {
+        let elapsed = start.elapsed().as_secs();
+        if elapsed >= 10 {
+            eprintln!();
+            eprintln!("*** DEADLOCK after {} seconds ***", elapsed);
+            eprintln!("   has_focus={} activated={}", has_focus, activated);
+            eprintln!("   This is the CUPHEAD BUG on Otto.");
+            break;
+        }
+
+        // Poll _NET_ACTIVE_WINDOW on root
+        if let Ok(reply) = conn.get_property(
+            false,
+            screen.root,
+            atoms._NET_ACTIVE_WINDOW,
+            AtomEnum::WINDOW,
+            0,
+            1,
+        )?.reply()
+        {
+            let active = reply.value32().and_then(|mut v| v.next());
+            if active == Some(win) && !activated {
+                activated = true;
+                eprintln!("[+] _NET_ACTIVE_WINDOW set to us! Game should start now.");
+            }
+        }
+
+        // Poll _NET_WM_STATE on our window
+        if let Ok(reply) = conn.get_property(
+            false,
+            win,
+            atoms._NET_WM_STATE,
+            AtomEnum::ATOM,
+            0,
+            64,
+        )?.reply()
+        {
+            if reply.format == 32 && reply.length > 0 {
+                eprint!("   _NET_WM_STATE:");
+                if let Some(atoms_iter) = reply.value32() {
+                    for atom in atoms_iter {
+                        let name = conn.get_atom_name(atom);
+                        if let Ok(reply) = name?.reply() {
+                            eprint!(" {}", String::from_utf8_lossy(&reply.name));
+                        }
+                    }
+                }
+                eprintln!();
+            }
+        }
+
+        // Process events
+        while let Some(event) = conn.poll_for_event()? {
+            match event {
+                Event::FocusIn(ev) => {
+                    has_focus = true;
+                    if first_focus_time.is_none() {
+                        first_focus_time = Some(Instant::now());
+                    }
+                    eprintln!("[+] FocusIn (mode={:?}, detail={:?})", ev.mode, ev.detail);
+
+                    // Debug: immediately read _NET_ACTIVE_WINDOW after FocusIn
+                    if let Ok(reply) = conn.get_property(
+                        false,
+                        screen.root,
+                        atoms._NET_ACTIVE_WINDOW,
+                        AtomEnum::WINDOW,
+                        0,
+                        1,
+                    )?.reply()
+                    {
+                        let active = reply.value32().and_then(|mut v| v.next());
+                        eprintln!("   Debug: _NET_ACTIVE_WINDOW on root = 0x{:x?} (format={}, len={})", active, reply.format, reply.length);
+                    }
+                }
+                Event::FocusOut(ev) => {
+                    has_focus = false;
+                    eprintln!("[-] FocusOut (mode={:?}, detail={:?})", ev.mode, ev.detail);
+                }
+                Event::MapNotify(_) => {
+                    eprintln!("[.] MapNotify");
+                }
+                Event::ClientMessage(ev) => {
+                    if ev.type_ == atoms.WM_PROTOCOLS && ev.format == 32 {
+                        let protocol = ev.data.as_data32()[0];
+                        if protocol == atoms.WM_TAKE_FOCUS {
+                            let timestamp = ev.data.as_data32()[1];
+                            eprintln!("[+] WM_TAKE_FOCUS received (ts={}). Taking focus.", timestamp);
+
+                            // Accept focus
+                            conn.set_input_focus(
+                                InputFocus::PARENT,
+                                win,
+                                timestamp,
+                            )?;
+                            has_focus = true;
+                        }
+                    }
+                }
+                Event::Expose(_) => {
+                    // Redraw: just clear to black and draw a white rectangle
+                    conn.poly_fill_rectangle(
+                        win,
+                        black,
+                        &[Rectangle {
+                            x: 0,
+                            y: 0,
+                            width: 800,
+                            height: 600,
+                        }],
+                    )?;
+                    conn.poly_fill_rectangle(
+                        win,
+                        white,
+                        &[Rectangle {
+                            x: 50,
+                            y: 50,
+                            width: 200,
+                            height: 100,
+                        }],
+                    )?;
+                    conn.flush()?;
+                }
+                Event::KeyPress(_) => {
+                    eprintln!("[.] KeyPress — exiting.");
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
+        // Success condition: got focus + activation
+        if has_focus && activated {
+            eprintln!();
+            eprintln!("*** SUCCESS after {} seconds ***", elapsed);
+            eprintln!(
+                "   Focus received at t={:.1}s, activated. Otto fix works.",
+                first_focus_time.map(|t| t.duration_since(start).as_secs_f64()).unwrap_or(0.0)
+            );
+
+            // Short render loop to prove we're alive
+            eprintln!("   Simulating render loop (5 frames, press any key to exit)...");
+            for frame in 1..=5 {
+                // Check for keypress to exit early
+                while let Some(event) = conn.poll_for_event()? {
+                    if let Event::KeyPress(_) = event {
+                        eprintln!("   Exiting on keypress.");
+                        return Ok(());
+                    }
+                }
+
+                conn.poly_fill_rectangle(
+                    win,
+                    black,
+                    &[Rectangle { x: 0, y: 0, width: 800, height: 600 }],
+                )?;
+                conn.poly_fill_rectangle(
+                    win,
+                    white,
+                    &[Rectangle {
+                        x: 50 + frame as i16 * 30,
+                        y: 50 + frame as i16 * 30,
+                        width: 200,
+                        height: 100,
+                    }],
+                )?;
+                conn.flush()?;
+                eprintln!("   Frame {} rendered", frame);
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
+            return Ok(());
+        }
+
+        // Prevent busy-waiting
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    eprintln!();
+    eprintln!("=== Final window state ===");
+
+    // Check map state
+    if let Ok(reply) = conn.get_window_attributes(win)?.reply() {
+        let state = match reply.map_state {
+            MapState::UNMAPPED => "Unmapped",
+            MapState::UNVIEWABLE => "Unviewable",
+            MapState::VIEWABLE => "Viewable",
+            _ => "Unknown",
+        };
+        eprintln!("Map state: {}", state);
+    }
+
+    // Print WM_HINTS
+    if let Ok(reply) = conn.get_property(
+        false,
+        win,
+        AtomEnum::WM_HINTS,
+        AtomEnum::WM_HINTS,
+        0,
+        9,
+    )?.reply()
+    {
+        if let Some(values) = reply.value32() {
+            let vals: Vec<u32> = values.collect();
+            eprintln!("WM_HINTS: flags=0x{:x} input={} initial_state={}",
+                      vals.get(0).unwrap_or(&0),
+                      vals.get(1).unwrap_or(&0),
+                      vals.get(2).unwrap_or(&0));
+        }
+    }
+
+    eprintln!("Exit: DEADLOCK (exit code 1)");
+    std::process::exit(1);
+}

--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -107,6 +107,11 @@ vibrancy even though the content behind it lives on other planes.
   chrome planes dropped; frames always render (client commits produce no
   scene damage) and only the fullscreen window receives frame callbacks.
   The compositor swapchain resets on scanout-mode transitions.
+  XWayland fullscreen windows use the same path — this needs the
+  clear-color CCS modifiers stripped from advertised dmabuf formats and
+  the explicit-sync acquire blocker (both in place); routing them through
+  the composite/promotion path instead freezes the output on the first
+  promoted frame.
 - The 3-finger workspace swipe (finger-drag, before any animation) gates
   all direct scanout: the drag moves content with no animation flag, and a
   fixed plane would not follow it.

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -365,6 +365,26 @@ impl<B: Backend> PointerTarget<Otto<B>> for PointerFocusTarget<B> {
     }
 }
 
+/// For a self-managing X11 client (Globally-Active / No-Input — Proton/Unity
+/// games like Cuphead), return its `wl_surface` so keyboard events are delivered
+/// straight to it, bypassing smithay's `X11Surface` focus protocol.
+///
+/// smithay's `X11Surface::enter` bundles the X11 focus protocol
+/// (`WM_TAKE_FOCUS` for Globally-Active) with `wl_keyboard` delivery. But
+/// `WM_TAKE_FOCUS` BREAKS Cuphead's render loop whenever it's sent (at map OR on
+/// a later click — confirmed). So for these clients we deliver `wl_keyboard`
+/// events directly to the surface (giving XWayland the keys + focus) WITHOUT
+/// sending `WM_TAKE_FOCUS`. Returns `None` for Passive/Local clients, which use
+/// the normal `X11Surface` path (they need `set_input_focus`).
+#[cfg(feature = "xwayland")]
+fn x11_self_managed_surface(s: &X11Surface) -> Option<WlSurface> {
+    use smithay::xwayland::xwm::WmInputModel;
+    match s.input_model() {
+        WmInputModel::GloballyActive | WmInputModel::None => s.wl_surface(),
+        WmInputModel::Passive | WmInputModel::LocallyActive => None,
+    }
+}
+
 impl<B: Backend> KeyboardTarget<Otto<B>> for KeyboardFocusTarget<B> {
     fn enter(
         &self,
@@ -379,7 +399,21 @@ impl<B: Backend> KeyboardTarget<Otto<B>> for KeyboardFocusTarget<B> {
                     KeyboardTarget::enter(w.wl_surface(), seat, data, keys, serial)
                 }
                 #[cfg(feature = "xwayland")]
-                WindowSurface::X11(s) => KeyboardTarget::enter(s, seat, data, keys, serial),
+                WindowSurface::X11(s) => match x11_self_managed_surface(s) {
+                    Some(surface) => {
+                        // gamescope model: force the X11 INPUT FOCUS to the game
+                        // (RevertToNone, no WM_TAKE_FOCUS). Without this the game has
+                        // wl_keyboard focus but XWayland — under a rootless WM —
+                        // delivers keys only to the X-input-focused window, so keys
+                        // never reach it. WM_TAKE_FOCUS would deliver them too but
+                        // breaks the game's render loop; bare set_input_focus does not.
+                        if let Err(err) = s.set_input_focus() {
+                            tracing::warn!(?err, "failed to set X11 input focus for self-managing game");
+                        }
+                        KeyboardTarget::enter(&surface, seat, data, keys, serial)
+                    }
+                    None => KeyboardTarget::enter(s, seat, data, keys, serial),
+                },
             },
             KeyboardFocusTarget::LayerSurface(l) => {
                 KeyboardTarget::enter(l.wl_surface(), seat, data, keys, serial)
@@ -412,7 +446,13 @@ impl<B: Backend> KeyboardTarget<Otto<B>> for KeyboardFocusTarget<B> {
                     KeyboardTarget::leave(w.wl_surface(), seat, data, serial)
                 }
                 #[cfg(feature = "xwayland")]
-                WindowSurface::X11(s) => KeyboardTarget::leave(s, seat, data, serial),
+                WindowSurface::X11(s) => match x11_self_managed_surface(s) {
+                    // Self-managing X11 game: never send wl_keyboard.leave (XWayland
+                    // turns it into an X11 FocusOut, which Unity "Run In Background
+                    // = false" games pause on). Focus retention keeps these focused.
+                    Some(_) => {}
+                    None => KeyboardTarget::leave(s, seat, data, serial),
+                },
             },
             KeyboardFocusTarget::LayerSurface(l) => {
                 KeyboardTarget::leave(l.wl_surface(), seat, data, serial)
@@ -438,9 +478,12 @@ impl<B: Backend> KeyboardTarget<Otto<B>> for KeyboardFocusTarget<B> {
                     KeyboardTarget::key(w.wl_surface(), seat, data, key, state, serial, time)
                 }
                 #[cfg(feature = "xwayland")]
-                WindowSurface::X11(s) => {
-                    KeyboardTarget::key(s, seat, data, key, state, serial, time)
-                }
+                WindowSurface::X11(s) => match x11_self_managed_surface(s) {
+                    Some(surface) => {
+                        KeyboardTarget::key(&surface, seat, data, key, state, serial, time)
+                    }
+                    None => KeyboardTarget::key(s, seat, data, key, state, serial, time),
+                },
             },
             KeyboardFocusTarget::LayerSurface(l) => {
                 KeyboardTarget::key(l.wl_surface(), seat, data, key, state, serial, time)
@@ -467,9 +510,12 @@ impl<B: Backend> KeyboardTarget<Otto<B>> for KeyboardFocusTarget<B> {
                     KeyboardTarget::modifiers(w.wl_surface(), seat, data, modifiers, serial)
                 }
                 #[cfg(feature = "xwayland")]
-                WindowSurface::X11(s) => {
-                    KeyboardTarget::modifiers(s, seat, data, modifiers, serial)
-                }
+                WindowSurface::X11(s) => match x11_self_managed_surface(s) {
+                    Some(surface) => {
+                        KeyboardTarget::modifiers(&surface, seat, data, modifiers, serial)
+                    }
+                    None => KeyboardTarget::modifiers(s, seat, data, modifiers, serial),
+                },
             },
             KeyboardFocusTarget::LayerSurface(l) => {
                 KeyboardTarget::modifiers(l.wl_surface(), seat, data, modifiers, serial)

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -53,6 +53,8 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
 
                     crate::shell::fixup_positions(&mut self.workspaces, current_location);
                     self.backend_data.reset_buffers(&output);
+                    #[cfg(feature = "xwayland")]
+                    self.update_xwayland_scale();
                 }
 
                 KeyAction::ScaleDown => {
@@ -74,6 +76,8 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
                     let current_location = self.pointer.current_location();
                     crate::shell::fixup_positions(&mut self.workspaces, current_location);
                     self.backend_data.reset_buffers(&output);
+                    #[cfg(feature = "xwayland")]
+                    self.update_xwayland_scale();
                 }
 
                 KeyAction::RotateOutput => {

--- a/src/shell/element.rs
+++ b/src/shell/element.rs
@@ -229,6 +229,25 @@ impl WindowElement {
         self.0.window.underlying_surface()
     }
 
+    /// True for X11 clients that manage their own input focus per ICCCM —
+    /// Globally-Active (`input=False` + `WM_TAKE_FOCUS`) and No-Input. These are
+    /// Proton/Unity games (e.g. Cuphead) that freeze their render loop when the
+    /// compositor pushes focus/activation/visibility state at them. We suppress
+    /// those signals (focus, `_NET_WM_STATE_FOCUSED`, `wl_output.leave`) for such
+    /// windows and only route raw keyboard events.
+    #[cfg(feature = "xwayland")]
+    pub fn x11_self_manages_focus(&self) -> bool {
+        use smithay::xwayland::xwm::WmInputModel;
+        matches!(
+            self.underlying_surface(),
+            WindowSurface::X11(x)
+                if matches!(
+                    x.input_model(),
+                    WmInputModel::GloballyActive | WmInputModel::None
+                )
+        )
+    }
+
     pub fn geometry(&self) -> Rectangle<i32, Logical> {
         self.0.window.geometry()
     }
@@ -485,12 +504,33 @@ impl SpaceElement for WindowElement {
     }
 
     fn set_activate(&self, activated: bool) {
+        // Never toggle `_NET_WM_STATE_FOCUSED` on self-managing X11 windows
+        // (Globally-Active / No-Input clients — Proton/Unity games such as
+        // Cuphead). `set_activated` emits a `PropertyNotify` on `_NET_WM_STATE`
+        // whenever FOCUSED changes; the off→on flap on a workspace switch makes
+        // their winex11/Wine layer stall the render loop (black screen). These
+        // clients manage their own focus per ICCCM, so we leave their X11 state
+        // untouched and only route keyboard events (see src/focus.rs).
+        #[cfg(feature = "xwayland")]
+        if self.x11_self_manages_focus() {
+            return;
+        }
         SpaceElement::set_activate(&self.0.window, activated);
     }
     fn output_enter(&self, output: &Output, overlap: Rectangle<i32, Logical>) {
         SpaceElement::output_enter(&self.0.window, output, overlap);
     }
     fn output_leave(&self, output: &Output) {
+        // Never send `wl_surface.leave(output)` to a self-managing X11 game.
+        // When its workspace scrolls off-screen the smithay Space would call this,
+        // and XWayland turns the output-leave into an X11 visibility signal that
+        // Cuphead/Wine reacts to by freezing its render loop (the workspace-switch
+        // freeze). Keeping the surface on the output leaves its visibility state
+        // unchanged. Frame callbacks/focus are handled separately (see src/focus.rs).
+        #[cfg(feature = "xwayland")]
+        if self.x11_self_manages_focus() {
+            return;
+        }
         SpaceElement::output_leave(&self.0.window, output);
     }
     #[profiling::function]

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -110,9 +110,11 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
             // committed one. smithay only validates these points in its own
             // commit_hook — the compositor must add the blocker so the surface
             // transaction waits until the client's GPU render completes. Without
-            // it, KMS plane scanout flips a half-rendered buffer (tearing),
-            // because smithay assumes a blocker already waited. udev-only:
-            // DrmSyncobjCachedState lives behind smithay's backend_drm feature.
+            // it, KMS plane scanout flips a half-rendered buffer (tearing), and
+            // Otto samples the buffer before it is rendered and shows a black
+            // texture (fullscreen Proton games, e.g. Cuphead via DXVK/vkd3d).
+            // udev-only: DrmSyncobjCachedState lives behind smithay's
+            // backend_drm feature.
             #[cfg(feature = "udev")]
             let mut acquire_point = None;
             let maybe_dmabuf = with_states(surface, |surface_data| {
@@ -139,22 +141,32 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
                 // Prefer the explicit acquire fence when the client provided one.
                 #[cfg(feature = "udev")]
                 if let Some(acquire_point) = acquire_point {
-                    if let Ok((blocker, source)) = acquire_point.generate_blocker() {
-                        if let Some(client) = surface.client() {
-                            let res = state.handle.insert_source(source, move |_, _, data| {
-                                let dh = data.display_handle.clone();
-                                data.client_compositor_state(&client)
-                                    .blocker_cleared(data, &dh);
-                                Ok(())
-                            });
-                            if res.is_ok() {
-                                add_blocker(surface, blocker);
-                                // Don't also add the implicit blocker for this commit.
-                                return;
+                    match acquire_point.generate_blocker() {
+                        Ok((blocker, source)) => {
+                            if let Some(client) = surface.client() {
+                                let res = state.handle.insert_source(source, move |_, _, data| {
+                                    let dh = data.display_handle.clone();
+                                    data.client_compositor_state(&client)
+                                        .blocker_cleared(data, &dh);
+                                    Ok(())
+                                });
+                                if res.is_ok() {
+                                    add_blocker(surface, blocker);
+                                    // Don't also add the implicit blocker for this commit.
+                                    return;
+                                }
                             }
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                ?err,
+                                "explicit-sync acquire_point.generate_blocker failed; \
+                                 falling back to the implicit dmabuf fence"
+                            );
                         }
                     }
                 }
+                // Fall back to the implicit dmabuf fence.
                 if let Ok((blocker, source)) = dmabuf.generate_blocker(Interest::READ) {
                     if let Some(client) = surface.client() {
                         let res = state.handle.insert_source(source, move |_, _, data| {

--- a/src/shell/x11.rs
+++ b/src/shell/x11.rs
@@ -84,6 +84,21 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
                 .cloned()
         });
         if let Some(elem) = maybe {
+            // Free the dedicated fullscreen workspace when a fullscreen window closes,
+            // mirroring the XDG path in xdg.rs::toplevel_destroyed.
+            if elem.is_fullscreen() {
+                let fullscreen_workspace = elem.get_fullscreen_workspace();
+                if let Some(workspace) = self.workspaces.get_workspace_at(fullscreen_workspace) {
+                    workspace.set_fullscreen_mode(false);
+                    workspace.set_fullscreen_animating(false);
+                    workspace.set_name(None);
+                }
+                if self.workspaces.get_current_workspace_index() == fullscreen_workspace {
+                    let prev_workspace = (fullscreen_workspace as i32 - 1).min(0) as usize;
+                    self.workspaces
+                        .set_current_workspace_index(prev_workspace, None);
+                }
+            }
             if let Some(surface) = elem.wl_surface() {
                 self.workspaces.unmap_window(&surface.as_ref().id());
             } else if let Some(space) = self.workspaces.space_mut() {
@@ -488,6 +503,27 @@ impl<BackendData: Backend> Otto<BackendData> {
         let current_workspace_index = self.workspaces.get_current_workspace_index();
         let (next_workspace_index, next_workspace) = self.workspaces.get_next_free_workspace();
         next_workspace.set_fullscreen_mode(true);
+
+        // Fetch app info asynchronously to get the proper display name for the workspace.
+        // Mirrors the XDG path in xdg.rs; `display_app_id` resolves to the X11 class
+        // (falling back to PID resolution) for X11 surfaces.
+        let app_id = elem.display_app_id(&self.display_handle);
+        if !app_id.is_empty() {
+            let workspace_clone = next_workspace.clone();
+            tokio::spawn(async move {
+                if let Some(app_info) =
+                    crate::workspaces::ApplicationsInfo::get_app_info_by_id(&app_id).await
+                {
+                    if let Some(name) = app_info.desktop_name() {
+                        workspace_clone.set_name(Some(name));
+                    } else {
+                        workspace_clone.set_name(Some(app_id));
+                    }
+                } else {
+                    workspace_clone.set_name(Some(app_id));
+                }
+            });
+        }
 
         self.workspaces.expose_set_visible(false);
 

--- a/src/shell/x11.rs
+++ b/src/shell/x11.rs
@@ -176,6 +176,17 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
                 .find(|e| matches!(e.underlying_surface(), WindowSurface::X11(x) if x == &window))
                 .cloned()
         }) else {
+            // The element does not exist yet: Otto defers X11 mapping to
+            // XWaylandShellHandler::surface_associated, so a client that maps and
+            // immediately requests _NET_WM_STATE_FULLSCREEN (Unity/Proton games)
+            // reaches this handler before the element is in the space. Record the
+            // request on the X11Surface (net_state) so surface_associated can replay
+            // it once the element exists, instead of silently dropping it.
+            tracing::debug!(
+                ?window,
+                "x11 fullscreen_request before element mapped; deferring to surface_associated"
+            );
+            let _ = window.set_fullscreen(true);
             return;
         };
 
@@ -183,57 +194,7 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
             return;
         }
 
-        let outputs_for_window = self.workspaces.outputs_for_element(&elem);
-        let output = outputs_for_window
-            .first()
-            .or_else(|| self.workspaces.outputs().next())
-            .expect("No outputs found")
-            .clone();
-        let geometry = self.workspaces.output_geometry(&output).unwrap();
-
-        let id = elem.id();
-
-        // Save the current geometry so unfullscreen can restore it
-        if let Some(mut view) = self.workspaces.get_window_view(&id) {
-            let current_element_geometry = self.workspaces.element_geometry(&elem).unwrap();
-            view.unmaximised_rect = current_element_geometry;
-            self.workspaces.set_window_view(&id, view);
-        }
-
-        // Register for direct scanout
-        output
-            .user_data()
-            .insert_if_missing(FullscreenSurface::default);
-        output
-            .user_data()
-            .get::<FullscreenSurface>()
-            .unwrap()
-            .set(elem.clone());
-
-        self.backend_data.reset_buffers(&output);
-
-        // Create a dedicated fullscreen workspace
-        let current_workspace_index = self.workspaces.get_current_workspace_index();
-        let (next_workspace_index, next_workspace) = self.workspaces.get_next_free_workspace();
-        next_workspace.set_fullscreen_mode(true);
-
-        self.workspaces.expose_set_visible(false);
-
-        elem.set_fullscreen(true, next_workspace_index);
-        elem.set_workspace(current_workspace_index);
-
-        self.workspaces
-            .move_window_to_workspace(&elem, next_workspace_index, (0, 0));
-
-        let transition = Transition::ease_in_out_quad(1.4);
-        self.workspaces
-            .set_current_workspace_index(next_workspace_index, Some(transition));
-
-        self.workspaces.set_fullscreen_overlay_visibility(true);
-        self.workspaces.dock.hide(None);
-
-        window.set_fullscreen(true).unwrap();
-        window.configure(geometry).unwrap();
+        self.apply_x11_fullscreen(&elem, &window);
     }
 
     fn unfullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -483,6 +444,77 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
 }
 
 impl<BackendData: Backend> Otto<BackendData> {
+    /// Run the X11 fullscreen transition for an already-mapped element.
+    ///
+    /// Split out of `XwmHandler::fullscreen_request` so `surface_associated` can
+    /// replay a fullscreen request that arrived before the element was mapped
+    /// (the Unity/Proton-game deferred-mapping race). The caller is responsible
+    /// for ensuring the element exists and is not already fullscreen.
+    pub fn apply_x11_fullscreen(
+        &mut self,
+        elem: &crate::shell::WindowElement,
+        window: &X11Surface,
+    ) {
+        let outputs_for_window = self.workspaces.outputs_for_element(elem);
+        let output = outputs_for_window
+            .first()
+            .or_else(|| self.workspaces.outputs().next())
+            .expect("No outputs found")
+            .clone();
+        let geometry = self.workspaces.output_geometry(&output).unwrap();
+
+        let id = elem.id();
+
+        // Save the current geometry so unfullscreen can restore it
+        if let Some(mut view) = self.workspaces.get_window_view(&id) {
+            let current_element_geometry = self.workspaces.element_geometry(elem).unwrap();
+            view.unmaximised_rect = current_element_geometry;
+            self.workspaces.set_window_view(&id, view);
+        }
+
+        // Register for direct scanout
+        output
+            .user_data()
+            .insert_if_missing(FullscreenSurface::default);
+        output
+            .user_data()
+            .get::<FullscreenSurface>()
+            .unwrap()
+            .set(elem.clone());
+
+        self.backend_data.reset_buffers(&output);
+
+        // Create a dedicated fullscreen workspace
+        let current_workspace_index = self.workspaces.get_current_workspace_index();
+        let (next_workspace_index, next_workspace) = self.workspaces.get_next_free_workspace();
+        next_workspace.set_fullscreen_mode(true);
+
+        self.workspaces.expose_set_visible(false);
+
+        elem.set_fullscreen(true, next_workspace_index);
+        elem.set_workspace(current_workspace_index);
+
+        self.workspaces
+            .move_window_to_workspace(elem, next_workspace_index, (0, 0));
+
+        let transition = Some(Transition::ease_in_out_quad(1.4));
+        self.workspaces
+            .set_current_workspace_index(next_workspace_index, transition);
+
+        self.workspaces.set_fullscreen_overlay_visibility(true);
+        self.workspaces.dock.hide(None);
+
+        // Ensure the X11 `_NET_WM_STATE_FULLSCREEN` atom is set so the client can read
+        // its fullscreen state back (Wine/Unity games block until they see it). We set
+        // ONLY fullscreen here, matching exactly what the client requested — adding
+        // MAXIMIZED would make the readback bitmask differ from the client's request and
+        // re-trigger the same wait/hang. The initial pre-map `_NET_WM_STATE` is already
+        // seeded into smithay's net_state (X11Surface::update_net_wm_state at map time),
+        // so this is usually a no-op; it covers runtime fullscreen toggles too.
+        window.set_fullscreen(true).unwrap();
+        window.configure(geometry).unwrap();
+    }
+
     pub fn maximize_request_x11(&mut self, window: &X11Surface) {
         let Some(elem) = self.workspaces.space().and_then(|s| {
             s.elements()

--- a/src/state/app_management.rs
+++ b/src/state/app_management.rs
@@ -121,6 +121,21 @@ impl<BackendData: Backend> Otto<BackendData> {
     /// keyboard focus when the workspace is empty.  Used by every code-path that
     /// lands on a workspace (gesture swipe, selector click, expose close, …).
     pub fn focus_top_window_or_clear(&mut self, workspace_index: usize) {
+        // While a self-managing X11 game (Cuphead) is fullscreen, keep keyboard
+        // focus ON IT across workspace switches. Moving focus to another window —
+        // or clearing it to None on an empty workspace — makes XWayland send the
+        // game an X11 `FocusOut`, and Unity games with "Run In Background = false"
+        // PAUSE rendering on FocusOut (the workspace-switch freeze). Holding focus
+        // on the game means it never sees FocusOut. Released once it unfullscreens.
+        #[cfg(feature = "xwayland")]
+        if self
+            .workspaces
+            .windows_map
+            .values()
+            .any(|w| w.is_fullscreen() && w.x11_self_manages_focus())
+        {
+            return;
+        }
         if let Some(top_wid) = self.workspaces.get_top_window_of_workspace(workspace_index) {
             self.set_keyboard_focus_on_surface(&top_wid);
         } else {
@@ -244,6 +259,21 @@ impl<BackendData: Backend> Otto<BackendData> {
     /// Centralized keyboard focus change: deactivates old window, activates new one,
     /// sends xdg configure and foreign-toplevel state for both.
     pub fn set_keyboard_focus_on_window(&mut self, window: &crate::shell::WindowElement) {
+        // While a self-managing X11 game (Cuphead) is fullscreen, never move focus
+        // to a DIFFERENT window (pointer, dock, self-activation by Steam Big
+        // Picture, …). XWayland would send the game an X11 `FocusOut` and Unity
+        // ("Run In Background = false") pauses rendering on it. Focusing the game
+        // itself is allowed (target == game).
+        #[cfg(feature = "xwayland")]
+        {
+            let target_id = window.id();
+            if self.workspaces.windows_map.values().any(|w| {
+                w.is_fullscreen() && w.x11_self_manages_focus() && w.id() != target_id
+            }) {
+                return;
+            }
+        }
+
         let keyboard = self.seat.get_keyboard().unwrap();
         let serial = SERIAL_COUNTER.next_serial();
 
@@ -274,7 +304,57 @@ impl<BackendData: Backend> Otto<BackendData> {
         }
         let wid = window.id();
         self.send_foreign_toplevel_state(&wid, true);
+
+        // Always give the window the seat keyboard focus, so its keys are routed.
+        // The ICCCM input model is honoured one level down, in
+        // `KeyboardFocusTarget`'s `KeyboardTarget` impl (src/focus.rs): for
+        // self-managing X11 clients (Globally-Active / No-Input) we deliver the
+        // wl_keyboard events straight to the underlying wl_surface and SKIP the X11
+        // focus protocol (set_input_focus / WM_TAKE_FOCUS). Forcing that protocol
+        // stalls the render loop of Globally-Active Proton/Unity games (e.g.
+        // Cuphead) — but they still need to receive keys, hence focus-but-no-X11-
+        // state. set_activate above sets _NET_WM_STATE_FOCUSED and the call below
+        // sets _NET_ACTIVE_WINDOW, which is what they actually poll for.
         keyboard.set_focus(self, Some(window.clone().into()), serial);
+        self.set_x11_active_window(window);
+    }
+
+    /// Mirror keyboard focus to the X11 world by setting `_NET_ACTIVE_WINDOW`.
+    ///
+    /// XWayland clients with a Globally Active input model (e.g. Unity games via
+    /// Proton, which set `input=False` and list `WM_TAKE_FOCUS`) block their
+    /// render loop until they observe activation. `WM_TAKE_FOCUS` + `_NET_WM_STATE_FOCUSED`
+    /// alone are not enough — they also poll `_NET_ACTIVE_WINDOW` on the root window.
+    /// Without this the window stays black with no frames (the Cuphead startup deadlock).
+    pub fn set_x11_active_window(&mut self, window: &crate::shell::WindowElement) {
+        use smithay::desktop::WindowSurface;
+
+        // Never hand `_NET_ACTIVE_WINDOW` to another window while a self-managing
+        // X11 game is fullscreen. Unity/Proton games (Cuphead) QUIT when they lose
+        // active-window status while fullscreen — losing it to Steam Big Picture on
+        // a focus flap, or to another workspace's top window on swipe, makes Cuphead
+        // tear down its X11 window (observed: unmap + ReparentWindow BadWindow).
+        // Keep the game `_NET_ACTIVE_WINDOW` until it's unfullscreened/closed.
+        #[cfg(feature = "xwayland")]
+        {
+            let target_id = window.id();
+            let game_is_fullscreen = self.workspaces.windows_map.values().any(|w| {
+                w.is_fullscreen() && w.x11_self_manages_focus() && w.id() != target_id
+            });
+            if game_is_fullscreen {
+                return;
+            }
+        }
+
+        let WindowSurface::X11(surface) = window.underlying_surface() else {
+            return;
+        };
+        let window_id = surface.window_id();
+        if let Some(xwm) = self.xwm.as_mut() {
+            if let Err(err) = xwm.set_active_window(window_id) {
+                tracing::warn!(?err, "failed to set _NET_ACTIVE_WINDOW for X11 window");
+            }
+        }
     }
 
     pub fn clear_keyboard_focus(&mut self) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -968,6 +968,12 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                     .expect("Failed to set xwayland default cursor");
                     data.xwm = Some(wm);
                     data.xdisplay = Some(display_number);
+                    // The native-resolution X screen (see client_scale above)
+                    // leaves X11 apps rendering at scale 1 — publish the scale
+                    // via XSETTINGS so toolkits (GTK, Chromium/CEF — e.g. the
+                    // Steam UI) scale themselves. Games ignore XSETTINGS and
+                    // keep the native resolution.
+                    data.apply_xwayland_xsettings();
                 }
                 XWaylandEvent::Error => {
                     warn!("XWayland crashed on startup");
@@ -1011,6 +1017,40 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
     pub fn update_xwayland_scale(&mut self) {
         if let Some(client) = self.xwayland_client.clone() {
             self.set_xwayland_client_scale(&client);
+        }
+        self.apply_xwayland_xsettings();
+    }
+
+    /// Publish the primary output's scale to X11 clients via XSETTINGS.
+    ///
+    /// The native-resolution X screen (`client_scale`, see `start_xwayland`)
+    /// makes X11 apps render at scale 1; well-behaved toolkits (GTK,
+    /// Chromium/CEF — e.g. the Steam UI) read `Gdk/WindowScalingFactor` and
+    /// `Xft/DPI` from XSETTINGS and scale themselves back up. Games ignore
+    /// XSETTINGS and keep rendering at the native resolution. Same approach
+    /// as mutter's xwayland-native-scaling.
+    #[cfg(feature = "xwayland")]
+    pub fn apply_xwayland_xsettings(&mut self) {
+        use smithay::xwayland::xwm::settings::Value;
+        let scale = self.xwayland_target_scale();
+        let Some(wm) = self.xwm.as_mut() else { return };
+        let settings = [
+            (
+                "Gdk/WindowScalingFactor".to_string(),
+                Value::Integer(scale as i32),
+            ),
+            // Base DPI before the window scaling factor (96 in 1024ths).
+            ("Gdk/UnscaledDPI".to_string(), Value::Integer(96 * 1024)),
+            // Effective DPI (in 1024ths) for toolkits without integer-scale
+            // support (Xft consumers, Chromium/CEF).
+            (
+                "Xft/DPI".to_string(),
+                Value::Integer((96.0 * scale * 1024.0) as i32),
+            ),
+        ];
+        match wm.set_xsettings(settings.into_iter()) {
+            Ok(()) => tracing::info!(scale, "published XWayland XSETTINGS scale"),
+            Err(err) => tracing::warn!(?err, "failed to set XWayland XSETTINGS"),
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -106,7 +106,7 @@ use smithay::{
     utils::{Point, Size},
     wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabState,
     wayland::xwayland_shell,
-    xwayland::{X11Wm, XWayland, XWaylandEvent},
+    xwayland::{X11Wm, XWayland, XWaylandClientData, XWaylandEvent},
 };
 
 pub struct CalloopData<BackendData: Backend + 'static> {
@@ -250,6 +250,10 @@ pub struct Otto<BackendData: Backend + 'static> {
     pub xwm: Option<X11Wm>,
     #[cfg(feature = "xwayland")]
     pub xdisplay: Option<u32>,
+    /// The XWayland client connection, kept so its `client_scale` can be updated
+    /// when the output scale changes (see `update_xwayland_scale`).
+    #[cfg(feature = "xwayland")]
+    pub xwayland_client: Option<smithay::reexports::wayland_server::Client>,
 
     #[cfg(feature = "debug")]
     pub renderdoc: Option<renderdoc::RenderDoc<renderdoc::V141>>,
@@ -759,6 +763,8 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             xwm: None,
             #[cfg(feature = "xwayland")]
             xdisplay: None,
+            #[cfg(feature = "xwayland")]
+            xwayland_client: None,
             #[cfg(feature = "debug")]
             renderdoc: renderdoc::RenderDoc::new().ok(),
 
@@ -924,6 +930,19 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         )
         .expect("failed to start XWayland");
 
+        // Seed the XWayland client's `client_scale` from the primary output's
+        // integer scale, BEFORE XWayland binds wl_output. smithay sends
+        // `wl_output.scale = integer_scale / client_scale`, so with
+        // client_scale == integer_scale XWayland receives scale 1 and builds an
+        // X screen at the native PHYSICAL resolution (e.g. 2880x1920) instead of
+        // the downscaled logical size (1440x960). This makes XRandR report the
+        // correct native modes to X11 clients (Unity/Proton games query these to
+        // pick a fullscreen resolution); smithay transparently scales the X11
+        // surfaces back into logical space. Without this the game reads back a
+        // half-size screen and bails out of fullscreen.
+        self.set_xwayland_client_scale(&client);
+        self.xwayland_client = Some(client.clone());
+
         let ret = self
             .handle
             .insert_source(xwayland, move |event, _, data| match event {
@@ -961,6 +980,40 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             );
         }
     }
+
+    /// The integer scale XWayland should run its X screen at — taken from the
+    /// primary (first) output. XWayland's `client_scale` is a single global
+    /// value, so multi-output mixed-DPI is a known compromise (as in mutter).
+    #[cfg(feature = "xwayland")]
+    fn xwayland_target_scale(&self) -> f64 {
+        self.workspaces
+            .outputs()
+            .next()
+            .map(|o| o.current_scale().integer_scale() as f64)
+            .unwrap_or(1.0)
+    }
+
+    /// Apply the primary output's integer scale to the given XWayland client's
+    /// `client_scale`. See `start_xwayland` for why this yields a native-resolution
+    /// X screen.
+    #[cfg(feature = "xwayland")]
+    fn set_xwayland_client_scale(&self, client: &smithay::reexports::wayland_server::Client) {
+        let scale = self.xwayland_target_scale();
+        if let Some(data) = client.get_data::<XWaylandClientData>() {
+            data.compositor_state.set_client_scale(scale);
+            tracing::info!(scale, "set XWayland client_scale (native-resolution X screen)");
+        }
+    }
+
+    /// Re-apply the XWayland `client_scale` after the output scale changes at
+    /// runtime, so the X screen tracks the new native resolution.
+    #[cfg(feature = "xwayland")]
+    pub fn update_xwayland_scale(&mut self) {
+        if let Some(client) = self.xwayland_client.clone() {
+            self.set_xwayland_client_scale(&client);
+        }
+    }
+
     pub fn set_cursor(&mut self, image: &CursorImageStatus) {
         *self.cursor_status.lock().unwrap() = image.clone();
         self.cursor_manager.set_cursor_image(image.clone());

--- a/src/state/xwayland_handler.rs
+++ b/src/state/xwayland_handler.rs
@@ -9,7 +9,6 @@ use smithay::{
     delegate_xwayland_keyboard_grab, delegate_xwayland_shell,
     desktop::{Window, WindowSurface},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
-    utils::SERIAL_COUNTER,
     wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabHandler,
     wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState},
     xwayland::xwm::XwmId,
@@ -83,21 +82,42 @@ impl<BackendData: Backend + 'static> XWaylandShellHandler for Otto<BackendData> 
         // Override-redirect popups must not steal focus (activate=false).
         self.workspaces
             .map_window(&window_element, location, !is_override_redirect, None);
-        let bbox = self
-            .workspaces
-            .space()
-            .and_then(|s| s.element_bbox(&window_element));
-        if let WindowSurface::X11(xsurface) = window_element.underlying_surface() {
-            let _ = xsurface.configure(bbox);
+
+        // A client may map with an initial _NET_WM_STATE_FULLSCREEN (Unity/Proton
+        // games set it via XChangeProperty before mapping). In that case fullscreen
+        // owns the geometry: sending the windowed-placement configure here would race
+        // the fullscreen configure and leave the window mis-sized at the windowed
+        // spawn point (collapsed -> black). Skip the windowed configure and let
+        // apply_x11_fullscreen be the sole authority on the X11 geometry.
+        let wants_fullscreen = !is_override_redirect && window.is_fullscreen();
+
+        if !wants_fullscreen {
+            let bbox = self
+                .workspaces
+                .space()
+                .and_then(|s| s.element_bbox(&window_element));
+            if let WindowSurface::X11(xsurface) = window_element.underlying_surface() {
+                let _ = xsurface.configure(bbox);
+            }
         }
 
         if !is_override_redirect {
-            let keyboard = self.seat.get_keyboard().unwrap();
-            keyboard.set_focus(
-                self,
-                Some(window_element.into()),
-                SERIAL_COUNTER.next_serial(),
-            );
+            // Focus the window at map. For self-managing X11 games this routes
+            // keyboard delivery to the `wl_surface` (see src/focus.rs) — the game
+            // gets wl_keyboard focus (so XWayland can deliver keys) WITHOUT a
+            // WM_TAKE_FOCUS, which would break its render loop. Activation
+            // (_NET_ACTIVE_WINDOW) is set inside the helper too.
+            self.set_keyboard_focus_on_window(&window_element);
+
+            // Replay a fullscreen request that arrived before the element was
+            // mapped. Otto defers X11 mapping to here, so a client that maps and
+            // immediately sets _NET_WM_STATE_FULLSCREEN (Unity/Proton games) had
+            // its fullscreen_request dropped — the initial _NET_WM_STATE property is
+            // seeded into the X11Surface (smithay update_net_wm_state at MapRequest),
+            // and we apply it now that the element exists.
+            if window.is_fullscreen() && !window_element.is_fullscreen() {
+                self.apply_x11_fullscreen(&window_element, &window);
+            }
         }
     }
 }

--- a/src/udev/feedback.rs
+++ b/src/udev/feedback.rs
@@ -15,6 +15,27 @@ use crate::skia_renderer::SkiaRenderer;
 
 use super::types::{DrmSurfaceDmabufFeedback, GbmDrmCompositor};
 
+/// Intel "clear color" CCS modifiers (`RC_CCS_CC`) carry an extra clear-color
+/// value plane (3 planes total). Otto's Skia dmabuf import samples them as pure
+/// black (the 2-plane `RC_CCS` variants render fine). Dropping these from the
+/// formats we advertise makes clients fall back to the 2-plane modifiers Otto
+/// renders correctly — notably DXVK/Proton fullscreen swapchains (e.g. Cuphead),
+/// which otherwise pick `Y_TILED_GEN12_RC_CCS_CC` and show a black screen.
+const CLEAR_COLOR_MODIFIERS: &[u64] = &[
+    0x0100_0000_0000_0008, // I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS_CC
+    0x0100_0000_0000_000c, // I915_FORMAT_MOD_4_TILED_DG2_RC_CCS_CC
+    0x0100_0000_0000_000f, // I915_FORMAT_MOD_4_TILED_MTL_RC_CCS_CC
+];
+
+/// Removes the clear-color CCS modifiers (see [`CLEAR_COLOR_MODIFIERS`]) from a
+/// set of dmabuf formats before it is advertised to clients.
+pub fn strip_clear_color_modifiers(formats: FormatSet) -> FormatSet {
+    formats
+        .into_iter()
+        .filter(|f| !CLEAR_COLOR_MODIFIERS.contains(&u64::from(f.modifier)))
+        .collect()
+}
+
 /// Constructs dmabuf feedback for a surface
 ///
 /// Creates two feedback objects:
@@ -29,8 +50,10 @@ pub fn get_surface_dmabuf_feedback(
     gpus: &mut GpuManager<GbmGlesBackend<SkiaRenderer, smithay::backend::drm::DrmDeviceFd>>,
     composition: &GbmDrmCompositor,
 ) -> Option<DrmSurfaceDmabufFeedback> {
-    let primary_formats = gpus.single_renderer(&primary_gpu).ok()?.dmabuf_formats();
-    let render_formats = gpus.single_renderer(&render_node).ok()?.dmabuf_formats();
+    let primary_formats =
+        strip_clear_color_modifiers(gpus.single_renderer(&primary_gpu).ok()?.dmabuf_formats());
+    let render_formats =
+        strip_clear_color_modifiers(gpus.single_renderer(&render_node).ok()?.dmabuf_formats());
 
     let all_render_formats = primary_formats
         .iter()

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -427,8 +427,10 @@ pub fn run_udev() {
         }
     }
 
-    // init dmabuf support with format list from our primary gpu
-    let dmabuf_formats = renderer.dmabuf_formats();
+    // init dmabuf support with format list from our primary gpu.
+    // Strip the clear-color CCS modifiers Otto can't sample (see
+    // feedback::strip_clear_color_modifiers) so clients fall back to renderable ones.
+    let dmabuf_formats = super::feedback::strip_clear_color_modifiers(renderer.dmabuf_formats());
     let default_feedback = DmabufFeedbackBuilder::new(primary_gpu.dev_id(), dmabuf_formats)
         .build()
         .unwrap();

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -117,12 +117,14 @@ impl Backend for UdevData {
     }
 
     fn early_import(&mut self, surface: &wl_surface::WlSurface) {
-        if let Err(err) = self.gpus.early_import(self.primary_gpu, surface) {
+        let early = self.gpus.early_import(self.primary_gpu, surface);
+        if let Err(ref err) = early {
             tracing::warn!("Early buffer import failed: {}", err);
         }
         let mut r = self.gpus.single_renderer(&self.primary_gpu).unwrap();
         compositor::with_states(surface, |states| {
-            if let Err(err) = import_surface(&mut r, states) {
+            let import_res = import_surface(&mut r, states);
+            if let Err(ref err) = import_res {
                 tracing::warn!("Early buffer import surface failed: {}", err);
             }
         });

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -118,6 +118,10 @@ impl Otto<UdevData> {
             return;
         };
 
+        // Debug (`/tmp/otto-slow`): a VBlank line proves page flips complete.
+        if std::path::Path::new("/tmp/otto-slow").exists() {
+            tracing::info!(target: "otto::planes", "SLOW vblank on {crtc:?}");
+        }
         let schedule_render =
             match surface.compositor.frame_submitted() {
                 Ok(user_data) => {
@@ -329,14 +333,11 @@ impl Otto<UdevData> {
         } else {
             None
         };
-        // XWayland surfaces must not take the fullscreen direct-scanout path:
-        // the single fullscreen dmabuf element it produces (correct geometry)
-        // scans out black, whereas the normal lay-rs scene composition renders
-        // the same surface correctly. This affects fullscreen Proton/Unity
-        // games (e.g. Cuphead), which run under XWayland and would otherwise
-        // show a black screen. Composite them through the scene instead.
-        // (Native Wayland fullscreen clients keep using direct scanout.)
-        let fullscreen_window = fullscreen_window.filter(|w| !w.is_x11());
+        // XWayland fullscreen windows take the same direct-scanout path as
+        // native clients: the black-scanout they used to show was the
+        // clear-color CCS modifiers (stripped since — see
+        // feedback::strip_clear_color_modifiers) plus the missing
+        // explicit-sync acquire blocker (added in shell::new_surface).
         // Whether this output uses the plane decomposition at all (set once at
         // surface creation from overlay count / atomic / GPU identity).
         let planes_enabled = self
@@ -1619,6 +1620,17 @@ pub(super) fn render_output_frame<'a>(
                                             e.geometry(scale),
                                             e.src(),
                                         );
+                                        // Debug (`/tmp/otto-slow`): commit counter must advance
+                                        // with every client frame — a constant value here means
+                                        // the surface's damage bag never ticks and the plane
+                                        // keeps scanning the first buffer forever.
+                                        if std::path::Path::new("/tmp/otto-slow").exists() {
+                                            tracing::info!(
+                                                target: "otto::planes",
+                                                "SLOW topwin {win_id:?} commit={:?}",
+                                                e.current_commit(),
+                                            );
+                                        }
                                     }
                                     workspace_render_elements
                                         .push(WorkspaceRenderElements::from(e));
@@ -1773,6 +1785,13 @@ pub(super) fn render_output_frame<'a>(
 
     let rendered = !render_frame_result.is_empty;
     let states = render_frame_result.states;
+
+    // Debug (`/tmp/otto-slow`): log the frame outcome — pairs with the
+    // pre-render SLOW frame line so a frozen screen can be attributed to
+    // either "no flip queued" (rendered=false) or a post-queue problem.
+    if std::path::Path::new("/tmp/otto-slow").exists() {
+        tracing::info!(target: "otto::planes", "SLOW result: rendered={rendered}");
+    }
 
     // 1 Hz: refresh /tmp debug toggles and log per-plane realization.
     super::debug::debug_tick(surface, &states, expose_active);

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -320,7 +320,8 @@ impl Otto<UdevData> {
         // are dropped for those frames. Disabled during capture and the
         // 3-finger swipe (the finger-drag moves the workspace with no
         // animation flag, so a fixed plane would not follow it).
-        let allow_fullscreen_scanout = self.workspaces.is_fullscreen_and_stable()
+        let allow_fullscreen_scanout = std::env::var_os("DISABLE_DIRECT_SCANOUT").is_none()
+            && self.workspaces.is_fullscreen_and_stable()
             && !self.swipe_gesture.is_active()
             && !capture_active;
         let fullscreen_window = if allow_fullscreen_scanout {
@@ -328,6 +329,14 @@ impl Otto<UdevData> {
         } else {
             None
         };
+        // XWayland surfaces must not take the fullscreen direct-scanout path:
+        // the single fullscreen dmabuf element it produces (correct geometry)
+        // scans out black, whereas the normal lay-rs scene composition renders
+        // the same surface correctly. This affects fullscreen Proton/Unity
+        // games (e.g. Cuphead), which run under XWayland and would otherwise
+        // show a black screen. Composite them through the scene instead.
+        // (Native Wayland fullscreen clients keep using direct scanout.)
+        let fullscreen_window = fullscreen_window.filter(|w| !w.is_x11());
         // Whether this output uses the plane decomposition at all (set once at
         // surface creation from overlay count / atomic / GPU identity).
         let planes_enabled = self

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -3,12 +3,27 @@ pub use context_menu_view::ContextMenuView;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use layers::prelude::{taffy, Layer};
 use layers::types::{Point, Size};
 use smithay::utils::Transform;
 
 use super::WindowViewSurface;
+
+/// `OTTO_ADAPTIVE_SAMPLING=0` forces bicubic for every per-window draw (the
+/// pre-change baseline). Anything else (unset, `1`, `true`, ...) keeps the
+/// adaptive path that picks nearest/linear/bicubic from the matrix. Read once
+/// at startup so the per-frame cost is a single atomic load.
+fn adaptive_sampling_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !matches!(
+            std::env::var("OTTO_ADAPTIVE_SAMPLING").as_deref(),
+            Ok("0") | Ok("false") | Ok("off")
+        )
+    })
+}
 
 #[allow(unused)]
 pub struct FontCache {
@@ -350,8 +365,36 @@ pub fn configure_surface_layer(
             Transform::Flipped270 => {}
         }
 
-        let sampling =
-            layers::skia::SamplingOptions::from(layers::skia::CubicResampler::catmull_rom());
+        // Pick the cheapest filter the matrix allows. Bicubic is ~12-16× the
+        // fragment-shader cost of nearest; the dominant desktop case (static
+        // window at native scale) maps every output pixel to one source pixel
+        // and gets identical results from any filter.
+        let sampling = if !adaptive_sampling_enabled() {
+            layers::skia::SamplingOptions::from(layers::skia::CubicResampler::catmull_rom())
+        } else {
+            let is_normal_transform = matches!(draw_wvs.transform, Transform::Normal);
+            let is_identity_scale =
+                (scale_x - 1.0).abs() < 1e-4 && (scale_y - 1.0).abs() < 1e-4;
+            let tx_total = -draw_wvs.phy_src_x + tx / scale_x;
+            let ty_total = -draw_wvs.phy_src_y + ty / scale_y;
+            let is_pixel_aligned = (tx_total - tx_total.round()).abs() < 1e-4
+                && (ty_total - ty_total.round()).abs() < 1e-4;
+
+            if is_normal_transform && is_identity_scale && is_pixel_aligned {
+                layers::skia::SamplingOptions::default()
+            } else if is_normal_transform
+                && (scale_x - 1.0).abs() < 0.05
+                && (scale_y - 1.0).abs() < 0.05
+            {
+                layers::skia::SamplingOptions::new(
+                    layers::skia::FilterMode::Linear,
+                    layers::skia::MipmapMode::None,
+                )
+            } else {
+                layers::skia::SamplingOptions::from(layers::skia::CubicResampler::catmull_rom())
+            }
+        };
+
         let mut paint =
             layers::skia::Paint::new(layers::skia::Color4f::new(1.0, 1.0, 1.0, 1.0), None);
         paint.set_shader(tex.image.to_shader(


### PR DESCRIPTION
Stacked on #107.

Makes fullscreen XWayland Unity/Proton games (e.g. Cuphead via Steam) work end-to-end on the multi-plane scanout stack:

- **Focus/activation**: gamescope-style `XSetInputFocus` (no `WM_TAKE_FOCUS`, which stalls DXVK), focus retention across workspace switches, `_NET_ACTIVE_WINDOW` kept on the game (Unity quits on losing it while fullscreen). Requires `X11Surface::set_input_focus` from the smithay fork (nongio/smithay@0e51d23fe on `feat/dmabuf-scanout`).
- **Fullscreen direct scanout for X11**: X11 fullscreen windows take the same primary-plane direct-scanout path as native clients. The black scanout that previously forced a composite fallback had two real causes, both fixed here: clear-color CCS modifiers (now stripped from advertised dmabuf formats) and the missing explicit-sync acquire blocker. Routing the game through the composite/promotion path instead froze the output on the first promoted frame.
- **Native-resolution X screen + XSETTINGS scaling**: XWayland `client_scale` runs the X screen at physical resolution so games see real modes via XRandR; `Gdk/WindowScalingFactor`/`Xft/DPI` are published via XSETTINGS so regular X11 apps (GTK, Chromium/CEF — e.g. the Steam UI) still honor the output scale (mutter's xwayland-native-scaling approach).
- **Fullscreen workspace lifecycle**: dedicated workspace is named after the app and freed when the X11 window unmaps, mirroring the XDG path.
- `sample-clients/deadlock-test`: GPU-free reproduction of the X11 activation deadlock.
- Debug: `/tmp/otto-slow` now also logs whether each frame queued a flip (`SLOW result`) and VBlank completion (`SLOW vblank`).

Verified on tty (Framework 13, 2880x1920@2x): Cuphead renders and animates in fullscreen via direct scanout, keyboard works, Steam UI scales at 2x.

https://claude.ai/code/session_01UT1Vua94m9urpB4McmmifG