### PR TITLE
feat(screenshare): share a single window

### DIFF
--- a/components/otto-islands/src/dialog.rs
+++ b/components/otto-islands/src/dialog.rs
@@ -34,6 +34,9 @@ const GROUP_LABEL_H: f32 = 18.0;
 const OPTION_H: f32 = 44.0;
 const OPTION_GAP: f32 = 6.0;
 const OPTION_RADIUS: f32 = 11.0;
+/// Space kept clear at the right edge of an option row for the checkmark.
+/// Reserved on unselected rows too, so labels don't reflow as selection moves.
+const CHECK_GUTTER: f32 = 30.0;
 const BTN_H: f32 = 36.0;
 const BTN_GAP: f32 = 10.0;
 const BTN_RADIUS: f32 = 10.0;
@@ -273,6 +276,47 @@ fn font(size: f32, weight: i32) -> skia_safe::Font {
     .font()
 }
 
+/// Truncate `text` to fit `max_w`, appending an ellipsis when it doesn't.
+///
+/// Window titles are arbitrary and frequently longer than the panel — without
+/// this they run under the checkmark and off the rounded edge. Walks back by
+/// character (not byte) so multi-byte titles can't be split mid-codepoint.
+fn ellipsize(text: &str, f: &skia_safe::Font, max_w: f32) -> String {
+    if f.measure_str(text, None).0 <= max_w {
+        return text.to_string();
+    }
+    const ELLIPSIS: &str = "…";
+    let ellipsis_w = f.measure_str(ELLIPSIS, None).0;
+    // Nothing sensible fits — an ellipsis alone still beats overflowing.
+    if ellipsis_w > max_w {
+        return ELLIPSIS.to_string();
+    }
+    let budget = max_w - ellipsis_w;
+    let mut end = 0;
+    for (idx, ch) in text.char_indices() {
+        let next = idx + ch.len_utf8();
+        if f.measure_str(&text[..next], None).0 > budget {
+            break;
+        }
+        end = next;
+    }
+    // Don't leave a dangling space before the ellipsis.
+    format!("{}{ELLIPSIS}", text[..end].trim_end())
+}
+
+/// Centered variant: truncates to `max_w`, then centers whatever survived.
+fn draw_text_centered_clamped(
+    canvas: &Canvas,
+    text: &str,
+    cx: f32,
+    baseline_y: f32,
+    f: &skia_safe::Font,
+    color: Color,
+    max_w: f32,
+) {
+    draw_text_centered(canvas, &ellipsize(text, f, max_w), cx, baseline_y, f, color);
+}
+
 fn draw_text_centered(
     canvas: &Canvas,
     text: &str,
@@ -302,11 +346,18 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
 
     let w = layout.width;
     let cx = w / 2.0;
+    // Every centered run of text is clamped to the panel's content width.
+    let text_max_w = w - PAD * 2.0;
     let theme = otto_kit::AppContext::current_theme();
-    // Text is black on light, white on dark — the theme decides.
-    let text = theme.text_primary;
-    let dim = theme.text_secondary;
-    let dim2 = theme.text_tertiary;
+    // Text is black on light, white on dark — the theme decides. The dialog
+    // takes it fully opaque: `text_primary` is deliberately soft (0xD9) for
+    // chrome that sits on solid fills, but this panel floats over a blurred
+    // backdrop of arbitrary content, where that softness reads as washed out.
+    let text = opaque(theme.text_primary);
+    // Same reasoning for the supporting text, but the hierarchy is preserved:
+    // subtitle and body stay lighter than the title, just not ghostly.
+    let dim = at_least_opaque(theme.text_secondary, 0xC0);
+    let dim2 = at_least_opaque(theme.text_tertiary, 0x99);
     let accent = theme.accent_blue;
     // Labels drawn on top of the accent fill stay white in both schemes.
     let on_accent = Color::WHITE;
@@ -322,23 +373,40 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
     }
 
     // Title.
-    draw_text_centered(
+    draw_text_centered_clamped(
         canvas,
         &view.title,
         cx,
         layout.title_y + 14.0,
         &font(15.0, 700),
         text,
+        text_max_w,
     );
 
     // Subtitle.
     if let Some(sy) = layout.subtitle_y {
-        draw_text_centered(canvas, &view.subtitle, cx, sy + 12.0, &font(12.0, 500), dim);
+        draw_text_centered_clamped(
+            canvas,
+            &view.subtitle,
+            cx,
+            sy + 12.0,
+            &font(12.0, 500),
+            dim,
+            text_max_w,
+        );
     }
 
     // Body.
     if let Some(by) = layout.body_y {
-        draw_text_centered(canvas, &view.body, cx, by + 12.0, &font(12.0, 400), dim2);
+        draw_text_centered_clamped(
+            canvas,
+            &view.body,
+            cx,
+            by + 12.0,
+            &font(12.0, 400),
+            dim2,
+            text_max_w,
+        );
     }
 
     // Group labels.
@@ -347,7 +415,13 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
             let mut paint = Paint::default();
             paint.set_anti_alias(true);
             paint.set_color(dim2);
-            canvas.draw_str(&group.label, (PAD, gy + 12.0), &font(11.0, 600), &paint);
+            let gf = font(11.0, 600);
+            canvas.draw_str(
+                ellipsize(&group.label, &gf, text_max_w),
+                (PAD, gy + 12.0),
+                &gf,
+                &paint,
+            );
         }
     }
 
@@ -389,10 +463,14 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
         let mut paint = Paint::default();
         paint.set_anti_alias(true);
         paint.set_color(if is_selected { on_accent } else { text });
+        // Reserve the checkmark gutter on every row, selected or not, so a
+        // label doesn't reflow when the selection moves.
+        let label_font = font(13.0, 500);
+        let label_max_w = (rect.right - CHECK_GUTTER) - text_x;
         canvas.draw_str(
-            &opt.label,
+            ellipsize(&opt.label, &label_font, label_max_w),
             (text_x, rect.center_y() + 4.5),
-            &font(13.0, 500),
+            &label_font,
             &paint,
         );
 
