### PR TITLE
feat(lock): idle lock, packaging, dock/expose fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install cargo-deb
         run: cargo install cargo-deb
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
       - name: Build Debian package
         run: cargo deb --no-strip
       - name: Upload Debian package
@@ -105,7 +105,7 @@ jobs:
       - name: Install cargo-generate-rpm
         run: cargo install cargo-generate-rpm
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
       - name: Build RPM package
         run: cargo generate-rpm
       - name: Upload RPM package
@@ -132,7 +132,7 @@ jobs:
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
       - name: Build Arch tarball
         run: |
           PKGVER=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -142,6 +142,8 @@ jobs:
           install -Dm755 target/release/otto "$tmpdir/$PKGDIR/target/release/otto"
           install -Dm755 target/release/otto-bar "$tmpdir/$PKGDIR/target/release/otto-bar"
           install -Dm755 target/release/otto-islands "$tmpdir/$PKGDIR/target/release/otto-islands"
+          install -Dm755 target/release/otto-lock "$tmpdir/$PKGDIR/target/release/otto-lock"
+          install -Dm755 target/release/otto-greeter "$tmpdir/$PKGDIR/target/release/otto-greeter"
           install -Dm755 target/release/xdg-desktop-portal-otto "$tmpdir/$PKGDIR/target/release/xdg-desktop-portal-otto"
           install -m644 LICENSE "$tmpdir/$PKGDIR/LICENSE"
           install -m644 README.md "$tmpdir/$PKGDIR/README.md"
@@ -150,6 +152,7 @@ jobs:
           install -Dm644 components/xdg-desktop-portal-otto/otto.portal "$tmpdir/$PKGDIR/components/xdg-desktop-portal-otto/otto.portal"
           install -Dm644 components/xdg-desktop-portal-otto/org.freedesktop.impl.portal.desktop.otto.service "$tmpdir/$PKGDIR/components/xdg-desktop-portal-otto/org.freedesktop.impl.portal.desktop.otto.service"
           install -Dm644 components/xdg-desktop-portal-otto/portals.conf.example "$tmpdir/$PKGDIR/components/xdg-desktop-portal-otto/portals.conf.example"
+          install -Dm644 components/otto-lock/otto-lock.pam "$tmpdir/$PKGDIR/components/otto-lock/otto-lock.pam"
           install -m644 PKGBUILD-git "$tmpdir/$PKGDIR/PKGBUILD-git"
           install -m644 PKGBUILD-nightly-bin "$tmpdir/$PKGDIR/PKGBUILD-nightly-bin"
           # VERSION file for PKGBUILD-nightly-bin pkgver()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           shared-key: workspace-build
           cache-on-failure: true
       - name: System dependencies
-        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme fonts-dejavu-core
+        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev hicolor-icon-theme fonts-dejavu-core
       - name: Clippy
         run: cargo clippy --features "default" -- -D warnings
       - name: Run tests
@@ -72,11 +72,11 @@ jobs:
           shared-key: workspace-build
           cache-on-failure: true
       - name: System dependencies
-        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme
+        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev hicolor-icon-theme
       - name: Install cargo-deb
         run: cargo install cargo-deb
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p otto-rdp -p xdg-desktop-portal-otto
       - name: Build Debian package
         run: cargo deb --no-strip
       - name: Upload Debian package
@@ -101,11 +101,11 @@ jobs:
           shared-key: workspace-build
           cache-on-failure: true
       - name: System dependencies
-        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme
+        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev hicolor-icon-theme
       - name: Install cargo-generate-rpm
         run: cargo install cargo-generate-rpm
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p otto-rdp -p xdg-desktop-portal-otto
       - name: Build RPM package
         run: cargo generate-rpm
       - name: Upload RPM package
@@ -130,9 +130,9 @@ jobs:
           shared-key: workspace-build
           cache-on-failure: true
       - name: System dependencies
-        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev hicolor-icon-theme
+        run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev hicolor-icon-theme
       - name: Build workspace binaries
-        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p xdg-desktop-portal-otto
+        run: cargo build --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p otto-rdp -p xdg-desktop-portal-otto
       - name: Build Arch tarball
         run: |
           PKGVER=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -144,6 +144,7 @@ jobs:
           install -Dm755 target/release/otto-islands "$tmpdir/$PKGDIR/target/release/otto-islands"
           install -Dm755 target/release/otto-lock "$tmpdir/$PKGDIR/target/release/otto-lock"
           install -Dm755 target/release/otto-greeter "$tmpdir/$PKGDIR/target/release/otto-greeter"
+          install -Dm755 target/release/otto-rdp "$tmpdir/$PKGDIR/target/release/otto-rdp"
           install -Dm755 target/release/xdg-desktop-portal-otto "$tmpdir/$PKGDIR/target/release/xdg-desktop-portal-otto"
           install -m644 LICENSE "$tmpdir/$PKGDIR/LICENSE"
           install -m644 README.md "$tmpdir/$PKGDIR/README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,12 +176,17 @@ multi-workspace support, and integrated screen sharing capabilities."""
 depends = "$auto, libdrm2, libudev1, libgbm1, libxkbcommon0, libegl1, libwayland-server0, libinput10, libdbus-1-3, libsystemd0, libseat1, libpipewire-0.3-0, libfreetype6, libfontconfig1, libpixman-1-0, fonts-inter, wireplumber"
 section = "x11"
 priority = "optional"
