### PR TITLE
doc: add user guide covering the desktop and its features

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Testing and issue reports are welcome. Development follows a draft roadmap of pl
 - **Multi-monitor:** per-output rendering, workspaces, fullscreen, Exposé and workspace selector; hotplug, display arrangement and modes from the config, and virtual outputs created on demand.
 - **Dock (task manager):** shows running apps, minimized windows and pinned/bookmarked apps, bounces an icon while a launch is in progress.
 - **App switcher** (default: `Ctrl+Tab`): searches app metadata/icons (XDG), can close apps, cycles between windows of the same app, appears on the monitor under the pointer.
-- **Exposé / overview** (default: `PageDown`, gesture: three-finger swipe up): shows all windows, shows window previews with names, includes “show desktop”.
+- **Exposé / overview** (default: `PageUp`, gesture: three-finger swipe up): shows all windows, shows window previews with names; “show desktop” is a separate action (default: `PageDown`, gesture: four-finger pinch out).
 - **Topbar:** clock, system tray, and application menus exported over DBusMenu.
-- **Dynamic island:** notifications, ongoing activities, and system UI (brightness, volume, keyboard backlight) in a floating panel.
+- **Dynamic island:** a `org.freedesktop.Notifications` daemon, ongoing activities pushed over D-Bus, and permission dialogs, in a floating panel. Volume and brightness changes show a separate compositor-drawn indicator.
 - **Session lock:** `ext-session-lock-v1` locking with a PAM-backed locker (`otto-lock`), lock on `Ctrl+Alt+Escape`, on the power button, on lid close, or after an idle timeout — respecting `idle-inhibit` clients.
 - **Login greeter:** `otto --login` hosts a login screen (`otto-greeter`) against greetd, with password and fingerprint prompts.
 - **Power management:** Otto-owned lid-close suspend with clamshell and remote-session awareness, configurable power-button and lid actions.
@@ -70,7 +70,7 @@ Testing and issue reports are welcome. Development follows a draft roadmap of pl
 > **Note on KMS scanout:** on the tty-udev backend, Otto puts parts of the desktop on their own hardware planes instead of compositing everything into one buffer, keeping the number of overlapping planes small to limit GPU work. This has mostly been tested on Intel GPUs. Other drivers are expected to fall back to full composition when the atomic test rejects a plane configuration, but that path is untested — if you see missing, misplaced or flickering elements on AMD or NVIDIA, this is the first thing to suspect, and a report is welcome. See [docs/developer/drm_plane.md](./docs/developer/drm_plane.md).
 
 ### Still to come
- - **Screen capture:** per-window capture and screenshots.
+ - **Screen capture:** per-window capture, and a built-in screenshot UI (whole-output and region capture already work through `wlr-screencopy`, e.g. with `grim`).
  - **Multi-monitor:** display mirroring.
  - **Dock improvements:** favorite locations; move Dock code out of compositor core.
  - **Input polish:** scroll acceleration.
@@ -250,7 +250,7 @@ You can create backend-specific configuration files for development using the na
 
 Backend-specific configs have the highest priority and override all other configuration files. This allows you to maintain different display settings, keyboard shortcuts, or other preferences for each backend. For instance, you might want different `screen_scale` values when running in a window (winit/X11) versus on bare metal (tty-udev).
 
