### PR TITLE
fix(scale): correct otto-bar sizing on fractional-scale outputs

### DIFF
--- a/components/otto-bar/src/app.rs
+++ b/components/otto-bar/src/app.rs
@@ -131,7 +131,11 @@ impl TopBarApp {
         txn.set_duration(0.5);
         txn.set_timing_function(&timing);
 
-        let scale = AppContext::scale_factor().max(1) as f64;
+        // Surface-style geometry is in physical pixels, so it must use the
+        // output's fractional scale — the integer buffer scale is 2 on a 1.5x
+        // output and would size the panel past its exclusive zone, over the
+        // maximized window below.
+        let scale = AppContext::fractional_scale();
         style.set_size(width as f64 * scale, height as f64 * scale);
 
         txn.commit();

--- a/components/otto-kit/src/app_runner/context.rs
+++ b/components/otto-kit/src/app_runner/context.rs
@@ -87,6 +87,12 @@ static EXIT_REQUESTED: std::sync::atomic::AtomicBool = std::sync::atomic::Atomic
 
 static DISPLAY_SCALE_FACTOR: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(2);
 
+/// Preferred fractional scale in 120ths, as sent by `wp_fractional_scale_v1`.
+/// 0 means the compositor has not sent one yet — callers fall back to the
+/// integer `wl_surface` scale.
+static DISPLAY_FRACTIONAL_SCALE_120: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
 // -- Wakeup pipe (cross-thread) --
 
 use std::sync::OnceLock;
@@ -133,6 +139,7 @@ pub struct AppContextData {
     pub otto_dock_manager: Option<crate::protocols::otto_dock_manager_v1::OttoDockManagerV1>,
     pub session_lock_manager: Option<wayland_protocols::ext::session_lock::v1::client::ext_session_lock_manager_v1::ExtSessionLockManagerV1>,
     pub cursor_shape_manager: Option<wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1>,
+    pub fractional_scale_manager: Option<wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
     pub display_ptr: *mut std::ffi::c_void,
 }
 
@@ -186,6 +193,24 @@ impl<'a> AppContext<'a> {
         DISPLAY_SCALE_FACTOR.store(factor, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// The output scale as a fraction (physical pixels per logical point).
+    ///
+    /// Buffers are still rendered at the integer [`scale_factor`], but geometry
+    /// handed to the compositor in physical pixels — surface-style sizes and
+    /// positions — must use this: on a 1.5x output the integer factor is 2, and
+    /// scaling by it makes a surface a third too large.
+    pub fn fractional_scale() -> f64 {
+        match DISPLAY_FRACTIONAL_SCALE_120.load(std::sync::atomic::Ordering::Relaxed) {
+            0 => Self::scale_factor().max(1) as f64,
+            n => n as f64 / 120.0,
+        }
+    }
+
+    /// Store the preferred scale from `wp_fractional_scale_v1` (in 120ths).
+    pub(crate) fn set_fractional_scale_120(scale_120: u32) {
+        DISPLAY_FRACTIONAL_SCALE_120.store(scale_120, std::sync::atomic::Ordering::Relaxed);
+    }
+
     pub fn xdg_shell_state() -> &'static XdgShell {
         Self::with_global(|ctx| unsafe { &*(ctx.xdg_shell_state_ref() as *const XdgShell) })
     }
@@ -195,6 +220,16 @@ impl<'a> AppContext<'a> {
         Self::with_global(|ctx| unsafe {
             ctx.surface_style_manager_ref()
                 .map(|r| &*(r as *const otto_surface_style_manager_v1::OttoSurfaceStyleManagerV1))
+        })
+    }
+
+    pub fn fractional_scale_manager() -> Option<&'static wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>{
+        use wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1;
+        Self::with_global(|ctx| unsafe {
+            ctx.data
+                .fractional_scale_manager
+                .as_ref()
+                .map(|r| &*(r as *const WpFractionalScaleManagerV1))
         })
     }
 

--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -367,6 +367,8 @@ impl<A: App + 'static> AppRunnerWithType<A> {
         let subcompositor = globals.bind(&qh, 1..=1, ()).ok();
         let cursor_shape_manager: Option<wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1> =
             globals.bind(&qh, 1..=2, ()).ok();
+        let fractional_scale_manager: Option<wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1> =
+            globals.bind(&qh, 1..=1, ()).ok();
 
         // Get display pointer for creating surfaces
         let display_ptr = conn.backend().display_ptr() as *mut std::ffi::c_void;
@@ -387,6 +389,7 @@ impl<A: App + 'static> AppRunnerWithType<A> {
             otto_dock_manager,
             session_lock_manager,
             cursor_shape_manager,
+            fractional_scale_manager,
             display_ptr,
         });
 