+# otto-rdp loads these at runtime (pipewiresrc, and the VA-API H.264 encoder
+# it falls back from), so dpkg-shlibdeps cannot see them. Recommended, not
+# required: everything except the RDP bridge works without them.
+recommends = "gstreamer1.0-plugins-base, gstreamer1.0-plugins-bad, gstreamer1.0-pipewire"
 assets = [
     ["target/release/otto", "usr/bin/", "755"],
     ["target/release/otto-bar", "usr/bin/", "755"],
     ["target/release/otto-islands", "usr/bin/", "755"],
     ["target/release/otto-lock", "usr/bin/", "755"],
     ["target/release/otto-greeter", "usr/bin/", "755"],
+    ["target/release/otto-rdp", "usr/bin/", "755"],
     ["target/release/xdg-desktop-portal-otto", "usr/libexec/", "755"],
     ["README.md", "usr/share/doc/otto/", "644"],
     ["LICENSE", "usr/share/doc/otto/", "644"],
@@ -203,6 +208,7 @@ assets = [
     { source = "target/release/otto-islands", dest = "/usr/bin/otto-islands", mode = "755" },
     { source = "target/release/otto-lock", dest = "/usr/bin/otto-lock", mode = "755" },
     { source = "target/release/otto-greeter", dest = "/usr/bin/otto-greeter", mode = "755" },
+    { source = "target/release/otto-rdp", dest = "/usr/bin/otto-rdp", mode = "755" },
     { source = "target/release/xdg-desktop-portal-otto", dest = "/usr/libexec/xdg-desktop-portal-otto", mode = "755" },
     { source = "README.md", dest = "/usr/share/doc/otto/README.md", mode = "644", doc = true },
     { source = "LICENSE", dest = "/usr/share/doc/otto/LICENSE", mode = "644", doc = true },
@@ -213,6 +219,12 @@ assets = [
     { source = "components/xdg-desktop-portal-otto/portals.conf.example", dest = "/usr/share/doc/otto/portals.conf.example", mode = "644", doc = true },
     { source = "components/otto-lock/otto-lock.pam", dest = "/etc/pam.d/otto-lock", mode = "644", config = true },
 ]
+# Runtime-loaded GStreamer plugins for otto-rdp — see the deb `recommends`.
+[package.metadata.generate-rpm.recommends]
+gstreamer1-plugins-base = "*"
+gstreamer1-plugins-bad-free = "*"
+pipewire-gstreamer = "*"
+
 [package.metadata.generate-rpm.requires]
 libdrm = "*"
 systemd-libs = "*"
@@ -251,6 +263,8 @@ optdepends = [
     "xdg-desktop-portal: Desktop integration",
     "fprintd: fingerprint unlock for otto-lock and otto-greeter",
     "greetd: login manager otto --login hosts a greeter for",
+    "gst-plugin-pipewire: otto-rdp video capture",
+    "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)",
 ]
 files = [
     ["target/release/otto", "/usr/bin/otto", "755"],
@@ -258,6 +272,7 @@ files = [
     ["target/release/otto-islands", "/usr/bin/otto-islands", "755"],
     ["target/release/otto-lock", "/usr/bin/otto-lock", "755"],
     ["target/release/otto-greeter", "/usr/bin/otto-greeter", "755"],
+    ["target/release/otto-rdp", "/usr/bin/otto-rdp", "755"],
     ["target/release/xdg-desktop-portal-otto", "/usr/libexec/xdg-desktop-portal-otto", "755"],
     ["README.md", "/usr/share/doc/otto/README.md", "644"],
     ["LICENSE", "/usr/share/licenses/otto/LICENSE", "644"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,8 @@ assets = [
     ["target/release/otto", "usr/bin/", "755"],
     ["target/release/otto-bar", "usr/bin/", "755"],
     ["target/release/otto-islands", "usr/bin/", "755"],
+    ["target/release/otto-lock", "usr/bin/", "755"],
+    ["target/release/otto-greeter", "usr/bin/", "755"],
     ["target/release/xdg-desktop-portal-otto", "usr/libexec/", "755"],
     ["README.md", "usr/share/doc/otto/", "644"],
     ["LICENSE", "usr/share/doc/otto/", "644"],
@@ -188,6 +190,10 @@ assets = [
     ["components/xdg-desktop-portal-otto/otto.portal", "usr/share/xdg-desktop-portal/portals/", "644"],
     ["components/xdg-desktop-portal-otto/org.freedesktop.impl.portal.desktop.otto.service", "usr/share/dbus-1/services/", "644"],
     ["components/xdg-desktop-portal-otto/portals.conf.example", "usr/share/doc/otto/", "644"],
+    # Debian's PAM stack is `common-auth`, not the `system-auth` this file
+    # includes, so it ships as an example to copy to /etc/pam.d/otto-lock
+    # rather than as a config that would deny every unlock as installed.
+    ["components/otto-lock/otto-lock.pam", "usr/share/doc/otto/otto-lock.pam.example", "644"],
 ]
 
 [package.metadata.generate-rpm]
@@ -195,6 +201,8 @@ assets = [
     { source = "target/release/otto", dest = "/usr/bin/otto", mode = "755" },
     { source = "target/release/otto-bar", dest = "/usr/bin/otto-bar", mode = "755" },
     { source = "target/release/otto-islands", dest = "/usr/bin/otto-islands", mode = "755" },
+    { source = "target/release/otto-lock", dest = "/usr/bin/otto-lock", mode = "755" },
+    { source = "target/release/otto-greeter", dest = "/usr/bin/otto-greeter", mode = "755" },
     { source = "target/release/xdg-desktop-portal-otto", dest = "/usr/libexec/xdg-desktop-portal-otto", mode = "755" },
     { source = "README.md", dest = "/usr/share/doc/otto/README.md", mode = "644", doc = true },
     { source = "LICENSE", dest = "/usr/share/doc/otto/LICENSE", mode = "644", doc = true },
@@ -203,6 +211,7 @@ assets = [
     { source = "components/xdg-desktop-portal-otto/otto.portal", dest = "/usr/share/xdg-desktop-portal/portals/otto.portal", mode = "644" },
     { source = "components/xdg-desktop-portal-otto/org.freedesktop.impl.portal.desktop.otto.service", dest = "/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.otto.service", mode = "644" },
     { source = "components/xdg-desktop-portal-otto/portals.conf.example", dest = "/usr/share/doc/otto/portals.conf.example", mode = "644", doc = true },
+    { source = "components/otto-lock/otto-lock.pam", dest = "/etc/pam.d/otto-lock", mode = "644", config = true },
 ]
 [package.metadata.generate-rpm.requires]
 libdrm = "*"
@@ -240,11 +249,15 @@ depends = [
 ]
 optdepends = [
     "xdg-desktop-portal: Desktop integration",
+    "fprintd: fingerprint unlock for otto-lock and otto-greeter",
+    "greetd: login manager otto --login hosts a greeter for",
 ]
 files = [
     ["target/release/otto", "/usr/bin/otto", "755"],
     ["target/release/otto-bar", "/usr/bin/otto-bar", "755"],
     ["target/release/otto-islands", "/usr/bin/otto-islands", "755"],
+    ["target/release/otto-lock", "/usr/bin/otto-lock", "755"],
+    ["target/release/otto-greeter", "/usr/bin/otto-greeter", "755"],
     ["target/release/xdg-desktop-portal-otto", "/usr/libexec/xdg-desktop-portal-otto", "755"],
     ["README.md", "/usr/share/doc/otto/README.md", "644"],
     ["LICENSE", "/usr/share/licenses/otto/LICENSE", "644"],
@@ -253,4 +266,5 @@ files = [
     ["components/xdg-desktop-portal-otto/otto.portal", "/usr/share/xdg-desktop-portal/portals/otto.portal", "644"],
     ["components/xdg-desktop-portal-otto/org.freedesktop.impl.portal.desktop.otto.service", "/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.otto.service", "644"],
     ["components/xdg-desktop-portal-otto/portals.conf.example", "/usr/share/doc/otto/portals.conf.example", "644"],
+    ["components/otto-lock/otto-lock.pam", "/etc/pam.d/otto-lock", "644"],
 ]

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ arch=("x86_64")
 provides=("otto")
 conflicts=("otto")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
-optdepends=("xdg-desktop-portal: Desktop integration")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
 source=("https://github.com/nongio/otto/releases/download/v$pkgver/otto-$pkgver-x86_64.tar.gz")
 sha256sums=("SKIP")
 
@@ -21,6 +21,8 @@ package() {
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
+    install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
+    install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
     
     # Install documentation
@@ -30,6 +32,9 @@ package() {
     
     # Install configuration
     install -Dm644 otto_config.example.toml "$pkgdir/etc/otto/config.toml"
+    # PAM stack otto-lock authenticates against; without it PAM falls through
+    # to `other`, which denies everything.
+    install -Dm644 components/otto-lock/otto-lock.pam "$pkgdir/etc/pam.d/otto-lock"
     
     # Install desktop files
     install -Dm644 resources/otto.desktop "$pkgdir/usr/share/wayland-sessions/otto.desktop"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,8 +9,8 @@ license=("MIT")
 arch=("x86_64")
 provides=("otto")
 conflicts=("otto")
-depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
+depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
 source=("https://github.com/nongio/otto/releases/download/v$pkgver/otto-$pkgver-x86_64.tar.gz")
 sha256sums=("SKIP")
 
@@ -23,6 +23,7 @@ package() {
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
     install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
+    install -Dm755 target/release/otto-rdp "$pkgdir/usr/bin/otto-rdp"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
     
     # Install documentation

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -11,10 +11,10 @@ provides=("otto")
 conflicts=("otto" "otto-bin")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
 makedepends=("git" "rust" "cargo" "libdisplay-info" "clang")
-optdepends=("xdg-desktop-portal: Desktop integration")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
 source=()
 sha256sums=()
-backup=("etc/otto/config.toml")
+backup=("etc/otto/config.toml" "etc/pam.d/otto-lock")
 
 pkgver() {
     cd "$startdir"
@@ -28,6 +28,8 @@ build() {
     cargo build --release
     cargo build --release -p otto-bar
     cargo build --release -p otto-islands
+    cargo build --release -p otto-lock
+    cargo build --release -p otto-greeter
     cargo build --release -p xdg-desktop-portal-otto
 }
 
@@ -38,6 +40,8 @@ package() {
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
+    install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
+    install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation
@@ -47,6 +51,9 @@ package() {
 
     # Install configuration
     install -Dm644 otto_config.example.toml "$pkgdir/etc/otto/config.toml"
+    # PAM stack otto-lock authenticates against; without it PAM falls through
+    # to `other`, which denies everything.
+    install -Dm644 components/otto-lock/otto-lock.pam "$pkgdir/etc/pam.d/otto-lock"
 
     # Install desktop files
     install -Dm644 resources/otto.desktop "$pkgdir/usr/share/wayland-sessions/otto.desktop"

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -9,9 +9,9 @@ license=("MIT")
 arch=("x86_64")
 provides=("otto")
 conflicts=("otto" "otto-bin")
-depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
+depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
 makedepends=("git" "rust" "cargo" "libdisplay-info" "clang")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
 source=()
 sha256sums=()
 backup=("etc/otto/config.toml" "etc/pam.d/otto-lock")
@@ -42,6 +42,7 @@ package() {
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
     install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
+    install -Dm755 target/release/otto-rdp "$pkgdir/usr/bin/otto-rdp"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation

--- a/PKGBUILD-nightly-bin
+++ b/PKGBUILD-nightly-bin
@@ -10,11 +10,11 @@ arch=("x86_64")
 provides=("otto")
 conflicts=("otto" "otto-bin" "otto-git")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
-optdepends=("xdg-desktop-portal: Desktop integration")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
 source=("otto-nightly-x86_64.tar.gz::https://github.com/nongio/otto/releases/download/nightly/otto-nightly-x86_64.tar.gz")
 sha256sums=("SKIP")
 noextract=("otto-nightly-x86_64.tar.gz")
-backup=("etc/otto/config.toml")
+backup=("etc/otto/config.toml" "etc/pam.d/otto-lock")
 
 prepare() {
     tar -xzf "$srcdir/otto-nightly-x86_64.tar.gz" -C "$srcdir"
@@ -33,6 +33,8 @@ package() {
     install -Dm755 target/release/otto "$pkgdir/usr/bin/otto"
     install -Dm755 target/release/otto-bar "$pkgdir/usr/bin/otto-bar"
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
+    install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
+    install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation
@@ -42,6 +44,9 @@ package() {
 
     # Install configuration
     install -Dm644 otto_config.example.toml "$pkgdir/etc/otto/config.toml"
+    # PAM stack otto-lock authenticates against; without it PAM falls through
+    # to `other`, which denies everything.
+    install -Dm644 components/otto-lock/otto-lock.pam "$pkgdir/etc/pam.d/otto-lock"
 
     # Install desktop files
     install -Dm644 resources/otto.desktop "$pkgdir/usr/share/wayland-sessions/otto.desktop"

--- a/PKGBUILD-nightly-bin
+++ b/PKGBUILD-nightly-bin
@@ -9,8 +9,8 @@ license=("MIT")
 arch=("x86_64")
 provides=("otto")
 conflicts=("otto" "otto-bin" "otto-git")
-depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for")
+depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
 source=("otto-nightly-x86_64.tar.gz::https://github.com/nongio/otto/releases/download/nightly/otto-nightly-x86_64.tar.gz")
 sha256sums=("SKIP")
 noextract=("otto-nightly-x86_64.tar.gz")
@@ -35,6 +35,7 @@ package() {
     install -Dm755 target/release/otto-islands "$pkgdir/usr/bin/otto-islands"
     install -Dm755 target/release/otto-lock "$pkgdir/usr/bin/otto-lock"
     install -Dm755 target/release/otto-greeter "$pkgdir/usr/bin/otto-greeter"
+    install -Dm755 target/release/otto-rdp "$pkgdir/usr/bin/otto-rdp"
     install -Dm755 target/release/xdg-desktop-portal-otto "$pkgdir/usr/libexec/xdg-desktop-portal-otto"
 
     # Install documentation

--- a/components/otto-lock/src/main.rs
+++ b/components/otto-lock/src/main.rs
@@ -537,16 +537,28 @@ impl Locker {
             PowerAction::Restart => "reboot",
             PowerAction::Shutdown => "poweroff",
         };
+        tracing::info!(verb, "power action requested");
 
-        match std::process::Command::new("systemctl").arg(verb).status() {
-            Ok(status) if status.success() => {}
-            Ok(status) => {
-                tracing::warn!(verb, ?status, "systemctl refused");
-                self.session.error = Some(format!("Not permitted to {verb}"));
+        // Captured rather than inherited: what systemd has to say about a
+        // refusal is the whole diagnosis, and on a lock screen there is no
+        // terminal for it to land in.
+        match std::process::Command::new("systemctl").arg(verb).output() {
+            Ok(output) if output.status.success() => {
+                tracing::info!(verb, "systemctl accepted");
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let reason = stderr.lines().next().unwrap_or("").trim().to_string();
+                tracing::warn!(verb, status = ?output.status, %stderr, "systemctl refused");
+                self.session.error = Some(if reason.is_empty() {
+                    format!("Not permitted to {verb}")
+                } else {
+                    reason
+                });
             }
             Err(err) => {
                 tracing::warn!(verb, %err, "could not run systemctl");
-                self.session.error = Some(format!("Could not {verb}"));
+                self.session.error = Some(format!("Could not {verb}: {err}"));
             }
         }
     }
@@ -771,6 +783,7 @@ impl App for Locker {
                     screen.surface.base_surface().wl_surface().id() == event.surface.id()
                 })
                 .and_then(|screen| screen.panel.action_at(x as f32, y as f32));
+            tracing::info!(x, y, ?action, "press on the lock surface");
             if let Some(action) = action {
                 self.activate(action);
                 acted = true;

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -172,6 +172,10 @@ manage_lid_switch = true
 #            external monitor is connected (clamshell mode) or a remote client
 #            is actively consuming frames (RDP bridge / screenshare), in which
 #            case the system keeps running
+#   "lock"   - Like "auto", but lock the session first (see [lock] below), the
+#            way on_power_button = "lock" does, so the machine wakes to the
+#            lock screen. Clamshell and remote sessions stay unlocked: the
+#            session is still in use
 #   "disable_internal_screen" - Always disable screen but stay running, never
 #            suspend (for display managers/kiosks)
 on_lid_close = "auto"

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -67,6 +67,11 @@ keyboard_repeat_rate = 30
 # [lock]
 # locker_command = "otto-lock"
 # locker_args = []
+# Lock the session after this many seconds with no keyboard, pointer, touch or
+# tablet input. 0 (the default) never locks on its own. Clients that take an
+# idle inhibitor (idle-inhibit-unstable-v1 — video players, presentations) hold
+# the lock off while they play and restart the countdown when they stop.
+# auto_lock_timeout = 300
 
 # Systemd integration — send READY=1 via sd_notify and activate graphical-session.target
 # when the Wayland socket is ready. Enable this when running Otto as a systemd user service

--- a/specs/lid-power.md
+++ b/specs/lid-power.md
@@ -37,7 +37,9 @@ Configuration (`[power_management]`):
 
 - `manage_lid_switch` (default `true`) — when `false`, Otto ignores the lid
   switch entirely and all handling is delegated to systemd-logind.
-- `on_lid_close` — `"auto"` (default) or `"disable_internal_screen"`.
+- `on_lid_close` — `"auto"` (default), `"lock"` or `"disable_internal_screen"`.
+  `"lock"` is `"auto"` plus a session lock, the same lock
+  `on_power_button = "lock"` performs.
 - `on_power_button` — `"lock"` (default), `"suspend"`, `"shutdown"` or
   `"ignore"`.
 
@@ -47,11 +49,15 @@ On lid close (`manage_lid_switch = true`):
    Wayland output global are torn down, but workspaces, windows, and scene
    layers are kept intact. The output's position and primary status are
    recorded.
-2. In `"auto"` mode, if no external monitor is connected and no remote client
-   is actively consuming frames, Otto invokes a system suspend (via logind).
-   Otherwise the system keeps running.
-3. In `"disable_internal_screen"` mode the system never suspends (kiosk /
-   display-manager use); the panel is kept off even with the lid open.
+2. If no external monitor is connected and no remote client is actively
+   consuming frames — i.e. the session is out of reach — Otto acts on the
+   close: in `"lock"` mode it launches the locker first, and both `"auto"` and
+   `"lock"` then invoke a system suspend (via logind), so the machine wakes to
+   the lock screen. Otherwise the system keeps running, and does not lock: a
+   clamshell or remote session is still in use.
+3. In `"disable_internal_screen"` mode the system never suspends and never
+   locks (kiosk / display-manager use); the panel is kept off even with the
+   lid open.
 
 "Remote client actively consuming frames" means: at least one portal
 screenshare session exists, or at least one virtual output's PipeWire stream
@@ -70,7 +76,7 @@ On lid open:
 3. If the recorded position now overlaps another output, it falls back to
    auto-placement (outputs never overlap).
 
-The suspend decision is edge-triggered on the panel teardown: a repeated
+The lock and suspend decisions are edge-triggered on the panel teardown: a repeated
 power-state evaluation with the lid still closed (e.g. wake with the lid
 shut) does not immediately re-suspend.
 
@@ -95,6 +101,10 @@ On power button press:
 - Suspending is delegated to logind (`systemctl suspend`); Otto does not
   freeze itself. On resume the session pause/activate path revalidates DRM
   state.
+- Locking is launching the locker, which then asks for the lock — so in
+  `"lock"` mode the suspend request may go out before the lock is confirmed. That is harmless: the panel is already torn down, and the lock
+  raises the blank on the output that comes back on lid open. A locker that
+  fails to come up leaves the session unlocked, as everywhere else.
 - The saved suspend record is keyed by connector name and consumed on
   reconnect; a real disconnect (`unmap_output`) discards it.
 - While the panel is suspended, another output (often a virtual one) becomes

--- a/specs/lock-screen.md
+++ b/specs/lock-screen.md
@@ -39,9 +39,9 @@ user. Any other `ext-session-lock-v1` client works too.
 
 - **Logging in.** A greeter authenticates a user who has no session yet and is
   bound to greetd's process model; see [login-mode](./login-mode.md).
-- **Idle detection.** What decides *when* to lock — an idle timer, the lid, a
-  suspend hook, a keybinding — is separate from the lock itself. This spec
-  covers only the mechanism and the explicit triggers below.
+- **Idle detection beyond input.** Auto-lock (below) measures the absence of
+  input, plus `idle-inhibit-unstable-v1` for clients that ask to be left alone.
+  A client that plays video without taking an inhibitor is not detected.
 - **Owning authentication.** The locker calls PAM; the compositor does not.
 - **Hiding the session from a privileged attacker.** A lock screen protects
   against someone at the keyboard, not against root or physical memory access.
@@ -139,8 +139,26 @@ user. Any other `ext-session-lock-v1` client works too.
 - `lock.locker_command` and `lock.locker_args` name that client, defaulting to
   `otto-lock`. `$OTTO_LOCKER_COMMAND` overrides both as a whitespace-separated
   argv, for testing uninstalled builds.
-- Launching the locker is the only trigger Otto implements; anything else that
-  wants to lock (an idle daemon, a suspend hook) runs the same command.
+- `lock.auto_lock_timeout` locks the session after that many seconds without
+  keyboard, pointer, touch or tablet input. `0`, the default, never locks on its
+  own. Every input event counts as activity, whatever the compositor goes on to
+  do with it; what a client does with the event does not.
+- A client holding an `idle-inhibit-unstable-v1` inhibitor (a video player, a
+  presentation) holds auto-lock off and restarts the countdown, so it runs from
+  when playback stops rather than from the last keypress. Inhibitors are honored
+  only while their surface is alive and its window is not minimized — the
+  protocol leaves that to the compositor because clients forget to drop them,
+  and a stale one would disable locking for the session.
+- The check runs on the timer's tick, so an inhibitor released just after a tick
+  delays the lock by up to one further timeout.
+- Auto-lock takes the same path as the action: it launches the locker, which
+  asks for the lock. Because launching is not locking yet, the idle clock is
+  reset when the locker is launched, so a slow-starting locker is not launched
+  twice.
+- Auto-lock is off in login mode: the greeter *is* the screen, and there is no
+  session behind it to hide.
+- Launching the locker is the only mechanism; anything else that wants to lock
+  (a suspend hook, an external idle daemon) runs the same command.
 
 ### The locker
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -495,6 +495,8 @@ pub struct PowerManagementConfig {
     ///   "auto" - Normal laptop: disable screen, then suspend via logind —
     ///     unless an external monitor is connected or a remote client (RDP
     ///     bridge / screenshare) is actively consuming frames
+    ///   "lock" - Like "auto", but lock the session first, the way
+    ///     `on_power_button = "lock"` does, so the machine wakes to the locker
     ///   "disable_internal_screen" - Always disable screen but stay running,
     ///     never suspend (for display managers/kiosks)
     #[serde(default = "default_on_lid_close")]
@@ -515,6 +517,10 @@ pub enum LidCloseAction {
     /// external monitor is connected or a remote session is active
     #[default]
     Auto,
+    /// [`LidCloseAction::Auto`] plus a session lock, so the machine wakes to
+    /// the locker. Skipped in the same cases the suspend is: a clamshell or
+    /// remote session is still in use, and stays unlocked
+    Lock,
     /// Always disable screen but keep running, never suspend (for display
     /// managers/kiosks)
     DisableInternalScreen,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -392,6 +392,12 @@ pub struct LockConfig {
     pub locker_command: String,
     /// Arguments passed to `locker_command`.
     pub locker_args: Vec<String>,
+    /// Lock the session after this many seconds with no input from the user.
+    /// `0` (the default) never locks on its own.
+    ///
+    /// A client holding an `idle-inhibit-unstable-v1` inhibitor — a video
+    /// player, a presentation — holds the lock off while it plays.
+    pub auto_lock_timeout: u64,
 }
 
 impl Default for LockConfig {
@@ -399,6 +405,7 @@ impl Default for LockConfig {
         Self {
             locker_command: "otto-lock".to_string(),
             locker_args: Vec::new(),
+            auto_lock_timeout: 0,
         }
     }
 }

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -121,6 +121,14 @@ impl<BackendData: Backend> Otto<BackendData> {
     /// Update the focus on the topmost surface under the cursor in the current workspace
     /// The window is raised and the keyboard focus is set to the window.
     pub(crate) fn focus_window_under_cursor(&mut self, serial: Serial) {
+        // A locked session has one keyboard focus, and the locker owns it. The
+        // desktop is still there under the lock surface, so without this a click
+        // anywhere on the lock screen would hand focus to whatever happens to be
+        // beneath the cursor — and the password typed next would go there.
+        if self.is_session_locked() {
+            return;
+        }
+
         let keyboard = self.seat.get_keyboard().unwrap();
         let input_method = self.seat.input_method();
 

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -31,6 +31,9 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
         event: InputEvent<B>,
         output_name: &str,
     ) {
+        // Every event, whatever it turns into: auto-lock measures idleness
+        // from the last one (`lock.auto_lock_timeout`).
+        self.note_input_activity();
         match event {
             InputEvent::Keyboard { event } => match self.keyboard_key_to_action::<B>(event) {
                 KeyAction::ScaleUp => {
@@ -204,6 +207,9 @@ impl Otto<UdevData> {
         dh: &DisplayHandle,
         event: InputEvent<B>,
     ) {
+        // Every event, whatever it turns into: auto-lock measures idleness
+        // from the last one (`lock.auto_lock_timeout`).
+        self.note_input_activity();
         match event {
             InputEvent::Keyboard { event, .. } => match self.keyboard_key_to_action::<B>(event) {
                 #[cfg(feature = "udev")]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -301,7 +301,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             .workspaces
             .outputs()
             .filter_map(|output| {
-                let geometry = self.workspaces.output_geometry(&output)?;
+                let geometry = self.workspaces.output_geometry(output)?;
                 let scale = output.current_scale().fractional_scale() as f32;
                 Some((
                     output.name(),

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -133,7 +133,105 @@ pub fn locker_command() -> (String, Vec<String>) {
     crate::config::Config::with(|c| (c.lock.locker_command.clone(), c.lock.locker_args.clone()))
 }
 
-impl<BackendData: Backend> Otto<BackendData> {
+impl<BackendData: Backend + 'static> Otto<BackendData> {
+    /// Note that the user did something. Auto-lock measures from the last such
+    /// moment, so every input path has to call this — a session that only ever
+    /// sees mouse motion is not idle.
+    pub fn note_input_activity(&mut self) {
+        self.lock_last_activity = std::time::Instant::now();
+    }
+
+    /// Start the timer that locks the session after
+    /// [`crate::config::LockConfig::auto_lock_timeout`] seconds without input.
+    ///
+    /// Nothing is scheduled when the setting is off — config is read once at
+    /// startup, so a session that starts without auto-locking never gets it —
+    /// and each tick is scheduled from the time left rather than at a fixed
+    /// rate, so an idle session wakes once per timeout instead of once a second.
+    pub fn start_auto_lock_timer(handle: &smithay::reexports::calloop::LoopHandle<'static, Self>) {
+        use smithay::reexports::calloop::timer::{TimeoutAction, Timer};
+
+        let timeout = crate::config::Config::with(|c| c.lock.auto_lock_timeout);
+        if timeout == 0 {
+            return;
+        }
+        // In login mode the greeter *is* the screen: there is no session behind
+        // it to hide, and the locker would authenticate a user who has not
+        // logged in yet.
+        if crate::login::is_login_mode() {
+            return;
+        }
+        let timeout = std::time::Duration::from_secs(timeout);
+
+        if handle
+            .insert_source(Timer::from_duration(timeout), move |_, _, data| {
+                // A client asking not to be considered idle (a video playing)
+                // both holds the lock off and restarts the clock, so the
+                // countdown runs from when it stops, not from the last time
+                // the user touched anything.
+                if data.idle_inhibited() {
+                    debug!("Auto-lock held off by an idle inhibitor");
+                    data.note_input_activity();
+                    return TimeoutAction::ToDuration(timeout);
+                }
+                let idle_for = data.lock_last_activity.elapsed();
+                let left = timeout.saturating_sub(idle_for);
+                if left.is_zero() {
+                    data.auto_lock_now(timeout);
+                    return TimeoutAction::ToDuration(timeout);
+                }
+                TimeoutAction::ToDuration(left)
+            })
+            .is_err()
+        {
+            warn!("failed to schedule the auto-lock timer; auto-locking is off");
+        } else {
+            info!(idle_secs = timeout.as_secs(), "Auto-lock armed");
+        }
+    }
+
+    /// Whether a client is asking for the session not to be considered idle
+    /// (`idle-inhibit-unstable-v1`) — a video playing, a presentation.
+    ///
+    /// An inhibitor only counts while its surface is on screen. The protocol
+    /// leaves that to the compositor precisely because clients forget to drop
+    /// them: a dead or minimized window holding one would block auto-lock for
+    /// the rest of the session.
+    pub fn idle_inhibited(&self) -> bool {
+        self.idle_inhibitors.iter().any(|surface| {
+            if !surface.alive() {
+                return false;
+            }
+            // Inhibitors are usually taken on a subsurface (the video area),
+            // so a surface with no window of its own is one whose toplevel we
+            // can't check — count it rather than silently ignore it.
+            match self
+                .workspaces
+                .get_window_for_surface(&surface.id())
+                .map(|w| w.is_minimised())
+            {
+                Some(minimized) => !minimized,
+                None => true,
+            }
+        })
+    }
+
+    /// Lock the session because it has been idle for `timeout`.
+    fn auto_lock_now(&mut self, timeout: std::time::Duration) {
+        if self.is_session_locked() {
+            return;
+        }
+        let (cmd, args) = locker_command();
+        info!(locker = %cmd, idle_secs = timeout.as_secs(), "Auto-locking idle session");
+        // Same path as the `lock` action: launching the locker is what locks —
+        // it binds `ext_session_lock_manager_v1` and asks for the lock itself.
+        self.launch_program(cmd, args);
+        // Launching is not locking yet; the locker takes a moment to come up.
+        // Without this the next tick — still idle, still unlocked — would
+        // launch a second one.
+        self.note_input_activity();
+    }
+
     /// Whether the session is locked, or locking.
     pub fn is_session_locked(&self) -> bool {
         self.lock_state.is_active()

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fmt::Debug,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -190,6 +190,9 @@ pub struct Otto<BackendData: Backend + 'static> {
     /// but the shade is still on screen until this passes and the frame has to
     /// be composited as a whole to carry it — see `Otto::lock_blank_on_screen`.
     pub lock_shade_until: Option<std::time::Instant>,
+    /// When the user last did anything. Auto-lock (`lock.auto_lock_timeout`)
+    /// measures idleness from here — see `Otto::note_input_activity`.
+    pub lock_last_activity: std::time::Instant,
     pub workspaces: Workspaces,
 
     // smithay state
@@ -197,6 +200,12 @@ pub struct Otto<BackendData: Backend + 'static> {
     pub data_device_state: DataDeviceState,
     pub layer_shell_state: WlrLayerShellState,
     pub session_lock_manager_state: smithay::wayland::session_lock::SessionLockManagerState,
+    #[allow(dead_code)]
+    pub idle_inhibit_manager_state: smithay::wayland::idle_inhibit::IdleInhibitManagerState,
+    /// Surfaces holding an `idle-inhibit-unstable-v1` inhibitor — a client
+    /// saying "don't consider the session idle" (a video playing, a
+    /// presentation). Consulted by auto-lock; see `Otto::idle_inhibited`.
+    pub idle_inhibitors: HashSet<WlSurface>,
     pub output_manager_state: OutputManagerState,
     pub primary_selection_state: PrimarySelectionState,
     pub data_control_state: DataControlState,
@@ -461,6 +470,19 @@ delegate_viewporter!(@<BackendData: Backend + 'static> Otto<BackendData>);
 delegate_xdg_shell!(@<BackendData: Backend + 'static> Otto<BackendData>);
 delegate_layer_shell!(@<BackendData: Backend + 'static> Otto<BackendData>);
 smithay::delegate_session_lock!(@<BackendData: Backend + 'static> Otto<BackendData>);
+smithay::delegate_idle_inhibit!(@<BackendData: Backend + 'static> Otto<BackendData>);
+
+impl<BackendData: Backend + 'static> smithay::wayland::idle_inhibit::IdleInhibitHandler
+    for Otto<BackendData>
+{
+    fn inhibit(&mut self, surface: WlSurface) {
+        self.idle_inhibitors.insert(surface);
+    }
+
+    fn uninhibit(&mut self, surface: WlSurface) {
+        self.idle_inhibitors.remove(&surface);
+    }
+}
 delegate_presentation!(@<BackendData: Backend + 'static> Otto<BackendData>);
 delegate_xdg_foreign!(@<BackendData: Backend + 'static> Otto<BackendData>);
 
@@ -601,6 +623,8 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
         let session_lock_manager_state =
             smithay::wayland::session_lock::SessionLockManagerState::new::<Self, _>(&dh, |_| true);
+        let idle_inhibit_manager_state =
+            smithay::wayland::idle_inhibit::IdleInhibitManagerState::new::<Self>(&dh);
         let output_manager_state = OutputManagerState::new_with_xdg_output::<Self>(&dh);
         let primary_selection_state = PrimarySelectionState::new::<Self>(&dh);
         let data_control_state =
@@ -725,6 +749,9 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         #[cfg(feature = "debugger")]
         layers_engine.start_debugger();
 
+        // No-op unless `lock.auto_lock_timeout` is set.
+        Self::start_auto_lock_timer(&handle);
+
         // Get backend name before moving backend_data
         #[cfg(feature = "metrics")]
         let backend_name = backend_data.backend_name();
@@ -746,12 +773,15 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             data_device_state,
             layer_shell_state,
             session_lock_manager_state,
+            idle_inhibit_manager_state,
+            idle_inhibitors: HashSet::new(),
             lock_state: crate::lock::LockState::Unlocked,
             lock_surfaces: Default::default(),
             lock_previous_focus: None,
             lock_locker_seen: false,
             lock_last_spawn: None,
             lock_shade_until: None,
+            lock_last_activity: std::time::Instant::now(),
             output_manager_state,
             primary_selection_state,
             data_control_state,

--- a/src/udev/backdrop.rs
+++ b/src/udev/backdrop.rs
@@ -294,10 +294,17 @@ pub(super) fn update_backdrop_and_upper_planes(
                         bs.context.flush_and_submit();
                         let bg_small = bs.surface.image_snapshot();
                         // Pre-blur so expose seeds it and skips its own blur.
+                        // The raw copy goes along too: the hover label sits on
+                        // top of the window previews painted in this same pass
+                        // and carries `blur_include_content`, so it seeds the
+                        // raw image and blurs the preview underneath in.
                         match blur_image(&bg_small, &mut bs.context, BACKDROP_BLUR_SIGMA) {
-                            Some(blurred) => {
-                                expose.set_backdrop(Some((blurred, BACKDROP_SCALE, true, None)))
-                            }
+                            Some(blurred) => expose.set_backdrop(Some((
+                                blurred,
+                                BACKDROP_SCALE,
+                                true,
+                                Some(bg_small),
+                            ))),
                             None => {
                                 expose.set_backdrop(Some((bg_small, BACKDROP_SCALE, false, None)))
                             }

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -868,7 +868,7 @@ impl Otto<UdevData> {
 
         // Determine if we should disable laptop panels based on lid state and config
         let disable_laptop_panels = match lid_action {
-            LidCloseAction::Auto => {
+            LidCloseAction::Auto | LidCloseAction::Lock => {
                 // Normal laptop behavior: only disable if lid is closed
                 self.is_lid_closed
             }
@@ -999,18 +999,13 @@ impl Otto<UdevData> {
             self.connector_connected(node, connector, crtc);
         }
 
-        // Lid closed on a plain laptop ("auto" mode, no external monitor):
-        // Otto owns the suspend decision — logind's lid handling is expected
-        // to be `ignore` so we can gate it. Skip while a remote client is
+        // Lid closed on a plain laptop (no external monitor): the session is
+        // out of reach, so Otto acts on it. Skip while a remote client is
         // consuming frames (RDP bridge / screenshare), so closing the lid
-        // during a remote session keeps serving instead of going to sleep.
-        // Edge-triggered on the panel teardown so a repeated call (or a
-        // wake-up with the lid still closed) doesn't immediately re-suspend.
-        if suspended_any_panel
-            && self.is_lid_closed
-            && matches!(lid_action, LidCloseAction::Auto)
-            && !has_external_monitor
-        {
+        // during a remote session keeps serving instead of locking or going to
+        // sleep. Edge-triggered on the panel teardown so a repeated call (or a
+        // wake-up with the lid still closed) doesn't immediately re-act.
+        if suspended_any_panel && self.is_lid_closed && !has_external_monitor {
             let screenshare_active = !self.screenshare_sessions.is_empty();
             let remote_streaming = self
                 .virtual_outputs
@@ -1021,9 +1016,23 @@ impl Otto<UdevData> {
                 tracing::info!(
                     screenshare_active,
                     remote_streaming,
-                    "Lid closed - NOT suspending, remote session active"
+                    "Lid closed - NOT acting, remote session active"
                 );
-            } else {
+                return;
+            }
+
+            // Lock first, so the blank is what the session comes back to. Same
+            // path as the power button's `lock`: launching the locker is what
+            // locks — it asks for the lock itself. See `src/lock.rs`.
+            if matches!(lid_action, LidCloseAction::Lock) && !self.is_session_locked() {
+                let (cmd, args) = crate::lock::locker_command();
+                tracing::info!(locker = %cmd, "Lid closed - locking session");
+                self.launch_program(cmd, args);
+            }
+
+            // Otto owns the suspend decision — logind's lid handling is
+            // expected to be `ignore` so we can gate it.
+            if matches!(lid_action, LidCloseAction::Auto | LidCloseAction::Lock) {
                 tracing::info!("Lid closed - suspending via logind (systemctl suspend)");
                 if let Err(err) = std::process::Command::new("systemctl")
                     .arg("suspend")

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -362,7 +362,7 @@ pub fn run_udev() {
                 let extent = data
                     .workspaces
                     .outputs()
-                    .filter_map(|output| data.workspaces.output_geometry(&output))
+                    .filter_map(|output| data.workspaces.output_geometry(output))
                     .fold(
                         None::<smithay::utils::Rectangle<i32, smithay::utils::Logical>>,
                         |acc, geo| {

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -971,7 +971,7 @@ impl Otto<UdevData> {
             expose_active,
             fullscreen_window.as_ref(),
             switcher_active,
-            chrome_output && !self.workspaces.dock.is_hidden(),
+            chrome_output && !self.workspaces.dock.is_hidden_for_render(),
             overlay_active,
             {
                 // The windows plane must stay up while a workspace switch is

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -387,6 +387,21 @@ impl DockView {
     pub fn is_autohide_enabled(&self) -> bool {
         self.dock_config.read().unwrap().autohide
     }
+    /// Whether the dock still has to be composited this frame.
+    ///
+    /// `is_hidden()` flips as soon as a hide is *scheduled*, which is the right
+    /// signal for input (the hot zone must arm immediately) but the wrong one
+    /// for rendering: gating the dock plane on it drops the dock from the frame
+    /// before its slide-out has run, so it appears to vanish instead of sliding
+    /// away. The autohide slide-out ends by setting `hidden` on the layer, so
+    /// that flag is the accurate "nothing left to draw" signal.
+    pub fn is_hidden_for_render(&self) -> bool {
+        if self.is_autohide_enabled() {
+            self.view_layer.hidden()
+        } else {
+            self.is_hidden()
+        }
+    }
     pub fn set_active_flag(&self, active: bool) {
         self.active
             .store(active, std::sync::atomic::Ordering::Relaxed);

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1535,8 +1535,11 @@ impl Workspaces {
         let current_workspace_index = self.get_current_workspace_index();
         let is_current_workspace = workspace_index == current_workspace_index;
 
-        // Hide popup overlay when entering expose mode
-        self.popup_overlay.set_hidden(is_gesture_ongoing);
+        // Popups belong to the normal desktop: keep them hidden for the whole
+        // expose lifetime (gesture, open/close animation and while expose is
+        // open). The on_finish below restores them once expose is fully closed.
+        self.popup_overlay
+            .set_hidden(is_gesture_ongoing || show_expose);
         let scale = Config::with(|c| c.screen_scale);
 
         let offset_y = 200.0;
@@ -1703,6 +1706,7 @@ impl Workspaces {
             let show_all_gesture_ref = self.show_all_gesture.clone();
             let expose_gesture_active_ref = self.expose_gesture_active.clone();
             let expose_dragged_window_ref = self.expose_dragged_window.clone();
+            let popup_overlay_layer = self.popup_overlay.layer.clone();
             let model_ref = self.model.clone();
 
             // Collect secondary output expose layers to sync with primary
@@ -1811,6 +1815,8 @@ impl Workspaces {
                         for el in &secondary_expose_layers {
                             el.set_hidden(!show_all);
                         }
+                        // Popups only come back once expose is fully closed.
+                        popup_overlay_layer.set_hidden(show_all);
                         // workspace_selector_view stays visible (positioned off-screen when closed)
                         // Restore workspace content layers when closing expose
                         for wl in &all_workspaces_layers {

--- a/src/workspaces/window_selector.rs
+++ b/src/workspaces/window_selector.rs
@@ -157,6 +157,17 @@ impl WindowSelectorView {
         );
         view.mount_layer(window_selector_view.clone());
 
+        // The hover label floats above the window previews, which are painted
+        // earlier in the SAME plane pass. Seeding the plane's pre-blurred
+        // backdrop would put the (bg-only) blur behind those previews, so the
+        // label reads as a flat panel with no vibrancy. Opt into the raw
+        // backdrop plus a real blur so the preview underneath is blurred in.
+        view.add_post_render_hook(|_state, view, _layer| {
+            if let Some(label) = view.layer_by_key("window_selector_label") {
+                label.set_blur_include_content(true);
+            }
+        });
+
         let window_selector_windows_container = layers_engine.new_layer();
         window_selector_windows_container
             .set_key(format!("window_selector_windows_container_{}", index));


### PR DESCRIPTION
**Stack 6/6** — base: `feat/session-lock-greeter`

## Summary

Finishes the lock/greeter work and packages it, plus a few shell fixes.

### Lock

- Lock the session after an idle timeout.
- Keyboard focus stays on the lock surface — previously it could leak to the
  session underneath.
- Report *why* `systemctl` refused a power action instead of failing silently.
- New `"lock"` action for `on_lid_close`, alongside `auto` and
  `disable_internal_screen`.

### Packaging

Ship `otto-lock`, `otto-greeter` and `otto-rdp` in the packaging manifests.

### Shell fixes

- Dock stays drawn through its autohide slide-out instead of disappearing mid-animation.
- Expose keeps popups hidden for its whole lifetime, and blurs window previews under
  the hover label.

## Test plan

- [ ] `cargo build` / `cargo clippy --features "default" -- -D warnings`
- [ ] Idle past the lock timeout, confirm the session locks and unlocks
- [ ] Type into the lock screen with a window focused underneath — no key leakage
- [ ] Trigger a power action that logind refuses, confirm the reason is reported
- [ ] `on_lid_close = "lock"`: close and reopen the lid
- [ ] Dock autohide slide-out; enter/leave expose with a popup open
- [ ] Install from the packaging manifest and confirm all three binaries land
