### PR TITLE
doc: recommend region-qualified locale identifiers in config

### DIFF
--- a/docs/user/theming.md
+++ b/docs/user/theming.md
@@ -115,11 +115,16 @@ inheritance — a theme that lacks an icon falls back to its parent.
 ## Language
 
 ```toml
-locales = ["en"]
+locales = ["en_US", "en"]
 ```
 
 Preferred languages for application names and descriptions read from `.desktop`
-files. `["fr", "en"]` means "French if the entry has it, English otherwise".
+files. Use standard locale identifiers, most specific first, and prefer the
+region-qualified form (`lang_COUNTRY`): `["fr_FR", "fr"]` means "French (France)
+if the entry has that variant, plain French otherwise, English as the ultimate
+fallback from the entry's untranslated name". Matching follows the freedesktop
+Desktop Entry spec and falls back automatically from region to bare language, so
+listing both `zh_CN` and `zh` catches entries that localize either form.
 
 This affects names shown in the dock, app switcher and menus. It does not change
 Otto's own UI language.
@@ -142,7 +147,7 @@ cursor_theme = "Adwaita"
 cursor_size = 32
 icon_theme = "Papirus-Dark"
 
-locales = ["en"]
+locales = ["en_US", "en"]
 ```
 
 ## Troubleshooting

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -1,6 +1,6 @@
 # Display
 screen_scale = 1.0
-locales = ["en"]  # Language preferences for app names/desktop entries (e.g., ["fr", "en"])
+locales = ["en_US", "en"]  # Language preferences for app names/desktop entries, most specific first. Use standard locale identifiers with region codes (e.g., ["fr_FR", "fr"], ["zh_CN", "zh"]); matching falls back from region to bare language.
 
 # Occlusion culling: skip rendering of layers fully hidden behind opaque layers.
 # Improves GPU/CPU throughput when windows overlap. Disable if you see missing content.


### PR DESCRIPTION
Config comments and the theming guide now recommend standard
lang_COUNTRY locale identifiers (e.g. en_US, zh_CN), most specific
first, matching the freedesktop fallback behavior already supported.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GeSMvU7NytBgUYHhG8QnhT