@@ -1072,9 +1075,32 @@ impl<A: App + 'static> Dispatch<otto_dock_item_v1::OttoDockItemV1, ()> for AppDa
     }
 }
 
+impl<A: App + 'static>
+    Dispatch<
+        wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1,
+        (),
+    > for AppData<A>
+{
+    fn event(
+        _state: &mut Self,
+        _proxy: &wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1,
+        event: wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        use wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_v1::Event;
+        if let Event::PreferredScale { scale } = event {
+            tracing::debug!("preferred fractional scale: {}", scale as f64 / 120.0);
+            AppContext::set_fractional_scale_120(scale);
+        }
+    }
+}
+
 // Delegate noop for protocols we don't handle
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_client::protocol::wl_subcompositor::WlSubcompositor);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_client::protocol::wl_subsurface::WlSubsurface);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore ZwlrLayerShellV1);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1);
+wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);

--- a/components/otto-kit/src/components/context_menu/context_menu.rs
+++ b/components/otto-kit/src/components/context_menu/context_menu.rs
@@ -1064,13 +1064,15 @@ impl ContextMenu {
             // buffer. Setting it on the scene layer as well composites it
             // twice, so a translucent material lands far more opaque than the
             // same menu drawn compositor-side (the dock's).
-            // Scene-layer geometry is in physical pixels, unlike the painted
-            // content, so the radius and shadow scale with the output. Values
-            // match the compositor-side menus (the dock's) so a menu looks the
-            // same wherever it is drawn.
+            // Shadow geometry is in physical pixels, so it scales with the
+            // output; values match the compositor-side menus (the dock's) so a
+            // menu looks the same wherever it is drawn. The corner radius does
+            // NOT get scaled here — it has to agree with the rounding the
+            // renderer paints into the buffer, and scaling it makes the bar's
+            // menus visibly rounder than the dock's.
             let scale = crate::app_runner::context::AppContext::fractional_scale();
             let shadow = style.theme.shadow;
-            scene_surface.set_corner_radius(style.corner_radius as f64 * scale);
+            scene_surface.set_corner_radius(style.corner_radius as f64);
             scene_surface.set_masks_to_bounds(ClipMode::Enabled);
             scene_surface.set_shadow(
                 shadow.a() as f64 / 255.0,

--- a/components/otto-kit/src/components/context_menu/context_menu.rs
+++ b/components/otto-kit/src/components/context_menu/context_menu.rs
@@ -1060,13 +1060,10 @@ impl ContextMenu {
 
     fn apply_surface_effects(style: &ContextMenuStyle, popup: &PopupSurface) {
         if let Some(scene_surface) = popup.base_surface().surface_style() {
-            let bg = style.background_color();
-            scene_surface.set_background_color(
-                bg.r() as f64 / 255.0,
-                bg.g() as f64 / 255.0,
-                bg.b() as f64 / 255.0,
-                bg.a() as f64 / 255.0,
-            );
+            // The renderer already paints `style.background_color()` into the
+            // buffer. Setting it on the scene layer as well composites it
+            // twice, so a translucent material lands far more opaque than the
+            // same menu drawn compositor-side (the dock's).
             scene_surface.set_corner_radius(style.corner_radius as f64);
             scene_surface.set_masks_to_bounds(ClipMode::Enabled);
             scene_surface.set_shadow(0.2, 2.0, 0.0, 7.0, 0.3, 0.3, 0.3);

--- a/components/otto-kit/src/components/context_menu/context_menu.rs
+++ b/components/otto-kit/src/components/context_menu/context_menu.rs
@@ -1064,9 +1064,23 @@ impl ContextMenu {
             // buffer. Setting it on the scene layer as well composites it
             // twice, so a translucent material lands far more opaque than the
             // same menu drawn compositor-side (the dock's).
-            scene_surface.set_corner_radius(style.corner_radius as f64);
+            // Scene-layer geometry is in physical pixels, unlike the painted
+            // content, so the radius and shadow scale with the output. Values
+            // match the compositor-side menus (the dock's) so a menu looks the
+            // same wherever it is drawn.
+            let scale = crate::app_runner::context::AppContext::fractional_scale();
+            let shadow = style.theme.shadow;
+            scene_surface.set_corner_radius(style.corner_radius as f64 * scale);
             scene_surface.set_masks_to_bounds(ClipMode::Enabled);
-            scene_surface.set_shadow(0.2, 2.0, 0.0, 7.0, 0.3, 0.3, 0.3);
+            scene_surface.set_shadow(
+                shadow.a() as f64 / 255.0,
+                16.0 * scale,
+                0.0,
+                4.0 * scale,
+                shadow.r() as f64 / 255.0,
+                shadow.g() as f64 / 255.0,
+                shadow.b() as f64 / 255.0,
+            );
             scene_surface.set_blend_mode(BlendMode::BackgroundBlur);
         }
     }

--- a/components/otto-kit/src/components/context_menu/style.rs
+++ b/components/otto-kit/src/components/context_menu/style.rs
@@ -152,7 +152,7 @@ impl ContextMenuStyle {
 
     /// Get the background color from theme
     pub fn background_color(&self) -> skia_safe::Color {
-        self.theme.material_medium
+        self.theme.material_popup
     }
 
     /// Get the border color from theme — lighter than the background for definition

--- a/components/otto-kit/src/surfaces/common.rs
+++ b/components/otto-kit/src/surfaces/common.rs
@@ -61,6 +61,12 @@ impl BaseWaylandSurface {
         });
         let surface_style = AppContext::surface_style_manager()
             .map(|manager| manager.get_surface_style(&wl_surface, AppContext::queue_handle(), ()));
+        // Learn the output's fractional scale. Buffers stay at the integer
+        // `buffer_scale`, but geometry sent to the compositor in physical
+        // pixels needs the real fraction — see `AppContext::fractional_scale`.
+        if let Some(manager) = AppContext::fractional_scale_manager() {
+            let _ = manager.get_fractional_scale(&wl_surface, AppContext::queue_handle(), ());
+        }
         Self {
             wl_surface,
             skia_surface: None,

--- a/components/otto-kit/src/theme.rs
+++ b/components/otto-kit/src/theme.rs
@@ -42,6 +42,9 @@ pub struct Theme {
     pub material_titlebar: Color,
     pub material_sidebar: Color,
     pub material_medium: Color,
+    /// Menus and popups. More opaque than `material_medium`: they float over
+    /// arbitrary content and their text has to stay readable against it.
+    pub material_popup: Color,
     pub material_highlight: Color,
     pub material_selection_focused: Color,
 
@@ -68,6 +71,7 @@ impl Theme {
             material_titlebar: Color::from_argb(0xCC, 0xEA, 0xEA, 0xEA),
             material_sidebar: Color::from_argb(0xAF, 0xEA, 0xEA, 0xEA),
             material_medium: Color::from_argb(0x7A, 0xF6, 0xF6, 0xF6),
+            material_popup: Color::from_argb(0xD8, 0xF6, 0xF6, 0xF6),
             material_highlight: Color::from_argb(0x9E, 0xF7, 0xF7, 0xF7),
             material_selection_focused: Color::from_argb(0xBF, 0x0A, 0x82, 0xFF),
 
@@ -95,6 +99,7 @@ impl Theme {
             material_titlebar: Color::from_argb(0xBF, 0x28, 0x28, 0x28),
             material_sidebar: Color::from_argb(0xA8, 0x1E, 0x1E, 0x1E),
             material_medium: Color::from_argb(0x83, 0x28, 0x28, 0x28),
+            material_popup: Color::from_argb(0xD8, 0x28, 0x28, 0x28),
             material_highlight: Color::from_argb(0xA2, 0x69, 0x67, 0x67),
             material_selection_focused: Color::from_argb(0xBF, 0x0A, 0x82, 0xFF),
 

--- a/specs/context-menus.md
+++ b/specs/context-menus.md
@@ -31,6 +31,7 @@ Context menus are hierarchical popup menus that display items for user selection
 4. Menu height is the sum of all item heights plus vertical padding.
 5. Items are rendered with a rounded-rect highlight when selected. Separators are not selectable.
 6. Disabled items are rendered with reduced opacity and do not respond to user interaction.
+6a. The menu background uses the theme's popup material, which is more opaque than the chrome materials used for bars and sidebars: a menu floats over arbitrary window content and its labels must stay readable against it.
 
 ### Keyboard Navigation
 

--- a/specs/topbar.md
+++ b/specs/topbar.md
@@ -100,7 +100,7 @@ The Top Bar is a persistent, full-width panel anchored to the top edge of the pr
 - **App has no dbusmenu:** Show only app name, no menu entries. Do not show an empty menu bar.
 - **SNI watcher absent:** Tray section is hidden. The bar must not crash — re-probe every 30 seconds.
 - **Menu root changes while open:** Close the current open menu and re-fetch before re-opening.
-- **HiDPI / fractional scaling:** The bar must render at the output's native scale. All sizes are in logical points; the bar converts to physical pixels using the output's scale factor.
+- **HiDPI / fractional scaling:** The bar must render at the output's native scale. All sizes are in logical points; the bar converts to physical pixels using the output's *fractional* scale (`wp_fractional_scale_v1`), not the integer buffer scale — on a 1.5x output the integer scale is 2, and sizing by it pushes the panels past their exclusive zone and over the window below.
 - **Theme change:** Re-apply colors within one second without restarting. Use the color-scheme D-Bus portal (`org.freedesktop.portal.Settings`) to track system theme.
 - **Multiple monitors:** Primary-output bar shows all three zones. Secondary-output bars (if enabled) show only tray + clock.
 - **Right-to-left locales:** Zone order reverses (right zone on left, left zone on right). Menu popup alignment mirrors accordingly.

--- a/src/workspaces/dock/render.rs
+++ b/src/workspaces/dock/render.rs
@@ -244,8 +244,10 @@ pub fn setup_miniwindow_icon(layer: &Layer, inner_layer: &Layer, icon_width: f32
 }
 
 pub fn setup_label(new_layer: &Layer, label_text: String) {
-    let _draw_scale = Config::with(|config| config.screen_scale as f32);
-    let text_size = 26.0;
+    // The tooltip is drawn straight into the scene, so every measurement below
+    // is in physical pixels: keep the design in logical points and scale once.
+    let scale = Config::with(|config| config.screen_scale as f32);
+    let text_size = 13.0 * scale;
     let font_family = Config::with(|config| config.font_family.clone());
     let font = FONT_CACHE.with(|font_cache| {
         font_cache.make_font_with_fallback(
@@ -260,17 +262,17 @@ pub fn setup_label(new_layer: &Layer, label_text: String) {
     let text_bounds = font.measure_str(label_text, Some(&paint));
 
     let text_bounds = text_bounds.1;
-    let arrow_height = 20.0;
-    let text_padding_h = 30.0;
-    let text_padding_v = 14.0;
-    let safe_margin = 100.0;
+    let arrow_height = 10.0 * scale;
+    let text_padding_h = 15.0 * scale;
+    let text_padding_v = 7.0 * scale;
+    let safe_margin = 50.0 * scale;
     let label_size_width = text_bounds.width() + text_padding_h * 2.0 + safe_margin * 2.0;
     // Fixed height based on font size, not measured text bounds
     let label_size_height = text_size + arrow_height + text_padding_v * 2.0 + safe_margin * 2.0;
 
-    let rect_corner_radius = 10.0;
-    let arrow_width = 25.0;
-    let arrow_corner_radius = 3.0;
+    let rect_corner_radius = 5.0 * scale;
+    let arrow_width = 12.5 * scale;
+    let arrow_corner_radius = 1.5 * scale;
     // Calculate tooltip dimensions
     let tooltip_width = label_size_width - safe_margin * 2.0;
     let tooltip_height = label_size_height - safe_margin * 2.0;
@@ -347,11 +349,11 @@ pub fn setup_label(new_layer: &Layer, label_text: String) {
         .background_color(theme_colors().materials_ultrathick)
         .position(Point {
             x: -label_size_width / 2.0,
-            y: -label_size_height - 10.0 + safe_margin,
+            y: -label_size_height - 5.0 * scale + safe_margin,
         })
         .shadow_color(theme_colors().shadow_color)
         .shadow_offset(((0.0, 0.0).into(), None))
-        .shadow_radius((20.0, None))
+        .shadow_radius((10.0 * scale, None))
         .opacity((0.0, None))
         .pointer_events(false)
         .content(Some(draw_label))

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -299,6 +299,22 @@ pub fn configure_surface_layer(
         let src_w = draw_wvs.phy_src_w.max(1.0);
         let src_h = draw_wvs.phy_src_h.max(1.0);
 
+        // Buffer pixels are not physical pixels: a client painting at buffer
+        // scale 2 on a 1.5x output hands us a 60px buffer for 45 physical px.
+        // The non-resizing gravities align the texture rather than stretch it,
+        // but they still have to bridge that ratio — otherwise the content is
+        // drawn oversized and cropped to the layer.
+        let base_x = if draw_wvs.phy_dst_w > 0.0 {
+            draw_wvs.phy_dst_w / src_w
+        } else {
+            1.0
+        };
+        let base_y = if draw_wvs.phy_dst_h > 0.0 {
+            draw_wvs.phy_dst_h / src_h
+        } else {
+            1.0
+        };
+
         // Use live w/h for all gravity modes so the draw scales correctly during animations.
         let (scale_x, scale_y, tx, ty) = match gravity {
             ContentsGravity::Resize => (w / src_w, h / src_h, 0.0f32, 0.0f32),
@@ -315,14 +331,14 @@ pub fn configure_surface_layer(
                 (s, s, tx, ty)
             }
             ContentsGravity::Center => {
-                let tx = (w - src_w) / 2.0;
-                let ty = (h - src_h) / 2.0;
-                (1.0f32, 1.0f32, tx, ty)
+                let tx = (w - src_w * base_x) / 2.0;
+                let ty = (h - src_h * base_y) / 2.0;
+                (base_x, base_y, tx, ty)
             }
-            ContentsGravity::TopLeft => (1.0f32, 1.0f32, 0.0f32, 0.0f32),
+            ContentsGravity::TopLeft => (base_x, base_y, 0.0f32, 0.0f32),
             ContentsGravity::TopRight => {
-                let tx = w - src_w;
-                (1.0f32, 1.0f32, tx, 0.0f32)
+                let tx = w - src_w * base_x;
+                (base_x, base_y, tx, 0.0f32)
             }
         };
 


### PR DESCRIPTION
A user reported windows positioned wrongly at `screen_scale = 1.5`. The root cause is that our chrome sizes itself from the *integer* buffer scale, which is 2 on a 1.5x output.

## What was broken

- **otto-bar panels overlapped the maximized window.** The exclusive zone was correct (30pt → 45px), but `animate_right_size` sized the panel via the surface-style protocol as `height × AppContext::scale_factor()` — the integer wl_surface scale. The panel came out 60px tall against a 45px reservation and spilled 15px over the window below.
- **Panel contents were drawn oversized and cropped.** `ContentsGravity::TopLeft`/`TopRight`/`Center` blit 1:1, assuming buffer pixels are physical pixels. That holds only when the client's buffer scale equals the output scale; at 1.5 a 60px buffer was blitted into a 45px layer, cutting off the tray icons and making the clock look too large for the strip.
- **The dock tooltip ignored the scale entirely** — it computed a `_draw_scale`, never used it, and hardcoded every measurement at 2x (26px font, 30/14 padding, 20/25 arrow).

## Changes

- otto-kit binds `wp_fractional_scale_v1` (the compositor already implements it) and exposes `AppContext::fractional_scale()`, falling back to the integer scale when no preferred scale has arrived. Buffers still render at the integer scale; only geometry sent to the compositor in physical pixels uses the fraction.
- otto-bar sizes its panels with it.
- `configure_surface_layer` scales the aligning gravities by `phy_dst / src` instead of 1.0. That ratio is exactly 1.0 when buffer scale matches output scale, so scale 1.0 and 2.0 are untouched.
- The dock tooltip derives its geometry and font from `screen_scale`; the constants reproduce today's values exactly at 2.0.

## Also here

Menus used `material_medium` — the material meant for the bar strip, under 50% alpha — which is hard to read floating over window content. They now use a dedicated `material_popup` at ~85%. Client-side popups additionally applied that color twice (painted into the buffer *and* set on the scene layer), landing near-opaque and visibly flatter than the dock's compositor-side menus; the duplicate is gone, so both paths match.

Specs updated: `specs/topbar.md` (fractional vs integer scale), `specs/context-menus.md` (popup material).

## Verification

Ran at `screen_scale = 1.5` on tty-udev. Pixel-measured from `grim` captures: the bar strip now spans y 0→45 physical, exactly 30pt × 1.5, with the window content starting at 45 and no overlap; tray icons render complete and proportional. Scale 2.0 paths are arithmetically unchanged (every new factor evaluates to its previous constant).

https://claude.ai/code/session_01YVaSStMgyRMnsvSnjaVakn