@@ -439,13 +517,16 @@ fn draw_button(canvas: &Canvas, rect: &Rect, label: &str, bg: Color, text: Color
     bg_paint.set_anti_alias(true);
     bg_paint.set_color(bg);
     canvas.draw_rrect(RRect::new_rect_xy(*rect, BTN_RADIUS, BTN_RADIUS), &bg_paint);
-    draw_text_centered(
+    // Caller-supplied labels ("Share", but also whatever an app passes as
+    // grant_label) must not spill past the button's rounded edge.
+    draw_text_centered_clamped(
         canvas,
         label,
         rect.center_x(),
         rect.center_y() + 4.5,
         &font(13.0, 600),
         text,
+        rect.width() - 16.0,
     );
 }
 
@@ -473,8 +554,25 @@ fn draw_icon(canvas: &Canvas, icon_name: &str, x: f32, y: f32, size: f32) {
 /// Apply the frosted-panel surface style to a dialog subsurface: a translucent
 /// theme material over a blurred backdrop, rounded clipping, drop shadow, and
 /// center anchor. [`draw_dialog`] draws only the content on top.
+/// Drop a colour's transparency, keeping its RGB.
+fn opaque(c: Color) -> Color {
+    Color::from_argb(0xFF, c.r(), c.g(), c.b())
+}
+
+/// Raise a colour's alpha to at least `min_alpha`, keeping its RGB.
+fn at_least_opaque(c: Color, min_alpha: u8) -> Color {
+    Color::from_argb(c.a().max(min_alpha), c.r(), c.g(), c.b())
+}
+
 pub fn apply_dialog_style(surface: &SubsurfaceSurface) {
-    let c = otto_kit::AppContext::current_theme().material_medium;
+    // `material_medium` is tuned for menus, which are small and sit close to
+    // what they belong to. This panel is large, modal, and carries a decision —
+    // it needs the backdrop legible behind it but the content unmistakably in
+    // front, so it runs a good deal more solid than the shared material.
+    let c = at_least_opaque(
+        otto_kit::AppContext::current_theme().material_medium,
+        0xE0,
+    );
     if let Some(ss) = surface.base_surface().surface_style() {
         ss.set_background_color(
             c.r() as f64 / 255.0,

--- a/components/otto-islands/src/dialog.rs
+++ b/components/otto-islands/src/dialog.rs
@@ -569,10 +569,7 @@ pub fn apply_dialog_style(surface: &SubsurfaceSurface) {
     // what they belong to. This panel is large, modal, and carries a decision —
     // it needs the backdrop legible behind it but the content unmistakably in
     // front, so it runs a good deal more solid than the shared material.
-    let c = at_least_opaque(
-        otto_kit::AppContext::current_theme().material_medium,
-        0xE0,
-    );
+    let c = at_least_opaque(otto_kit::AppContext::current_theme().material_medium, 0xE0);
     if let Some(ss) = surface.base_surface().surface_style() {
         ss.set_background_color(
             c.r() as f64 / 255.0,

--- a/components/otto-islands/src/dialog.rs
+++ b/components/otto-islands/src/dialog.rs
@@ -302,24 +302,18 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
 
     let w = layout.width;
     let cx = w / 2.0;
-    let white = Color::WHITE;
-    let dim = Color::from_argb(190, 255, 255, 255);
-    let dim2 = Color::from_argb(140, 255, 255, 255);
-    let accent = Color::from_argb(0xFF, 0x0A, 0x84, 0xFF);
+    let theme = otto_kit::AppContext::current_theme();
+    // Text is black on light, white on dark — the theme decides.
+    let text = theme.text_primary;
+    let dim = theme.text_secondary;
+    let dim2 = theme.text_tertiary;
+    let accent = theme.accent_blue;
+    // Labels drawn on top of the accent fill stay white in both schemes.
+    let on_accent = Color::WHITE;
 
-    // Panel background fill (rounded). The surface style also paints a blurred
-    // near-black backdrop; this fill gives a solid, self-contained card look.
-    let mut bg = Paint::default();
-    bg.set_anti_alias(true);
-    bg.set_color(Color::from_argb(0xF2, 0x1C, 0x1C, 0x1E));
-    canvas.draw_rrect(
-        RRect::new_rect_xy(
-            Rect::from_xywh(0.0, 0.0, w, layout.height),
-            PANEL_RADIUS,
-            PANEL_RADIUS,
-        ),
-        &bg,
-    );
+    // No panel fill here: the surface style paints the translucent material over
+    // a blurred backdrop (see [`apply_dialog_style`]) and clips the rounded
+    // corners, so the canvas only carries content.
 
     // Icon.
     if layout.icon_present {
@@ -334,7 +328,7 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
         cx,
         layout.title_y + 14.0,
         &font(15.0, 700),
-        white,
+        text,
     );
 
     // Subtitle.
@@ -372,7 +366,7 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
         row_bg.set_color(if is_selected {
             accent
         } else {
-            Color::from_argb(28, 255, 255, 255)
+            theme.fill_secondary
         });
         canvas.draw_rrect(
             RRect::new_rect_xy(*rect, OPTION_RADIUS, OPTION_RADIUS),
@@ -394,7 +388,7 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
 
         let mut paint = Paint::default();
         paint.set_anti_alias(true);
-        paint.set_color(white);
+        paint.set_color(if is_selected { on_accent } else { text });
         canvas.draw_str(
             &opt.label,
             (text_x, rect.center_y() + 4.5),
@@ -406,7 +400,7 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
         if is_selected {
             let mut ck = Paint::default();
             ck.set_anti_alias(true);
-            ck.set_color(white);
+            ck.set_color(on_accent);
             ck.set_style(skia_safe::paint::Style::Stroke);
             ck.set_stroke_width(2.0);
             ck.set_stroke_cap(skia_safe::paint::Cap::Round);
@@ -425,11 +419,17 @@ pub fn draw_dialog(canvas: &Canvas, view: &DialogView, selected: &[usize], layou
         canvas,
         &layout.deny_rect,
         &view.deny_label,
-        Color::from_argb(40, 255, 255, 255),
-        white,
+        theme.fill_secondary,
+        text,
     );
     // Grant button (accent).
-    draw_button(canvas, &layout.grant_rect, &view.grant_label, accent, white);
+    draw_button(
+        canvas,
+        &layout.grant_rect,
+        &view.grant_label,
+        accent,
+        on_accent,
+    );
 
     canvas.restore();
 }
@@ -470,12 +470,18 @@ fn draw_icon(canvas: &Canvas, icon_name: &str, x: f32, y: f32, size: f32) {
     }
 }
 
-/// Apply the frosted-panel surface style to a dialog subsurface. The panel's
-/// solid fill is drawn in [`draw_dialog`]; the style provides the blur backdrop,
-/// rounded clipping, drop shadow, and center anchor.
+/// Apply the frosted-panel surface style to a dialog subsurface: a translucent
+/// theme material over a blurred backdrop, rounded clipping, drop shadow, and
+/// center anchor. [`draw_dialog`] draws only the content on top.
 pub fn apply_dialog_style(surface: &SubsurfaceSurface) {
+    let c = otto_kit::AppContext::current_theme().material_medium;
     if let Some(ss) = surface.base_surface().surface_style() {
-        ss.set_background_color(0.0, 0.0, 0.0, 0.0);
+        ss.set_background_color(
+            c.r() as f64 / 255.0,
+            c.g() as f64 / 255.0,
+            c.b() as f64 / 255.0,
+            c.a() as f64 / 255.0,
+        );
         ss.set_corner_radius(PANEL_RADIUS as f64 * BUFFER_SCALE);
         ss.set_masks_to_bounds(ClipMode::Enabled);
         ss.set_shadow(0.35, 24.0, 0.0, 8.0, 0.0, 0.0, 0.0);

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1103,6 +1103,13 @@ impl IslandApp {
         let surface =
             SubsurfaceSurface::new(&wl, 0, 0, dialog::DIALOG_BUF_W, dialog::DIALOG_BUF_H).ok()?;
         dialog::apply_dialog_style(&surface);
+        // Start fully transparent. The panel is created before anything knows
+        // its layout, so until `render_dialog` has positioned it and started
+        // the entrance it must not be able to show at its default geometry —
+        // otherwise it flashes for a frame in the wrong place.
+        if let Some(ss) = surface.base_surface().surface_style() {
+            ss.set_opacity(0.0);
+        }
         // Keep the panel above the island pills.
         for island in &self.islands {
             surface.place_above(island.surface.wl_surface());
@@ -1133,36 +1140,28 @@ impl IslandApp {
         let w = layout.width;
         let h = layout.height;
 
+        let cx = layer_w / 2.0;
+        let cy = DIALOG_TOP + h / 2.0;
+        panel.origin = (cx - w / 2.0, DIALOG_TOP);
+        panel.layout_h = h;
+
+        // Geometry before content: `draw` commits the buffer, so a panel drawn
+        // while still at its default position would be presented there for a
+        // frame before the entrance moved it.
+        set_size_and_position(&panel.surface, w, h, cx, cy);
+
         let selected = panel.selected.clone();
         let view = panel.view.clone();
         panel.surface.draw(|canvas| {
             dialog::draw_dialog(canvas, &view, &selected, &layout);
         });
 
-        let cx = layer_w / 2.0;
-        let cy = DIALOG_TOP + h / 2.0;
-        panel.origin = (cx - w / 2.0, DIALOG_TOP);
-        panel.layout_h = h;
-
         if !panel.entered {
-            // Start slightly above and transparent, then spring in.
-            set_size_and_position(&panel.surface, w, h, cx, cy - 12.0);
-            if let Some(ss) = panel.surface.base_surface().surface_style() {
-                ss.set_opacity(0.0);
-            }
-            renderer::animate_to_with_opacity(
-                &panel.surface,
-                w,
-                h,
-                cx,
-                cy,
-                dialog::PANEL_RADIUS as f64,
-                Some(1.0),
-                0.0,
-            );
+            // Pop open from a small rounded shape — the transform animates,
+            // the content does not. Opacity was pinned to 0 at creation, so
+            // this is the first frame the panel can be seen at all.
+            renderer::animate_enter_pop(&panel.surface, dialog::PANEL_RADIUS as f64);
             panel.entered = true;
-        } else {
-            set_size_and_position(&panel.surface, w, h, cx, cy);
         }
     }
 

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -549,6 +549,49 @@ fn animate_position_opacity_duration(
     }
 }
 
+/// Entrance animation: pop open from a small rounded shape.
+///
+/// The surface must already be sized and positioned at its final layout — this
+/// only drives the transform, so the content never reflows. Starts as a small,
+/// fully-rounded, transparent blob at the panel's centre (anchor is 0.5/0.5)
+/// and springs out to full size with a pronounced bounce, the corner radius
+/// relaxing to `radius` on the way.
+pub fn animate_enter_pop(surface: &otto_kit::SubsurfaceSurface, radius: f64) {
+    /// Scale the panel starts at. Small enough to read as "a shape opening up"
+    /// rather than "a panel that was already there, slightly smaller".
+    const FROM_SCALE: f64 = 0.32;
+    /// Corner radius at rest in the start state. Once divided by FROM_SCALE it
+    /// is far larger than half the collapsed box, so the blob reads as a pill.
+    const FROM_RADIUS: f64 = 44.0;
+    /// Spring bounce. Higher than the 0.15 used for ordinary layout moves —
+    /// this is the one moment the panel is meant to feel springy.
+    const BOUNCE: f64 = 0.42;
+
+    if let Some(scene_surface) = surface.base_surface().surface_style() {
+        // Start state, applied outside any transaction so it is instant.
+        scene_surface.set_scale(FROM_SCALE, FROM_SCALE);
+        scene_surface.set_corner_radius(FROM_RADIUS * BUFFER_SCALE);
+        scene_surface.set_opacity(0.0);
+
+        if let Some(scene) = AppContext::surface_style_manager() {
+            let qh = AppContext::queue_handle();
+
+            let timing = scene.create_timing_function(qh, ());
+            timing.set_spring(BOUNCE, 0.0);
+
+            let anim = scene.begin_transaction(qh, ());
+            anim.set_duration(0.55);
+            anim.set_timing_function(&timing);
+
+            scene_surface.set_scale(1.0, 1.0);
+            scene_surface.set_corner_radius(radius * BUFFER_SCALE);
+            scene_surface.set_opacity(1.0);
+
+            anim.commit();
+        }
+    }
+}
+
 /// Dismiss animation: scale up to `scale` while fading out to opacity 0.
 pub fn animate_dismiss(surface: &otto_kit::SubsurfaceSurface, scale: f64) {
     if let Some(scene_surface) = surface.base_surface().surface_style() {

--- a/components/xdg-desktop-portal-otto/src/otto_client/dialog.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/dialog.rs
@@ -1,8 +1,14 @@
-//! Client for otto-islands' `org.otto.Dialog1` Access-style dialog renderer.
+//! Clients for the Access-style dialog renderers this portal can broker to.
 //!
-//! The portal is the broker: it owns which renderer presents a dialog. Today
-//! the only renderer is otto-islands. See `specs/portal-access-dialog.md`.
+//! The portal owns which renderer presents a dialog. The native one is
+//! otto-islands (`org.otto.Dialog1`); when it isn't running we fall back to any
+//! other desktop's `org.freedesktop.impl.portal.Access` implementation, which
+//! is the standard interface `org.otto.Dialog1` was modelled on.
+//! See `specs/portal-access-dialog.md`.
 
+use std::collections::HashMap;
+
+use zbus::zvariant::{ObjectPath, OwnedValue, Value};
 use zbus::Result;
 
 use crate::otto_client::OttoClient;
@@ -37,9 +43,132 @@ trait Dialog {
     ) -> Result<(u32, Vec<(String, String)>)>;
 }
 
+/// A choice group in the **standard** `org.freedesktop.impl.portal.Access`
+/// shape: `(group_id, group_label, [(option_id, option_label)], default)`.
+///
+/// Note the option tuple is `(ss)`, not `(sss)` — the standard interface has no
+/// per-option icon, so icons are dropped on this path.
+pub type AccessChoice = (String, String, Vec<(String, String)>, String);
+
+/// Other desktops' Access implementations, tried in order when otto-islands
+/// isn't running.
+///
+/// These are named explicitly rather than resolved through portals.conf on
+/// purpose: **this portal implements Access itself**, so asking for "the
+/// configured Access backend" could route straight back here and deadlock.
+/// GTK leads because it's the one most likely present on a system that is
+/// neither GNOME nor KDE.
+pub const ACCESS_FALLBACK_BACKENDS: &[&str] = &[
+    "org.freedesktop.impl.portal.desktop.gtk",
+    "org.freedesktop.impl.portal.desktop.gnome",
+    "org.freedesktop.impl.portal.desktop.kde",
+];
+
+/// D-Bus proxy for `org.freedesktop.impl.portal.Access`.
+///
+/// No `default_service`: the destination is chosen per call from
+/// [`ACCESS_FALLBACK_BACKENDS`].
+#[zbus::proxy(
+    interface = "org.freedesktop.impl.portal.Access",
+    default_path = "/org/freedesktop/portal/desktop"
+)]
+trait Access {
+    /// Present a dialog and block until the user answers.
+    ///
+    /// `options` carries `modal`, `grant_label`, `deny_label`, `icon` and
+    /// `choices`; `results` carries the selected `choices` back.
+    #[allow(clippy::too_many_arguments)]
+    async fn access_dialog(
+        &self,
+        handle: &ObjectPath<'_>,
+        app_id: &str,
+        parent_window: &str,
+        title: &str,
+        subtitle: &str,
+        body: &str,
+        options: HashMap<&str, Value<'_>>,
+    ) -> Result<(u32, HashMap<String, OwnedValue>)>;
+}
+
 impl OttoClient {
     /// Build a proxy to the dialog renderer.
     pub async fn dialog_proxy(&self) -> Result<DialogProxy<'_>> {
         DialogProxy::new(&self.connection).await
+    }
+
+    /// Present a dialog through the first reachable standard Access backend.
+    ///
+    /// Returns `(response, [(group_id, option_id)])`, matching
+    /// [`DialogProxy::present_access`] so callers can treat the two
+    /// interchangeably. `Err` means no backend answered at all.
+    #[allow(clippy::too_many_arguments)] // mirrors the Access interface 1:1
+    pub async fn present_access_fallback(
+        &self,
+        app_id: &str,
+        title: &str,
+        subtitle: &str,
+        body: &str,
+        icon: &str,
+        grant_label: &str,
+        deny_label: &str,
+        modal: bool,
+        choices: Vec<AccessChoice>,
+    ) -> Result<(u32, Vec<(String, String)>)> {
+        let handle = ObjectPath::try_from("/org/freedesktop/portal/desktop/request/otto/1")
+            .map_err(|e| zbus::Error::Failure(format!("bad request handle: {e}")))?;
+
+        let mut last_err = None;
+        for service in ACCESS_FALLBACK_BACKENDS {
+            let proxy: AccessProxy<'_> =
+                match AccessProxy::builder(&self.connection).destination(*service) {
+                    Ok(builder) => match builder.build().await {
+                        Ok(p) => p,
+                        Err(err) => {
+                            last_err = Some(err);
+                            continue;
+                        }
+                    },
+                    Err(err) => {
+                        last_err = Some(err);
+                        continue;
+                    }
+                };
+
+            let mut options: HashMap<&str, Value<'_>> = HashMap::new();
+            options.insert("modal", Value::Bool(modal));
+            options.insert("grant_label", Value::from(grant_label));
+            options.insert("deny_label", Value::from(deny_label));
+            if !icon.is_empty() {
+                options.insert("icon", Value::from(icon));
+            }
+            options.insert(
+                "choices",
+                Value::from(choices.clone())
+                    .try_clone()
+                    .map_err(|e| zbus::Error::Failure(format!("bad choices: {e}")))?,
+            );
+
+            match proxy
+                .access_dialog(&handle, app_id, "", title, subtitle, body, options)
+                .await
+            {
+                Ok((response, results)) => {
+                    tracing::info!(service, response, "Access fallback answered");
+                    let selected = results
+                        .get("choices")
+                        .and_then(|v| v.try_clone().ok())
+                        .and_then(|v| Vec::<(String, String)>::try_from(v).ok())
+                        .unwrap_or_default();
+                    return Ok((response, selected));
+                }
+                Err(err) => {
+                    tracing::debug!(service, ?err, "Access backend unavailable");
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        Err(last_err
+            .unwrap_or_else(|| zbus::Error::Failure("no Access backend available".to_string())))
     }
 }

--- a/components/xdg-desktop-portal-otto/src/otto_client/screencast.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/screencast.rs
@@ -25,6 +25,18 @@ trait ScreenCast {
 
     /// Lists available output connectors.
     async fn list_outputs(&self) -> Result<Vec<String>>;
+
+    /// Lists capturable windows as `(identifier, app_id, title)`.
+    async fn list_windows(&self) -> Result<Vec<(String, String, String)>>;
+}
+
+/// A capturable window as reported by the compositor.
+#[derive(Clone, Debug)]
+pub struct WindowSource {
+    /// `ext-foreign-toplevel-list-v1` identifier — opaque, pass back verbatim.
+    pub id: String,
+    pub app_id: String,
+    pub title: String,
 }
 
 /// D-Bus proxy for `org.otto.ScreenCast.Session`.
@@ -95,6 +107,40 @@ impl OttoClient {
             outputs
         );
         Ok(outputs)
+    }
+
+    /// Lists capturable windows from the compositor.
+    pub async fn list_windows(&self) -> Result<Vec<WindowSource>> {
+        debug!("Requesting list_windows from compositor");
+        let proxy = ScreenCastProxy::builder(&self.connection).build().await?;
+        let windows = proxy.list_windows().await?;
+        debug!("Received {} windows from compositor", windows.len());
+        Ok(windows
+            .into_iter()
+            .map(|(id, app_id, title)| WindowSource { id, app_id, title })
+            .collect())
+    }
+
+    /// Starts recording a single window by its foreign-toplevel identifier.
+    pub async fn record_window(
+        &self,
+        session_path: &OwnedObjectPath,
+        window_id: &str,
+        cursor_mode: u32,
+    ) -> Result<OwnedObjectPath> {
+        let proxy = ScreenCastSessionProxy::builder(&self.connection)
+            .path(session_path)?
+            .build()
+            .await?;
+
+        let mut properties = HashMap::new();
+        properties.insert("window-id", Value::from(window_id));
+        properties.insert("cursor-mode", Value::U32(cursor_mode));
+        debug!(window_id, "Recording window");
+        let stream_path = proxy.record_window(properties).await?;
+        debug!(%stream_path, "Stream created");
+
+        Ok(stream_path)
     }
 
     /// Starts recording a monitor identified by connector name.

--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -170,25 +170,69 @@ impl ScreenCastPortal {
             return Ok(None);
         };
 
-        let proxy = self.sc_client.dialog_proxy().await?;
-        let (response, results) = proxy
-            .present_access(
-                app_id,
-                "Share your screen",
-                &format!("{} wants to share your screen", display_app_name(app_id)),
-                "The selected source will be visible to the application.",
-                "video-display",
-                "Share",
-                "Cancel",
-                true,
-                vec![(
-                    "source".to_string(),
-                    "Choose what to share".to_string(),
-                    options,
-                    default_id,
-                )],
-            )
-            .await?;
+        let title = "Share your screen";
+        let subtitle = format!("{} wants to share your screen", display_app_name(app_id));
+        let body = "The selected source will be visible to the application.";
+
+        // Native renderer first — it's the only one that shows app icons.
+        let native = async {
+            let proxy = self.sc_client.dialog_proxy().await?;
+            proxy
+                .present_access(
+                    app_id,
+                    title,
+                    &subtitle,
+                    body,
+                    "video-display",
+                    "Share",
+                    "Cancel",
+                    true,
+                    vec![(
+                        "source".to_string(),
+                        "Choose what to share".to_string(),
+                        options.clone(),
+                        default_id.clone(),
+                    )],
+                )
+                .await
+        }
+        .await;
+
+        let (response, results) = match native {
+            Ok(answer) => answer,
+            Err(err) => {
+                // otto-islands isn't running. Rather than fail — which would
+                // make window sharing impossible without it — borrow another
+                // desktop's Access dialog. Icons are lost: the standard
+                // choices tuple has no icon field.
+                warn!(
+                    ?err,
+                    "Native dialog unavailable; trying standard Access backends"
+                );
+                let plain: Vec<(String, String)> = options
+                    .into_iter()
+                    .map(|(id, label, _icon)| (id, label))
+                    .collect();
+                self.sc_client
+                    .present_access_fallback(
+                        app_id,
+                        title,
+                        &subtitle,
+                        body,
+                        "video-display",
+                        "Share",
+                        "Cancel",
+                        true,
+                        vec![(
+                            "source".to_string(),
+                            "Choose what to share".to_string(),
+                            plain,
+                            default_id,
+                        )],
+                    )
+                    .await?
+            }
+        };
 
         if response != 0 {
             return Ok(None);

--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -12,11 +12,12 @@ use zbus::interface;
 use zbus::object_server::ObjectServer;
 use zbus::zvariant::{OwnedFd, OwnedObjectPath, OwnedValue};
 
+use crate::otto_client::screencast::WindowSource;
 use crate::otto_client::OttoClient;
 use crate::portal::{
-    build_streams_value_from_descriptors, make_output_mapping_id, PortalState, Request, Session,
-    SessionState, StreamDescriptor, CURSOR_MODE_EMBEDDED, SOURCE_TYPE_MONITOR,
-    SUPPORTED_CURSOR_MODES,
+    build_streams_value_from_descriptors, make_output_mapping_id, PortalState, Request,
+    SelectedWindow, Session, SessionState, StreamDescriptor, CURSOR_MODE_EMBEDDED,
+    SOURCE_TYPE_MONITOR, SOURCE_TYPE_WINDOW, SUPPORTED_CURSOR_MODES,
 };
 use zbus::zvariant::Str;
 
@@ -71,6 +72,44 @@ fn preferred_output_override() -> Option<String> {
     (!name.is_empty()).then_some(name)
 }
 
+/// Best-effort human-readable name for a requesting app, for the dialog copy.
+fn display_app_name(app_id: &str) -> String {
+    match app_id.rsplit('.').next() {
+        Some(name) if !name.is_empty() => name.to_string(),
+        _ => "An application".to_string(),
+    }
+}
+
+/// Picks the output to capture when no picker dialog is reachable: the
+/// `screencast-output` override if it names a present output, else the first.
+fn fallback_output(available: &[String]) -> Option<String> {
+    if available.is_empty() {
+        return None;
+    }
+    match preferred_output_override() {
+        Some(preferred) if available.contains(&preferred) => {
+            info!(output = %preferred, "Using screencast-output override");
+            Some(preferred)
+        }
+        Some(preferred) => {
+            warn!(
+                output = %preferred,
+                ?available,
+                "screencast-output override not among available outputs; using first"
+            );
+            available.first().cloned()
+        }
+        None => available.first().cloned(),
+    }
+}
+
+/// What the user picked in the source dialog.
+#[derive(Clone, Debug)]
+pub enum SourceSelection {
+    Monitor(String),
+    Window(WindowSource),
+}
+
 #[derive(Clone)]
 pub struct ScreenCastPortal {
     state: Arc<Mutex<PortalState>>,
@@ -83,6 +122,95 @@ impl ScreenCastPortal {
             state: Arc::new(Mutex::new(PortalState::default())),
             sc_client: Arc::new(sc_client),
         }
+    }
+
+    /// Ask the user which source to share.
+    ///
+    /// Monitors and windows are offered as one radio list — the portal spec
+    /// lets an app request both types, and the user shouldn't have to care
+    /// which bit was set. Returns `Ok(None)` if the user dismissed the dialog,
+    /// and `Err` only when no dialog renderer answered (see the caller's
+    /// fallback).
+    async fn pick_source(
+        &self,
+        app_id: &str,
+        outputs: &[String],
+        windows: &[WindowSource],
+    ) -> zbus::Result<Option<SourceSelection>> {
+        // Option ids are prefixed so one flat list can carry both kinds.
+        let mut options: Vec<(String, String, String)> = Vec::new();
+
+        for connector in outputs {
+            let label = if outputs.len() == 1 {
+                "Entire screen".to_string()
+            } else {
+                format!("Screen — {connector}")
+            };
+            options.push((
+                format!("monitor:{connector}"),
+                label,
+                "video-display".into(),
+            ));
+        }
+
+        for window in windows {
+            let label = if window.title.is_empty() {
+                window.app_id.clone()
+            } else {
+                window.title.clone()
+            };
+            options.push((
+                format!("window:{}", window.id),
+                label,
+                window.app_id.clone(),
+            ));
+        }
+
+        let Some((default_id, _, _)) = options.first().cloned() else {
+            return Ok(None);
+        };
+
+        let proxy = self.sc_client.dialog_proxy().await?;
+        let (response, results) = proxy
+            .present_access(
+                app_id,
+                "Share your screen",
+                &format!("{} wants to share your screen", display_app_name(app_id)),
+                "The selected source will be visible to the application.",
+                "video-display",
+                "Share",
+                "Cancel",
+                true,
+                vec![(
+                    "source".to_string(),
+                    "Choose what to share".to_string(),
+                    options,
+                    default_id,
+                )],
+            )
+            .await?;
+
+        if response != 0 {
+            return Ok(None);
+        }
+
+        let Some((_, choice)) = results.into_iter().find(|(group, _)| group == "source") else {
+            warn!("Picker returned no selection for the source group");
+            return Ok(None);
+        };
+
+        Ok(match choice.split_once(':') {
+            Some(("monitor", connector)) => Some(SourceSelection::Monitor(connector.to_string())),
+            Some(("window", id)) => windows
+                .iter()
+                .find(|w| w.id == id)
+                .cloned()
+                .map(SourceSelection::Window),
+            _ => {
+                warn!(%choice, "Picker returned an unrecognised option id");
+                None
+            }
+        })
     }
 
     /// Export a temporary Request object in dbus so the frontend can listen for the response signal.
@@ -154,6 +282,7 @@ impl ScreenCastPortal {
                     SessionState {
                         sc_session: sc_session_obj_path.clone(),
                         selected_outputs: Vec::new(),
+                        selected_window: None,
                         cursor_mode: default_cursor_mode,
                         persist_mode: None,
                         next_stream_id: 0,
@@ -203,7 +332,7 @@ impl ScreenCastPortal {
                 .and_then(|value| u32::try_from(value).ok())
                 .unwrap_or(SOURCE_TYPE_MONITOR);
 
-            if requested_types & SOURCE_TYPE_MONITOR == 0 {
+            if requested_types & (SOURCE_TYPE_MONITOR | SOURCE_TYPE_WINDOW) == 0 {
                 warn!(
                     session = %session_handle,
                     requested_types,
@@ -230,42 +359,68 @@ impl ScreenCastPortal {
                 .and_then(|value| bool::try_from(value).ok())
                 .unwrap_or(false);
 
-            info!(session = %session_handle, "Requesting available outputs from compositor");
-            let available_outputs =
+            let monitors_allowed = requested_types & SOURCE_TYPE_MONITOR != 0;
+            let windows_allowed = requested_types & SOURCE_TYPE_WINDOW != 0;
+
+            let available_outputs = if monitors_allowed {
                 self.sc_client.list_outputs().await.map_err(|err| {
                     error!(session = %session_handle, ?err, "Failed to enumerate outputs");
                     fdo::Error::Failed(format!("Failed to enumerate outputs: {err}"))
-                })?;
+                })?
+            } else {
+                Vec::new()
+            };
 
-            info!(session = %session_handle, count = available_outputs.len(), ?available_outputs, "Received outputs from compositor");
+            // A compositor too old to know ListWindows just yields no windows;
+            // the monitor half of the picker still works.
+            let available_windows = if windows_allowed {
+                self.sc_client.list_windows().await.unwrap_or_else(|err| {
+                    warn!(session = %session_handle, ?err, "Failed to enumerate windows");
+                    Vec::new()
+                })
+            } else {
+                Vec::new()
+            };
 
-            if available_outputs.is_empty() {
-                warn!(session = %session_handle, "No outputs available for screencast");
+            info!(
+                session = %session_handle,
+                outputs = available_outputs.len(),
+                windows = available_windows.len(),
+                "Received sources from compositor"
+            );
+
+            if available_outputs.is_empty() && available_windows.is_empty() {
+                warn!(session = %session_handle, "No sources available for screencast");
                 return Ok((3, HashMap::new()));
             }
 
             if multiple {
                 info!(
                     session = %session_handle,
-                    "Multiple selection requested; limiting to first output"
+                    "Multiple selection requested; limiting to a single source"
                 );
             }
 
-            let chosen_output = match preferred_output_override() {
-                Some(preferred) if available_outputs.contains(&preferred) => {
-                    info!(session = %session_handle, output = %preferred, "Using screencast-output override");
-                    preferred
+            let selection = match self
+                .pick_source(&app_id, &available_outputs, &available_windows)
+                .await
+            {
+                Ok(Some(selection)) => selection,
+                // User dismissed the picker.
+                Ok(None) => {
+                    info!(session = %session_handle, "User cancelled source selection");
+                    return Ok((1, HashMap::new()));
                 }
-                Some(preferred) => {
-                    warn!(
-                        session = %session_handle,
-                        output = %preferred,
-                        ?available_outputs,
-                        "screencast-output override not among available outputs; using first"
-                    );
-                    available_outputs.first().cloned().unwrap_or_default()
+                // No dialog renderer on the bus. Monitor capture keeps its
+                // pre-picker behaviour so an islands-less session still works;
+                // a window is never picked on the user's behalf.
+                Err(err) => {
+                    warn!(session = %session_handle, ?err, "Source picker unavailable");
+                    let Some(fallback) = fallback_output(&available_outputs) else {
+                        return Ok((2, HashMap::new()));
+                    };
+                    SourceSelection::Monitor(fallback)
                 }
-                None => available_outputs.first().cloned().unwrap_or_default(),
             };
 
             {
@@ -275,7 +430,19 @@ impl ScreenCastPortal {
                     .get_mut(session_handle.as_str())
                     .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
 
-                entry.selected_outputs = vec![chosen_output.clone()];
+                match &selection {
+                    SourceSelection::Monitor(connector) => {
+                        entry.selected_outputs = vec![connector.clone()];
+                        entry.selected_window = None;
+                    }
+                    SourceSelection::Window(window) => {
+                        entry.selected_outputs = Vec::new();
+                        entry.selected_window = Some(SelectedWindow {
+                            id: window.id.clone(),
+                            title: window.title.clone(),
+                        });
+                    }
+                }
                 entry.cursor_mode = cursor_mode;
                 entry.persist_mode = persist_mode;
                 entry.next_stream_id = 0;
@@ -283,7 +450,7 @@ impl ScreenCastPortal {
 
             info!(
                 session = %session_handle,
-                output = %chosen_output,
+                selection = ?selection,
                 cursor_mode,
                 persist_mode = ?persist_mode,
                 "Stored source selection"
@@ -319,24 +486,33 @@ impl ScreenCastPortal {
             .await?;
 
         let result = async {
-            let (sc_session_path, selected_output, cursor_mode, stream_index, persist_mode) = {
+            let (sc_session_path, selected_source, cursor_mode, stream_index, persist_mode) = {
                 let mut state = self.state.lock().await;
                 let entry = state
                     .sessions
                     .get_mut(session_handle.as_str())
                     .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
 
-                if entry.selected_outputs.is_empty() {
-                    return Err(fdo::Error::Failed(
-                        "No output selected for session".to_string(),
-                    ));
-                }
+                let selected_source = match (&entry.selected_window, entry.selected_outputs.first())
+                {
+                    (Some(window), _) => SourceSelection::Window(WindowSource {
+                        id: window.id.clone(),
+                        app_id: String::new(),
+                        title: window.title.clone(),
+                    }),
+                    (None, Some(connector)) => SourceSelection::Monitor(connector.clone()),
+                    (None, None) => {
+                        return Err(fdo::Error::Failed(
+                            "No source selected for session".to_string(),
+                        ))
+                    }
+                };
 
                 entry.next_stream_id += 1;
 
                 (
                     entry.sc_session.clone(),
-                    entry.selected_outputs[0].clone(),
+                    selected_source,
                     entry.cursor_mode,
                     entry.next_stream_id,
                     entry.persist_mode,
@@ -345,23 +521,39 @@ impl ScreenCastPortal {
 
             let stream_identifier = format!("screen-{stream_index}");
 
+            // Name kept for the mapping-id fallback below, which is
+            // output-shaped; a window stream carries its own mapping id.
+            let selected_output = match &selected_source {
+                SourceSelection::Monitor(connector) => connector.clone(),
+                SourceSelection::Window(window) => window.id.clone(),
+            };
+
             info!(
                 sc_session = %sc_session_path,
-                output = %selected_output,
+                source = ?selected_source,
                 cursor_mode,
-                "Calling RecordMonitor on ScreenComposer session"
+                "Recording selected source"
             );
 
-            let sc_stream_path = self
-                .sc_client
-                .record_monitor(&sc_session_path, selected_output.as_str(), cursor_mode)
-                .await
-                .map_err(|err| {
-                    fdo::Error::Failed(format!(
-                        "Failed to record monitor '{}': {err}",
-                        selected_output
-                    ))
-                })?;
+            let sc_stream_path = match &selected_source {
+                SourceSelection::Monitor(connector) => self
+                    .sc_client
+                    .record_monitor(&sc_session_path, connector.as_str(), cursor_mode)
+                    .await
+                    .map_err(|err| {
+                        fdo::Error::Failed(format!("Failed to record monitor '{connector}': {err}"))
+                    })?,
+                SourceSelection::Window(window) => self
+                    .sc_client
+                    .record_window(&sc_session_path, window.id.as_str(), cursor_mode)
+                    .await
+                    .map_err(|err| {
+                        fdo::Error::Failed(format!(
+                            "Failed to record window '{}': {err}",
+                            window.title
+                        ))
+                    })?,
+            };
 
             info!(sc_stream = %sc_stream_path, "Got stream path, starting session");
 
@@ -475,6 +667,10 @@ impl ScreenCastPortal {
                 fourcc,
                 modifier,
                 buffer_kind,
+                source_type: match &selected_source {
+                    SourceSelection::Monitor(_) => SOURCE_TYPE_MONITOR,
+                    SourceSelection::Window(_) => SOURCE_TYPE_WINDOW,
+                },
             };
 
             let streams_value =

--- a/components/xdg-desktop-portal-otto/src/portal/mod.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/mod.rs
@@ -17,7 +17,7 @@ pub use interface::{
     fallback_mapping_id, validate_cursor_mode, validate_persist_mode, ScreenCastPortal,
 };
 pub use settings::SettingsPortal;
-pub use state::{PortalState, SessionState};
+pub use state::{PortalState, SelectedWindow, SessionState};
 pub use stream::{build_streams_value_from_descriptors, StreamDescriptor};
 
 pub(crate) use request::Request;
@@ -28,7 +28,6 @@ pub const DESKTOP_PATH: &str = "/org/freedesktop/portal/desktop";
 
 // Source type bitmask values per XDG Desktop Portal spec.
 pub const SOURCE_TYPE_MONITOR: u32 = 1;
-#[allow(dead_code)]
 pub const SOURCE_TYPE_WINDOW: u32 = 2;
 #[allow(dead_code)]
 pub const SOURCE_TYPE_VIRTUAL: u32 = 4;

--- a/components/xdg-desktop-portal-otto/src/portal/state.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/state.rs
@@ -17,11 +17,25 @@ pub struct SessionState {
     /// Object path of the corresponding compositor session.
     pub sc_session: OwnedObjectPath,
     /// Output connectors selected for this session.
+    ///
+    /// Empty when the user picked a window instead — the two are mutually
+    /// exclusive, since the picker offers a single choice.
     pub selected_outputs: Vec<String>,
+    /// Window selected for this session, if the user picked a window source.
+    pub selected_window: Option<SelectedWindow>,
     /// Cursor mode (Hidden=1, Embedded=2, Metadata=4).
     pub cursor_mode: u32,
     /// Persistence mode (None=0, Application=1, Permanent=2).
     pub persist_mode: Option<u32>,
     /// Counter for generating unique stream IDs.
     pub next_stream_id: u32,
+}
+
+/// A window the user chose in the source picker.
+#[derive(Clone, Debug)]
+pub struct SelectedWindow {
+    /// `ext-foreign-toplevel-list-v1` identifier.
+    pub id: String,
+    /// Title at pick time — for logging and the stream's mapping id only.
+    pub title: String,
 }

--- a/components/xdg-desktop-portal-otto/src/portal/stream.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/stream.rs
@@ -33,6 +33,28 @@ pub struct StreamDescriptor {
     pub modifier: Option<u64>,
     /// Buffer type (e.g., "DMA", "SHM").
     pub buffer_kind: Option<String>,
+    /// Portal source type bit for this stream (monitor or window).
+    pub source_type: u32,
+}
+
+impl Default for StreamDescriptor {
+    fn default() -> Self {
+        Self {
+            node_id: 0,
+            stream_id: String::new(),
+            mapping_id: None,
+            width: None,
+            height: None,
+            position: None,
+            scale_factor: None,
+            refresh_millihz: None,
+            stride: None,
+            fourcc: None,
+            modifier: None,
+            buffer_kind: None,
+            source_type: SOURCE_TYPE_MONITOR,
+        }
+    }
 }
 
 /// Converts stream descriptors to the D-Bus vardict format.
@@ -48,7 +70,7 @@ pub fn build_streams_value_from_descriptors(
         let mut dict: HashMap<String, OwnedValue> = HashMap::new();
         dict.insert(
             "source_type".to_string(),
-            OwnedValue::from(SOURCE_TYPE_MONITOR),
+            OwnedValue::from(descriptor.source_type),
         );
         dict.insert(
             "id".to_string(),

--- a/docs/developer/screenshare.md
+++ b/docs/developer/screenshare.md
@@ -87,10 +87,11 @@ The compositor runs a zbus server on a dedicated tokio thread and registers:
 org.otto.ScreenCast:
   CreateSession(properties: a{sv}) -> session_path: o
   ListOutputs() -> connectors: as
+  ListWindows() -> windows: a(sss)      # (identifier, app_id, title)
 
 org.otto.ScreenCast.Session:
   RecordMonitor(connector: s, properties: a{sv}) -> stream_path: o
-  RecordWindow(properties: a{sv}) -> stream_path: o
+  RecordWindow(properties: a{sv}) -> stream_path: o   # properties: window-id, cursor-mode
   Start()
   Stop()
   OpenPipeWireRemote(options: a{sv}) -> fd: h
@@ -99,11 +100,12 @@ org.otto.ScreenCast.Stream:
   Start()
   Stop()
   PipeWireNode() -> info: a{sv}
-  Metadata() -> info: a{sv}
+  Metadata() -> info: a{sv}             # connector|window-id, source-type, size, cursor-mode
 
 Notes:
 
-- `RecordWindow` currently returns “not supported”.
+- `RecordWindow`'s `window-id` is an `ext-foreign-toplevel-list-v1` identifier, as returned
+  by `ListWindows`. See "Window capture" below.
 - `Start()` is where the compositor actually creates a PipeWire stream and returns a node id
   through `PipeWireNode()`.
 ```
@@ -172,6 +174,36 @@ Screen sharing uses a **direct GPU blit** approach:
 3. Otto blits the framebuffer into that DMA-BUF using `Blit<Dmabuf>` (GPU-only
   `glBlitFramebuffer`).
 4. Otto signals PipeWire that a new frame can be queued.
+
+### Window capture
+
+A stream targets either an output or a single window — `StreamTarget` in
+`src/screenshare/mod.rs`, which also supplies the key for `ScreencastSession::streams`
+(`output:<connector>` / `window:<identifier>`).
+
+Window streams do **not** blit the composited framebuffer. They re-render the window's own
+surface tree (toplevel + subsurfaces + popups) into the PipeWire dmabuf via
+`window_to_dmabuf`, with the window's geometry origin at (0, 0). Consequences worth knowing:
+
+- Nothing stacked above the shared window can leak into the capture, and the window keeps
+  streaming while occluded, on another workspace, or minimized.
+- lay-rs scene decoration (shadows, rounded corners, blur) is *not* in the capture — this is
+  the client's raw content.
+- The stream size is fixed at `RecordWindow` time (even-rounded physical pixels). A window
+  that resizes is cropped or letterboxed; the format is never renegotiated.
+
+Two supporting mechanisms make this work:
+
+- **Frame pacing**: `WindowThrottleState::Captured` (`src/state/window_throttle.rs`) pins a
+  captured window to full-rate frame callbacks, outranking minimize/occlusion, without
+  marking it `activated`. Without this a shared background window would tick at 2 Hz.
+- **Render triggers**: `screencast_active` and `kick_screencast_outputs` in
+  `src/udev/render.rs` resolve a window target to the output currently hosting it, so that
+  output forces a composite and keeps painting while idle.
+
+Both paths call `crate::screenshare::window_for_identifier`, which takes `&Workspaces` and
+`&foreign_toplevels` separately rather than `&Otto` — the render loop already holds a
+mutable borrow of `backend_data`, so only field-disjoint borrows compile there.
 
 #### Udev Backend (`src/udev.rs`)
 
@@ -352,15 +384,19 @@ silent fallback to LINEAR (that previously caused tiled-read-as-linear corrupted
 SHM fallback pods are offered alongside DMA-BUF today, so non-DMA_DRM gst pipelines can't
 currently negotiate. Full behavior and rationale: `specs/screenshare.md`.
 
-### Screencast Output Selection
+### Screencast Source Selection
 
-`xdg-desktop-portal-otto`'s `SelectSources` (`components/xdg-desktop-portal-otto/src/portal/interface.rs`)
-defaults to the first output from the compositor's `ListOutputs`, but checks
-`$XDG_CONFIG_HOME/otto/screencast-output` (falling back to `~/.config/otto/screencast-output`)
-for a one-line connector-name override, re-read on every call so it can be changed between
-sessions with no restart. An override naming an output not currently present falls back to
-the first output with a warning. This is a stopgap until a real source-picker UI exists. Full
-behavior: `specs/screenshare.md`.
+`xdg-desktop-portal-otto`'s `SelectSources`
+(`components/xdg-desktop-portal-otto/src/portal/interface.rs`) presents a picker: one radio
+list combining every output and every window, rendered by otto-islands through the
+Access-style `org.otto.Dialog1` service (the same dialog the portal's Access implementation
+uses). Option ids are `monitor:<connector>` / `window:<identifier>`.
+
+If no dialog renderer answers on the bus, monitor capture falls back to the pre-picker
+behaviour: `$XDG_CONFIG_HOME/otto/screencast-output` (falling back to
+`~/.config/otto/screencast-output`) for a one-line connector-name override, re-read on every
+call, else the first output. A window is never auto-selected in that path. Full behavior:
+`specs/screenshare.md`.
 
 ### Known Issues and Fixes
 

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -9,7 +9,8 @@ Otto exposes a compositor-side `org.otto.ScreenCast` D-Bus service that a portal
 (`xdg-desktop-portal-otto`) uses to implement `org.freedesktop.portal.ScreenCast` for
 applications (OBS, Chrome, Firefox, etc.). This spec covers two pieces of that path: how
 the PipeWire video stream negotiates a DMA-BUF format/modifier with the consuming client,
-and how the portal picks which output gets shared when a session starts. Everything else
+and how the portal picks which source (an output or a single window) gets shared when a
+session starts. Everything else
 about the screenshare pipeline (D-Bus service shape, GPU blit, damage metadata) is
 documented in `docs/developer/screenshare.md`.
 
@@ -23,19 +24,23 @@ documented in `docs/developer/screenshare.md`.
   plane only).
 - The modifier a client actually negotiates must be read correctly and unambiguously; Otto
   must never allocate a buffer in one layout while the client reads it as another.
-- A user must be able to choose which output a screencast session records without a
-  source-picker UI, and change that choice between sessions without restarting anything.
+- A user must be able to choose what a screencast session records — any output, or any
+  single toplevel window — from a picker presented at `SelectSources` time.
+- A shared window must be captured from its own surfaces, so the stream shows neither
+  windows stacked above it nor the desktop behind it, and keeps updating while the window
+  is occluded, on another workspace, or minimized.
 
 ## Non-Goals
 
-- A graphical source-picker UI for choosing the shared output (tracked as future work).
+- Live thumbnails in the source picker (the list is text + app icon only; previews are
+  future work, most likely via `ext-image-copy-capture-v1`).
+- Region capture, and capture of a window's sub-surface or a specific tab.
+- Renegotiating the PipeWire stream format when a captured window resizes.
 - Negotiating DMA-BUF for pixel formats other than `Argb8888`/BGRA.
 - A CPU/SHM fill path for the DMA-BUF format when no GBM device is available beyond the
   existing SHM-only fallback (see Constraints).
-- Multi-monitor / multiple simultaneous output selection (the portal always resolves to a
-  single output; see `multiple` handling below).
-- Window or region capture (`RecordWindow` is unimplemented; only monitor capture is
-  supported).
+- Multiple simultaneous sources in one session (the portal always resolves to a single
+  source; see `multiple` handling below).
 
 ## Behavior
 
@@ -76,10 +81,69 @@ documented in `docs/developer/screenshare.md`.
   - A negotiated modifier value of `DRM_FORMAT_MOD_INVALID` is accepted and treated as
     "implicit modifier" DMA-BUF, distinct from a parse failure.
 
-### Portal output selection (`SelectSources`)
+### Window identity
 
-- On every `SelectSources` call, the portal backend asks the compositor for the current
-  output list (`ListOutputs`) and by default selects the **first** output in that list.
+- A capturable window is named by its `ext-foreign-toplevel-list-v1` **identifier** — the
+  opaque, stable, cross-process handle the protocol defines for exactly this purpose. Otto
+  never exposes surface ids, PIDs, or window titles as the addressing key.
+- `org.otto.ScreenCast.ListWindows` returns `(identifier, app_id, title)` for every mapped
+  toplevel that has a foreign-toplevel handle. A toplevel without one is not capturable.
+- `org.otto.ScreenCast.Session.RecordWindow` takes a `window-id` property carrying that
+  identifier, and a `cursor-mode` property, mirroring `RecordMonitor`.
+- An identifier that no longer resolves (window closed or unmapped between the picker and
+  `Start`) fails `RecordWindow` rather than falling back to any other window.
+
+### Portal source selection (`SelectSources`)
+
+- `SelectSources` accepts `types` containing `MONITOR` (1), `WINDOW` (2), or both. A request
+  for neither is rejected as before.
+- On every call the portal asks the compositor for the current sources: `ListOutputs` when
+  monitors are allowed, `ListWindows` when windows are allowed. A `ListWindows` failure
+  (e.g. an older compositor) degrades to an empty window list rather than failing the call.
+- If both lists are empty, the portal returns response `3` (no sources).
+- The portal then presents a **single radio list** containing every allowed source: each
+  output (labelled `Entire screen` when there is exactly one, else `Screen — <connector>`),
+  followed by each window (labelled by title, falling back to app_id, with app_id as the
+  icon hint). Monitors and windows are offered together regardless of which `types` bits
+  the app set, so the user is never forced back to the app to change the request.
+- The list is presented through the `org.otto.Dialog1` renderer (otto-islands), the same
+  Access-style permission/choice dialog used by the portal's Access implementation. Option
+  ids are namespaced `monitor:<connector>` and `window:<identifier>`.
+- The user's answer resolves as:
+  - **Chose a source** → stored on the session; response `0`.
+  - **Dismissed the dialog** → response `1` (cancelled). Nothing is captured.
+  - **No dialog renderer answered on the bus** → the portal falls back to the pre-picker
+    behaviour for monitors (override file, else first output) so a session without
+    otto-islands still shares a screen. A window is **never** selected on the user's behalf
+    in this path; if only windows were available the call returns response `2`.
+- `Start` calls `RecordMonitor` or `RecordWindow` according to the stored selection, and the
+  resulting portal stream carries `source_type` = 1 or 2 to match.
+
+### Window capture
+
+- A window stream renders the window's **own surface tree** (toplevel + subsurfaces, plus
+  its popups) into the PipeWire DMA-BUF; it does not blit the composited output. Content
+  stacked above the window, the dock/topbar, and the desktop behind it are therefore never
+  in the capture.
+- The window's geometry origin is placed at (0, 0) of the stream buffer, so client-side
+  decoration shadow margins are cropped out.
+- The buffer is cleared to opaque black before each frame.
+- The stream size is fixed at `RecordWindow` time to the window's geometry in physical
+  pixels, rounded **down to even** dimensions. A window that later grows is cropped to that
+  size; one that shrinks leaves the remainder black. The format is never renegotiated.
+- With cursor mode `EMBEDDED`, the cursor is drawn into the window stream at window-relative
+  coordinates, so it appears only while the pointer is over the captured window.
+- Window streams are serviced from the render frame of whichever output currently hosts the
+  window, so moving a window between outputs does not interrupt its stream. They force that
+  output to composite (no direct scanout) and to keep painting when otherwise idle, exactly
+  as a monitor stream does.
+- A window with an active stream is classified `Captured` by the frame-callback throttler:
+  it receives frame callbacks at full rate even when occluded, on an inactive workspace, or
+  minimized, and is **not** reported as `activated` (it has no keyboard focus).
+- A locked session suspends all capture, window streams included.
+
+### Output-selection override file
+
 - Before falling back to the default, the portal checks for an override file at
   `$XDG_CONFIG_HOME/otto/screencast-output` (falling back to `~/.config/otto/screencast-output`
   if `XDG_CONFIG_HOME` is unset). The file is read fresh on every `SelectSources` call — there
@@ -93,8 +157,10 @@ documented in `docs/developer/screenshare.md`.
   `ListOutputs`, the portal logs a warning and falls back to selecting the first output from
   `ListOutputs`, exactly as if no override existed.
 - If the app requests `multiple` source selection, the portal logs that it is limiting
-  selection to a single output and proceeds with the same first-output-or-override
-  resolution above; it never selects more than one output.
+  selection to a single source and proceeds with the single-choice picker above; it never
+  selects more than one source.
+- The override only applies to the no-renderer fallback path; when the picker is reachable
+  the user's answer wins.
 
 ## Constraints & Edge Cases
 
@@ -120,9 +186,22 @@ documented in `docs/developer/screenshare.md`.
   is a single trimmed line with no quoting, comments, or multi-output support; an invalid or
   stale connector name degrades gracefully (falls back to first output with a warning) rather
   than failing the session.
-- **This override is a stopgap:** it exists only because there is no interactive
-  source-picker in the portal flow yet. It is expected to be superseded by a real UI that
-  lets the user choose the output per-session.
+- **The override is now only a fallback:** with the picker in place it applies solely when
+  no `org.otto.Dialog1` renderer answers, keeping headless/islands-less sessions working.
+- **A resized captured window is not renegotiated:** the stream keeps its original
+  dimensions for its lifetime, cropping or letterboxing instead. Renegotiating mid-stream
+  would require tearing down and re-announcing the PipeWire format, which many consumers
+  handle poorly; a fixed size trades fidelity for a stream that never drops.
+- **Window capture bypasses the compositor's effects:** because it renders the client's own
+  surfaces rather than the composited scene, rounded corners, shadows, blur and any other
+  lay-rs scene decoration are absent from the capture. This is intentional — the consumer
+  wants the window's content, not Otto's presentation of it.
+- **A captured window is pinned at full frame rate**, which removes the power savings the
+  throttler would otherwise get from occlusion/minimization for that one window. This is
+  required: the remote viewer sees the window even when the local user does not.
+- **The picker is modal and blocking:** `SelectSources` does not return until the user
+  answers. An app that times out its portal call will fail the session; this matches the
+  behaviour of every other portal implementation's chooser.
 
 ## Rationale
 
@@ -150,10 +229,29 @@ documented in `docs/developer/screenshare.md`.
   which virtual/monitor output gets captured across ad hoc RDP/screenshare testing sessions)
   where restarting the whole D-Bus session is disruptive.
 
+- **Reusing the Access-style choice dialog for the picker** avoids building a bespoke
+  source-picker UI: `org.freedesktop.impl.portal.Access` already defines a labelled radio
+  list (`choices`), Otto's `org.otto.Dialog1` mirrors that shape, and otto-islands already
+  renders it with app icons. A dedicated picker with live previews can replace it later
+  without changing the compositor-side contract.
+- **`ext-foreign-toplevel-list-v1` identifiers as the window key** were chosen over any
+  internal id because the protocol defines them precisely for naming a window to another
+  process, Otto already implements the protocol, and it keeps the door open for a picker
+  that enumerates windows itself instead of via `ListWindows`.
+- **Re-rendering the window's surfaces instead of cropping the output framebuffer** is what
+  makes occluded, off-workspace and minimized capture work at all, and prevents leaking
+  whatever happens to be stacked on top of the shared window to the remote viewer — the
+  privacy property users assume when they pick "share a window" over "share a screen".
+
 ## Open Questions
 
 - Should the SHM fallback path also be re-enabled as an *additional* pod when DMA-BUF pods
   are offered, so a client that can't negotiate `DMA_DRM` caps still gets a (CPU-copied)
   stream instead of failing outright?
-- Should the output-selection override file be replaced by an actual portal-side UI, and if
-  so, does the override file stay as a scriptable/testing escape hatch afterward?
+- Should the picker show live thumbnails, and if so, does that arrive via
+  `ext-image-copy-capture-v1` (picker captures for itself) or a compositor-side thumbnail
+  API?
+- Should a captured window that is resized renegotiate the stream format rather than being
+  cropped, and is any consumer robust enough to make that worthwhile?
+- Should the compositor show a persistent indicator while a window is being cast, as it
+  arguably should for monitor casts too?

--- a/specs/workspaces-multi-output.md
+++ b/specs/workspaces-multi-output.md
@@ -44,6 +44,8 @@ Otto supports multiple workspaces across multiple outputs (physical monitors and
 
 **Removing a workspace:**
 
+- The "×" button is revealed when the pointer hovers a workspace preview, and stays visible while the pointer moves from the preview onto the button itself. It hides again once the pointer leaves both.
+- No "×" is rendered for the current workspace, nor for a fullscreen workspace that still has windows — neither can be removed.
 - When the user clicks "×" on a workspace preview, that workspace is removed from that output only.
 - If the output has only one workspace, the remove action is ignored (minimum one workspace per output).
 - A removal animation plays (the preview shrinks to zero width) before the workspace is actually removed.

--- a/src/screenshare/dbus_service.rs
+++ b/src/screenshare/dbus_service.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, warn};
 use zbus::zvariant::{ObjectPath, OwnedFd, OwnedObjectPath, OwnedValue, Value};
 use zbus::{interface, Connection};
 
-use super::CompositorCommand;
+use super::{CompositorCommand, StreamTarget};
 
 /// Global session counter for unique IDs.
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -142,6 +142,34 @@ impl ScreenCastInterface {
         debug!("Received {} outputs: {:?}", connectors.len(), connectors);
         Ok(connectors)
     }
+
+    /// Lists capturable windows as `(identifier, app_id, title)`.
+    ///
+    /// The identifier is the window's `ext-foreign-toplevel-list-v1` handle
+    /// identifier; pass it back as the `window-id` property of `RecordWindow`.
+    async fn list_windows(&self) -> zbus::fdo::Result<Vec<(String, String, String)>> {
+        debug!("Listing windows (D-Bus handler)");
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.compositor_tx
+            .send(CompositorCommand::ListWindows { response_tx: tx })
+            .map_err(|e| {
+                error!("Failed to send ListWindows command: {}", e);
+                zbus::fdo::Error::Failed(format!("Channel send error: {e}"))
+            })?;
+
+        let windows = rx.await.map_err(|e| {
+            error!("Failed to receive ListWindows response: {}", e);
+            zbus::fdo::Error::Failed(format!("Response channel error: {e}"))
+        })?;
+
+        debug!("Received {} windows", windows.len());
+        Ok(windows
+            .into_iter()
+            .map(|w| (w.id, w.app_id, w.title))
+            .collect())
+    }
 }
 
 /// Session D-Bus interface.
@@ -163,7 +191,7 @@ pub struct SessionInterface {
 /// Internal state for a stream.
 #[derive(Clone)]
 struct StreamState {
-    connector: String,
+    target: StreamTarget,
     cursor_mode: u32,
     node_id: Option<u32>,
     width: u32,
@@ -186,44 +214,22 @@ impl SessionInterface {
             streams: Arc::new(RwLock::new(HashMap::new())),
         }
     }
-}
 
-#[interface(name = "org.otto.ScreenCast.Session")]
-impl SessionInterface {
-    /// Starts recording a monitor by connector name.
-    async fn record_monitor(
-        &mut self,
-        connector: &str,
-        properties: HashMap<&str, Value<'_>>,
+    /// Allocate a stream object for `target` and export it on the bus.
+    ///
+    /// The PipeWire stream itself is not created until `Session.Start`; until
+    /// then `node_id` stays `None`.
+    async fn register_stream(
+        &self,
+        target: StreamTarget,
+        cursor_mode: u32,
+        width: u32,
+        height: u32,
     ) -> zbus::fdo::Result<OwnedObjectPath> {
-        let cursor_mode = properties
-            .get("cursor-mode")
-            .and_then(|v| u32::try_from(v).ok())
-            .unwrap_or(1);
-
         let stream_id = STREAM_COUNTER.fetch_add(1, Ordering::Relaxed);
         let stream_path = format!("{}/stream/{stream_id}", self.session_path);
 
-        info!(
-            %connector,
-            cursor_mode,
-            "Recording monitor, stream at {stream_path}"
-        );
-
-        // Get output info from compositor to know dimensions
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.compositor_tx
-            .send(CompositorCommand::ListOutputs { response_tx: tx })
-            .map_err(|e| zbus::fdo::Error::Failed(format!("Channel send error: {e}")))?;
-
-        let outputs = rx
-            .await
-            .map_err(|e| zbus::fdo::Error::Failed(format!("Response channel error: {e}")))?;
-
-        let output = outputs
-            .iter()
-            .find(|o| o.connector == connector)
-            .ok_or_else(|| zbus::fdo::Error::Failed(format!("Output {connector} not found")))?;
+        debug!(target = %target.key(), width, height, "Registering stream at {stream_path}");
 
         // Store stream state (node_id will be set when PipeWire stream starts)
         {
@@ -231,11 +237,11 @@ impl SessionInterface {
             streams.insert(
                 stream_path.clone(),
                 StreamState {
-                    connector: connector.to_string(),
+                    target,
                     cursor_mode,
                     node_id: None,
-                    width: output.width,
-                    height: output.height,
+                    width,
+                    height,
                     started: false,
                 },
             );
@@ -268,15 +274,93 @@ impl SessionInterface {
         OwnedObjectPath::try_from(stream_path)
             .map_err(|e| zbus::fdo::Error::Failed(format!("Invalid path: {e}")))
     }
+}
 
-    /// Starts recording a window (not implemented).
-    async fn record_window(
-        &self,
-        _properties: HashMap<&str, Value<'_>>,
+#[interface(name = "org.otto.ScreenCast.Session")]
+impl SessionInterface {
+    /// Starts recording a monitor by connector name.
+    async fn record_monitor(
+        &mut self,
+        connector: &str,
+        properties: HashMap<&str, Value<'_>>,
     ) -> zbus::fdo::Result<OwnedObjectPath> {
-        Err(zbus::fdo::Error::NotSupported(
-            "Window recording not yet implemented".to_string(),
-        ))
+        let cursor_mode = properties
+            .get("cursor-mode")
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(1);
+
+        info!(%connector, cursor_mode, "Recording monitor");
+
+        // Get output info from compositor to know dimensions
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.compositor_tx
+            .send(CompositorCommand::ListOutputs { response_tx: tx })
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Channel send error: {e}")))?;
+
+        let outputs = rx
+            .await
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Response channel error: {e}")))?;
+
+        let output = outputs
+            .iter()
+            .find(|o| o.connector == connector)
+            .ok_or_else(|| zbus::fdo::Error::Failed(format!("Output {connector} not found")))?;
+
+        self.register_stream(
+            StreamTarget::Output(connector.to_string()),
+            cursor_mode,
+            output.width,
+            output.height,
+        )
+        .await
+    }
+
+    /// Starts recording a single window.
+    ///
+    /// Properties:
+    /// - `window-id`: s — the window's `ext-foreign-toplevel-list-v1`
+    ///   identifier, as returned by `org.otto.ScreenCast.ListWindows`.
+    /// - `cursor-mode`: u32 — optional, defaults to embedded.
+    async fn record_window(
+        &mut self,
+        properties: HashMap<&str, Value<'_>>,
+    ) -> zbus::fdo::Result<OwnedObjectPath> {
+        let window_id: String = properties
+            .get("window-id")
+            .and_then(|v| String::try_from(v.try_clone().ok()?).ok())
+            .ok_or_else(|| {
+                zbus::fdo::Error::InvalidArgs("RecordWindow requires a window-id".to_string())
+            })?;
+
+        let cursor_mode = properties
+            .get("cursor-mode")
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(1);
+
+        info!(%window_id, cursor_mode, "Recording window");
+
+        // Resolve the identifier to current window dimensions.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.compositor_tx
+            .send(CompositorCommand::ListWindows { response_tx: tx })
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Channel send error: {e}")))?;
+
+        let windows = rx
+            .await
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Response channel error: {e}")))?;
+
+        let window = windows
+            .iter()
+            .find(|w| w.id == window_id)
+            .ok_or_else(|| zbus::fdo::Error::Failed(format!("Window {window_id} not found")))?;
+
+        self.register_stream(
+            StreamTarget::Window(window_id.clone()),
+            cursor_mode,
+            window.width,
+            window.height,
+        )
+        .await
     }
 
     /// Starts all streams in the session.
@@ -297,20 +381,16 @@ impl SessionInterface {
         };
 
         for stream_path in stream_paths {
-            let (connector, cursor_mode) = {
+            let Some((target, cursor_mode)) = ({
                 let streams = self.streams.read().await;
                 streams
                     .get(&stream_path)
-                    .map(|s| (s.connector.clone(), s.cursor_mode))
-                    .unwrap_or_else(|| {
-                        // Skip if stream not found
-                        (String::new(), 0)
-                    })
-            };
-
-            if connector.is_empty() {
+                    .map(|s| (s.target.clone(), s.cursor_mode))
+            }) else {
+                // Stream vanished between listing and starting
                 continue;
-            }
+            };
+            let connector = target.key();
 
             // Create response channel for node_id
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -318,7 +398,7 @@ impl SessionInterface {
             // Notify compositor to start recording
             if let Err(e) = self.compositor_tx.send(CompositorCommand::StartRecording {
                 session_id: self.session_path.clone(),
-                output_connector: connector.clone(),
+                target,
                 cursor_mode,
                 response_tx: tx,
             }) {
@@ -366,17 +446,17 @@ impl SessionInterface {
         info!(session = %self.session_path, stream_count = streams.len(), "Stopping {} streams", streams.len());
         for (path, stream) in streams.iter_mut() {
             if stream.started {
-                info!(session = %self.session_path, stream_path = %path, connector = %stream.connector, "Stopping started stream");
+                info!(session = %self.session_path, stream_path = %path, target = %stream.target.key(), "Stopping started stream");
                 stream.started = false;
 
                 if let Err(e) = self.compositor_tx.send(CompositorCommand::StopRecording {
                     session_id: self.session_path.clone(),
-                    output_connector: stream.connector.clone(),
+                    target: stream.target.clone(),
                 }) {
                     warn!(?e, "Failed to stop recording");
                 }
             } else {
-                info!(session = %self.session_path, stream_path = %path, connector = %stream.connector, "Skipping non-started stream");
+                info!(session = %self.session_path, stream_path = %path, target = %stream.target.key(), "Skipping non-started stream");
             }
         }
 
@@ -500,10 +580,24 @@ impl StreamInterface {
             .ok_or_else(|| zbus::fdo::Error::Failed("Stream not found".to_string()))?;
 
         let mut result = HashMap::new();
-        result.insert(
-            "connector".to_string(),
-            Value::from(stream.connector.as_str()).try_into().unwrap(),
-        );
+        // `source-type` mirrors the portal's SOURCE_TYPE_* bits so the portal
+        // can build the right stream properties without tracking targets itself.
+        match &stream.target {
+            StreamTarget::Output(connector) => {
+                result.insert(
+                    "connector".to_string(),
+                    Value::from(connector.as_str()).try_into().unwrap(),
+                );
+                result.insert("source-type".to_string(), OwnedValue::from(1u32));
+            }
+            StreamTarget::Window(window_id) => {
+                result.insert(
+                    "window-id".to_string(),
+                    Value::from(window_id.as_str()).try_into().unwrap(),
+                );
+                result.insert("source-type".to_string(), OwnedValue::from(2u32));
+            }
+        }
         result.insert("width".to_string(), OwnedValue::from(stream.width));
         result.insert("height".to_string(), OwnedValue::from(stream.height));
         result.insert(

--- a/src/screenshare/mod.rs
+++ b/src/screenshare/mod.rs
@@ -61,12 +61,36 @@ pub struct ScreencastSession {
     pub streams: HashMap<String, ActiveStream>,
 }
 
-/// Active stream for one output.
+/// What a stream captures.
+///
+/// Monitor capture blits the finished output framebuffer; window capture
+/// re-renders one toplevel's surface tree into the PipeWire buffer. The two
+/// live in the same session map, keyed by [`StreamTarget::key`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StreamTarget {
+    /// An output, by connector name (e.g. "HDMI-A-1").
+    Output(String),
+    /// A toplevel, by its `ext-foreign-toplevel-list-v1` identifier.
+    Window(String),
+}
+
+impl StreamTarget {
+    /// Map key for `ScreencastSession::streams`. Prefixed so an output and a
+    /// window can never collide.
+    pub fn key(&self) -> String {
+        match self {
+            StreamTarget::Output(connector) => format!("output:{connector}"),
+            StreamTarget::Window(id) => format!("window:{id}"),
+        }
+    }
+}
+
+/// Active stream for one capture target.
 ///
 /// Contains the PipeWire stream.
 pub struct ActiveStream {
-    /// Output connector name (e.g., "HDMI-A-1").
-    pub output_connector: String,
+    /// What this stream captures.
+    pub target: StreamTarget,
     /// PipeWire stream instance.
     pub pipewire_stream: PipeWireStream,
     /// Frame rendered last cycle, awaiting its GPU fence before the dmabuf is
@@ -87,18 +111,22 @@ pub enum CompositorCommand {
     ListOutputs {
         response_tx: tokio::sync::oneshot::Sender<Vec<OutputInfo>>,
     },
-    /// Start recording on a specific output.
+    /// List capturable toplevel windows.
+    ListWindows {
+        response_tx: tokio::sync::oneshot::Sender<Vec<WindowInfo>>,
+    },
+    /// Start recording a capture target.
     StartRecording {
         session_id: String,
-        output_connector: String,
+        target: StreamTarget,
         cursor_mode: u32,
         /// Response channel for the PipeWire node ID.
         response_tx: tokio::sync::oneshot::Sender<Result<u32, String>>,
     },
-    /// Stop recording on a specific output.
+    /// Stop recording a capture target.
     StopRecording {
         session_id: String,
-        output_connector: String,
+        target: StreamTarget,
     },
     /// Get a PipeWire file descriptor for the session.
     GetPipeWireFd {
@@ -119,6 +147,19 @@ pub struct OutputInfo {
     pub width: u32,
     pub height: u32,
     pub refresh_rate: u32,
+}
+
+/// Information about a capturable window.
+#[derive(Debug, Clone)]
+pub struct WindowInfo {
+    /// `ext-foreign-toplevel-list-v1` identifier — the handle the portal
+    /// passes back to `RecordWindow`.
+    pub id: String,
+    pub app_id: String,
+    pub title: String,
+    /// Window geometry in physical pixels.
+    pub width: u32,
+    pub height: u32,
 }
 
 /// Information about an active stream.
@@ -179,6 +220,64 @@ impl ScreenshareManager {
     }
 }
 
+/// Resolve an `ext-foreign-toplevel-list-v1` identifier to a mapped window and
+/// the output hosting it.
+///
+/// Returns `None` if the identifier is unknown or the window is no longer
+/// mapped to any output (the portal may hold a stale identifier from before
+/// the user answered the picker dialog).
+///
+/// Takes the two fields it needs rather than `&Otto` so callers inside the
+/// render loop — which already hold a mutable borrow of `backend_data` — can
+/// still use it under field-disjoint borrows.
+#[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+pub fn window_for_identifier(
+    workspaces: &crate::workspaces::Workspaces,
+    foreign_toplevels: &HashMap<
+        smithay::reexports::wayland_server::backend::ObjectId,
+        crate::state::foreign_toplevel_shared::ForeignToplevelHandles,
+    >,
+    identifier: &str,
+) -> Option<(crate::shell::WindowElement, smithay::output::Output)> {
+    let window = workspaces.spaces_elements().find(|window| {
+        foreign_toplevels
+            .get(&window.id())
+            .and_then(|handles| handles.identifier())
+            .is_some_and(|id| id == identifier)
+    })?;
+    let output = workspaces.outputs_for_element(window).first().cloned()?;
+    Some((window.clone(), output))
+}
+
+/// Ids of windows with an active screencast stream.
+///
+/// Drives [`crate::state::window_throttle::WindowThrottleState::Captured`] so a
+/// shared window keeps painting while occluded or on another workspace. Takes
+/// individual fields for the same borrow reason as [`window_for_identifier`].
+#[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+pub fn screencast_window_ids(
+    sessions: &HashMap<String, ScreencastSession>,
+    workspaces: &crate::workspaces::Workspaces,
+    foreign_toplevels: &HashMap<
+        smithay::reexports::wayland_server::backend::ObjectId,
+        crate::state::foreign_toplevel_shared::ForeignToplevelHandles,
+    >,
+) -> std::collections::HashSet<smithay::reexports::wayland_server::backend::ObjectId> {
+    let mut ids = std::collections::HashSet::new();
+    for session in sessions.values() {
+        for stream in session.streams.values() {
+            if let StreamTarget::Window(identifier) = &stream.target {
+                if let Some((window, _)) =
+                    window_for_identifier(workspaces, foreign_toplevels, identifier)
+                {
+                    ids.insert(window.id());
+                }
+            }
+        }
+    }
+    ids
+}
+
 /// Handle a command from the D-Bus service.
 fn handle_screenshare_command<B: crate::state::Backend + 'static>(
     state: &mut crate::state::Otto<B>,
@@ -225,33 +324,100 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             tracing::info!("Returning {} outputs", outputs.len());
             let _ = response_tx.send(outputs);
         }
+        CompositorCommand::ListWindows { response_tx } => {
+            let windows: Vec<WindowInfo> = state
+                .workspaces
+                .spaces_elements()
+                .filter_map(|window| {
+                    // Only toplevels the foreign-toplevel protocol knows about
+                    // are addressable by a portal — that identifier is the
+                    // whole contract with the picker.
+                    let handles = state.foreign_toplevels.get(&window.id())?;
+                    let id = handles.identifier()?;
+                    let output = state
+                        .workspaces
+                        .outputs_for_element(window)
+                        .first()
+                        .cloned();
+                    let scale = output
+                        .map(|o| o.current_scale().fractional_scale())
+                        .unwrap_or(1.0);
+                    let size = smithay::desktop::space::SpaceElement::geometry(window).size;
+                    Some(WindowInfo {
+                        id,
+                        app_id: handles.app_id(),
+                        title: handles.title(),
+                        width: ((size.w as f64) * scale).round().max(0.0) as u32,
+                        height: ((size.h as f64) * scale).round().max(0.0) as u32,
+                    })
+                })
+                .collect();
+            tracing::info!("Returning {} windows", windows.len());
+            let _ = response_tx.send(windows);
+        }
         CompositorCommand::StartRecording {
             session_id,
-            output_connector,
+            target,
             cursor_mode,
             response_tx,
         } => {
             tracing::debug!(
-                "StartRecording: session={}, output={}, cursor_mode={}",
+                "StartRecording: session={}, target={:?}, cursor_mode={}",
                 session_id,
-                output_connector,
+                target,
                 cursor_mode
             );
 
-            // Find the output by connector name
-            let output = state
-                .workspaces
-                .outputs()
-                .find(|o| o.name() == output_connector);
+            // Resolve the target to a capture size, plus the output whose
+            // refresh rate paces the stream. A window is captured at its
+            // current size; later resizes are letterboxed into these fixed
+            // dimensions rather than renegotiating the PipeWire format.
+            let resolved = match &target {
+                StreamTarget::Output(connector) => state
+                    .workspaces
+                    .outputs()
+                    .find(|o| o.name() == *connector)
+                    .cloned()
+                    .ok_or_else(|| format!("Output not found: {connector}"))
+                    .map(|output| {
+                        let (w, h, refresh) = output
+                            .current_mode()
+                            .map(|m| (m.size.w as u32, m.size.h as u32, m.refresh as u32))
+                            .unwrap_or((1920, 1080, 60000));
+                        (w, h, refresh)
+                    }),
+                StreamTarget::Window(id) => {
+                    window_for_identifier(&state.workspaces, &state.foreign_toplevels, id)
+                        .ok_or_else(|| format!("Window not found: {id}"))
+                        .and_then(|(window, output)| {
+                            let scale = output.current_scale().fractional_scale();
+                            let size =
+                                smithay::desktop::space::SpaceElement::geometry(&window).size;
+                            // Even dimensions: several PipeWire consumers (and
+                            // every YUV encoder downstream) reject odd sizes.
+                            let w = (((size.w as f64) * scale).round() as u32) & !1;
+                            let h = (((size.h as f64) * scale).round() as u32) & !1;
+                            if w == 0 || h == 0 {
+                                return Err(format!("Window {id} has zero size"));
+                            }
+                            let refresh = output
+                                .current_mode()
+                                .map(|m| m.refresh as u32)
+                                .unwrap_or(60000);
+                            Ok((w, h, refresh))
+                        })
+                }
+            };
 
-            let output = match output {
-                Some(o) => o.clone(),
-                None => {
-                    let _ =
-                        response_tx.send(Err(format!("Output not found: {}", output_connector)));
+            let (width, height, refresh_rate) = match resolved {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = response_tx.send(Err(e));
                     return;
                 }
             };
+
+            let stream_key = target.key();
 
             // Get the session and update cursor_mode
             let session = match state.screenshare_sessions.get_mut(&session_id) {
@@ -265,20 +431,11 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             // Update cursor mode for this session
             session.cursor_mode = cursor_mode;
 
-            // Check if already recording this output
-            if session.streams.contains_key(&output_connector) {
-                let _ = response_tx.send(Err(format!(
-                    "Already recording output: {}",
-                    output_connector
-                )));
+            // Check if already recording this target
+            if session.streams.contains_key(&stream_key) {
+                let _ = response_tx.send(Err(format!("Already recording: {}", stream_key)));
                 return;
             }
-
-            // Get output dimensions for stream config
-            let (width, height, refresh_rate) = output
-                .current_mode()
-                .map(|m| (m.size.w as u32, m.size.h as u32, m.refresh as u32))
-                .unwrap_or((1920, 1080, 60000));
 
             // Build backend capabilities
             let gbm_device = state.backend_data.gbm_device();
@@ -360,23 +517,19 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             };
 
             tracing::debug!(
-                "PipeWire stream started: session={}, output={}, node_id={}",
+                "PipeWire stream started: session={}, target={}, node_id={}, size={}x{}",
                 session_id,
-                output_connector,
-                node_id
-            );
-
-            tracing::debug!(
-                "Started PipeWire stream for session={}, output={}",
-                session_id,
-                output_connector
+                stream_key,
+                node_id,
+                width,
+                height
             );
 
             // Store the active stream
             session.streams.insert(
-                output_connector.clone(),
+                stream_key,
                 ActiveStream {
-                    output_connector,
+                    target,
                     pipewire_stream,
                     pending_frame: None,
                 },
@@ -385,15 +538,8 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             // Send success response with node_id
             let _ = response_tx.send(Ok(node_id));
         }
-        CompositorCommand::StopRecording {
-            session_id,
-            output_connector,
-        } => {
-            tracing::debug!(
-                "StopRecording: session={}, output={}",
-                session_id,
-                output_connector
-            );
+        CompositorCommand::StopRecording { session_id, target } => {
+            tracing::debug!("StopRecording: session={}, target={:?}", session_id, target);
 
             // Get the session
             let session = match state.screenshare_sessions.get_mut(&session_id) {
@@ -405,17 +551,18 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             };
 
             // Remove and stop the stream
-            if let Some(_stream) = session.streams.remove(&output_connector) {
+            let stream_key = target.key();
+            if let Some(_stream) = session.streams.remove(&stream_key) {
                 tracing::debug!(
-                    "Stopped stream for session={}, output={}",
+                    "Stopped stream for session={}, target={}",
                     session_id,
-                    output_connector
+                    stream_key
                 );
                 // PipeWire stream will be dropped here
             } else {
                 tracing::warn!(
-                    "No active stream for output {} in session {}",
-                    output_connector,
+                    "No active stream for {} in session {}",
+                    stream_key,
                     session_id
                 );
             }
@@ -449,6 +596,67 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
             state.focus_app(&app_id);
         }
     }
+}
+
+/// Render render elements into a PipeWire dmabuf, over an opaque black clear.
+///
+/// This is the window-capture counterpart of [`fullscreen_to_dmabuf`]. Instead
+/// of blitting the composited output it re-renders the window's own surface
+/// tree, so the capture is unaffected by windows stacked on top of it, by the
+/// dock/topbar, or by which workspace is currently on screen.
+///
+/// Elements are expected to be positioned by the caller so the window's
+/// geometry origin lands at (0, 0). Content outside `size` is clipped: a window
+/// that grew since recording started is cropped, one that shrank leaves the
+/// remainder black.
+pub fn window_to_dmabuf<R, E>(
+    renderer: &mut R,
+    dst_dmabuf: &mut smithay::backend::allocator::dmabuf::Dmabuf,
+    size: smithay::utils::Size<i32, smithay::utils::Physical>,
+    elements: &[E],
+    scale: smithay::utils::Scale<f64>,
+) -> Result<(), String>
+where
+    R: smithay::backend::renderer::Renderer
+        + smithay::backend::renderer::Bind<smithay::backend::allocator::dmabuf::Dmabuf>,
+    E: smithay::backend::renderer::element::RenderElement<R>,
+{
+    use smithay::backend::renderer::{Color32F, Frame};
+    use smithay::utils::{Physical, Rectangle};
+
+    let full = Rectangle::<i32, Physical>::from_size(size);
+
+    let mut dmabuf_fb = renderer
+        .bind(dst_dmabuf)
+        .map_err(|e| format!("Failed to bind dmabuf: {:?}", e))?;
+
+    let mut frame = renderer
+        .render(&mut dmabuf_fb, size, smithay::utils::Transform::Normal)
+        .map_err(|e| format!("Failed to create frame: {:?}", e))?;
+
+    // Opaque black: the stream is ARGB, and consumers that ignore alpha would
+    // otherwise show whatever was left in the recycled buffer.
+    frame
+        .clear(Color32F::new(0.0, 0.0, 0.0, 1.0), &[full])
+        .map_err(|e| format!("Failed to clear: {:?}", e))?;
+
+    // Front-to-back element order is top-most first; draw in reverse so upper
+    // elements land on top.
+    for element in elements.iter().rev() {
+        let src = element.src();
+        let dst = element.geometry(scale);
+        let Some(mut damage) = full.intersection(dst) else {
+            continue;
+        };
+        damage.loc -= dst.loc;
+        element
+            .draw(&mut frame, src, dst, &[damage], &[])
+            .map_err(|e| format!("Failed to draw element: {:?}", e))?;
+    }
+
+    std::mem::drop(frame);
+
+    Ok(())
 }
 
 /// Copy compositor framebuffer to PipeWire buffer with cursor rendering

--- a/src/screenshare/pipewire_stream.rs
+++ b/src/screenshare/pipewire_stream.rs
@@ -231,6 +231,14 @@ impl PipeWireStream {
         self.shared.streaming.load(Ordering::SeqCst)
     }
 
+    /// The size this stream negotiated, in pixels.
+    ///
+    /// Fixed for the stream's lifetime — a window that resizes mid-capture is
+    /// cropped or letterboxed into these dimensions rather than renegotiating.
+    pub fn stream_size(&self) -> (u32, u32) {
+        (self.config.width, self.config.height)
+    }
+
     /// Get access to the buffer pool for rendering from main thread.
     pub fn buffer_pool(&self) -> Arc<Mutex<BufferPool>> {
         self.shared.buffer_pool.clone()

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -276,6 +276,7 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
 
                     if let Some(window) = window {
                         window.on_commit();
+                        self.settle_initial_placement(&window);
 
                         if self.popups.find_popup(surface).is_some() {
                             tracing::debug!(
@@ -800,6 +801,69 @@ impl<BackendData: Backend> WlrLayerShellHandler for Otto<BackendData> {
 pub struct SurfaceData {
     pub geometry: Option<Rectangle<i32, Logical>>,
     pub resize_state: ResizeState,
+}
+
+/// A window at most this fraction of the usable area, in **both** axes, is
+/// treated as a dialog and centered.
+///
+/// There is no protocol signal to key on: GTK dialogs send `set_parent(nil)`
+/// and don't implement `xdg-dialog-v1`, so "small" is the only thing that
+/// actually distinguishes a dialog from a document window across toolkits.
+const DIALOG_MAX_FRACTION: f64 = 0.6;
+
+impl<BackendData: crate::state::Backend> crate::state::Otto<BackendData> {
+    /// Re-place a freshly mapped window now that its real size is known.
+    ///
+    /// Initial placement runs at `new_toplevel`, before the client has
+    /// configured, so it assumes a default size and spreads windows by least
+    /// overlap — which puts a small dialog in the top-left corner. Once the
+    /// first sized commit arrives we can tell a dialog from a normal window and
+    /// center it. Runs at most once per window.
+    fn settle_initial_placement(&mut self, window: &WindowElement) {
+        let id = window.id();
+        if !self.pending_initial_placement.contains(&id) {
+            return;
+        }
+
+        let size = window.geometry().size;
+        // Still unsized — wait for a later commit.
+        if size.w <= 0 || size.h <= 0 {
+            return;
+        }
+        self.pending_initial_placement.remove(&id);
+
+        // Fullscreen/maximized windows own their geometry already.
+        if window.is_fullscreen() || window.is_maximized() {
+            return;
+        }
+
+        let Some(output) = self.workspaces.output_for_window(window) else {
+            return;
+        };
+        let Some(usable) = self.workspaces.usable_geometry(&output) else {
+            return;
+        };
+
+        let is_dialog = (size.w as f64) <= usable.size.w as f64 * DIALOG_MAX_FRACTION
+            && (size.h as f64) <= usable.size.h as f64 * DIALOG_MAX_FRACTION;
+        if !is_dialog {
+            return;
+        }
+
+        let location = smithay::utils::Point::<i32, Logical>::from((
+            usable.loc.x + (usable.size.w - size.w) / 2,
+            usable.loc.y + (usable.size.h - size.h) / 2,
+        ));
+
+        tracing::debug!(
+            "settle_initial_placement: centering {}x{} dialog at {:?}",
+            size.w,
+            size.h,
+            location
+        );
+        self.workspaces
+            .map_window_on_output(&output, window, location, false, None);
+    }
 }
 
 fn ensure_initial_configure<Backend: crate::state::Backend>(

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -164,6 +164,10 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                 .map_window(&window_element, location, true, None);
         }
 
+        // The placement above assumed a default size because the client hasn't
+        // configured yet. Revisit it once the real size arrives.
+        self.pending_initial_placement.insert(window_element.id());
+
         // Register with foreign toplevel protocols (both ext and wlr)
         let surface_id = surface.wl_surface().id();
         let app_id = window_element.xdg_app_id();

--- a/src/state/foreign_toplevel_shared.rs
+++ b/src/state/foreign_toplevel_shared.rs
@@ -92,6 +92,16 @@ impl ForeignToplevelHandles {
             .unwrap_or_default()
     }
 
+    /// Stable, opaque cross-process identifier from the ext handle.
+    ///
+    /// `ext-foreign-toplevel-list-v1` defines this string for exactly this
+    /// purpose: naming a window to another process (a portal picking a
+    /// screencast source). The wlr protocol has no equivalent, so this is
+    /// `None` for toplevels that somehow lack an ext handle.
+    pub fn identifier(&self) -> Option<String> {
+        self.ext.as_ref().map(|h| h.identifier())
+    }
+
     /// Get app_id from ext handle (they should be in sync)
     pub fn app_id(&self) -> String {
         self.ext

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -311,6 +311,13 @@ pub struct Otto<BackendData: Backend + 'static> {
     // foreign toplevel list - maps surface ObjectId to unified toplevel handles (both protocols)
     pub foreign_toplevels: HashMap<ObjectId, foreign_toplevel_shared::ForeignToplevelHandles>,
 
+    /// Toplevels mapped but not yet placed against their real size.
+    ///
+    /// Initial placement runs before a client has configured, so it can only
+    /// guess at dimensions. Windows land here at map time and are re-placed on
+    /// their first sized commit — see `Otto::settle_initial_placement`.
+    pub pending_initial_placement: std::collections::HashSet<ObjectId>,
+
     // surface style protocol
     // Map from surface ID to list of surface styles augmenting that surface
     pub surfaces_style: HashMap<ObjectId, Vec<crate::surface_style::SurfaceStyle>>,
@@ -852,6 +859,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
 
             // foreign toplevel list
             foreign_toplevels: HashMap::new(),
+            pending_initial_placement: std::collections::HashSet::new(),
 
             // Surface style protocol
             surfaces_style: HashMap::new(),

--- a/src/state/window_throttle.rs
+++ b/src/state/window_throttle.rs
@@ -41,6 +41,10 @@ pub enum WindowThrottleState {
     Minimized,
     /// Window's workspace is not active on any output. Throttle heavily.
     HiddenWorkspace,
+    /// Being screencast. Full rate regardless of what covers it or which
+    /// workspace it is on — the remote viewer is looking at it even when the
+    /// local user is not — but *not* activated, since it has no keyboard focus.
+    Captured,
 }
 
 impl WindowThrottleState {
@@ -58,7 +62,7 @@ impl WindowThrottleState {
         match self {
             // Zero means "always send". The render-loop's own pacing (VBlank +
             // draw-deadline timer) limits the actual rate to the output refresh.
-            WindowThrottleState::Focused => Duration::ZERO,
+            WindowThrottleState::Focused | WindowThrottleState::Captured => Duration::ZERO,
             // ~30 Hz — halves the work for unfocused visible windows without
             // making their animations visibly stutter.
             WindowThrottleState::Secondary => Duration::from_millis(33),
@@ -93,6 +97,9 @@ pub struct ClassifierContext<'a> {
     /// True when the expose overview is animating or open; all non-minimized
     /// windows get smooth live previews during this period.
     pub expose_active: bool,
+    /// Windows with an active screencast stream. Outranks occlusion and
+    /// workspace visibility — see [`WindowThrottleState::Captured`].
+    pub captured_ids: &'a HashSet<ObjectId>,
 }
 
 /// Classify a single window given its own minimized flag and a context
@@ -102,6 +109,11 @@ pub fn classify_one(
     is_minimized: bool,
     ctx: &ClassifierContext<'_>,
 ) -> WindowThrottleState {
+    if ctx.captured_ids.contains(window_id) {
+        // Checked before `is_minimized`: a minimized window still has live
+        // content if something is casting it.
+        return WindowThrottleState::Captured;
+    }
     if is_minimized {
         return WindowThrottleState::Minimized;
     }
@@ -145,6 +157,7 @@ pub fn classify_windows(
     windows: &[&WindowElement],
     occluded_ids: &HashSet<ObjectId>,
     expose_active: bool,
+    captured_ids: &HashSet<ObjectId>,
 ) -> HashMap<ObjectId, WindowThrottleState> {
     // Fullscreen and top-of-stack are per-output properties of each output's
     // CURRENT workspace: a fullscreen window on one screen must not demote
@@ -176,6 +189,7 @@ pub fn classify_windows(
             top_of_current,
             occluded_ids,
             expose_active,
+            captured_ids,
         };
         let state = classify_one(&id, window.is_minimised(), &ctx);
         result.insert(id, state);
@@ -222,6 +236,7 @@ mod tests {
             top_of_current: Some(&id),
             occluded_ids: &occ,
             expose_active: true,
+            captured_ids: &empty_occluded(),
         };
         assert_eq!(
             classify_one(&id, true, &ctx),
@@ -239,6 +254,7 @@ mod tests {
             top_of_current: None,
             occluded_ids: &occ,
             expose_active: true,
+            captured_ids: &empty_occluded(),
         };
         assert_eq!(
             classify_one(&id, false, &ctx),
@@ -256,11 +272,41 @@ mod tests {
             top_of_current: Some(&id),
             occluded_ids: &occ,
             expose_active: false,
+            captured_ids: &empty_occluded(),
         };
         assert_eq!(
             classify_one(&id, false, &ctx),
             WindowThrottleState::Focused,
             "the fullscreen window itself is Focused"
+        );
+    }
+
+    #[test]
+    fn captured_window_beats_minimized() {
+        let id = mk_id();
+        let occ = empty_occluded();
+        let mut captured = HashSet::new();
+        captured.insert(id.clone());
+        let ctx = ClassifierContext {
+            fullscreen_id: None,
+            top_of_current: None,
+            occluded_ids: &occ,
+            expose_active: false,
+            captured_ids: &captured,
+        };
+        assert_eq!(
+            classify_one(&id, true, &ctx),
+            WindowThrottleState::Captured,
+            "a minimized window still streams at full rate while screencast"
+        );
+        assert_eq!(
+            WindowThrottleState::Captured.throttle(),
+            Duration::ZERO,
+            "captured windows are not frame-throttled"
+        );
+        assert!(
+            !WindowThrottleState::Captured.is_activated(),
+            "being captured must not make a window think it has focus"
         );
     }
 

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -771,11 +771,18 @@ impl Otto<UdevData> {
         #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
         let occluded_ids = self.workspaces.occluded_window_ids();
         #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+        let captured_ids = crate::screenshare::screencast_window_ids(
+            &self.screenshare_sessions,
+            &self.workspaces,
+            &self.foreign_toplevels,
+        );
+        #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
         let window_throttle_states = crate::state::window_throttle::classify_windows(
             &self.workspaces,
             &all_window_elements,
             &occluded_ids,
             expose_active,
+            &captured_ids,
         );
 
         // ── Shadow-only / direct scanout window selection ─────────────────────
@@ -793,10 +800,24 @@ impl Otto<UdevData> {
         // of frames and the remote client spins forever. The off-VBlank timer
         // (`kick_screencast_outputs`) supplies the render trigger when idle;
         // this makes that trigger actually paint.
-        let screencast_active = self
-            .screenshare_sessions
-            .values()
-            .any(|s| s.streams.contains_key(&output.name()));
+        // A window stream counts too: it is serviced from this output's frame,
+        // so this output must keep painting even when nothing else changed.
+        // The composite is forced for the same reason as a monitor stream —
+        // `blit_current_frame` and the window re-render both need the GPU
+        // path, not direct scanout.
+        let screencast_active = self.screenshare_sessions.values().any(|s| {
+            s.streams.values().any(|stream| match &stream.target {
+                crate::screenshare::StreamTarget::Output(connector) => connector == &output.name(),
+                crate::screenshare::StreamTarget::Window(id) => {
+                    crate::screenshare::window_for_identifier(
+                        &self.workspaces,
+                        &self.foreign_toplevels,
+                        id,
+                    )
+                    .is_some_and(|(_, window_output)| window_output.name() == output.name())
+                }
+            })
+        });
         let screencopy_pending = screencast_active
             || self
                 .pending_screencopy_frames
@@ -1092,97 +1113,153 @@ impl Otto<UdevData> {
                         should_render_cursor
                     );
 
-                    // Build cursor elements for screenshare if needed
-                    let cursor_elements: Vec<WorkspaceRenderElements<_>> = if should_render_cursor {
-                        let output_geometry =
-                            Rectangle::new((0, 0).into(), output.current_mode().unwrap().size);
-                        let output_scale = output.current_scale().fractional_scale();
-                        // Rebase the global pointer to this output's space —
-                        // same correction as in render_output_frame.
-                        let pointer_location =
-                            self.pointer.current_location() - output.current_location().to_f64();
-
-                        let pointer_in_output = output_geometry
-                            .to_f64()
-                            .contains(pointer_location.to_physical(scale));
-
-                        if pointer_in_output {
-                            use crate::cursor::RenderCursor;
-                            use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
-                            use smithay::backend::renderer::element::surface::render_elements_from_surface_tree;
-
-                            let mut elements = Vec::new();
-
-                            match self
-                                .cursor_manager
-                                .get_render_cursor(output_scale.round() as i32)
-                            {
-                                RenderCursor::Hidden => {}
-                                RenderCursor::Surface { hotspot, surface } => {
-                                    let cursor_pos_scaled = (pointer_location.to_physical(scale)
-                                        - hotspot.to_f64().to_physical(scale))
-                                    .to_i32_round();
-                                    let cursor_elems: Vec<WorkspaceRenderElements<_>> =
-                                        render_elements_from_surface_tree(
-                                            &mut renderer,
-                                            &surface,
-                                            cursor_pos_scaled,
-                                            scale,
-                                            1.0,
-                                            Kind::Cursor,
-                                        );
-                                    elements.extend(cursor_elems);
+                    for (stream_key, stream) in &session.streams {
+                        // Window streams are serviced on the frame of whatever
+                        // output currently hosts the window, so a window that
+                        // moves between outputs keeps streaming.
+                        let window_capture = match &stream.target {
+                            crate::screenshare::StreamTarget::Output(connector) => {
+                                if connector != &output.name() {
+                                    continue;
                                 }
-                                RenderCursor::Named {
-                                    icon,
-                                    scale: _,
-                                    cursor,
-                                } => {
-                                    let elapsed_millis = self.clock.now().as_millis();
-                                    let (idx, image) = cursor.frame(elapsed_millis);
-                                    let texture = self.cursor_texture_cache.get(
-                                        icon,
-                                        output_scale.round() as i32,
-                                        &cursor,
-                                        idx,
-                                    );
-                                    let hotspot_physical =
-                                        Point::from((image.xhot as f64, image.yhot as f64));
-                                    let cursor_pos_scaled: Point<i32, Physical> =
-                                        (pointer_location.to_physical(scale) - hotspot_physical)
-                                            .to_i32_round();
-                                    let elem = MemoryRenderBufferRenderElement::from_buffer(
-                                        &mut renderer,
-                                        cursor_pos_scaled.to_f64(),
-                                        &texture,
-                                        None,
-                                        None,
-                                        None,
-                                        Kind::Cursor,
-                                    )
-                                    .expect("Failed to create cursor render element");
-                                    elements.push(WorkspaceRenderElements::from(elem));
+                                None
+                            }
+                            crate::screenshare::StreamTarget::Window(id) => {
+                                match crate::screenshare::window_for_identifier(
+                                    &self.workspaces,
+                                    &self.foreign_toplevels,
+                                    id,
+                                ) {
+                                    Some((window, window_output))
+                                        if window_output.name() == output.name() =>
+                                    {
+                                        Some(window)
+                                    }
+                                    // Unmapped, or on another output's frame.
+                                    _ => continue,
                                 }
                             }
+                        };
 
-                            elements
-                        } else {
-                            Vec::new()
-                        }
-                    } else {
-                        Vec::new()
-                    };
+                        // Cursor elements are positioned in the capture
+                        // target's own space: output space for a monitor
+                        // stream, window space for a window stream. Built per
+                        // stream because that offset differs.
+                        let capture_origin_px: Point<i32, Physical> = match &window_capture {
+                            Some(window) => self
+                                .workspaces
+                                .element_location(window)
+                                .unwrap_or_default()
+                                .to_physical_precise_round(scale),
+                            None => Point::from((0, 0)),
+                        };
 
-                    for (connector, stream) in &session.streams {
-                        if connector == &output.name() {
+                        let cursor_elements: Vec<WorkspaceRenderElements<_>> =
+                            if should_render_cursor {
+                                let output_geometry = Rectangle::new(
+                                    (0, 0).into(),
+                                    output.current_mode().unwrap().size,
+                                );
+                                let output_scale = output.current_scale().fractional_scale();
+                                // Rebase the global pointer to this output's space —
+                                // same correction as in render_output_frame.
+                                let pointer_location = self.pointer.current_location()
+                                    - output.current_location().to_f64();
+
+                                let pointer_in_output = output_geometry
+                                    .to_f64()
+                                    .contains(pointer_location.to_physical(scale));
+
+                                if pointer_in_output {
+                                    use crate::cursor::RenderCursor;
+                                    use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
+                                    use smithay::backend::renderer::element::surface::render_elements_from_surface_tree;
+
+                                    let mut elements = Vec::new();
+
+                                    match self
+                                        .cursor_manager
+                                        .get_render_cursor(output_scale.round() as i32)
+                                    {
+                                        RenderCursor::Hidden => {}
+                                        RenderCursor::Surface { hotspot, surface } => {
+                                            let cursor_pos_scaled = (pointer_location
+                                                .to_physical(scale)
+                                                - hotspot.to_f64().to_physical(scale))
+                                            .to_i32_round()
+                                                - capture_origin_px;
+                                            let cursor_elems: Vec<WorkspaceRenderElements<_>> =
+                                                render_elements_from_surface_tree(
+                                                    &mut renderer,
+                                                    &surface,
+                                                    cursor_pos_scaled,
+                                                    scale,
+                                                    1.0,
+                                                    Kind::Cursor,
+                                                );
+                                            elements.extend(cursor_elems);
+                                        }
+                                        RenderCursor::Named {
+                                            icon,
+                                            scale: _,
+                                            cursor,
+                                        } => {
+                                            let elapsed_millis = self.clock.now().as_millis();
+                                            let (idx, image) = cursor.frame(elapsed_millis);
+                                            let texture = self.cursor_texture_cache.get(
+                                                icon,
+                                                output_scale.round() as i32,
+                                                &cursor,
+                                                idx,
+                                            );
+                                            let hotspot_physical =
+                                                Point::from((image.xhot as f64, image.yhot as f64));
+                                            let cursor_pos_scaled: Point<i32, Physical> =
+                                                (pointer_location.to_physical(scale)
+                                                    - hotspot_physical)
+                                                    .to_i32_round()
+                                                    - capture_origin_px;
+                                            let elem =
+                                                MemoryRenderBufferRenderElement::from_buffer(
+                                                    &mut renderer,
+                                                    cursor_pos_scaled.to_f64(),
+                                                    &texture,
+                                                    None,
+                                                    None,
+                                                    None,
+                                                    Kind::Cursor,
+                                                )
+                                                .expect("Failed to create cursor render element");
+                                            elements.push(WorkspaceRenderElements::from(elem));
+                                        }
+                                    }
+
+                                    elements
+                                } else {
+                                    Vec::new()
+                                }
+                            } else {
+                                Vec::new()
+                            };
+
+                        {
                             let buffer_pool = stream.pipewire_stream.buffer_pool();
                             let mut pool = buffer_pool.lock().unwrap();
 
                             if let Some(available) = pool.available.pop_front() {
-                                let size = output
-                                    .current_mode()
-                                    .map(|m| m.size)
-                                    .unwrap_or_else(|| (1920, 1080).into());
+                                let size = match &window_capture {
+                                    // The stream's negotiated size, fixed at
+                                    // RecordWindow time — not the window's
+                                    // current size, which may have changed.
+                                    Some(_) => {
+                                        let (w, h) = stream.pipewire_stream.stream_size();
+                                        (w as i32, h as i32).into()
+                                    }
+                                    None => output
+                                        .current_mode()
+                                        .map(|m| m.size)
+                                        .unwrap_or_else(|| (1920, 1080).into()),
+                                };
 
                                 // Force full frame for first render (when last_rendered_fd is None)
                                 let is_first_frame = pool.last_rendered_fd.is_none();
@@ -1199,20 +1276,84 @@ impl Otto<UdevData> {
 
                                 if is_first_frame {
                                     tracing::debug!(
-                                        "First frame for stream on {}, forcing full blit",
-                                        connector
+                                        "First frame for stream {}, forcing full blit",
+                                        stream_key
                                     );
                                 }
 
-                                // Blit from source framebuffer and render cursor on top
-                                let blit_result = crate::screenshare::fullscreen_to_dmabuf(
-                                    &mut renderer,
-                                    &mut available.dmabuf.clone(),
-                                    size,
-                                    damage_to_use,
-                                    &cursor_elements,
-                                    scale,
-                                );
+                                let blit_result = if let Some(window) = &window_capture {
+                                    // Re-render just this window's surfaces,
+                                    // with the window's geometry origin at
+                                    // (0, 0) so CSD shadow margins are cropped
+                                    // out. `render_elements` positions the
+                                    // surface origin, which sits at -geometry.loc
+                                    // relative to that.
+                                    use smithay::backend::renderer::element::surface::render_elements_from_surface_tree;
+
+                                    let geometry =
+                                        smithay::desktop::space::SpaceElement::geometry(window);
+                                    let surface_origin_px = Point::<i32, Physical>::from((0, 0))
+                                        - geometry.loc.to_physical_precise_round(scale);
+
+                                    let mut elements: Vec<WorkspaceRenderElements<_>> = Vec::new();
+
+                                    if let Some(surface) = window.wl_surface() {
+                                        // Popups first — front-to-back order
+                                        // puts them above the toplevel.
+                                        for (popup, popup_offset) in
+                                            smithay::desktop::PopupManager::popups_for_surface(
+                                                &surface,
+                                            )
+                                        {
+                                            let offset: Point<i32, Physical> = (popup_offset
+                                                - popup.geometry().loc)
+                                                .to_physical_precise_round(scale);
+                                            elements.extend(render_elements_from_surface_tree::<
+                                                _,
+                                                WorkspaceRenderElements<_>,
+                                            >(
+                                                &mut renderer,
+                                                popup.wl_surface(),
+                                                surface_origin_px + offset,
+                                                scale,
+                                                1.0,
+                                                Kind::Unspecified,
+                                            ));
+                                        }
+
+                                        elements.extend(render_elements_from_surface_tree::<
+                                            _,
+                                            WorkspaceRenderElements<_>,
+                                        >(
+                                            &mut renderer,
+                                            &surface,
+                                            surface_origin_px,
+                                            scale,
+                                            1.0,
+                                            Kind::Unspecified,
+                                        ));
+                                    }
+
+                                    // Front-to-back order: cursor on top.
+                                    elements.splice(0..0, cursor_elements);
+                                    crate::screenshare::window_to_dmabuf(
+                                        &mut renderer,
+                                        &mut available.dmabuf.clone(),
+                                        size,
+                                        &elements,
+                                        scale,
+                                    )
+                                } else {
+                                    // Blit from source framebuffer and render cursor on top
+                                    crate::screenshare::fullscreen_to_dmabuf(
+                                        &mut renderer,
+                                        &mut available.dmabuf.clone(),
+                                        size,
+                                        damage_to_use,
+                                        &cursor_elements,
+                                        scale,
+                                    )
+                                };
 
                                 if let Err(e) = blit_result {
                                     tracing::debug!("Screenshare blit failed: {}", e);
@@ -1229,7 +1370,10 @@ impl Otto<UdevData> {
                                 // No buffer available - trigger to dequeue any released buffers
                                 drop(pool);
                                 stream.pipewire_stream.trigger_frame();
-                                tracing::trace!("No available buffers for screenshare on {}, triggering dequeue", connector);
+                                tracing::trace!(
+                                    "No available buffers for screenshare {}, triggering dequeue",
+                                    stream_key
+                                );
                             }
                         }
                     }
@@ -1434,11 +1578,25 @@ impl Otto<UdevData> {
         self.backend_data.last_screencast_kick = Some(std::time::Instant::now());
         self.backend_data.last_kick_cursor_pos = Some(cursor_pos);
         // Collect the connectors with an active cast (dedup across sessions).
+        // A window stream kicks the output its window currently lives on.
         let mut connectors: Vec<String> = Vec::new();
         for session in self.screenshare_sessions.values() {
-            for connector in session.streams.keys() {
-                if !connectors.contains(connector) {
-                    connectors.push(connector.clone());
+            for stream in session.streams.values() {
+                let connector = match &stream.target {
+                    crate::screenshare::StreamTarget::Output(connector) => connector.clone(),
+                    crate::screenshare::StreamTarget::Window(id) => {
+                        match crate::screenshare::window_for_identifier(
+                            &self.workspaces,
+                            &self.foreign_toplevels,
+                            id,
+                        ) {
+                            Some((_, output)) => output.name(),
+                            None => continue,
+                        }
+                    }
+                };
+                if !connectors.contains(&connector) {
+                    connectors.push(connector);
                 }
             }
         }
@@ -1723,8 +1881,12 @@ impl Otto<UdevData> {
             // Same deferred-fence model as the virtual-output stream above.
             for session in self.screenshare_sessions.values_mut() {
                 for stream in session.streams.values_mut() {
-                    if stream.output_connector != output_name {
-                        continue;
+                    // Window streams are driven from the physical output
+                    // hosting the window, never from a virtual output tap.
+                    match &stream.target {
+                        crate::screenshare::StreamTarget::Output(connector)
+                            if connector == &output_name => {}
+                        _ => continue,
                     }
                     let ss_pool = stream.pipewire_stream.buffer_pool();
 

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -645,6 +645,9 @@ pub fn run_winit() {
                                     &all_window_elements,
                                     &std::collections::HashSet::new(),
                                     expose_active,
+                                    // Winit has no per-frame screenshare tap,
+                                    // so nothing is ever capture-pinned here.
+                                    &std::collections::HashSet::new(),
                                 );
                             post_repaint(
                                 &output,

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -2489,6 +2489,32 @@ impl Workspaces {
 
     // Helpers / Windows Management
 
+    /// The area of `output` a normal window may occupy: the output geometry
+    /// minus layer-shell exclusive zones and the dock.
+    pub fn usable_geometry(
+        &self,
+        output: &Output,
+    ) -> Option<Rectangle<i32, smithay::utils::Logical>> {
+        let geo = self.output_geometry(output)?;
+        let map = layer_map_for_output(output);
+        let zone = map.non_exclusive_zone();
+        let mut adjusted = Rectangle::new(geo.loc + zone.loc, zone.size);
+
+        // Account for the dock geometry (internal compositor UI, not layer-shell)
+        let dock_geom = self.get_dock_geometry();
+        if dock_geom.size.h > 0 {
+            let dock_top = dock_geom.loc.y;
+            let available_bottom = adjusted.loc.y + adjusted.size.h;
+
+            // If dock is in the usable area, reduce height to stop above dock
+            if dock_top < available_bottom {
+                adjusted.size.h = dock_top - adjusted.loc.y;
+            }
+        }
+
+        Some(adjusted)
+    }
+
     /// Determine the initial placement of a new window within the workspace.
     /// It calculates the appropriate position and bounds for the window based
     /// on the current pointer location and the output geometry under the pointer.
@@ -2505,26 +2531,7 @@ impl Workspaces {
             .or_else(|| self.default_client_output())
             .cloned();
         let output_geometry = output
-            .and_then(|o| {
-                let geo = self.output_geometry(&o)?;
-                let map = layer_map_for_output(&o);
-                let zone = map.non_exclusive_zone();
-                let mut adjusted = Rectangle::new(geo.loc + zone.loc, zone.size);
-
-                // Account for the dock geometry (internal compositor UI, not layer-shell)
-                let dock_geom = self.get_dock_geometry();
-                if dock_geom.size.h > 0 {
-                    let dock_top = dock_geom.loc.y;
-                    let available_bottom = adjusted.loc.y + adjusted.size.h;
-
-                    // If dock is in the usable area, reduce height to stop above dock
-                    if dock_top < available_bottom {
-                        adjusted.size.h = dock_top - adjusted.loc.y;
-                    }
-                }
-
-                Some(adjusted)
-            })
+            .and_then(|o| self.usable_geometry(&o))
             .unwrap_or_else(|| Rectangle::new((0, 0).into(), (800, 800).into()));
 
         // The client's real size is unknown until it configures; assume a typical

--- a/src/workspaces/workspace_selector.rs
+++ b/src/workspaces/workspace_selector.rs
@@ -292,6 +292,12 @@ impl WorkspaceSelectorView {
     }
 }
 
+/// Is the scene-space point `(x, y)` inside this layer's transformed bounds?
+fn layer_contains(layer: &Layer, x: f32, y: f32) -> bool {
+    let r = layer.render_bounds_transformed();
+    x >= r.x() && x <= r.x() + r.width() && y >= r.y() && y <= r.y() + r.height()
+}
+
 fn render_workspace_selector_view(
     state: &WorkspaceSelectorViewState,
     view: &View<WorkspaceSelectorViewState>,
@@ -401,13 +407,20 @@ fn render_workspace_selector_view(
                 })
                 .on_pointer_out({
                     let view_ref = view.clone();
-                    move |_layer: &Layer, _x, _y| {
+                    move |layer: &Layer, x, y| {
                         let key = format!("workspace_selector_desktop_remove_{}", workspace_index);
-                        if let Some(remove_button) = view_ref.layer_by_key(key.as_str()) {
-                            remove_button.set_opacity(0.0, Transition::spring(0.3, 0.1));
-                            remove_button
-                                .set_scale(Point::new(0.8, 0.8), Transition::spring(0.3, 0.1));
+                        let Some(remove_button) = view_ref.layer_by_key(key.as_str()) else {
+                            return;
+                        };
+                        // Reaching for the button crosses out of the preview, so the
+                        // engine emits Out here (after the Move that revealed it) and
+                        // the button would vanish under the cursor. Keep it shown while
+                        // the pointer is still over the preview or over the button.
+                        if layer_contains(layer, x, y) || layer_contains(&remove_button, x, y) {
+                            return;
                         }
+                        remove_button.set_opacity(0.0, Transition::spring(0.3, 0.1));
+                        remove_button.set_scale(Point::new(0.8, 0.8), Transition::spring(0.3, 0.1));
                     }
                 })
                 .children::<LayerTree>({

--- a/tests/workspace_selector.rs
+++ b/tests/workspace_selector.rs
@@ -1,0 +1,135 @@
+//! Workspace selector interaction tests (headless).
+
+#[cfg(feature = "headless")]
+mod workspace_selector_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use serial_test::serial;
+
+    fn find<'a>(
+        nodes: &'a [layers::engine::scene::SceneNodeSnapshot],
+        key: &str,
+    ) -> Option<&'a layers::engine::scene::SceneNodeSnapshot> {
+        for n in nodes {
+            if n.key == key {
+                return Some(n);
+            }
+            if let Some(found) = find(&n.children, key) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn workspace_indices(handle: &HeadlessHandle) -> Vec<usize> {
+        handle.query(|state| {
+            (0..8)
+                .filter_map(|i| state.workspaces.get_workspace_at(i).map(|w| w.index))
+                .collect()
+        })
+    }
+
+    fn output_scale(handle: &HeadlessHandle) -> f32 {
+        handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale() as f32)
+                .unwrap_or(1.0)
+        })
+    }
+
+    /// Move the pointer to the centre of a selector layer. Scene bounds are
+    /// physical pixels, synthetic pointer input is logical.
+    fn hover_layer_centre(handle: &HeadlessHandle, key: &str) {
+        let scale = output_scale(handle);
+        let snapshot = handle.scene_snapshot();
+        let bounds = find(&snapshot.nodes, key)
+            .unwrap_or_else(|| panic!("layer {key} not in scene"))
+            .global_bounds
+            .clone();
+        handle.pointer_move(
+            ((bounds.x + bounds.width / 2.0) / scale) as f64,
+            ((bounds.y + bounds.height / 2.0) / scale) as f64,
+        );
+        handle.settle(200);
+    }
+
+    fn open_selector_with_workspaces() -> HeadlessHandle {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        handle.with_state(|state| {
+            state.workspaces.add_workspace_to_output("headless");
+        });
+        handle.settle(200);
+        handle.toggle_expose();
+        handle.settle(300);
+        handle
+    }
+
+    /// Hovering a workspace preview reveals its remove button; the current
+    /// workspace has none (it cannot be removed).
+    #[test]
+    #[serial]
+    fn hover_reveals_remove_button() {
+        let handle = open_selector_with_workspaces();
+        let indices = workspace_indices(&handle);
+        assert!(indices.len() >= 2, "expected at least two workspaces");
+        let current = handle.current_workspace_index();
+
+        for (pos, index) in indices.iter().enumerate() {
+            hover_layer_centre(
+                &handle,
+                &format!("workspace_selector_desktop_content_{index}"),
+            );
+            let opacity =
+                handle.layer_opacity(&format!("workspace_selector_desktop_remove_{index}"));
+            if pos == current {
+                assert_eq!(
+                    opacity, None,
+                    "current workspace must have no remove button"
+                );
+            } else {
+                let opacity = opacity.expect("remove button missing");
+                assert!(
+                    opacity > 0.9,
+                    "hovering workspace {index} should reveal its remove button, got {opacity}"
+                );
+            }
+        }
+
+        handle.stop();
+    }
+
+    /// Moving onto the remove button itself must not hide it: reaching for it
+    /// leaves the preview layer, which emits a pointer-out on the container.
+    #[test]
+    #[serial]
+    fn remove_button_stays_visible_while_hovered() {
+        let handle = open_selector_with_workspaces();
+        let indices = workspace_indices(&handle);
+        let target = indices[indices.len() - 1];
+        let remove_key = format!("workspace_selector_desktop_remove_{target}");
+
+        hover_layer_centre(
+            &handle,
+            &format!("workspace_selector_desktop_content_{target}"),
+        );
+        hover_layer_centre(&handle, &remove_key);
+        let opacity = handle.layer_opacity(&remove_key).expect("button missing");
+        assert!(
+            opacity > 0.9,
+            "remove button should stay visible under the cursor, got {opacity}"
+        );
+
+        // Leaving the workspace entirely hides it again.
+        handle.pointer_move(10.0, 900.0);
+        handle.settle(200);
+        let opacity = handle.layer_opacity(&remove_key).expect("button missing");
+        assert!(
+            opacity < 0.1,
+            "remove button should hide once the pointer leaves, got {opacity}"
+        );
+
+        handle.stop();
+    }
+}


### PR DESCRIPTION
Adds single-window screencast alongside the existing monitor capture.

## Control plane

`org.otto.ScreenCast` gains `ListWindows() -> a(sss)` and implements the
previously-stubbed `RecordWindow{window-id, cursor-mode}`. Windows are keyed by
their **`ext-foreign-toplevel-list-v1` identifier** — the opaque, stable handle
that protocol defines for naming a window to another process. Otto already
implements the protocol, so nothing new is exposed, and a future picker could
enumerate windows itself instead of via `ListWindows`.

This follows Mutter's shape (`RecordWindow` + a separate window-list API) rather
than Hyprland's dedicated capture protocol, because the portal already speaks to
`org.otto.ScreenCast`.

## Picker

`SelectSources` accepts `SOURCE_TYPE_WINDOW` and presents one radio list of every
output *and* every window through the existing Access-style `org.otto.Dialog1`
dialog (otto-islands), with app icons. Monitors and windows are offered together
regardless of which `types` bits the app set.

Note this means **monitor sharing now prompts too**, where it previously
auto-picked silently. If no dialog renderer answers on the bus, monitor capture
falls back to the old override-file/first-output behaviour so an islands-less
session keeps working; a window is never auto-selected in that path.

## Capture

Window streams re-render the window's own surface tree (toplevel + subsurfaces +
popups) into the PipeWire dmabuf rather than blitting the composited output. That
is what makes occluded / off-workspace / minimized capture work, and it means
nothing stacked above the shared window can leak to the remote viewer — the
privacy property users assume when they pick "share a window" over "share a
screen".

Two supporting changes:

- `WindowThrottleState::Captured` pins a shared window to full-rate frame
  callbacks, outranking minimize and occlusion, without marking it `activated`.
  Without it a backgrounded shared window ticks at 2 Hz.
- `screencast_active` and `kick_screencast_outputs` resolve a window target to
  the output currently hosting it, so that output composites and keeps painting
  while idle. Both previously probed the stream map by bare output name, which
  the new keying would have silently broken.

## Dialog polish

Entrance pops open from a small rounded shape (spring, bounce 0.42) instead of
sliding down, and a stray first frame at the panel's default geometry is fixed.
Panel material and text run more opaque than the shared theme values, which are
tuned for menus on solid fills rather than a modal over a blurred backdrop. All
labels are ellipsized to their box so long window titles don't run past the
rounded edge.

## Known limitations

- No live thumbnails in the picker — text + app icon only. `ext-image-copy-capture-v1`
  is the likely route later, and would let the picker capture for itself.
- A window resized mid-capture is cropped or letterboxed; the stream size is
  fixed at `RecordWindow` time and never renegotiated.
- Capture bypasses lay-rs scene decoration (shadows, rounded corners, blur) by
  design — consumers want the window's content, not Otto's presentation of it.

## Testing

Verified live on tty/udev: `ListWindows` → `CreateSession` → `RecordWindow` →
`Start` yields a PipeWire node with `source-type: 2`, and the picker renders and
resolves through otto-islands. `cargo clippy` clean; 51 lib tests pass, including
a new one covering the `Captured` throttle tier.

`specs/screenshare.md` and `docs/developer/screenshare.md` updated to match.

https://claude.ai/code/session_01DH7PHuWqGGyjT2x2EeZYWX