-For detailed configuration options, see the [configuration documentation](./docs/user/configuration.md).
+For detailed configuration options, see the [configuration documentation](./docs/user/configuration.md), and the [User Guide](./docs/user/README.md) for everything else — window management, workspaces, gestures, the dock and top bar, screen sharing, remote desktop, locking and login.
 
 ### Keyboard Shortcuts
 Hotkeys are now fully configurable via the `otto_config.toml` file. See the `[keyboard_shortcuts]` section to customize keybindings for your setup. Example:

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,56 @@
+# Otto User Guide
+
+Otto is a Wayland compositor and desktop system with a Skia-rendered,
+animation-first interface. This guide covers everything you can do with it as a
+user: what the desktop is made of, how to drive it, and how to configure it.
+
+If you are installing Otto for the first time, start with
+[Getting Started](getting-started.md), then take the
+[Desktop Tour](desktop-tour.md).
+
+## Using the desktop
+
+| Page | What it covers |
+|------|----------------|
+| [Getting Started](getting-started.md) | Installing, launching, backends, first-run checklist |
+| [Desktop Tour](desktop-tour.md) | Every element on screen and what it does |
+| [Window Management](window-management.md) | Move, resize, maximize, minimize, tile, fullscreen, placement |
+| [Workspaces](workspaces.md) | Multiple workspaces, per-monitor workspaces, moving windows |
+| [Exposé & App Switcher](expose-and-switcher.md) | Overview of all windows, switching between apps |
+| [Dock](dock.md) | Running apps, minimized windows, bookmarks, autohide, magnification |
+| [Top Bar](topbar.md) | Clock, system tray, global application menus |
+| [Dynamic Island](dynamic-island.md) | Notifications, live activities, system HUD, permission dialogs |
+| [Keyboard Shortcuts](keyboard-shortcuts.md) | Binding syntax and the complete action list |
+| [Touchpad Gestures](gestures.md) | Three-finger swipes, four-finger pinch |
+
+## Configuring Otto
+
+| Page | What it covers |
+|------|----------------|
+| [Configuration](configuration.md) | Where config files live and how they merge |
+| [Display](display.md) | Scaling, monitor arrangement, modes, virtual outputs, panels |
+| [Theming](theming.md) | Light/dark, accent color, fonts, wallpaper, cursors, icons |
+| [Input](input.md) | Keyboard layout and repeat, touchpad, pointer acceleration |
+| [Audio](audio.md) | UI sound effects and sound themes |
+| [Power Management](power-management.md) | Lid close, power button, suspend, clamshell |
+| [Night Shift](night-shift.md) | Color temperature and brightness |
+| [Autostart](autostart.md) | `exec_once`, XDG autostart, systemd integration |
+| [Clipboard](clipboard.md) | Clipboard persistence and history managers |
+
+## Sessions and remote access
+
+| Page | What it covers |
+|------|----------------|
+| [Lock Screen](lock-screen.md) | Locking, idle auto-lock, fingerprint unlock, PAM setup |
+| [Login Greeter](login-greeter.md) | Using Otto as the login screen with greetd |
+| [Screen Sharing](screen-sharing.md) | Portal setup, browsers, OBS, AirPlay, screenshots |
+| [Remote Desktop](remote-desktop.md) | `otto-rdp`, virtual outputs, connecting from RDP clients |
+
+## Getting help
+
+| Page | What it covers |
+|------|----------------|
+| [Troubleshooting](troubleshooting.md) | Logs, common failures, and how to report a bug |
+
+Questions and feedback are welcome in the Matrix room
+[`#otto-compositor:matrix.org`](https://matrix.to/#/#otto-compositor:matrix.org).

--- a/docs/user/audio.md
+++ b/docs/user/audio.md
@@ -1,0 +1,110 @@
+# Audio
+
+Otto handles two audio concerns: **volume control** from the media keys, and
+**UI sound effects** for feedback.
+
+It is not an audio server — PipeWire or PulseAudio does the actual mixing. Otto
+talks to whichever you run.
+
+## Volume keys
+
+```toml
+[keyboard_shortcuts]
+"XF86AudioRaiseVolume" = "VolumeUp"
+"XF86AudioLowerVolume" = "VolumeDown"
+"XF86AudioMute"        = "VolumeMute"
+```
+
+Volume moves in 5% steps. Each change shows an on-screen indicator and, if sound
+feedback is on, plays a short click so you can hear where the level is.
+
+## Media keys
+
+```toml
+"XF86AudioPlay" = "MediaPlayPause"
+"XF86AudioNext" = "MediaNext"
+"XF86AudioPrev" = "MediaPrev"
+"XF86AudioStop" = "MediaStop"
+```
+
+These control whichever media player is registered on MPRIS — Spotify, VLC,
+mpv with the MPRIS script, browsers playing video. No configuration needed;
+Otto talks to the active player.
+
+## Sound effects
+
+```toml
+[audio]
+sound_enabled = true
+sound_theme = "freedesktop"
+```
+
+`sound_enabled = false` turns off all UI feedback sounds.
+
+### Sound themes
+
+`sound_theme` names an XDG sound theme, following the
+[freedesktop Sound Theme specification](https://specifications.freedesktop.org/sound-theme-spec/latest/).
+Sounds are looked up at:
+
+```
+/usr/share/sounds/{theme}/stereo/{event}.oga
+```
+
+Commonly available themes: `freedesktop`, `Pop`, `ocean`. See what you have:
+
+```sh
+ls /usr/share/sounds/
+```
+
+Comment `sound_theme` out and Otto auto-detects an installed theme.
+
+### Custom sounds
+
+Drop your own files in Otto's `resources/` directory to override the theme:
+
+```
+resources/audio-volume-change.oga
+```
+
+Custom files take precedence over the theme's version of the same event.
+
+## Choosing an output device
+
+Otto has no audio device picker. Use your audio server's tools:
+
+```sh
+pavucontrol          # graphical, works with PipeWire and PulseAudio
+wpctl status         # list PipeWire devices
+wpctl set-default 42 # make node 42 the default sink
+```
+
+`pavucontrol` in the system tray is the usual setup — see
+[Top Bar](topbar.md).
+
+## Audio over remote sessions
+
+Neither [screen sharing](screen-sharing.md) nor the
+[RDP bridge](remote-desktop.md) carries audio. They are video-only. Route audio
+separately if you need it — for instance with a PipeWire network sink.
+
+## Troubleshooting
+
+**Volume keys do nothing.** Check they are bound: not every keyboard produces
+`XF86AudioRaiseVolume`. Run `wev` or `./scripts/show-keys.sh` and press the key
+to see what it actually emits, then bind that keysym.
+
+**Volume changes but nothing gets louder.** Otto is adjusting a different sink
+from the one playing. Check `wpctl status` for which sink is default.
+
+**No feedback sound.** Confirm `sound_enabled = true`, that the theme is
+installed (`ls /usr/share/sounds/`), and that the file for the event exists in
+the theme's `stereo/` directory. Many themes are incomplete.
+
+**Media keys do nothing.** The player must expose MPRIS. Check with:
+
+```sh
+busctl --user list | grep mpris
+```
+
+Some players need a plugin (mpv) or a setting (Spotify's `--enable-mpris`).

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -43,16 +43,22 @@ $EDITOR ~/.config/otto/config.toml
 
 | Topic | Description |
 |-------|-------------|
-| [Display](display.md) | Scaling, display profiles, layer shell zones |
+| [Display](display.md) | Scaling, display profiles, monitor arrangement, virtual outputs, layer shell zones |
 | [Theming](theming.md) | Theme scheme, accent color, fonts, background, cursors, icons |
-| [Input](input.md) | Keyboard repeat, touchpad, pointer acceleration |
-| [Keyboard Shortcuts](keyboard-shortcuts.md) | Key remapping, shortcut bindings, available actions |
+| [Input](input.md) | Keyboard layout and repeat, touchpad, pointer acceleration |
+| [Keyboard Shortcuts](keyboard-shortcuts.md) | Binding syntax and the complete action list |
 | [Dock](dock.md) | Dock appearance, bookmarks, autohide, magnification |
+| [Top Bar](topbar.md) | Clock format, tray, global menus (`topbar.toml`) |
 | [Audio](audio.md) | Sound effects and sound themes |
-| [Power Management](power-management.md) | Lid switch behavior |
+| [Power Management](power-management.md) | Lid switch, power button, suspend, clamshell |
+| [Lock Screen](lock-screen.md) | Locker command, idle auto-lock, PAM setup |
+| [Login Greeter](login-greeter.md) | `--login` mode and the greeter command |
 | [Night Shift](night-shift.md) | Color temperature and brightness control |
 | [Autostart](autostart.md) | exec_once, XDG autostart, systemd integration |
 | [Clipboard](clipboard.md) | Clipboard persistence and managers |
+
+For everything else — how to *use* the desktop rather than configure it — start
+from the [User Guide index](README.md).
 
 ## Tips
 
@@ -75,10 +81,14 @@ $EDITOR ~/.config/otto/config.toml
 - Some themes may require additional packages.
 
 **Keyboard shortcuts not working:**
-- Modifier names are `Logo`, `Ctrl`, `Alt`, `Shift` (case-sensitive).
-- Some shortcuts may conflict with system bindings.
+- Modifiers are `Ctrl`, `Alt`, `Shift` and `Logo` (aliases accepted, case-insensitive).
+- An unparsable trigger or action is **skipped with a warning**, not an error —
+  grep the log for `skipping shortcut`.
+- Some shortcuts may conflict with an application's shortcut inhibitor.
 
 **Touchpad settings ignored:**
 - Settings only apply to touchpad devices, not mice.
 - Some hardware may not support all features.
 - Check `libinput` capabilities for your device.
+
+For a fuller list, see [Troubleshooting](troubleshooting.md).

--- a/docs/user/desktop-tour.md
+++ b/docs/user/desktop-tour.md
@@ -1,0 +1,134 @@
+# Desktop Tour
+
+A guided walk through everything Otto puts on screen, and what each piece is for.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Firefox  File  Edit  View      ( O o )        🔊 🔋  Mar 23, 21:16   │  ← Top bar + Dynamic island
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│      ┌────────────────────┐        ┌───────────────────┐             │
+│      │                    │        │                   │             │
+│      │      window        │        │      window       │             │  ← Workspace
+│      │                    │        │                   │             │
+│      └────────────────────┘        └───────────────────┘             │
+│                                                                      │
+│                                                                      │
+│              ╭──────────────────────────────────────╮                │
+│              │  🦊  📁  🎵  │  ▫ ▫ ▫                │                │  ← Dock
+│              ╰──────────────────────────────────────╯                │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## The Dock
+
+The bar at the bottom edge. It is part of the compositor, not a separate app.
+
+It holds three groups, left to right: **bookmarked launchers** (apps you pinned
+in the config), **running applications**, and **minimized windows**.
+
+- A running app carries a small dot under its icon.
+- Icons magnify as the pointer approaches, macOS-style.
+- Hovering an icon shows its name in a balloon tooltip.
+- Clicking a running app raises and focuses it; clicking again cycles through
+  that app's windows. Clicking a bookmark launches it, or focuses the existing
+  instance.
+- An icon **bounces** while a launch is in progress, so you know the click
+  registered before the window appears.
+- Clicking a minimized window restores it with the genie animation.
+
+The dock can auto-hide, and its size and magnification are configurable — see
+[Dock](dock.md).
+
+## The Top Bar (`otto-bar`)
+
+A full-width panel pinned to the top edge of the primary monitor, with frosted
+glass blur and rounded bottom corners. Three zones:
+
+- **Left** — the focused application's name, followed by its global menu
+  (File, Edit, View …) when the app exports one over DBusMenu. Click a title to
+  drop the menu down; arrow keys navigate, Enter activates, Escape closes.
+- **Center** — deliberately empty. This is where the dynamic island lives.
+- **Right** — system tray icons (StatusNotifierItem) and the clock.
+
+Tray icons respond to left-click (context menu), right-click (activate, usually
+raising the app's window) and middle-click (secondary activate). Hovering shows
+a tooltip.
+
+The bar is a normal Wayland client. Start it from `exec_once`. See
+[Top Bar](topbar.md).
+
+## The Dynamic Island (`otto-islands`)
+
+The floating pill at the top-center. At rest it is two circles — a large "O"
+and a small "o" — echoing the Otto logo. It grows and morphs to carry:
+
+- **Notifications**, grouped by application. Otto Islands is a full
+  `org.freedesktop.Notifications` daemon, so ordinary desktop notifications
+  land here.
+- **Live activities** — anything a program submits over D-Bus: a running build,
+  a download with a progress bar, now-playing music.
+- **System HUD** — brightness, volume and keyboard-backlight changes appear
+  here rather than as a separate overlay.
+- **Permission dialogs** — the screen-sharing consent prompt and output pickers
+  render as an interactive island panel.
+
+Click a mini circle to focus it into a pill; click the pill to expand the stack
+of notification cards beneath it. See [Dynamic Island](dynamic-island.md).
+
+## Windows
+
+Otto is a **stacking** window manager, not a tiling one. Windows are freely
+positioned and overlap.
+
+New windows are placed where they overlap existing windows the least, rather
+than cascading from the corner. Maximize and fullscreen are animated; minimize
+uses a genie effect that sucks the window into its dock icon.
+
+Otto always asks applications to draw their own decorations (client-side), so
+title bars and window buttons come from the app's own toolkit. See
+[Window Management](window-management.md).
+
+## Workspaces
+
+Each monitor has its own independent set of workspaces. Switching is animated —
+the whole workspace slides horizontally. Drive it with `Ctrl+1`…`Ctrl+4`, or a
+three-finger horizontal swipe.
+
+## Exposé
+
+Press `PageUp` (or swipe up with three fingers) and every window on the current
+workspace scales down into a packed grid, each labeled with its title. Hover to
+highlight, click to focus, or drag a preview onto a workspace thumbnail to move
+the window there.
+
+Above the grid sits the **workspace selector**: a strip of live workspace
+previews with a `+` button to add a workspace and an `×` on hover to remove one.
+The strip follows you to whichever monitor the pointer is on.
+
+`PageDown` runs **show desktop** instead, pushing all windows off-screen to
+reveal the wallpaper.
+
+## The App Switcher
+
+`Ctrl+Tab` brings up a horizontal panel of running applications with icons,
+names and a blurred backdrop. Hold `Ctrl` and tap `Tab` to walk forward,
+`Ctrl+Shift+Tab` to walk back, `` Ctrl+` `` to cycle windows within the
+highlighted app, and `Ctrl+Q` to quit it. Release `Ctrl` to commit.
+
+The panel appears on whichever monitor the pointer is on. See
+[Exposé & App Switcher](expose-and-switcher.md).
+
+## The Lock Screen
+
+`Ctrl+Alt+Escape`, the power button, closing the lid, or an idle timeout hides
+the session behind `otto-lock`: a centered authentication panel that accepts
+your password or a registered fingerprint. The session underneath is untouched
+and comes back exactly as you left it. See [Lock Screen](lock-screen.md).
+
+## What is *not* on screen
+
+Some things Otto deliberately does not have yet: a settings GUI (everything is
+TOML), a window list or workspace switcher in the top bar (that is the dock's
+and exposé's job), and per-monitor docks or top bars (both are
+primary-monitor-only for now).

--- a/docs/user/display.md
+++ b/docs/user/display.md
@@ -1,0 +1,207 @@
+# Display
+
+Scaling, monitor arrangement, resolutions, virtual outputs and panel zones.
+
+## Finding your monitors
+
+```sh
+otto --probe
+```
+
+This prints every connector Otto can see with its available resolutions and
+refresh rates, then exits. Use the connector names it reports (`eDP-1`,
+`HDMI-A-1`, `DP-2`, …) in the config below.
+
+## Scaling
+
+```toml
+screen_scale = 1.0
+```
+
+The global scale factor: `1.0` for a standard-DPI display, `2.0` for HiDPI,
+and fractional values in between (`1.25`, `1.5`) for the awkward middle ground.
+Otto implements `wp-fractional-scale-v1`, so well-behaved clients render crisply
+at fractional scales instead of being upscaled.
+
+To change the scale of a single monitor while the session runs, put the pointer
+on it and use the `ScaleUp` / `ScaleDown`
+[shortcut actions](keyboard-shortcuts.md). That change is not saved — use a
+display profile for a permanent setting.
+
+X11 applications get the scale via XSETTINGS, so they size correctly under
+XWayland.
+
+## Display profiles
+
+A profile pins a monitor's resolution, refresh rate and position. There are two
+kinds: **named** (matched by connector name) and **generic** (matched by a
+pattern).
+
+### Named profiles
+
+```toml
+[displays.named."eDP-1"]
+primary = true
+resolution = { width = 2256, height = 1504 }
+refresh_hz = 60.0
+position = { x = 0, y = 0 }
+
+[displays.named."DP-1"]
+resolution = { width = 3840, height = 2160 }
+refresh_hz = 144.0
+position = { x = 2256, y = 0 }
+```
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Optional friendly label |
+| `primary` | Mark this monitor as primary — where the dock and top bar go |
+| `resolution` | Mode to set, in pixels |
+| `refresh_hz` | Refresh rate; combined with `resolution` to pick a mode |
+| `position` | Where the monitor sits in the desktop layout, in logical points |
+
+Every field is optional. Omit `resolution` and Otto picks the preferred mode.
+
+The key is the connector name. `"winit"` is a valid key for the windowed
+development backend:
+
+```toml
+[displays.named."winit"]
+resolution = { width = 1280, height = 1000 }
+refresh_hz = 60.0
+```
+
+### Generic profiles
+
+Match by connector prefix instead of exact name — handy for "any HDMI monitor I
+plug in":
+
+```toml
+[[displays.generic]]
+match = { connector_prefix = "HDMI" }
+resolution = { width = 1920, height = 1080 }
+refresh_hz = 60.0
+position = { x = 1920, y = 0 }
+```
+
+Named profiles take precedence over generic ones.
+
+## Monitor arrangement
+
+Monitors are arranged in a **single horizontal row**. Vertical stacking and grid
+arrangements are not supported.
+
+Without a configured `position`, the first monitor sits at the origin and each
+one after it is placed immediately to the right of everything already placed.
+
+A configured `position` is honoured **as long as it does not overlap** another
+monitor's area. An overlapping position is rejected and that monitor falls back
+to automatic left-to-right placement — monitors are never allowed to overlap.
+
+Positions are recomputed from scratch whenever anything changes: a hotplug, a
+mode change, or waking from suspend. This keeps the layout consistent instead of
+drifting.
+
+### Hotplug
+
+Plugging in a monitor adds it to the right of the existing row and gives it its
+own set of [workspaces](workspaces.md). Unplugging removes it; windows on it
+move to a remaining monitor.
+
+The dock, top bar and dynamic island all live on the primary monitor.
+
+## Primary monitor
+
+The primary monitor is the first physical output brought up, unless a display
+profile sets `primary = true`.
+
+It matters because the dock, the top bar and the dynamic island are shown there
+and only there.
+
+## Virtual outputs
+
+A virtual output is a monitor with no physical display behind it. Otto renders
+it like any other screen and pushes the frames to a PipeWire stream, where any
+PipeWire client can pick them up — OBS, a recorder, or the
+[RDP bridge](remote-desktop.md).
+
+```toml
+[[virtual_outputs]]
+name = "virtual-1"
+resolution = { width = 1920, height = 1080 }
+refresh_hz = 60.0
+position = { x = 3840, y = 0 }   # optional
+interactive = false
+```
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Output name, used to address it from clients |
+| `resolution` | Size in pixels |
+| `refresh_hz` | Frame rate; defaults to 60 |
+| `position` | Where it sits in the layout; follows the same overlap rule as physical monitors |
+| `interactive` | Accept remote pointer and keyboard input aimed at this output |
+
+Set `interactive = true` for a screen you intend to control remotely (RDP). Leave
+it `false` for a view-only feed (recording, AirPlay).
+
+Otto logs the PipeWire node id at startup:
+
+```
+Virtual output 'virtual-1' started (PipeWire node 42)
+```
+
+Connect to it with any PipeWire client:
+
+```sh
+gst-launch-1.0 pipewiresrc path=42 ! videoconvert ! autovideosink
+```
+
+A virtual output behaves exactly like a physical one: its own workspaces, its
+own exposé, its own workspace selector. Windows can be dragged onto it.
+
+> If a virtual output has no configured `position` it defaults to the same
+> origin as the first monitor, which overlaps it. Give it an explicit position
+> to the right of your real screens.
+
+## Panels and exclusive zones
+
+Layer-shell clients — the top bar, docks, notification daemons — can reserve
+space along a screen edge so maximized windows do not slide underneath. Otto
+caps how much any one client may claim:
+
+```toml
+[layer_shell]
+max_top = 100       # logical points
+max_bottom = 100
+max_left = 50
+max_right = 50
+```
+
+`0` means unlimited. These values are in logical points and are multiplied by
+the scale factor internally. Raise them if you run a tall custom panel that
+looks clipped.
+
+## Screen rotation
+
+`RotateOutput` (bind it in `[keyboard_shortcuts]`) rotates the monitor under the
+pointer by 90°. Like the scale actions, this affects the live session only and
+is not written to the config. There is no rotation field in display profiles yet.
+
+## Wallpaper
+
+Wallpaper and background colour are global rather than per-monitor. See
+[Theming](theming.md).
+
+## Night shift
+
+Colour temperature is handled by external tools over
+`zwlr-gamma-control-v1`. See [Night Shift](night-shift.md).
+
+## Not yet supported
+
+- Display mirroring
+- Vertical or grid monitor arrangement
+- Rotation and scale in display profiles
+- A graphical display settings panel
+- Per-monitor wallpaper

--- a/docs/user/dock.md
+++ b/docs/user/dock.md
@@ -1,0 +1,122 @@
+# Dock
+
+The dock is Otto's task manager, pinned to the bottom edge of the primary
+monitor. Unlike the top bar and the dynamic island, it is part of the
+compositor — there is nothing to start.
+
+## What it shows
+
+Three groups, left to right:
+
+1. **Bookmarks** — launchers you pinned in the config.
+2. **Running applications** — one icon each, with a dot underneath.
+3. **Minimized windows** — a thumbnail per minimized window, in a drawer that
+   opens when the first one arrives.
+
+Icons and names come from the application's `.desktop` entry, loaded in the
+background so a slow icon theme never stalls the compositor.
+
+## Interacting
+
+| Action | Effect |
+|--------|--------|
+| Hover an icon | Balloon tooltip with the app's name; icons magnify |
+| Click a running app | Raise and focus it |
+| Click it again | Cycle to that app's next window |
+| Click a bookmark | Focus the running instance, or launch it |
+| Click a minimized window | Restore it with the genie animation |
+
+While a launch is in flight the icon **bounces**, so you know the click landed
+before the window shows up.
+
+The dock takes pointer priority over windows underneath it, so clicks near the
+bottom edge always reach the dock rather than the window behind.
+
+## Bookmarks
+
+```toml
+[dock]
+bookmarks = [
+  { desktop_id = "org.gnome.Nautilus.desktop" },
+  { desktop_id = "org.mozilla.firefox.desktop", label = "Web", exec_args = ["--private-window"] },
+  { desktop_id = "org.gnome.Terminal.desktop" },
+]
+```
+
+| Field | Meaning |
+|-------|---------|
+| `desktop_id` | The `.desktop` file name. Required. |
+| `label` | Override the tooltip text. Optional. |
+| `exec_args` | Extra arguments appended to the entry's `Exec` line. Optional. |
+
+Find desktop ids with `ls /usr/share/applications ~/.local/share/applications`.
+
+Bookmarks behave exactly like running apps once launched — same icon, same
+hover, same window cycling.
+
+There is no way to pin an app by dragging it into the dock yet; bookmarks are
+config-only.
+
+## Appearance and behaviour
+
+```toml
+[dock]
+size = 1.0             # overall size multiplier, 0.5 – 2.0
+magnification = true   # macOS-style icon magnification on hover
+autohide = false       # hide when the pointer leaves
+genie_scale = 0.5      # shape of the minimize animation
+genie_span = 10.0      # and how far it reaches
+```
+
+### Size
+
+`size` scales the whole dock. `0.5` is half-height, `2.0` is double. Icon sizes,
+padding and the bar height all follow.
+
+### Magnification
+
+Icons grow as the pointer approaches, with a Gaussian falloff — the icon under
+the pointer is largest and neighbours taper off. `genie_scale` and `genie_span`
+control the intensity and reach of the curve.
+
+Set `magnification = false` for a flat dock with no hover scaling.
+
+### Auto-hide
+
+With `autohide = true` the dock slides away when the pointer leaves and comes
+back when the pointer enters the hot zone along the bottom edge of the screen.
+
+### Icon colorization
+
+```toml
+[dock]
+colorize_icons = true
+colorize_color = "#ffffff"
+colorize_intensity = 1.0
+```
+
+Tints every dock icon toward a single colour — a monochrome dock. `intensity`
+blends between the original icon (`0.0`) and the flat tint (`1.0`).
+
+## Visuals
+
+The dock bar uses background blur and picks its colours from the active theme,
+so it follows your light/dark setting. See [Theming](theming.md).
+
+It hides automatically when a window goes fullscreen, and when exposé opens.
+
+## Multi-monitor
+
+The dock lives on the **primary monitor only**. A per-monitor dock is not
+implemented.
+
+The primary monitor is the first physical output brought up, or whichever
+display profile sets `primary = true` — see [Display](display.md).
+
+## Not yet supported
+
+- Pinning by drag-and-drop
+- Right-click context menus on dock icons
+- Bookmarked folders and locations
+- Moving the dock to another screen edge
+- A per-monitor dock

--- a/docs/user/dynamic-island.md
+++ b/docs/user/dynamic-island.md
@@ -1,0 +1,160 @@
+# Dynamic Island
+
+`otto-islands` is the floating pill at the top-centre of the screen. It is
+Otto's notification centre, live-activity display and permission-dialog surface,
+all in one morphing element.
+
+It is a separate program. Start it from your config:
+
+```toml
+[[exec_once]]
+cmd = "otto-islands"
+```
+
+## At rest
+
+With nothing to show, the island is two circles side by side — a large `O` and a
+small `o`, echoing the Otto logo — sitting in the empty centre of the
+[top bar](topbar.md).
+
+## Notifications
+
+Otto Islands implements the standard `org.freedesktop.Notifications` D-Bus
+service, so it is a drop-in notification daemon: anything that sends a desktop
+notification (`notify-send`, your mail client, a build script) shows up here.
+
+Run only one notification daemon at a time — starting `otto-islands` alongside
+`dunst` or `mako` means whichever claims the bus name first wins and the other
+silently does nothing.
+
+Try it:
+
+```sh
+notify-send "Build finished" "42 tests passed"
+```
+
+### Grouping and modes
+
+All notifications from the same application are grouped into **one island**.
+Each island has three presentations:
+
+| Mode | Looks like | How to get there |
+|------|------------|------------------|
+| **Mini** | Small circle with the app icon and a count badge | Default for unfocused islands |
+| **Compact** | A pill with icon, app name, count and a chevron | Click a mini circle |
+| **Expanded** | The pill, with the notification cards stacked below it | Click the compact pill |
+
+Clicking cycles **Mini → Compact → Expanded → Compact**. Only one island can be
+compact or expanded at a time; focusing one shrinks the previous back to a mini
+circle.
+
+Multiple islands sit as a centred horizontal row, oldest on the left.
+
+Hovering any island grows it slightly — an invitation, not a mode change.
+
+### Actions
+
+Notifications carrying actions render them as buttons on the card. Clicking one
+sends the standard `ActionInvoked` signal back to the sending application.
+
+## Live activities
+
+Beyond notifications, any program can push an **activity** into the island over
+D-Bus — a long-running thing with a title, an icon, and optionally a progress
+bar. A build, a file transfer, a backup, the currently playing track.
+
+The interface is `org.otto.Island1` at `/org/otto/Island`:
+
+```sh
+# Create an activity; prints the activity id
+gdbus call --session \
+  --dest org.otto.Island \
+  --object-path /org/otto/Island \
+  --method org.otto.Island1.CreateActivity \
+  "my-script" "Syncing photos" "folder-download" 0.0 0 "normal" true
+```
+
+| Argument | Meaning |
+|----------|---------|
+| `app_id` | Who is sending it |
+| `title` | The text shown |
+| `icon` | An icon name from your theme |
+| `progress` | `0.0`–`1.0` for a progress bar; negative for none |
+| `timeout_ms` | Auto-dismiss after this long; `0` to stay |
+| `priority` | `"low"`, `"normal"`, `"high"` or `"critical"` |
+| `live` | `true` if it updates continuously — the island shows an animated indicator |
+
+Then update or dismiss it by id:
+
+```sh
+gdbus call --session --dest org.otto.Island \
+  --object-path /org/otto/Island \
+  --method org.otto.Island1.UpdateActivity 1 "Syncing photos (40%)" 0.4
+
+gdbus call --session --dest org.otto.Island \
+  --object-path /org/otto/Island \
+  --method org.otto.Island1.DismissActivity 1
+```
+
+`UpdateActivity` takes an empty title to leave the text unchanged, and a
+negative progress to clear the bar.
+
+This makes the island a general-purpose status surface for your own scripts.
+
+## Permission dialogs
+
+When an application asks to share your screen, the request surfaces as an
+interactive island panel: what is being requested, by whom, and a list of things
+to pick from (which monitor to share, which AirPlay receiver to send to).
+
+This is brokered by the portal and rendered by `otto-islands` over the
+`org.otto.Dialog1` interface, which mirrors the freedesktop
+`org.freedesktop.impl.portal.Access` contract. See
+[Screen Sharing](screen-sharing.md).
+
+If `otto-islands` is not running there is nothing to render the dialog, and the
+request resolves to a safe default — denied — rather than hanging.
+
+## Volume and brightness
+
+Volume and screen brightness changes show a **separate on-screen indicator**
+drawn by the compositor itself, not by the island. Pressing
+`XF86AudioRaiseVolume` or `XF86MonBrightnessUp` adjusts the level, shows the
+indicator, and (for volume) plays a feedback sound if
+[audio feedback](audio.md) is enabled.
+
+Volume steps by 5% per press.
+
+## Visuals
+
+The island is drawn with the `otto-surface-style-unstable-v1` protocol rather
+than as a flat picture: each element is its own surface whose size, position,
+corner radius, blur, shadow and colour are animated by the **compositor** using
+springs. That is why it morphs between shapes fluidly instead of cross-fading —
+the geometry itself is animated, and the content is drawn once at the target
+size and revealed as the shape grows.
+
+## Troubleshooting
+
+**Nothing appears when I send a notification.** Check that `otto-islands` owns
+the bus name:
+
+```sh
+busctl --user status org.freedesktop.Notifications
+```
+
+If another daemon holds it, stop that one first.
+
+**The island is behind my top bar, or in the wrong place.** It anchors to the
+top-centre as an overlay layer surface, assuming a bar around 30 points tall. A
+much taller custom panel will overlap it.
+
+**Screen sharing hangs or is instantly denied.** `otto-islands` is what renders
+the consent dialog — make sure it is running.
+
+## Not yet supported
+
+- A notification history or "do not disturb" mode
+- Persisting notifications across restarts
+- Configuration file (position, size, timeouts are fixed)
+- Multi-monitor: the island shows on the primary monitor only

--- a/docs/user/expose-and-switcher.md
+++ b/docs/user/expose-and-switcher.md
@@ -1,0 +1,135 @@
+# Exposé & App Switcher
+
+Two ways to find a window: see them all at once (Exposé), or step through
+applications (App Switcher).
+
+---
+
+## Exposé
+
+Exposé scales every window on the current workspace down into a packed grid, so
+you can see all of them at once.
+
+### Opening and closing
+
+| How | Effect |
+|-----|--------|
+| `PageUp` (`Prior`) | Toggle exposé |
+| Three-finger swipe **up** | Open, tracking your fingers |
+| Three-finger swipe **down** | Close |
+| `Escape`, or click empty space | Close |
+
+The gesture is continuous: the windows shrink and spread in step with your
+fingers, so you can peek at the grid and swipe back down to abandon it. On
+release, Otto springs open or closed depending on how far you got and how fast
+you were moving.
+
+Exposé opens on **every monitor at once**, each showing its own current
+workspace.
+
+### The grid
+
+Windows are packed into a flowing grid that preserves each window's aspect
+ratio. Nothing is ever scaled *up* — a small window stays small rather than
+being blown up to fill a cell.
+
+- **Hover** a preview to highlight it with the accent colour and show its title.
+- **Click** a preview to focus that window and close exposé. If the window
+  lives on a different workspace or monitor, that screen scrolls to it.
+- **Drag** a preview onto a workspace thumbnail in the selector strip above to
+  move the window there. See [Workspaces](workspaces.md).
+
+Minimized windows are not shown.
+
+Previews are **live**, not screenshots — a playing video keeps playing in its
+preview.
+
+### The workspace selector
+
+While exposé is open, a strip of live workspace previews sits above the grid,
+with a `+` to add a workspace and an `×` on hover to remove one. Each monitor
+gets its own strip showing only its own workspaces. See
+[Workspaces](workspaces.md).
+
+### Show desktop
+
+A separate mode: `PageDown` (`Next`), or a **four-finger pinch out**, slides all
+windows off toward the edges of the screen to reveal the wallpaper. Press again,
+or pinch in, to bring them back.
+
+This is not the same as exposé — the windows move aside rather than scaling into
+a grid, and there is no selector strip.
+
+---
+
+## App Switcher
+
+A horizontal panel of running applications with icons, names and a blurred
+backdrop.
+
+### Using it
+
+| Keys | Effect |
+|------|--------|
+| `Ctrl+Tab` | Open the switcher / move to the next app |
+| `Ctrl+Shift+Tab` | Move to the previous app |
+| `` Ctrl+` `` (`Ctrl+grave`) | Cycle windows within the highlighted app |
+| `Ctrl+Q` | Quit the highlighted app |
+| Release `Ctrl` | Commit — focus the highlighted app |
+
+The switcher stays up as long as you **hold the modifier** that opened it. Any
+of `Ctrl`, `Alt`, `Logo` or `Shift` works as the hold key, depending on what you
+bound the action to; release it and the switcher commits and disappears.
+
+Applications are ordered most-recently-used first, so a single `Ctrl+Tab` press
+and release flips between the last two apps.
+
+### Which monitor it appears on
+
+By default the switcher appears on the monitor **under the pointer**. To pin it
+to the primary monitor instead:
+
+```toml
+[appswitcher]
+follow_cursor = false
+```
+
+The panel is sized from its host monitor's own resolution and scale, so it looks
+right on a screen of a different size. Once it is on screen it stays put — it
+will not hop to another monitor mid-cycle however far the pointer moves.
+
+It lists windows from **every** monitor. Selecting one focuses it wherever it
+lives, which may not be the screen showing the switcher.
+
+### Rebinding
+
+```toml
+[keyboard_shortcuts]
+"Alt+Tab"                 = "ApplicationSwitchNext"
+"Alt+Shift+ISO_Left_Tab"  = "ApplicationSwitchPrev"
+"Alt+grave"               = "ApplicationSwitchNextWindow"
+"Alt+F4"                  = "ApplicationSwitchQuit"
+```
+
+Note `ISO_Left_Tab` for the shifted variant — `Shift+Tab` produces that keysym,
+not `Tab`. See [Keyboard Shortcuts](keyboard-shortcuts.md).
+
+---
+
+## The Dock as a switcher
+
+The [Dock](dock.md) does the same job with the pointer: click a running app's
+icon to raise it, click again to cycle through that app's windows.
+
+## Troubleshooting
+
+**Exposé previews are frozen or blank.** This is a bug worth reporting — grab
+`RUST_LOG=debug` output and note whether the window was fullscreen just before.
+
+**The switcher opens on the wrong screen.** It resolves the monitor from the
+last confirmed pointer position. If you drive Otto entirely from the keyboard,
+the pointer may be somewhere you forgot; set `follow_cursor = false` to pin it.
+
+**`Ctrl+Q` quit my app by accident.** That is the shipped binding for
+`ApplicationSwitchQuit` and only fires while the switcher is up — but it is easy
+to hit. Rebind or remove it if it bites.

--- a/docs/user/gestures.md
+++ b/docs/user/gestures.md
@@ -1,0 +1,115 @@
+# Touchpad Gestures
+
+Otto's gestures are driven by libinput and work on any multi-touch touchpad.
+They are not configurable yet — the mappings below are fixed.
+
+## Three-finger swipe
+
+A three-finger swipe does one of two things, decided by direction:
+
+| Direction | Effect |
+|-----------|--------|
+| Horizontal (left / right) | Switch workspaces |
+| Vertical (up / down) | Open / close [Exposé](expose-and-switcher.md) |
+
+Otto does not commit to either the moment you touch down. It accumulates the
+movement and waits until you have travelled about 20 pixels in one direction,
+then picks whichever axis has moved further. This means a slightly diagonal
+swipe still does what you meant, and small stray movements never trigger
+anything.
+
+Once the direction is decided, it holds for the rest of the gesture — you cannot
+turn a workspace swipe into an exposé by changing direction mid-way.
+
+### Workspace switching
+
+The workspaces track your fingers continuously: the whole desktop slides
+horizontally as you move, so you can see the next workspace coming and back out
+by reversing.
+
+When you lift your fingers, Otto snaps to the nearest workspace using the
+**velocity** of the last part of the gesture, not just the final position. A
+quick flick carries you to the next workspace even if you barely moved; a slow
+drag that stops short springs back.
+
+Swiping past the first or last workspace has no wraparound.
+
+### Exposé
+
+Swiping **up** opens the exposé grid; the windows scale down and spread out in
+step with your fingers, so you can peek at the grid and abandon it by swiping
+back down. Lifting your fingers snaps open or closed based on how far you got,
+with a spring animation carrying the momentum.
+
+Swiping **down** from the open state closes it again.
+
+While exposé is up, the [workspace selector](workspaces.md) strip appears above
+the grid, and the dock hides.
+
+## Four-finger pinch
+
+| Gesture | Effect |
+|---------|--------|
+| Pinch **out** (spread) | Show desktop — windows slide away to the edges |
+| Pinch **in** (close) | Bring the windows back |
+
+Like the swipes, this tracks your fingers rather than firing at a threshold, so
+you can pinch part-way to peek at the desktop and release to snap back.
+
+The four-finger pinch is ignored while a three-finger swipe is in progress, and
+while exposé is open — the two modes do not stack.
+
+## Two-finger scroll
+
+Two-finger scrolling is ordinary scroll input forwarded to whatever is under
+the pointer. Natural (reversed) scrolling is on by default and configurable, as
+are speed and acceleration — see [Input](input.md).
+
+## Tap and click
+
+Tap-to-click is on by default:
+
+| Fingers | Button |
+|---------|--------|
+| 1 | Left |
+| 2 | Right |
+| 3 | Middle |
+
+Physical clicks use the `clickfinger` method by default — the same mapping,
+using how many fingers rest on the pad rather than where you click. Switch to
+`buttonareas` (bottom-right corner = right click) in the config if you prefer.
+
+Tap-and-drag is enabled; drag lock is not. Otto also disables the touchpad while
+you type by default. All of this is configurable — see [Input](input.md).
+
+## Keyboard equivalents
+
+Every gesture has a keyboard action, so gestures are never the only route:
+
+| Gesture | Action |
+|---------|--------|
+| Three-finger swipe left/right | `Workspace` with an index |
+| Three-finger swipe up | `ExposeShowAll` |
+| Four-finger pinch out | `ExposeShowDesktop` |
+
+See [Keyboard Shortcuts](keyboard-shortcuts.md).
+
+## Touchscreen
+
+Touch input is supported for ordinary interaction — tap, drag, and window
+move/resize requests from clients. The gestures above are touchpad-only.
+
+## Troubleshooting
+
+**Gestures do nothing.** Confirm libinput sees your touchpad as a multi-touch
+device: `libinput list-devices` should report gesture support. Gestures do not
+work on the `--winit` backend, where the host compositor consumes them.
+
+**Swipes feel over- or under-sensitive.** The 20-pixel direction threshold and
+the momentum model are not configurable yet. `scroll_speed` and
+`pointer_accel_speed` in `[input]` affect scrolling and pointer motion, not
+gestures.
+
+**A swipe switched workspaces when I meant exposé.** Start the swipe with a
+more deliberate vertical movement — the axis with the larger accumulated delta
+at the 20-pixel mark wins.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,139 @@
+# Getting Started
+
+## Installing
+
+Pre-built packages are published on the
+[GitHub Releases](https://github.com/nongio/otto/releases) page.
+
+### Debian / Ubuntu
+
+```sh
+sudo dpkg -i otto_*.deb
+sudo apt-get install -f   # pull in any missing dependencies
+```
+
+### Fedora / RHEL
+
+```sh
+sudo dnf install otto-*.rpm
+```
+
+### Arch Linux
+
+```sh
+curl -O https://raw.githubusercontent.com/nongio/otto/main/PKGBUILD
+makepkg -si
+```
+
+If you already downloaded the release tarball, drop the `PKGBUILD` next to it
+and `makepkg` will use it without re-downloading.
+
+### Building from source
+
+```sh
+git clone https://github.com/nongio/otto
+cd otto
+cargo build --release
+```
+
+You need `libwayland`, `libxkbcommon`, `libudev`, `libinput`, `libgbm` and
+[`libseat`](https://git.sr.ht/~kennylevinsen/seatd). Add `xwayland` if you want
+to run X11 applications. Minimum supported Rust version is 1.85.0.
+
+## What gets installed
+
+| Binary | Role |
+|--------|------|
+| `otto` | The compositor itself |
+| `otto-bar` | [Top bar](topbar.md) — clock, tray, application menus |
+| `otto-islands` | [Dynamic island](dynamic-island.md) — notifications, activities, dialogs |
+| `otto-lock` | [Screen locker](lock-screen.md) |
+| `otto-greeter` | [Login screen](login-greeter.md) client for greetd |
+| `otto-rdp` | [Remote desktop](remote-desktop.md) bridge |
+| `xdg-desktop-portal-otto` | [Screen sharing](screen-sharing.md) portal backend |
+
+Packages also install `/etc/otto/config.toml` (a copy of
+`otto_config.example.toml`), a `wayland-sessions` entry so Otto appears in your
+display manager, the portal service files, and — on Arch and Fedora — the PAM
+service for `otto-lock`.
+
+## Launching
+
+After installing, "Otto" appears in the session list of GDM, SDDM, LightDM and
+friends. Pick it and log in.
+
+To start it by hand:
+
+```sh
+otto                # auto-detects the backend
+```
+
+Otto chooses `--winit` when it finds an existing Wayland or X11 session
+(it runs as a window, which is what you want for development), and `--tty-udev`
+when started from a bare TTY.
+
+### Backends
+
+| Flag | Use |
+|------|-----|
+| `--tty-udev` | Bare metal: DRM/KMS + libinput. The real session. Needs logind/seatd, or root. |
+| `--winit` | Runs as a window inside another Wayland or X11 session. Best for trying Otto out. |
+| `--x11` | Runs as an X11 client. Basic and not actively maintained. |
+| `--headless` | No display output; used by the test harness. |
+
+### Other flags
+
+| Flag | Effect |
+|------|--------|
+| `--login` | Run as a greeter host — see [Login Greeter](login-greeter.md) |
+| `--probe` | Print the connectors, resolutions and refresh rates Otto can see, then exit |
+| `--systemd-notify` | Send `READY=1` and activate `graphical-session.target` (for `Type=notify` user units) |
+| `--version`, `--help` | As expected |
+
+`--login` and `--systemd-notify` are orthogonal to the backend flag and can be
+combined with it.
+
+Use `--probe` first if you are writing display profiles — it tells you the exact
+connector names (`eDP-1`, `HDMI-A-1`, …) and modes to put in your config.
+
+## First-run checklist
+
+Otto ships lean: the top bar and the dynamic island are separate programs, and
+nothing is started for you unless you ask. A useful starting configuration in
+`~/.config/otto/config.toml`:
+
+```toml
+[[exec_once]]
+cmd = "otto-bar"
+
+[[exec_once]]
+cmd = "otto-islands"
+```
+
+See [Autostart](autostart.md) for XDG autostart and systemd integration.
+
+Then, in rough order of how much you will miss them:
+
+1. **Keyboard shortcuts** — the shipped `/etc/otto/config.toml` defines them.
+   If you write your own config from scratch, Otto starts with *no* bindings at
+   all. See [Keyboard Shortcuts](keyboard-shortcuts.md).
+2. **Screen sharing** — needs `xdg-desktop-portal` installed and a
+   `portals.conf` pointing at Otto. See [Screen Sharing](screen-sharing.md).
+3. **Screen locking** — needs `/etc/pam.d/otto-lock`. Debian and Ubuntu users
+   must install it manually. See [Lock Screen](lock-screen.md).
+4. **Lid and power button** — Otto handles these itself, which requires
+   `HandleLidSwitch=ignore` and `HandlePowerKey=ignore` in `logind.conf`.
+   See [Power Management](power-management.md).
+5. **Clipboard persistence** — Wayland loses clipboard contents when the source
+   app exits. See [Clipboard](clipboard.md).
+
+## Quitting
+
+`Logo+Q` and `Ctrl+Alt+Backspace` always quit Otto. These two are wired into the
+compositor ahead of the config file and cannot be rebound or removed, so there
+is always a way out of a session whose config is broken.
+
+## Where to go next
+
+Take the [Desktop Tour](desktop-tour.md) to learn what everything on screen is,
+then [Configuration](configuration.md) to start making it yours.

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -1,0 +1,178 @@
+# Input
+
+Keyboard layout and repeat, touchpad behaviour, pointer acceleration and
+scrolling. Everything here lives under `[input]` except the two keyboard-repeat
+keys, which are top-level.
+
+## Keyboard layout
+
+```toml
+[input]
+xkb_layout = "us"
+xkb_variant = "dvorak"
+xkb_options = ["caps:escape"]
+```
+
+These are standard XKB settings — the same names `setxkbmap` uses.
+
+### Multiple layouts
+
+```toml
+[input]
+xkb_layout = "us,ru"
+xkb_options = ["grp:win_space_toggle", "caps:escape"]
+```
+
+`grp:win_space_toggle` binds `Logo+Space` to cycle layouts. Other common
+switchers: `grp:alt_shift_toggle`, `grp:caps_toggle`, `grp:win_space_toggle`.
+
+### Useful options
+
+| Option | Effect |
+|--------|--------|
+| `caps:escape` | Caps Lock becomes Escape |
+| `caps:swapescape` | Swap Caps Lock and Escape |
+| `ctrl:swapcaps` | Swap Ctrl and Caps Lock |
+| `ctrl:nocaps` | Caps Lock becomes another Ctrl |
+| `altwin:ctrl_win` | Super becomes Ctrl (Mac-like) |
+| `compose:ralt` | Right Alt is the Compose key, for accented characters |
+| `terminate:ctrl_alt_bksp` | Ctrl+Alt+Backspace terminates — already built in |
+
+Discover what is available:
+
+```sh
+xkbcli list                    # every layout, variant and option
+man xkeyboard-config           # the full reference
+./scripts/show-keys.sh         # print the keysym for whatever you press
+```
+
+Layout changes apply at startup. Edit and restart the session to change them.
+
+## Key repeat
+
+```toml
+keyboard_repeat_delay = 300    # ms before repeat starts
+keyboard_repeat_rate = 30      # repeats per second
+```
+
+These are top-level keys, not inside `[input]`. Otto sends them to clients over
+`wl_keyboard`, so applications repeat at the rate you set.
+
+## Touchpad
+
+```toml
+[input]
+tap_enabled = true
+tap_drag_enabled = true
+tap_drag_lock_enabled = false
+touchpad_click_method = "clickfinger"
+touchpad_dwt_enabled = true
+touchpad_natural_scroll_enabled = true
+touchpad_left_handed = false
+touchpad_middle_emulation_enabled = false
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `tap_enabled` | `true` | Tap to click: 1 finger = left, 2 = right, 3 = middle |
+| `tap_drag_enabled` | `true` | Tap, hold, then drag |
+| `tap_drag_lock_enabled` | `false` | Keep dragging after lifting your finger briefly |
+| `touchpad_click_method` | `"clickfinger"` | How a physical click maps to a button — see below |
+| `touchpad_dwt_enabled` | `true` | Disable the touchpad while typing |
+| `touchpad_natural_scroll_enabled` | `true` | Reversed ("natural") two-finger scrolling |
+| `touchpad_left_handed` | `false` | Swap left and right buttons |
+| `touchpad_middle_emulation_enabled` | `false` | Left + right pressed together = middle click |
+
+### Click method
+
+| Value | Behaviour |
+|-------|-----------|
+| `"clickfinger"` | The number of fingers on the pad decides: 1 = left, 2 = right, 3 = middle |
+| `"buttonareas"` | Traditional: where you click decides — bottom-right corner = right click |
+
+`clickfinger` is the default and matches how macOS behaves. `buttonareas` is
+what most Windows laptops do.
+
+These settings apply to **touchpads only**, not to mice. Some hardware does not
+support every option; libinput ignores what it cannot do.
+
+## Pointer
+
+```toml
+[input]
+pointer_accel_speed = 0.0        # -1.0 (slowest) to 1.0 (fastest)
+pointer_accel_profile = "adaptive"
+scroll_speed = 1.0
+```
+
+`pointer_accel_speed` and `pointer_accel_profile` apply to **all** pointing
+devices — mice and touchpads alike.
+
+| Profile | Behaviour |
+|---------|-----------|
+| `"adaptive"` | Speed depends on how fast you move — the usual desktop feel |
+| `"flat"` | No acceleration; 1:1 movement, which gamers usually want |
+
+`scroll_speed` is a software multiplier applied to scroll events. `1.0` leaves
+them alone, `2.0` doubles them, `0.5` halves them. Use it when a mouse wheel's
+notches move too far.
+
+Scroll *acceleration* (speed varying with how fast you spin the wheel) is not
+implemented.
+
+## Touchscreen
+
+Touch input works for ordinary interaction — tap, drag, and window move and
+resize requests from applications. There are no touchscreen gestures; the
+[gestures](gestures.md) documented for Otto are touchpad-only.
+
+## Tablets
+
+Otto implements the tablet protocol (`wp-tablet-v2`), so drawing tablets with
+pressure and tilt work in applications that support them. There are no
+tablet-specific settings — mapping and pressure curves come from the
+application.
+
+## Input methods and virtual devices
+
+Otto implements the protocols an input-method framework needs, so IBus, fcitx5
+and similar work for CJK and other complex input: `text-input`, `input-method`
+and `virtual-keyboard`.
+
+`zwlr-virtual-pointer-v1` is also implemented, which is what tools like
+`wtype`, `ydotool` and the [RDP bridge](remote-desktop.md) use to synthesize
+input.
+
+## Shortcut inhibition
+
+Applications can ask Otto to suspend its keyboard shortcuts while they are
+focused, via `keyboard-shortcuts-inhibit`. Remote-desktop viewers, virtual
+machines and terminal multiplexers use this so keys like `Ctrl+Tab` reach the
+guest rather than being eaten by Otto.
+
+The always-on keys (`Logo+Q`, `Ctrl+Alt+Backspace`, VT switching,
+`Ctrl+Alt+Escape`, the power button) are never inhibited. See
+[Keyboard Shortcuts](keyboard-shortcuts.md#always-on-keys).
+
+## Troubleshooting
+
+**Touchpad settings are ignored.** They apply to touchpads only. Confirm
+libinput classifies your device as one:
+
+```sh
+libinput list-devices
+```
+
+Check the `Tap-to-click` and `Click methods` lines — a device that reports
+`n/a` for a capability cannot do it.
+
+**The layout does not change.** Layout is applied at startup. Restart the
+session. A typo in `xkb_layout` leaves you on the previous layout with a warning
+in the log.
+
+**Keys produce the wrong characters.** Check `xkb_variant` — many layouts
+(`dvorak`, `colemak`, `intl`) are variants of a base layout, not layouts in
+their own right.
+
+**A shortcut does nothing in one app but works elsewhere.** That app has
+probably taken a shortcuts inhibitor. That is intentional.

--- a/docs/user/keyboard-shortcuts.md
+++ b/docs/user/keyboard-shortcuts.md
@@ -1,0 +1,259 @@
+# Keyboard Shortcuts
+
+Every shortcut in Otto is defined in your config file, under
+`[keyboard_shortcuts]`. There are no built-in bindings apart from two escape
+hatches (see [Always-on keys](#always-on-keys) below) — if your config has no
+`[keyboard_shortcuts]` table, Otto starts with no shortcuts at all.
+
+The shipped `/etc/otto/config.toml` (a copy of `otto_config.example.toml`)
+defines a full set. Those are the "defaults" referred to throughout this guide.
+
+## Binding syntax
+
+Each entry maps a **trigger** on the left to an **action** on the right:
+
+```toml
+[keyboard_shortcuts]
+"Ctrl+Esc"          = "Quit"
+"Ctrl+Return"       = { run = { cmd = "terminator", args = [] } }
+"Logo+B"            = { open_default = "browser" }
+"Ctrl+1"            = { builtin = "Workspace", index = 0 }
+```
+
+### Triggers
+
+A trigger is zero or more modifiers followed by a key, joined by `+`:
+
+```
+Ctrl+Shift+Q
+Logo+Space
+XF86AudioMute
+```
+
+**Modifiers** (case-insensitive, with aliases):
+
+| Modifier | Also accepted as |
+|----------|------------------|
+| `Ctrl` | `Control`, `Primary` |
+| `Alt` | — |
+| `Shift` | — |
+| `Logo` | `Super`, `Meta`, `Win`, `Command` |
+
+**Keys** are XKB keysym names. Letters are case-insensitive (`W` and `w` bind
+the same physical key — use `Shift+W` if you mean shifted). Otto also accepts a
+few friendly aliases for names people actually write:
+
+| You can write | XKB name |
+|---------------|----------|
+| `Esc` | `Escape` |
+| `ArrowUp` / `ArrowDown` / `ArrowLeft` / `ArrowRight` | `Up` / `Down` / `Left` / `Right` |
+
+Everything else uses the real keysym name: `Return`, `space`, `Tab`, `Prior`
+(Page Up), `Next` (Page Down), `grave` (`` ` ``), `ISO_Left_Tab` (Shift+Tab),
+`XF86AudioRaiseVolume`, and so on. `xkbcli list` and
+`man xkeyboard-config` are the references; the repo also ships
+`scripts/show-keys.sh` to print the keysym for whatever you press.
+
+A trigger Otto cannot parse is **skipped with a warning in the log**, not an
+error — so a typo silently costs you that one binding. If a shortcut "does
+nothing", check the log first.
+
+Two triggers that resolve to the same key combination collide; the later one
+(alphabetically, since the table is sorted) wins, and a warning is logged.
+
+### Action forms
+
+There are four ways to write an action:
+
+**1. A built-in, by name:**
+```toml
+"Ctrl+Tab" = "ApplicationSwitchNext"
+```
+
+**2. A built-in that takes an index:**
+```toml
+"Ctrl+1" = { builtin = "Workspace", index = 0 }
+"Ctrl+F2" = { builtin = "Screen", index = 1 }
+```
+
+**3. Run a command:**
+```toml
+"Ctrl+Return" = { run = { cmd = "alacritty", args = [] } }
+"Logo+Shift+B" = { run = { cmd = "firefox", args = ["--private-window"] } }
+```
+The command is spawned fire-and-forget. It is not run through a shell, so
+pipes, globs and `&&` do not work — call `sh -c` explicitly if you need them.
+
+**4. Open the user's default application for a role:**
+```toml
+"Logo+B"     = { open_default = "browser" }
+"Logo+Space" = { open_default = "file_manager" }
+"Logo+T"     = { open_default = { role = "terminal", fallback = "alacritty" } }
+```
+
+This resolves through your `mimeapps.list` defaults, so it launches whatever
+*you* have set as the handler rather than a hard-coded program. Recognised
+roles:
+
+| Role | Resolved via |
+|------|--------------|
+| `browser` | `x-scheme-handler/https`, then `http`, then `text/html` |
+| `file_manager` / `files` | `inode/directory` |
+| `terminal` / `shell` | `x-scheme-handler/terminal`, then `application/x-terminal` |
+| anything containing `/` | used directly as a MIME type |
+| anything else | `x-scheme-handler/<role>` |
+
+You can also give a desktop file id directly (`open_default = "firefox.desktop"`).
+The optional `fallback` is used when the role resolves to nothing; it may be a
+desktop id or a plain command line.
+
+## Built-in actions
+
+### Session
+
+| Action | Effect |
+|--------|--------|
+| `Quit` | Exit Otto, ending the session |
+| `LockSession` | Launch the configured locker — see [Lock Screen](lock-screen.md) |
+
+### Windows
+
+| Action | Effect |
+|--------|--------|
+| `CloseWindow` | Ask the focused window to close |
+| `ToggleMaximizeWindow` | Maximize / restore the focused window (animated) |
+| `TileWindowLeft` | Snap the focused window to the left half of its monitor |
+| `TileWindowRight` | Snap the focused window to the right half |
+| `ToggleDecorations` | Flip every window between client-side and server-side decoration mode |
+
+### Applications
+
+| Action | Effect |
+|--------|--------|
+| `ApplicationSwitchNext` | Open the app switcher / move forward |
+| `ApplicationSwitchPrev` | Move backward in the app switcher |
+| `ApplicationSwitchNextWindow` | Cycle windows within the highlighted app |
+| `ApplicationSwitchQuit` | Quit the highlighted app |
+
+The switcher stays up as long as you hold the modifier that opened it, and
+commits when you release it. See [Exposé & App Switcher](expose-and-switcher.md).
+
+### Workspaces and overview
+
+| Action | Effect |
+|--------|--------|
+| `Workspace` (needs `index`) | Switch to workspace *N*, zero-based |
+| `ExposeShowAll` | Toggle the exposé grid of all windows |
+| `ExposeShowDesktop` | Push all windows aside to reveal the desktop |
+
+### Displays
+
+| Action | Effect |
+|--------|--------|
+| `Screen` (needs `index`) | Warp the pointer to the center of monitor *N*, zero-based |
+| `ScaleUp` | Increase the scale factor of the monitor under the pointer |
+| `ScaleDown` | Decrease it |
+| `RotateOutput` | Rotate the monitor under the pointer by 90° |
+
+`ScaleUp`, `ScaleDown` and `RotateOutput` change the live session only; they do
+not write anything back to the config. Use [display profiles](display.md) to
+make a scale or rotation stick.
+
+### Hardware keys
+
+| Action | Effect |
+|--------|--------|
+| `BrightnessUp` / `BrightnessDown` | Screen backlight |
+| `VolumeUp` / `VolumeDown` / `VolumeMute` | Audio volume |
+| `MediaPlayPause` / `MediaNext` / `MediaPrev` / `MediaStop` | Media player control (MPRIS) |
+
+Volume and brightness changes surface in the [dynamic island](dynamic-island.md)
+and can play a feedback sound — see [Audio](audio.md).
+
+### Debugging
+
+| Action | Effect |
+|--------|--------|
+| `SceneSnapshot` (alias `ExportSceneJson`) | Dump the scene graph to `scene.json` in the working directory |
+| `SkpSnapshot` (alias `ExportSceneSkp`) | Dump the focused monitor's render tree as a Skia `.skp` picture |
+
+Useful when reporting a rendering bug.
+
+## Always-on keys
+
+These are handled before the config is consulted and cannot be rebound or
+disabled. They exist so a locked, grabbed or misconfigured session is never a
+dead end.
+
+| Keys | Effect |
+|------|--------|
+| `Logo+Q` | Quit Otto immediately |
+| `Ctrl+Alt+Backspace` | Quit Otto immediately |
+| `Ctrl+Alt+F1`…`F12` | Switch virtual terminal — works even while locked |
+| `Ctrl+Alt+Escape` | Lock the session — works whatever holds the keyboard |
+| Power button | Runs `power_management.on_power_button` — see [Power Management](power-management.md) |
+
+`Ctrl+Alt+Escape` and the power button are read from raw hardware key codes, so
+they work regardless of your keyboard layout and regardless of which client has
+grabbed the keyboard — including a fullscreen game or a lock screen.
+
+> If you are testing something over a remote session, note that `Logo+Q` and
+> `Ctrl+Alt+Backspace` will kill the compositor instantly. Avoid them.
+
+While the session is locked, **all** configured shortcuts are inactive: the
+locker owns the keyboard. Only the always-on keys above still work.
+
+## The shipped default set
+
+For reference, this is what `/etc/otto/config.toml` binds:
+
+```toml
+[keyboard_shortcuts]
+"Ctrl+Esc"                  = "Quit"
+"Ctrl+Return"               = { run = { cmd = "terminator", args = [] } }
+
+"Ctrl+1"                    = { builtin = "Workspace", index = 0 }
+"Ctrl+2"                    = { builtin = "Workspace", index = 1 }
+"Ctrl+3"                    = { builtin = "Workspace", index = 2 }
+"Ctrl+4"                    = { builtin = "Workspace", index = 3 }
+
+"Ctrl+Tab"                  = "ApplicationSwitchNext"
+"Ctrl+Shift+ISO_Left_Tab"   = "ApplicationSwitchPrev"
+"Ctrl+grave"                = "ApplicationSwitchNextWindow"
+"Ctrl+q"                    = "ApplicationSwitchQuit"
+
+"Ctrl+ArrowUp"              = "ToggleMaximizeWindow"
+"Ctrl+ArrowLeft"            = "TileWindowLeft"
+"Ctrl+ArrowRight"           = "TileWindowRight"
+
+"Prior"                     = "ExposeShowAll"       # Page Up
+"Next"                      = "ExposeShowDesktop"   # Page Down
+
+"XF86MonBrightnessUp"       = "BrightnessUp"
+"XF86MonBrightnessDown"     = "BrightnessDown"
+"XF86AudioRaiseVolume"      = "VolumeUp"
+"XF86AudioLowerVolume"      = "VolumeDown"
+"XF86AudioMute"             = "VolumeMute"
+"XF86AudioPlay"             = "MediaPlayPause"
+"XF86AudioNext"             = "MediaNext"
+"XF86AudioPrev"             = "MediaPrev"
+"XF86AudioStop"             = "MediaStop"
+```
+
+Note that `Ctrl+Esc` quits and `Ctrl+Q` quits the *highlighted app in the
+switcher* — both are easy to hit by accident. Rebinding them is a reasonable
+first customization.
+
+## Shortcuts and applications
+
+Clients can request a keyboard-shortcuts inhibitor (via
+`keyboard-shortcuts-inhibit`), which suspends Otto's bindings while that window
+is focused. Remote-desktop clients, virtual machines and terminal multiplexers
+use this so that, for example, `Ctrl+Tab` reaches the guest instead of Otto.
+The always-on keys above are never inhibited.
+
+## See also
+
+- [Touchpad Gestures](gestures.md) — the pointer-driven equivalents
+- [Input](input.md) — keyboard layout, XKB options, repeat rate
+- [Configuration](configuration.md) — where config files live

--- a/docs/user/lock-screen.md
+++ b/docs/user/lock-screen.md
@@ -1,0 +1,184 @@
+# Lock Screen
+
+Locking hides your session behind an opaque surface on every monitor and routes
+all input to the locker. Everything underneath — windows, workspaces, focus,
+running programs — is untouched and comes back exactly as you left it.
+
+Otto uses `ext-session-lock-v1`, the Wayland protocol designed for this. Its
+key guarantee: if the locker crashes, the screen **stays blank** rather than
+revealing what was behind it.
+
+Otto ships `otto-lock` as the default locker, but any `ext-session-lock-v1`
+client works.
+
+## Setup
+
+### 1. Install the PAM service
+
+`otto-lock` authenticates through PAM using a dedicated service. **The service
+file must exist**, otherwise PAM falls through to `other`, which denies
+everything.
+
+Arch and Fedora packages install it for you. On Debian and Ubuntu, copy it
+yourself:
+
+```sh
+sudo cp /usr/share/doc/otto/otto-lock.pam /etc/pam.d/otto-lock
+```
+
+Then edit it: the shipped file is written for distributions with a `system-auth`
+stack (Arch, Fedora, openSUSE). On Debian and Ubuntu, replace `system-auth` with
+`common-auth` and `common-account`:
+
+```
+auth      sufficient pam_fprintd.so
+auth      include    common-auth
+account   include    common-account
+```
+
+`otto-lock` does notice a missing service file and falls back to `system-auth`,
+then `login` — but the fallback is not the configuration anyone reviewed, so
+install the file properly.
+
+### 2. Bind the lock action
+
+`Ctrl+Alt+Escape` locks the session. It is handled ahead of the config from the
+raw hardware key code, so it works whatever your layout is and whatever holds
+the keyboard.
+
+You can bind it elsewhere too:
+
+```toml
+[keyboard_shortcuts]
+"Logo+L" = "LockSession"
+```
+
+### 3. Optionally, choose a different locker
+
+```toml
+[lock]
+locker_command = "otto-lock"
+locker_args = []
+```
+
+Any `ext-session-lock-v1` locker fits here — `swaylock`, `hyprlock`, `gtklock`.
+
+## Using it
+
+The `otto-lock` panel is a frosted card with your avatar, a password field and —
+when a fingerprint reader is configured — a Touch ID mark. It shows a clock,
+which keeps time however long you are away.
+
+Type your password and press Enter, or touch the reader.
+
+A refused attempt returns you to the field with the error shown and offers
+another try. The delay between attempts comes from PAM's own rate limiting, not
+from the locker.
+
+The lock screen picks up your Otto configuration, including your own user
+config, so it matches the session's theme.
+
+## Fingerprint unlock
+
+The shipped PAM file lists `pam_fprintd` explicitly:
+
+```
+auth sufficient pam_fprintd.so
+```
+
+It has to be listed explicitly because a distribution's `system-auth` usually
+does not include it — a reader configured for `sudo` or polkit is configured in
+*those* services, not in the shared stack.
+
+`sufficient` means a recognised finger is enough, and anything else falls
+through to the password prompt below. The module holds the conversation open
+until it times out, and anything you type meanwhile waits for the prompt that
+follows — which is what the panel's "Enter Password" button is for.
+
+Enroll fingers with `fprintd-enroll` first. On a machine with no reader, delete
+the line.
+
+## Automatic locking
+
+```toml
+[lock]
+auto_lock_timeout = 300   # seconds; 0 (the default) never auto-locks
+```
+
+The countdown measures the absence of keyboard, pointer, touch and tablet
+input. Any input event resets it, regardless of what the compositor does with
+it afterwards.
+
+### Idle inhibitors
+
+A client holding an `idle-inhibit-unstable-v1` inhibitor — a video player during
+playback, a presentation tool — holds auto-lock off, and **restarts** the
+countdown when it releases the inhibitor. So the timer runs from when the video
+stops, not from your last keypress.
+
+Otto only honours an inhibitor while its surface is alive and its window is not
+minimized. The protocol leaves that judgment to the compositor precisely
+because clients forget to drop inhibitors, and one stale inhibitor would
+otherwise disable locking for the whole session.
+
+The check runs on the timer's tick, so an inhibitor released just after a tick
+can delay the lock by up to one further timeout.
+
+## What still works while locked
+
+| | |
+|---|---|
+| `Ctrl+Alt+F1`…`F12` | VT switching — always available |
+| `Ctrl+Alt+Escape` | Lock (already locked, so a no-op) |
+| Power button | Runs your `on_power_button` action |
+| Everything else | Nothing. The locker owns the keyboard; all configured shortcuts are inactive. |
+
+Multiple monitors are all covered, including ones plugged in, unplugged, or
+mode-changed while locked.
+
+If the locker crashes, Otto restarts it — rate-limited — so a crash is
+recoverable without a VT switch, and the screen never uncovers in the meantime.
+
+## Locking from a script
+
+Anything that wants to lock runs the same command:
+
+```sh
+otto-lock
+```
+
+That is what the shortcut and the auto-lock timer both do. A suspend hook or an
+external idle daemon (`swayidle`) can call it directly.
+
+## Locking and the lid
+
+`on_lid_close = "lock"` locks before suspending, so the machine wakes to the
+lock screen. Clamshell and remote sessions deliberately stay unlocked — the
+session is still in use. See [Power Management](power-management.md).
+
+## Troubleshooting
+
+**Nothing happens when I press `Ctrl+Alt+Escape`.** The locker failed to launch.
+Run `otto-lock` from a terminal inside the session to see the error.
+
+**My password is rejected even though it is correct.** The PAM service file is
+missing or wrong. Check `/etc/pam.d/otto-lock` exists and uses the right stack
+for your distribution (`system-auth` vs `common-auth`). The log says which
+fallback the locker resorted to.
+
+**The screen is blank but there is no password panel.** The locker died after
+locking. Otto keeps the screen blank — that is the protocol working as
+designed. Switch VT with `Ctrl+Alt+F2`, log in, and check the logs.
+
+**The fingerprint reader is not offered.** Confirm `pam_fprintd.so` is in
+`/etc/pam.d/otto-lock` and that you have enrolled a finger
+(`fprintd-list $USER`).
+
+**The session never auto-locks.** `auto_lock_timeout` defaults to `0`, which
+means never. If it is set and still does not fire, a client is probably holding
+an idle inhibitor — check for a paused-but-not-closed video.
+
+## See also
+
+- [Login Greeter](login-greeter.md) — the same panel, for logging *in*
+- [Power Management](power-management.md) — locking on lid close and power button

--- a/docs/user/login-greeter.md
+++ b/docs/user/login-greeter.md
@@ -1,0 +1,175 @@
+# Login Greeter
+
+Otto can be your login screen. Started with `--login`, it runs as a host
+compositor for a greeter client — the role `cage` plays for `gtkgreet` — and
+`otto-greeter` provides the login panel.
+
+Authentication is handled entirely by [greetd](https://sr.ht/~kennylevinsen/greetd/).
+Otto links no PAM code and never touches your password.
+
+## Setup
+
+### 1. Install greetd
+
+```sh
+sudo pacman -S greetd        # Arch
+sudo dnf install greetd      # Fedora
+sudo apt install greetd      # Debian/Ubuntu
+```
+
+### 2. Point greetd at Otto
+
+```toml
+# /etc/greetd/config.toml
+[terminal]
+vt = 1
+
+[default_session]
+command = "otto --login"
+user = "greeter"
+```
+
+`otto --login` is the greeter *session* as far as greetd is concerned. Otto in
+turn launches `otto-greeter`, which speaks greetd's IPC over the `$GREETD_SOCK`
+it inherits.
+
+### 3. Enable it
+
+```sh
+sudo systemctl enable --now greetd
+sudo systemctl disable gdm    # or sddm, lightdm — only one display manager
+```
+
+### 4. Optionally, choose a different greeter
+
+```toml
+# ~/.config/otto/config.toml — or /etc/otto/config.toml, see below
+[login]
+greeter_command = "otto-greeter"
+greeter_args = []
+```
+
+## What login mode changes
+
+`--login` is a distinct mode, fixed for the life of the process. In it:
+
+- **One monitor.** The first desktop connector brought up becomes the primary
+  output and is the only one driven. Every other connector — at startup or
+  hotplugged — is ignored: no mode set, no `wl_output`. (VR headsets and other
+  non-desktop connectors are still offered for DRM leasing, as usual.)
+- **No desktop chrome.** The dock, app switcher, exposé and workspace selector
+  never appear, by shortcut or by gesture.
+- **No autostart.** `exec_once` and XDG autostart are skipped. Exactly one
+  client is launched: the greeter.
+- **No auto-lock.** The greeter *is* the screen; there is no session behind it
+  to hide.
+
+The greeter is tied to Otto's lifetime — if Otto dies, the greeter gets
+`SIGTERM`.
+
+`--login` is orthogonal to the backend flag and can be combined with
+`--tty-udev` (production) or `--winit` (development).
+
+### Which config it reads
+
+Running as the `greeter` user, Otto can only read `/etc/otto/config.toml`. Put
+anything you want the login screen to look like — theme, wallpaper, scale —
+there rather than in your own `~/.config`.
+
+## Using the greeter
+
+The panel is a frosted card with an avatar, a username field, a password field
+and, where a reader is configured, a Touch ID mark. Same panel as
+[otto-lock](lock-screen.md), plus a session picker.
+
+### The username is pre-filled
+
+The field starts with the machine's primary user — the login account with the
+lowest UID. greetd exposes no user list and there is no unprivileged record of
+who logged in last, so this is the closest thing to "whoever this machine is
+for". On a single-user machine it is the only candidate.
+
+The greeter submits it as soon as the panel exists, so the first thing you see
+is the password field or the fingerprint reader, not a name to confirm.
+
+It is a **suggestion**, not a prefix:
+
+- Typing any character replaces the whole name.
+- Backspace clears it.
+- `Escape` empties the field, which is how somebody else logs in.
+
+Editing the field also clears the avatar — it belonged to the account being
+offered.
+
+### Fingerprint login
+
+If your PAM stack includes `pam_fprintd`, the reader is offered alongside the
+password.
+
+A recognised finger draws the ridge mark in, in blue, over the grey resting
+mark. This takes about a second, deliberately: greetd kills the greeter the
+instant the session starts, so if the animation were quick you would never see
+that the login worked.
+
+A missed finger is reported as an error and the reader asks again — the mark and
+the button stay up, because the reader is still what is being waited on.
+
+**Reaching the password past the reader:** PAM is serialised, so a module
+holding the stack cannot be hurried. Clicking "Enter Password" puts the field
+back immediately and masks what you type, but holds the answer until the
+password prompt actually arrives — which is what `pam_fprintd` produces when it
+times out or runs out of tries, on a stack where it is `sufficient` rather than
+`required`. The panel tells you what it is waiting for.
+
+A held answer is only ever given to a password prompt. If a one-time-code prompt
+arrives instead, it is discarded and you are asked again — handing a password to
+the wrong prompt is worse than retyping it.
+
+### Session picker
+
+Sessions come from `.desktop` files in `/usr/share/wayland-sessions` and
+`/usr/local/share/wayland-sessions`, sorted by name, skipping entries marked
+`Hidden=true` or `NoDisplay=true`.
+
+If nothing is installed, a single fallback session running `otto` is offered.
+
+## Developing against it
+
+You do not need root or a spare VT to work on the greeter. When `GREETD_SOCK` is
+unset, `otto-greeter` uses a self-contained mock backend, so you can run it
+inside a normal Otto session:
+
+```sh
+cargo run -- --winit --login
+```
+
+`$OTTO_GREETER_COMMAND` overrides `[login]` entirely (a whitespace-separated
+argv), and `$OTTO_GREETER_SESSION` overrides session discovery with one argv —
+both for testing uninstalled builds.
+
+## Troubleshooting
+
+**Black screen, no panel.** Otto started but the greeter did not. Check
+`journalctl -u greetd`. A common cause is `otto-greeter` not being on the
+`greeter` user's `PATH`.
+
+**"Starting session…" forever.** `start_session` succeeded but greetd's exec did
+not happen. The greeter gives up after a few seconds and returns to the username
+field rather than hanging — check the session's `Exec` line in its `.desktop`
+file.
+
+**The login screen is unstyled or the wrong theme.** It reads
+`/etc/otto/config.toml`, not your user config. The `greeter` user cannot see
+your home directory.
+
+**Only one monitor lights up.** That is by design in login mode. Every session
+monitor comes back once you are logged in.
+
+**The password is rejected.** That is greetd and PAM, not Otto. Check the PAM
+stack greetd uses (`/etc/pam.d/greetd`).
+
+## See also
+
+- [Lock Screen](lock-screen.md) — the same panel, for locking an existing
+  session. Different lifecycle: a lock screen sits over a session that outlives
+  it; a greeter authenticates a user who has no session yet.

--- a/docs/user/night-shift.md
+++ b/docs/user/night-shift.md
@@ -1,0 +1,115 @@
+# Night Shift
+
+Otto has no built-in colour-temperature setting. Instead it implements
+`zwlr-gamma-control-v1`, the protocol the established tools use, so they work
+against Otto directly and drive the display hardware's gamma tables — no
+software post-processing, no cost per frame.
+
+## wlsunset
+
+Follows sunrise and sunset for your location.
+
+```sh
+sudo pacman -S wlsunset      # Arch
+sudo dnf install wlsunset    # Fedora
+sudo apt install wlsunset    # Debian/Ubuntu
+```
+
+Start it with your latitude and longitude:
+
+```toml
+[[exec_once]]
+cmd = "wlsunset"
+args = ["-l", "48.8", "-L", "2.3"]
+```
+
+`-l` is latitude, `-L` is longitude — negative for south and west.
+
+Fixed temperatures instead of sun-following:
+
+```sh
+wlsunset -t 3500 -T 6500     # night 3500K, day 6500K
+wlsunset -T 6500 -t 6500     # effectively off
+```
+
+## gammastep
+
+A fork of redshift with more options — manual times, a systemd unit, and a
+config file.
+
+```sh
+gammastep -l 48.8:2.3
+```
+
+```ini
+# ~/.config/gammastep/config.ini
+[general]
+temp-day=6500
+temp-night=3800
+location-provider=manual
+
+[manual]
+lat=48.8
+lon=2.3
+```
+
+Then:
+
+```toml
+[[exec_once]]
+cmd = "gammastep"
+```
+
+or `systemctl --user enable --now gammastep`.
+
+## Brightness
+
+Backlight brightness is separate from colour temperature and is handled by Otto:
+
+```toml
+[keyboard_shortcuts]
+"XF86MonBrightnessUp"   = "BrightnessUp"
+"XF86MonBrightnessDown" = "BrightnessDown"
+```
+
+Each press shows an on-screen indicator. This adjusts the actual hardware
+backlight, so it saves power — unlike gamma-based dimming, which only makes the
+picture darker.
+
+For external monitors that expose DDC/CI, use `ddcutil`:
+
+```sh
+ddcutil setvcp 10 50    # 50% brightness
+```
+
+## Choosing a temperature
+
+| Kelvin | Feels like |
+|--------|------------|
+| 6500K | Daylight — no shift, the display's native point |
+| 5000K | A gentle warmth, usable all day |
+| 4000K | Clearly warm; a common evening setting |
+| 3400K | Halogen bulb; the usual "night" default |
+| 2700K | Incandescent; very orange |
+| 1900K | Candlelight; only for late-night reading |
+
+## Troubleshooting
+
+**"Failed to bind gamma control".** Otto must be running as your compositor —
+the protocol is not available on the `--winit` backend, where the host
+compositor owns the display hardware.
+
+**Colours do not change.** Some drivers ignore gamma tables on some outputs.
+Try a different output, and check the tool's own output for errors.
+
+**Colours stay shifted after the tool exits.** A crashed tool leaves the gamma
+ramp where it was. Restart it and stop it cleanly, or restart the session.
+
+**Two tools are fighting.** Run only one gamma client at a time; the last one to
+set the ramp wins.
+
+## Not planned
+
+Otto is unlikely to grow its own night-shift implementation — `wlsunset` and
+`gammastep` do the job well, and the protocol exists so that compositors do not
+have to.

--- a/docs/user/power-management.md
+++ b/docs/user/power-management.md
@@ -1,0 +1,156 @@
+# Power Management
+
+Otto handles the laptop lid switch and the hardware power button itself, rather
+than leaving them to systemd-logind. This lets it make smarter decisions — it
+knows whether you have an external monitor attached, or whether someone is
+watching a remote session.
+
+## Prerequisite: tell logind to stay out of the way
+
+For any of this to work, logind must be configured not to act first:
+
+```ini
+# /etc/systemd/logind.conf
+HandleLidSwitch=ignore
+HandlePowerKey=ignore
+```
+
+Then `sudo systemctl restart systemd-logind` (or reboot).
+
+If you skip this, logind suspends the machine before Otto sees the event, and
+Otto's settings have no effect.
+
+## The lid switch
+
+```toml
+[power_management]
+manage_lid_switch = true
+on_lid_close = "auto"
+```
+
+### `manage_lid_switch`
+
+`true` (the default) means Otto owns the lid. `false` hands everything back to
+logind — set your policy there instead.
+
+### `on_lid_close`
+
+| Value | Behaviour |
+|-------|-----------|
+| `"auto"` | Turn off the internal panel, then suspend **unless** the session is still in use |
+| `"lock"` | Same as `"auto"`, but lock the session first, so the machine wakes to the lock screen |
+| `"disable_internal_screen"` | Turn off the internal panel and keep running. Never suspend, never lock. |
+
+### What "still in use" means
+
+With `"auto"` or `"lock"`, Otto does **not** suspend when either is true:
+
+- **An external monitor is connected** — clamshell mode. The internal panel goes
+  dark, the session keeps running on the external screen, and it does *not*
+  lock: you are sitting in front of it.
+- **A remote client is actively consuming frames** — a portal
+  [screenshare](screen-sharing.md) session exists, or a virtual output's
+  PipeWire stream is actually streaming (an [RDP](remote-desktop.md) client is
+  connected and pulling frames). Closing the lid does not cut off a remote user.
+
+  A stream that merely exists but is paused, with nothing consuming it, does not
+  block suspend.
+
+Otherwise the session is out of reach, and Otto suspends — because a laptop that
+keeps running in a bag gets hot.
+
+### Reopening
+
+The internal panel comes back exactly as it was: same position in the monitor
+layout, same primary status, same workspaces, same windows, same dock. Closing
+and reopening the lid is visually a no-op.
+
+`disable_internal_screen` is the exception — it keeps the panel off even with
+the lid open, which is what you want for a kiosk or a display-manager host.
+
+## The power button
+
+```toml
+[power_management]
+on_power_button = "lock"
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| `"lock"` | Launch the configured locker (the default) |
+| `"suspend"` | Suspend via logind |
+| `"shutdown"` | Power off via logind |
+| `"ignore"` | Otto stays out of it — logind's `HandlePowerKey` decides, and the key reaches the focused application as `XF86PowerOff` |
+
+Anything other than `"ignore"` needs `HandlePowerKey=ignore` in `logind.conf`,
+otherwise logind acts first.
+
+Otto reads the power button from its **raw hardware key code**, so it works
+whatever your keyboard layout is and whatever has grabbed the keyboard — a
+fullscreen game, a lock screen, a greeter. There is no state in which pressing
+the power button does nothing.
+
+## Idle locking
+
+Auto-lock after a period of inactivity is configured separately, under `[lock]`:
+
+```toml
+[lock]
+auto_lock_timeout = 300   # seconds; 0 disables
+```
+
+See [Lock Screen](lock-screen.md) for the full picture, including how
+`idle-inhibit` clients (video players, presentations) hold the countdown off.
+
+## What is not implemented
+
+- **DPMS blanking on idle.** The screen does not turn off by itself. Only
+  auto-lock is timer-driven.
+- **Idle suspend.** Otto never suspends on a timer, only on lid close.
+- **Hibernate and hybrid sleep.**
+- **Battery-level policies** — no "suspend at 5%".
+- **Moving the dock and top bar to the external monitor** while the internal
+  panel is off in clamshell mode. They stay assigned to the primary monitor.
+
+For the missing pieces, `systemd-logind` and tools like `swayidle` still work
+alongside Otto.
+
+## A couple of recipes
+
+**Laptop that suspends and wakes locked:**
+```toml
+[power_management]
+manage_lid_switch = true
+on_lid_close = "lock"
+on_power_button = "lock"
+
+[lock]
+locker_command = "otto-lock"
+auto_lock_timeout = 600
+```
+
+**Machine that should never suspend (media box, always-on server with a display):**
+```toml
+[power_management]
+manage_lid_switch = true
+on_lid_close = "disable_internal_screen"
+on_power_button = "ignore"
+```
+
+## Troubleshooting
+
+**The machine suspends on lid close even with an external monitor attached.**
+Check that logind is set to `HandleLidSwitch=ignore` — otherwise it is logind
+suspending, not Otto, and clamshell detection never runs.
+
+**Closing the lid cut off my screen share.** Otto only detects an *actively
+streaming* PipeWire node. If the consumer had disconnected or paused, the
+session counted as unused. Check the log around the lid-close event.
+
+**The power button does nothing.** With `on_power_button = "ignore"` that is
+expected: the key goes to the focused application. Any other value requires
+`HandlePowerKey=ignore` in `logind.conf`.
+
+**The session does not lock on lid close.** Clamshell and remote sessions
+deliberately stay unlocked — the session is still in use. It also needs a
+working locker; see [Lock Screen](lock-screen.md).

--- a/docs/user/remote-desktop.md
+++ b/docs/user/remote-desktop.md
@@ -1,0 +1,198 @@
+# Remote Desktop
+
+`otto-rdp` serves an Otto output over RDP, so you can view **and control** your
+desktop from Microsoft Remote Desktop, FreeRDP, or the Windows / iOS / Android
+Remote Desktop apps.
+
+It is a standalone bridge: it captures an output's frames, encodes them, and
+forwards the remote client's keyboard and pointer back into the compositor. The
+compositor itself knows nothing about RDP.
+
+## Two ways to use it
+
+**Serve a physical screen** — mirror what is on your monitor:
+
+```sh
+otto-rdp --connector eDP-1 --listen 0.0.0.0:3389 --tls
+```
+
+**Serve a virtual output** — a headless screen that exists only for the remote
+user, with its own workspaces and windows, independent of your physical
+displays. This is usually what you want.
+
+First declare it in your Otto config:
+
+```toml
+[[virtual_outputs]]
+name = "virtual-1"
+resolution = { width = 1920, height = 1080 }
+refresh_hz = 60.0
+position = { x = 3840, y = 0 }
+interactive = true          # required for remote input
+```
+
+`interactive = true` is what allows remote pointer and keyboard events to be
+aimed at that output. Without it the feed is view-only.
+
+Otto logs the PipeWire node id at startup:
+
+```
+Virtual output 'virtual-1' started (PipeWire node 42)
+```
+
+Then:
+
+```sh
+otto-rdp --node 42 --output virtual-1 --listen 0.0.0.0:3389 --tls
+```
+
+## Connecting
+
+```sh
+# FreeRDP, hardware H.264
+xfreerdp3 /v:192.168.1.10:3389 /gfx:AVC420 /cert:ignore
+
+# mstsc, or the mobile / Windows App clients
+# just point them at 192.168.1.10:3389 — TLS must be on
+```
+
+## Command-line reference
+
+```
+otto-rdp (--node <id> | --connector <name>) [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--node <id>` | PipeWire node id of a virtual output's stream (from Otto's log) |
+| `--connector <name>` | Capture a physical output instead, e.g. `eDP-1`. Mutually exclusive with `--node`; also becomes the default `--output`. |
+| `--output <name>` | Wayland output to aim input at. Defaults to `virtual-1`, or the `--connector` value. |
+| `--listen <addr:port>` | Listen address. Default `0.0.0.0:3389`. |
+| `--desktop <WxH>` | Serve this desktop size instead of the client's reported box |
+| `--tls` | Accept TLS-security connections with a self-signed certificate |
+| `--bitmap` | Force the legacy raw-bitmap path instead of hardware H.264 |
+
+### Environment
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `OTTO_RDP_FPS` | 30 (H.264), 12 (bitmap) | Frame rate |
+| `OTTO_RDP_BITRATE` | — | Target bitrate in kbps, H.264 only |
+| `OTTO_RDP_H264_ENCODER` | `vah264enc` | GStreamer encoder element; try `vah264lpenc` on some Intel GPUs |
+
+## TLS
+
+Use `--tls` unless you have a reason not to. `mstsc` and Microsoft's mobile,
+iOS and Windows App clients **require** it — they refuse to run graphics over
+plain RDP security.
+
+The certificate is self-signed and persisted in `~/.local/state/otto-rdp`, so it
+stays stable between runs and your client stops warning about a changed
+certificate. Pass `/cert:ignore` to FreeRDP the first time.
+
+With `--tls` on, plain-RDP clients (`xfreerdp /sec:rdp`) can no longer connect.
+
+## Video transport
+
+By default the bridge encodes with **hardware H.264** (VA-API) and ships it over
+RDP's Graphics Pipeline Extension as AVC420. It falls back to raw bitmaps
+automatically, per connection, for clients that cannot do H.264.
+
+The choice is made once per client, from the capabilities that client advertises
+when it connects, and does not change for the life of the connection.
+
+- A client advertising AVC support gets the H.264 path.
+- A client that sets `AVC_DISABLED` — which Microsoft's **mobile, iOS, Android
+  and Windows App clients all do**, since they do not implement H.264 — falls
+  back to bitmaps automatically.
+- A client that never opens the graphics channel at all also falls back, after a
+  short grace period.
+
+`--bitmap` forces the legacy path for every client. Use it to isolate a
+suspected H.264 problem.
+
+Hardware encoding needs `gst-plugin-pipewire` and `gst-plugins-bad` (for VA-API)
+installed.
+
+## Input
+
+Remote keyboard and pointer events are forwarded into the compositor as virtual
+input devices, aimed at the output named by `--output`. Absolute pointer
+coordinates are mapped into that output's own geometry, so the remote pointer
+lands where the remote user clicked even when the served output is not the first
+one.
+
+Remote input drives the compositor's UI exactly like physical input: dock hover,
+magnification and tooltips all respond.
+
+## The `--tty-udev` caveat
+
+Otto only renders while its virtual terminal is **active**. If you switch away
+from Otto's VT, the DRM session is paused by libseat and the remote feed
+freezes. That is expected, not a bug.
+
+Run Otto on the VT you intend to leave it on.
+
+## A helper script
+
+The repo ships `run-rdp.sh`, which starts Otto and the bridge together with
+logging, waits for the compositor to be ready, extracts the Wayland socket and
+PipeWire node from the log automatically, and reports why Otto exited if it
+does:
+
+```sh
+./run-rdp.sh            # serve the physical screen (eDP-1)
+./run-rdp.sh virtual    # serve virtual-1
+```
+
+> **Careful:** `Logo+Q` and `Ctrl+Alt+Backspace` quit Otto instantly and cannot
+> be rebound. Avoid pressing them from the remote client.
+
+## Remote sessions and power
+
+A lid close does **not** suspend the machine while an RDP client is actively
+pulling frames, so the remote user is not cut off. A stream that exists but has
+no consumer does not block suspend. See
+[Power Management](power-management.md).
+
+## Security
+
+The bridge has **no authentication of its own** — anyone who can reach the port
+gets your desktop. `--tls` encrypts the transport; it does not gate access.
+
+Do not expose port 3389 to an untrusted network. Bind it to localhost and tunnel
+over SSH instead:
+
+```sh
+otto-rdp --node 42 --output virtual-1 --listen 127.0.0.1:3389 --tls
+# from the client machine:
+ssh -L 3389:localhost:3389 you@your-host
+```
+
+## Troubleshooting
+
+**The client connects but the screen is black.** Otto's VT is not active, or the
+virtual output has no PipeWire node. Check Otto's log for the
+`Virtual output ... started` line.
+
+**"No graphics" or the client disconnects immediately.** The client cannot do
+AVC420 and the fallback did not kick in. Retry with `--bitmap`.
+
+**Input does nothing.** The virtual output needs `interactive = true`, and
+`--output` must name the output you are actually serving.
+
+**mstsc or the mobile app refuses to connect.** You need `--tls`.
+
+**The H.264 encoder fails to start.** Install `gst-plugins-bad` for VA-API and
+try `OTTO_RDP_H264_ENCODER=vah264lpenc`. Failing that, `--bitmap`.
+
+**Clicks land in the wrong place from a mobile client.** Some clients render 1:1
+in physical pixels but report their box in points. Pass the device's physical
+resolution with `--desktop 2532x1170`.
+
+## Not yet supported
+
+- Audio, clipboard, and drive or device redirection
+- Multi-monitor RDP sessions — one output per connection
+- Switching transport mid-connection
+- Any built-in access control

--- a/docs/user/screen-sharing.md
+++ b/docs/user/screen-sharing.md
@@ -1,0 +1,220 @@
+# Screen Sharing
+
+Otto shares your screen through the standard XDG Desktop Portal plus PipeWire —
+the same mechanism GNOME and KDE use. Browsers, video-call apps, OBS and
+Flatpak'd applications all work through it without knowing anything about Otto.
+
+## Portal setup
+
+Screen sharing needs three things running: `xdg-desktop-portal` (the frontend),
+`xdg-desktop-portal-otto` (Otto's backend), and PipeWire.
+
+### 1. Install the portal frontend
+
+```sh
+sudo pacman -S xdg-desktop-portal    # Arch
+sudo dnf install xdg-desktop-portal  # Fedora
+sudo apt install xdg-desktop-portal  # Debian/Ubuntu
+```
+
+Otto's own packages install the backend, its D-Bus service file and
+`/usr/share/xdg-desktop-portal/portals/otto.portal`.
+
+### 2. Tell the frontend to use Otto
+
+Create `~/.config/xdg-desktop-portal/portals.conf`:
+
+```ini
+[preferred]
+default=gtk
+
+org.freedesktop.impl.portal.ScreenCast=otto
+org.freedesktop.impl.portal.Settings=otto
+```
+
+This routes screen capture and the appearance settings (light/dark) to Otto, and
+leaves everything else — file chooser, printing, notifications — to the GTK
+backend. A copy of this file ships as
+`/usr/share/doc/otto/portals.conf.example`.
+
+`org.freedesktop.impl.portal.Settings` is what makes applications follow your
+`theme_scheme` — see [Theming](theming.md).
+
+### 3. Restart the portal
+
+```sh
+systemctl --user restart xdg-desktop-portal
+```
+
+### Verify
+
+```sh
+gdbus call --session \
+  --dest org.freedesktop.portal.Desktop \
+  --object-path /org/freedesktop/portal/desktop \
+  --method org.freedesktop.portal.ScreenCast.CreateSession \
+  "{'handle_token':<'t1'>,'session_handle_token':<'s1'>}"
+```
+
+A successful call returns a request object path immediately.
+
+## Sharing your screen
+
+In a browser, click "Share screen"; in a video call, pick screen sharing. The
+portal takes over from there:
+
+1. A **permission dialog** appears in the
+   [dynamic island](dynamic-island.md) — who is asking, and what for.
+2. You grant or deny.
+3. On grant, Otto starts a PipeWire stream of the chosen monitor and hands the
+   node to the application.
+
+`otto-islands` is what renders that dialog. **If it is not running, the request
+is denied** rather than left hanging — a screenshare that cannot ask fails
+closed.
+
+### Choosing which monitor
+
+There is no graphical source picker yet. Without one, Otto shares the first
+monitor it enumerates.
+
+To override, write the connector name into a file:
+
+```sh
+echo "HDMI-A-1" > ~/.config/otto/screencast-output
+```
+
+It is read fresh on every share request, so you can change it between sessions
+without restarting anything. Use a name from `otto --probe`, or a virtual output
+name like `virtual-1`.
+
+If the name does not match any available output, Otto logs a warning and falls
+back to the first one.
+
+### Cursor
+
+The portal's three cursor modes are supported: hidden, embedded (drawn into the
+video) and metadata (sent alongside, for the receiver to draw). The application
+picks; there is nothing to configure.
+
+## Recording with OBS
+
+OBS uses the portal like any other client:
+
+1. Add a source → **Screen Capture (PipeWire)**.
+2. Grant the permission dialog.
+
+For a dedicated recording surface that is not one of your real monitors, set up
+a [virtual output](display.md#virtual-outputs) and point OBS at its PipeWire
+node directly:
+
+```toml
+[[virtual_outputs]]
+name = "virtual-1"
+resolution = { width = 1920, height = 1080 }
+refresh_hz = 60.0
+position = { x = 3840, y = 0 }
+interactive = false
+```
+
+Otto logs the node id at startup:
+
+```
+Virtual output 'virtual-1' started (PipeWire node 42)
+```
+
+```sh
+gst-launch-1.0 pipewiresrc path=42 ! videoconvert ! autovideosink
+```
+
+A virtual output is a real workspace you can drag windows onto — a "recording
+stage" separate from what you are looking at.
+
+## Screenshots
+
+Otto implements `zwlr-screencopy-v1`, so the usual wlroots screenshot tools
+work:
+
+```sh
+grim ~/Pictures/shot.png                      # whole screen
+grim -o eDP-1 ~/Pictures/shot.png             # one monitor
+grim -g "$(slurp)" ~/Pictures/shot.png        # a region you drag out
+```
+
+Bind one to a key:
+
+```toml
+[keyboard_shortcuts]
+"Print" = { run = { cmd = "sh", args = ["-c", "grim ~/Pictures/$(date +%s).png"] } }
+```
+
+There is no built-in screenshot UI, and **per-window capture is not implemented**
+— screencopy captures whole outputs or rectangles of them.
+
+## AirPlay
+
+You can send an Otto output to an Apple TV using
+[doubletake](https://github.com/omarroth/doubletake), which captures through
+the very portal you just configured:
+
+1. Set up a non-interactive virtual output (AirPlay mirroring has no input
+   channel — it is view-only).
+2. Point `~/.config/otto/screencast-output` at it.
+3. Run doubletake and pick your receiver.
+
+Otto does not implement the AirPlay protocol itself. The sender side requires
+Apple's FairPlay handshake, which no clean-room implementation exists for.
+
+Receiving *from* an Apple device (an iPhone screen appearing as a window in
+Otto) is not implemented either; UxPlay works as an independent application.
+
+## Remote control
+
+Screen sharing is view-only. To *control* Otto remotely, use the RDP bridge —
+see [Remote Desktop](remote-desktop.md).
+
+## Screen sharing and power
+
+A lid close does not suspend the machine while a screenshare session is
+actively streaming, so a remote viewer is not cut off. See
+[Power Management](power-management.md).
+
+## Troubleshooting
+
+**The screen-share picker in my browser is empty, or sharing fails silently.**
+Check the backend is running and reachable:
+
+```sh
+busctl --user status org.freedesktop.impl.portal.desktop.otto
+tail -f /tmp/portal-otto.log
+```
+
+That log records every method call, the compositor interaction and the PipeWire
+node ids.
+
+**The permission dialog never appears.** `otto-islands` is not running. Start
+it (`[[exec_once]]`) and try again.
+
+**The wrong monitor is shared.** See
+[Choosing which monitor](#choosing-which-monitor) above.
+
+**The video is mangled — torn, sheared or wrongly coloured.** This is a dmabuf
+modifier negotiation problem between Otto and the consumer. Capture a log with:
+
+```sh
+GST_DEBUG=3 <your app>
+```
+
+and open an issue with it.
+
+**Sharing works in Firefox but not in a Flatpak app.** Flatpak apps use the
+portal from inside the sandbox; make sure `xdg-desktop-portal` and the Otto
+backend are both on the session bus the sandbox sees.
+
+## Not yet implemented
+
+- A graphical source picker (window thumbnails, region selection)
+- Per-window capture
+- Restore tokens — every share asks permission again
+- Multiple simultaneous outputs in one session (the first is used)
+- Audio capture

--- a/docs/user/theming.md
+++ b/docs/user/theming.md
@@ -1,0 +1,176 @@
+# Theming
+
+Otto's look is set entirely from the config file. There is no theme picker GUI.
+
+## Light and dark
+
+```toml
+theme_scheme = "Light"   # or "Dark"
+```
+
+This drives the compositor's own chrome — the dock, app switcher, exposé,
+workspace selector — and is also **exported to applications** through the XDG
+Desktop Portal Settings interface as `org.freedesktop.appearance color-scheme`.
+
+That means GTK apps, Firefox, Chromium, Electron apps and the
+[top bar](topbar.md) all follow this one setting, and switch within about a
+second when you change it. No restart needed for clients that listen for the
+change signal.
+
+For this to work, the Otto portal backend must be selected for the Settings
+interface — see [Screen Sharing](screen-sharing.md#portal-setup), which covers
+the same `portals.conf`.
+
+```toml
+# gtk_theme = "Adwaita"
+```
+
+`gtk_theme` is recorded for reference only; Otto does not apply it. Set your GTK
+theme the usual way (`gsettings`, `~/.config/gtk-3.0/settings.ini`).
+
+## Accent colour
+
+```toml
+accent_color = "blue"
+```
+
+The accent tints selection borders in the workspace selector and the exposé
+window highlight. Available values:
+
+`red`, `orange`, `yellow`, `green`, `mint`, `teal`, `cyan`, `blue`, `indigo`,
+`purple`, `pink`, `gray`, `brown`
+
+Arbitrary hex colours are not accepted here — pick from the list.
+
+## Wallpaper
+
+```toml
+background_image = "/usr/share/otto/background.jpg"
+background_color = "#2c2ca0"
+```
+
+`background_image` is an absolute path to the image shown on the desktop.
+
+`background_color` is the fallback: when the image is missing or fails to load,
+Otto draws a gradient using this as the bottom colour. It is worth setting to
+something you like even if you use an image.
+
+The wallpaper is global — the same on every monitor and every workspace.
+
+Otto also supports the `wlr-layer-shell` background layer, so wallpaper daemons
+like `swaybg` and `swww` work if you want animated or per-monitor backgrounds:
+
+```toml
+[[exec_once]]
+cmd = "swaybg"
+args = ["-i", "/path/to/wallpaper.jpg", "-m", "fill"]
+```
+
+## Fonts
+
+```toml
+font_family = "Inter"
+```
+
+The font used by Otto's own UI — dock tooltips, exposé window titles, the app
+switcher. Applications use their own font settings; this does not change them.
+
+Otto ships with [Inter](https://rsms.me/inter/) as its default. Any font
+installed on the system works.
+
+## Cursor
+
+```toml
+cursor_theme = "Notwaita-Black"
+cursor_size = 24
+```
+
+Cursor theme names are the directory names under `/usr/share/icons/` and
+`~/.local/share/icons/`, and they are **case-sensitive**. Check what you have:
+
+```sh
+ls /usr/share/icons ~/.local/share/icons
+```
+
+Otto also implements `wp-cursor-shape-v1`, so applications that use the modern
+cursor-shape protocol get themed cursors without shipping their own bitmaps.
+
+## Icon theme
+
+```toml
+icon_theme = "Adwaita"
+```
+
+Used for application icons in the dock, the app switcher and notification
+islands. Commented out or absent, Otto auto-detects a reasonable theme from
+what is installed.
+
+Popular choices: `Adwaita`, `Papirus`, `WhiteSur`, `Fluent`. Otto's own
+screenshots use the
+[Fluent icon theme](https://github.com/vinceliuice/Fluent-icon-theme).
+
+Icons are looked up per the freedesktop icon theme specification, including
+inheritance — a theme that lacks an icon falls back to its parent.
+
+## Language
+
+```toml
+locales = ["en"]
+```
+
+Preferred languages for application names and descriptions read from `.desktop`
+files. `["fr", "en"]` means "French if the entry has it, English otherwise".
+
+This affects names shown in the dock, app switcher and menus. It does not change
+Otto's own UI language.
+
+## A worked example
+
+A dark HiDPI setup:
+
+```toml
+screen_scale = 2.0
+
+theme_scheme = "Dark"
+accent_color = "purple"
+font_family = "Inter"
+
+background_image = "/home/me/Pictures/wallpaper.jpg"
+background_color = "#101018"
+
+cursor_theme = "Adwaita"
+cursor_size = 32
+icon_theme = "Papirus-Dark"
+
+locales = ["en"]
+```
+
+## Troubleshooting
+
+**Icon or cursor theme not found.** Names are case-sensitive and must match the
+directory name exactly. Check with `ls /usr/share/icons/`. Some themes need a
+separate package for their cursor variant.
+
+**Applications ignore light/dark.** They read it from the XDG Settings portal,
+which needs `xdg-desktop-portal` running with Otto selected for
+`org.freedesktop.impl.portal.Settings` in your `portals.conf`. Verify with:
+
+```sh
+gdbus call --session --dest org.freedesktop.portal.Desktop \
+  --object-path /org/freedesktop/portal/desktop \
+  --method org.freedesktop.portal.Settings.Read \
+  org.freedesktop.appearance color-scheme
+```
+
+`1` means dark, `2` means light, `0` means no preference.
+
+**The wallpaper is a gradient instead of my image.** The path is wrong or
+unreadable. Check the log — Otto reports the failure and falls back to
+`background_color`.
+
+## Not yet supported
+
+- Per-monitor or per-workspace wallpaper
+- Automatic light/dark switching by time of day
+- Custom hex accent colours
+- Animated wallpaper without an external daemon

--- a/docs/user/topbar.md
+++ b/docs/user/topbar.md
@@ -1,0 +1,149 @@
+# Top Bar
+
+`otto-bar` is Otto's menu bar: a full-width panel along the top edge of the
+primary monitor, with frosted-glass blur, rounded bottom corners and a soft
+shadow.
+
+It is a separate program, not part of the compositor. Start it from your
+config:
+
+```toml
+[[exec_once]]
+cmd = "otto-bar"
+```
+
+See [Autostart](autostart.md) for other ways to launch it.
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Firefox  File  Edit  View  Help      (island)      🔊 🔋  Mar 23, 21:16│
+└──────────────────────────────────────────────────────────────────────┘
+  ← left zone ────────────────►      centre       ← right zone ───────►
+```
+
+- **Left** — the focused application's name in bold, then its global menu.
+- **Centre** — deliberately empty, leaving room for the
+  [Dynamic Island](dynamic-island.md).
+- **Right** — system tray icons, then the clock.
+
+The bar reserves its own height as an exclusive zone, so maximized windows and
+other panels stop below it rather than sliding underneath.
+
+## Global application menus
+
+The left zone shows the focused window's menu — File, Edit, View and so on —
+sourced over D-Bus using the `com.canonical.dbusmenu` protocol. This is the same
+mechanism Unity and KDE's global menu use.
+
+| Action | Effect |
+|--------|--------|
+| Click a top-level title | Drop the menu down |
+| `↑` / `↓` | Move through items |
+| `→` / `Enter` on a submenu | Open it |
+| `←` | Back to the parent menu |
+| `Enter` | Activate the highlighted item |
+| `Escape` | Close |
+
+Hovering a submenu opens it after a short delay (about 300 ms) rather than
+instantly, so passing over an item on the way somewhere else does not fire it.
+Exactly one item is highlighted anywhere in the menu tree at a time.
+
+Menu items support labels, icons, keyboard-shortcut hints, separators,
+checkboxes, radio groups and arbitrarily nested submenus. Disabled items are
+dimmed and inert.
+
+### Getting an app to export its menu
+
+Not every application exports a DBusMenu. When one does not, the left zone shows
+just the application's name and the app keeps drawing its own menu bar in its
+window.
+
+- **GTK 3/4 apps** — usually export automatically over the GTK application-menu
+  D-Bus interfaces.
+- **Qt/KDE apps** — need `appmenu-qt5` / the `AppMenu` platform theme plugin.
+- **Electron and browsers** — mostly do not export menus.
+- **X11 apps** — can export via `appmenu-gtk-module` and the `UNITY_MENUBAR`
+  path.
+
+The application name shown comes from the window's `app_id` mapped through the
+desktop entry database.
+
+## System tray
+
+The right zone implements `StatusNotifierHost`, the modern tray standard
+(`org.kde.StatusNotifierItem`). Any app that registers an SNI icon appears here:
+Nextcloud, Telegram, Slack, Steam, KeePassXC, network and volume applets.
+
+| Click | Effect |
+|-------|--------|
+| Left | Open the icon's context menu |
+| Right | Activate — usually raises the app's window |
+| Middle | Secondary activate (app-defined) |
+
+Hovering shows the tooltip the app supplies. Icons are ordered by registration
+time, newest to the left.
+
+Legacy XEmbed tray icons (the old X11 system tray) are **not** supported; that
+standard has no Wayland equivalent. Apps that only do XEmbed will not appear.
+
+## Clock
+
+The clock is on the far right. Its format is a
+[chrono strftime](https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+string:
+
+```toml
+# ~/.config/otto/topbar.toml
+clock_format = "%B %-d, %A %H:%M"
+```
+
+That default renders as `March 23, Thursday 21:16`. Some other useful formats:
+
+| Format | Renders as |
+|--------|------------|
+| `"%H:%M"` | `21:16` |
+| `"%a %d %b  %H:%M"` | `Thu 23 Mar  21:16` |
+| `"%I:%M %p"` | `09:16 PM` |
+| `"%Y-%m-%d %H:%M:%S"` | `2026-03-23 21:16:04` |
+
+## Configuration
+
+`otto-bar` has its own config file, loaded from — in order, later overriding
+earlier:
+
+1. `/etc/otto/topbar.toml`
+2. `~/.config/otto/topbar.toml`
+3. `./otto_topbar.toml` (development override in the working directory)
+
+`clock_format` is currently the only option. Bar height, colours and blur follow
+the compositor's theme.
+
+## Theming
+
+The bar follows the system light/dark setting, read from the XDG Settings portal
+(`org.freedesktop.appearance color-scheme`). Change `theme_scheme` in your Otto
+config and the bar re-colours within about a second, no restart needed. See
+[Theming](theming.md).
+
+## Multi-monitor
+
+The bar appears on the **primary monitor only**. A reduced clock-and-tray bar
+for secondary monitors is designed but not implemented.
+
+## Troubleshooting
+
+**The bar does not appear.** Check it is running (`pgrep otto-bar`) and that it
+found the Wayland socket. Run it by hand from a terminal inside the session to
+see errors.
+
+**No menus for any app.** DBusMenu is opt-in per toolkit — see
+[Getting an app to export its menu](#getting-an-app-to-export-its-menu) above.
+
+**A tray icon is missing.** It is probably XEmbed-only. Check whether the app
+has an SNI or "AppIndicator" option.
+
+**The clock format is ignored.** A malformed strftime string falls back to the
+default. Verify the file parses as TOML and the key is at the top level, not in
+a table.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1,0 +1,187 @@
+# Troubleshooting
+
+Otto is in a testing phase. This page covers how to gather evidence, the
+failures people hit most often, and what makes a useful bug report.
+
+## Getting logs
+
+Otto logs to stderr, controlled by `RUST_LOG`:
+
+```sh
+RUST_LOG=info otto --winit &> /tmp/otto.log
+RUST_LOG=debug otto --winit &> /tmp/otto.log
+```
+
+Use `&>` (both stdout and stderr), not `2>` — some output goes to stdout and a
+half-captured log is a frustrating thing to debug from.
+
+Narrow it down when `debug` is too noisy:
+
+```sh
+RUST_LOG="info,otto::udev=debug,otto::workspaces=trace" otto
+```
+
+When Otto is started by a display manager, its output goes to the journal:
+
+```sh
+journalctl --user -b            # this boot, user services
+journalctl -b | grep -i otto
+```
+
+Component logs:
+
+| Component | Where |
+|-----------|-------|
+| `xdg-desktop-portal-otto` | `/tmp/portal-otto.log` |
+| `otto-bar`, `otto-islands`, `otto-lock` | stderr — run them by hand to see it |
+| `otto-rdp` | stderr; `run-rdp.sh` captures it to `/tmp/otto-rdp.log` |
+
+## Configuration problems
+
+**My config seems to be ignored.** Otto merges several files, later ones
+overriding earlier:
+
+1. `/etc/otto/config.toml`
+2. `~/.config/otto/config.toml`
+3. `./otto_config.toml` (working directory)
+4. `./otto_config.{backend}.toml` — highest priority
+
+A stray `otto_config.toml` in the directory you launched from silently wins over
+your user config. The log reports which files were loaded.
+
+**A setting has no effect.** Check the TOML parses (`taplo check`, or any TOML
+validator), and check the log for a parse error. Otto keeps running with
+defaults for a section it cannot read.
+
+**A keyboard shortcut does nothing.** Unparsable triggers and actions are
+**skipped with a warning**, not treated as an error:
+
+```sh
+grep -i "skipping shortcut" /tmp/otto.log
+```
+
+Common causes: a keysym name that does not exist, a modifier misspelled, or the
+action name in the wrong case. See
+[Keyboard Shortcuts](keyboard-shortcuts.md).
+
+## Startup failures
+
+**Otto exits immediately on a TTY.** It needs seat access — `seatd` or
+`systemd-logind` running, and your user in the right group:
+
+```sh
+systemctl status seatd
+groups        # look for 'seat' or 'video' / 'input' depending on distro
+```
+
+**"Permission denied" opening a DRM device.** Same cause. As a last resort Otto
+runs as root, but that is a diagnostic, not a setup.
+
+**Nothing appears after login from a display manager.** Check the session file
+exists (`/usr/share/wayland-sessions/otto.desktop`) and look at the journal for
+the failure.
+
+## Rendering problems
+
+**Missing, misplaced or flickering elements on the `--tty-udev` backend.**
+Otto puts parts of the desktop on separate hardware planes instead of
+compositing everything into one buffer. This is well tested on Intel GPUs; AMD
+and NVIDIA are expected to fall back to full composition when the atomic test
+rejects a configuration, but that fallback path is untested.
+
+If you see this on AMD or NVIDIA, it is the first thing to suspect, and a report
+is genuinely useful. See
+[docs/developer/drm_plane.md](../developer/drm_plane.md).
+
+**Windows are missing content or partially blank.** Try turning off occlusion
+culling — Otto skips drawing layers it believes are fully hidden, and a wrong
+belief shows up exactly like this:
+
+```toml
+occlusion_culling = false
+```
+
+**Tearing.** Explicit sync (`wp-linux-drm-syncobj-v1`) is implemented; tearing
+usually means a client is not using it. Note which application, and report it.
+
+**Otto crashes when a video plays.** Some dmabuf pixel formats are not handled
+and abort the compositor. `mpv --vo=dmabuf-wayland` with NV12 content is a known
+trigger. Work around it with `mpv --vo=gpu`, and report the format from the log.
+
+## Applications
+
+**An X11 app does not take keyboard focus.** Otto handles globally-active X11
+clients explicitly, but there may be cases it misses. Note the application and
+report it.
+
+**An X11 app is the wrong size on a HiDPI screen.** Otto exports the scale via
+XSETTINGS; a toolkit that ignores XSETTINGS needs its own env var
+(`GDK_SCALE`, `QT_SCALE_FACTOR`).
+
+**The clipboard empties when I close an app.** That is Wayland's design, not a
+bug. See [Clipboard](clipboard.md).
+
+**An app's menus do not appear in the top bar.** DBusMenu is opt-in per toolkit.
+See [Top Bar](topbar.md#getting-an-app-to-export-its-menu).
+
+## Performance
+
+Otto ships with a [puffin](https://github.com/EmbarkStudios/puffin) profiling
+server on port 8585:
+
+```sh
+cargo install puffin_viewer
+puffin_viewer --url 127.0.0.1:8585
+```
+
+Match the versions: Otto's puffin 0.19.x needs puffin_viewer 0.22.0 or later.
+
+For a build with the debugging and profiling tools enabled:
+
+```sh
+cargo run --features "dev"
+```
+
+**Everything is slow on battery (laptops).** Before blaming Otto, check whether
+your firmware is throttling the CPU — some Intel laptops pin the CPU to a few
+hundred MHz on battery via `BD_PROCHOT`. `watch -n1 "grep MHz /proc/cpuinfo"`
+tells you quickly.
+
+## Getting unstuck
+
+| Situation | Way out |
+|-----------|---------|
+| Compositor unresponsive | `Ctrl+Alt+F2` to another VT, log in, investigate |
+| Need to quit now | `Logo+Q` or `Ctrl+Alt+Backspace` |
+| Locked out by a broken locker | `Ctrl+Alt+F2` — VT switching always works while locked |
+| Broken config | Move `~/.config/otto/config.toml` aside and restart |
+
+## Reporting a bug
+
+Open an issue at [github.com/nongio/otto](https://github.com/nongio/otto/issues)
+with:
+
+1. **What you did, what happened, what you expected.**
+2. **Otto version** — `otto --version`, or the commit if you built it.
+3. **Backend** — `--tty-udev`, `--winit` or `--x11`.
+4. **Hardware** — GPU and driver especially. `lspci -k | grep -A3 VGA`.
+5. **Distribution**, and how you installed Otto.
+6. **A log** — `RUST_LOG=debug otto &> /tmp/otto.log`, attached.
+7. **Your config**, if it is not the shipped default.
+
+For a rendering bug, the scene snapshot helps a lot. Bind these and press them
+while the problem is visible:
+
+```toml
+[keyboard_shortcuts]
+"Ctrl+Alt+J" = "SceneSnapshot"   # writes scene.json
+"Ctrl+Alt+K" = "SkpSnapshot"     # writes a Skia picture of the focused screen
+```
+
+Attach `scene.json` — it describes exactly what Otto thought it was drawing.
+
+## Getting help
+
+The Matrix room is
+[`#otto-compositor:matrix.org`](https://matrix.to/#/#otto-compositor:matrix.org).
+Questions and "is this expected?" are welcome there.

--- a/docs/user/window-management.md
+++ b/docs/user/window-management.md
@@ -1,0 +1,143 @@
+# Window Management
+
+Otto is a **stacking** window manager: windows float, overlap, and go where you
+put them. There is no automatic tiling layout — but there are tiling shortcuts,
+smart initial placement, and animated state changes.
+
+## Focus and raising
+
+Otto uses click-to-focus. Clicking anywhere in a window raises it to the top of
+the stack and gives it keyboard focus. Focus also follows:
+
+- clicking the app's icon in the [Dock](dock.md),
+- selecting it in the [App Switcher](expose-and-switcher.md) or
+  [Exposé](expose-and-switcher.md),
+- an `xdg-activation` request from another app (for instance, a link opening in
+  your browser raises the browser).
+
+The focused window's name and menus appear in the [Top Bar](topbar.md).
+
+## Moving and resizing
+
+Drag a window by its title bar to move it; drag an edge or corner to resize.
+Both are driven by the application: Otto starts the move or resize when the app
+asks it to, which is what happens when you grab the parts of the window its
+toolkit designates for that.
+
+Dragging a **maximized** window unmaximizes it and keeps the grab point under
+your pointer, proportionally — so the window shrinks to its restored size around
+where you grabbed it rather than jumping away.
+
+There is no modifier-drag (`Alt`+drag) to move a window from anywhere yet.
+
+## Decorations
+
+Otto always asks applications to draw their own decorations. Even when a client
+requests server-side decorations via `xdg-decoration`, Otto answers
+*client-side*. Title bars, close buttons and shadows therefore come from the
+application's own toolkit, and look like whatever that toolkit does.
+
+The `ToggleDecorations` shortcut action flips every window's requested
+decoration mode, which is mostly useful for testing how apps respond.
+
+## Maximize
+
+`ToggleMaximizeWindow` (`Ctrl+Up` by default) maximizes the focused window to
+fill its monitor's usable area — that is, minus any exclusive zones claimed by
+the top bar or other panels. Pressing it again restores the previous geometry.
+
+The transition is animated: the window grows or shrinks into place rather than
+snapping.
+
+Applications with their own maximize button use the same path.
+
+## Tiling to halves
+
+| Shortcut | Effect |
+|----------|--------|
+| `Ctrl+Left` | Snap the focused window to the left half of its monitor |
+| `Ctrl+Right` | Snap it to the right half |
+
+These are one-shot geometry changes, not a managed tiling mode: nothing keeps
+the two windows in sync, and moving or resizing either one afterwards just
+works normally. Tiling a maximized window unmaximizes it first.
+
+There is no drag-to-edge snapping yet — tiling is keyboard-only.
+
+## Fullscreen
+
+Fullscreen is driven by the application (a video player's fullscreen button, a
+game's settings, `F11` in a browser). Otto animates the window into the
+monitor's full extent and hides the dock while it is up.
+
+Fullscreen windows are the best case for Otto's direct-scanout path on the
+`--tty-udev` backend: a fullscreen window can be handed straight to the display
+hardware without going through composition at all, which is why fullscreen games
+and video playback are noticeably more efficient. This includes X11 games under
+XWayland.
+
+## Minimize
+
+Minimizing sends the window into the Dock with a **genie** animation — the
+window stretches and funnels down into the dock's minimized-windows area.
+Clicking its thumbnail in the dock plays the animation in reverse.
+
+The genie effect's shape is tunable with `dock.genie_scale` and
+`dock.genie_span` — see [Dock](dock.md).
+
+Minimized windows are excluded from Exposé.
+
+## Where new windows appear
+
+Otto places a new window where it overlaps existing windows the **least**,
+rather than cascading from a corner.
+
+It considers the four corners of the usable area first (clockwise from
+top-left), then positions flush to the right edge and bottom edge of every
+window already on screen. Whichever candidate produces the smallest total
+overlap area wins, with ties going to the earlier candidate — so an empty
+top-left corner is preferred over a technically-equal position elsewhere.
+
+Windows that end up disjoint rather than overlapping also stay eligible for
+hardware plane scanout, which is a rendering win, not just a visual preference.
+
+Applications that position their own windows (dialogs anchored to a parent,
+tooltips, menus) are unaffected; this only governs top-level windows that
+leave placement to the compositor.
+
+## Closing
+
+`CloseWindow` politely asks the focused window to close, the same as clicking
+its close button — the application can still prompt you about unsaved work.
+There is no force-kill shortcut.
+
+`ApplicationSwitchQuit` (`Ctrl+Q` by default, while the app switcher is open)
+quits the highlighted **application**, closing all of its windows.
+
+## Moving windows between workspaces and monitors
+
+Drag a window preview in [Exposé](expose-and-switcher.md) onto a workspace
+thumbnail in the selector strip to move it there. Dragging a window across the
+boundary between two monitors moves it to the other monitor. See
+[Workspaces](workspaces.md).
+
+## X11 applications
+
+X11 apps run under XWayland and are managed exactly like native ones — same
+focus, tiling, minimize and exposé behaviour.
+
+Two things get special handling:
+
+- **Globally-active clients** (many Java and game-engine applications) do not
+  take focus the normal way. Otto explicitly sets X11 input focus for them, so
+  keyboard input reaches them.
+- **Scale.** Otto exports the output scale to X11 clients via XSETTINGS, so
+  they render at the right size on HiDPI displays instead of at 1×.
+
+## What is not there yet
+
+- Drag-to-edge tiling and quarter tiles
+- A modifier-drag to move or resize from anywhere in a window
+- Window rules (per-app placement, size, workspace assignment)
+- Always-on-top / sticky windows
+- Per-window capture (see [Screen Sharing](screen-sharing.md))

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -1,0 +1,121 @@
+# Workspaces
+
+A workspace is a full-screen page of windows. Otto arranges them in a
+horizontal row and slides between them.
+
+## Per-monitor workspaces
+
+**Each monitor has its own independent set of workspaces.** Adding a workspace
+on your laptop screen does not add one on the external monitor; switching to
+workspace 3 on one screen leaves the other where it is; and the two can have
+different numbers of workspaces.
+
+This applies to virtual outputs too — a screenshare or RDP output has its own
+workspaces exactly like a physical monitor.
+
+Every monitor always has at least one workspace.
+
+## Switching
+
+| How | What it does |
+|-----|--------------|
+| `Ctrl+1` … `Ctrl+4` | Jump to workspace 1–4 (the shipped bindings) |
+| Three-finger horizontal swipe | Slide between adjacent workspaces |
+| Click a preview in the workspace selector | Jump to that workspace |
+
+Keyboard and gesture switching both act on the **focused monitor** — the one
+your pointer was last over.
+
+More than four workspaces? Add bindings with a higher `index`:
+
+```toml
+"Ctrl+5" = { builtin = "Workspace", index = 4 }
+"Ctrl+6" = { builtin = "Workspace", index = 5 }
+```
+
+The index is zero-based, so `index = 4` is the fifth workspace. Switching to a
+workspace that does not exist does nothing.
+
+### Swipe behaviour
+
+The desktop tracks your fingers as you swipe, so you can see the neighbouring
+workspace arrive and reverse out of it. Otto snaps on release based on both
+position and velocity — a fast flick advances even from a short movement.
+
+At the first and last workspace the slide meets rubber-band resistance rather
+than a hard stop.
+
+## The workspace selector
+
+Open [Exposé](expose-and-switcher.md) (`PageUp`, or three-finger swipe up) and a
+strip of live workspace previews appears above the window grid. Each monitor
+shows its own strip, listing only its own workspaces.
+
+| Control | Effect |
+|---------|--------|
+| Click a preview | Switch that monitor to that workspace |
+| Click `+` at the end of the strip | Add a workspace to that monitor |
+| Hover a preview, click the `×` | Remove that workspace from that monitor |
+
+The previews are live: they show the actual current content of each workspace,
+at that monitor's own size and scale, not a stale screenshot.
+
+Adding and removing are animated — a new preview grows in from zero width, a
+removed one shrinks away before the workspace actually goes.
+
+### Removing a workspace
+
+- A monitor's last remaining workspace cannot be removed.
+- Windows on the removed workspace are **not** closed — they move to that
+  monitor's current workspace.
+- A workspace holding a fullscreen window with content in it cannot be removed.
+
+## Moving windows between workspaces
+
+Open exposé, then **drag a window preview onto a workspace thumbnail** in the
+selector strip. Release, and the window moves to that workspace; the grid
+relaws out around the gap it left.
+
+Dropping outside any thumbnail cancels — the preview springs back to where it
+came from.
+
+## Moving windows between monitors
+
+Drag a window across the boundary between two monitors and it moves to the
+other one, keeping its own workspaces and geometry. While it straddles the
+edge only one monitor draws it at a time; a live preview on both is planned but
+not implemented.
+
+## Fullscreen and workspaces
+
+Fullscreening a window puts it on a workspace of its own, on the monitor it
+already lived on, and scrolls only that monitor to it. Other monitors do not
+move. Leaving fullscreen restores the window to its previous size and workspace
+and removes the temporary one.
+
+## What is shared and what is not
+
+| Element | Scope |
+|---------|-------|
+| Workspaces | Per monitor |
+| Workspace selector | Per monitor, one strip each |
+| Exposé grid | Per monitor, all open together |
+| [Dock](dock.md) | Primary monitor only |
+| [Top bar](topbar.md) | Primary monitor only |
+| [App switcher](expose-and-switcher.md) | One panel; moves to the monitor under the pointer |
+
+## Configuring
+
+Workspaces are not configured in TOML — there is no "number of workspaces"
+setting. They are created and removed at runtime through the selector, and each
+monitor starts with one.
+
+Wallpaper and background colour are set globally under
+[Theming](theming.md).
+
+## Not yet supported
+
+- Naming workspaces
+- Dragging a workspace from one monitor to another
+- Assigning applications to a workspace by rule
+- Persisting the workspace layout across restarts


### PR DESCRIPTION
Adds a user-facing guide under `docs/user/`, covering the desktop and the features that landed over the last release cycle. `docs/user/` previously held three pages (`configuration.md`, `autostart.md`, `clipboard.md`), and `configuration.md` linked to eight topic pages that did not exist.

## New pages

**Orientation** — `README.md` (index), `getting-started.md` (install, backends, CLI flags, first-run checklist), `desktop-tour.md`

**Using the desktop** — `window-management.md`, `workspaces.md`, `expose-and-switcher.md`, `dock.md`, `topbar.md`, `dynamic-island.md`, `keyboard-shortcuts.md`, `gestures.md`

**Configuration** — `display.md`, `theming.md`, `input.md`, `audio.md`, `power-management.md`, `night-shift.md`

**Sessions and remote access** — `lock-screen.md`, `login-greeter.md`, `screen-sharing.md`, `remote-desktop.md`

**`troubleshooting.md`** — logs, common failures, and what makes a useful bug report.

`configuration.md`'s topic table now resolves, and the root README links the guide.

## Corrections

Content was derived from the source and specs rather than existing prose, which surfaced four inaccuracies in the README, fixed here:

- Exposé's default key is `PageUp` (`Prior`); `PageDown` (`Next`) is show-desktop.
- The dynamic island does not render the brightness/volume HUD — that is a separate compositor-drawn OSD (`workspaces.osd`). The island is the notification daemon, activity surface and dialog renderer.
- Screenshots already work through `wlr-screencopy` (`grim`); only per-window capture and a built-in UI are outstanding.
- The Exposé/show-desktop gesture split (three-finger swipe up vs four-finger pinch out) was not documented.

## Two gaps worth a look

- **`otto.portal` advertises only `ScreenCast` and `Settings`**, although `AccessPortal` is implemented and registered on the bus. As shipped, `xdg-desktop-portal` will not route a sandboxed app's Access request to Otto's dialog. The docs describe the ScreenCast/Settings routing as the supported setup and scope the permission dialog to Otto-initiated flows. Adding `org.freedesktop.impl.portal.Access` to `otto.portal` is a separate change.
- **`otto-rdp` has no access control.** `--tls` encrypts the transport but does not gate it. `remote-desktop.md` says so plainly and recommends binding to localhost with an SSH tunnel.

## Notes

Documentation only — no behavior change, so no spec sync was needed.
