### PR TITLE
fix(planes): map plane damage without the workspace scroll

### DIFF
--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -137,6 +137,11 @@ vibrancy even though the content behind it lives on other planes.
   double-count: on any workspace but the first, the windows and background
   plane roots sit a full output width to the left and every dirty rect
   would clamp to a sliver at the buffer edge, freezing those planes.
+- Damage that falls entirely outside a buffer after that mapping does not
+  render it: a window on a workspace scrolled off screen changes nothing
+  visible, and rendering would repaint — and report FB_DAMAGE_CLIPS for —
+  an edge sliver on every frame it animates. Scrolling that workspace back
+  into view damages the moved subtree itself, so it repaints then.
 - A buffer's damage is expanded to the full bounds of any `BackgroundBlur`
   shape it contains that the damage reaches: because a blur samples a
   neighborhood of its input, damage under (or within a blur radius of) a

--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -129,6 +129,14 @@ vibrancy even though the content behind it lives on other planes.
   or surface failure) forces its next successful render to redraw fully —
   the frame's damage evidence is gone by then (engine damage clears at end
   of frame), and clipping past it would leave the region permanently stale.
+- Subtree damage is reported in scene coordinates and mapped into buffer
+  coordinates by subtracting only the output's scene origin and the
+  element's viewport — never the root node's own `render_position()`. The
+  root's position already carries the dynamic workspace-scroll offset, and
+  the subtree is drawn with that offset re-applied, so subtracting it would
+  double-count: on any workspace but the first, the windows and background
+  plane roots sit a full output width to the left and every dirty rect
+  would clamp to a sliver at the buffer edge, freezing those planes.
 - A buffer's damage is expanded to the full bounds of any `BackgroundBlur`
   shape it contains that the damage reaches: because a blur samples a
   neighborhood of its input, damage under (or within a blur radius of) a

--- a/src/render_elements/scene_dmabuf_element.rs
+++ b/src/render_elements/scene_dmabuf_element.rs
@@ -333,16 +333,48 @@ impl SceneDmabufElement {
         let has_dmabuf = self.current_dmabuf.lock().unwrap().is_some();
         if has_dmabuf {
             match inner.node_ref {
-                Some(node_ref) => {
-                    dirty_rect = inner.engine.subtree_damage(node_ref);
-                    if dirty_rect.is_none() && !backdrop_changed && !force_full {
-                        return false;
-                    }
-                }
+                Some(node_ref) => dirty_rect = inner.engine.subtree_damage(node_ref),
                 None => return false,
             }
         } else {
             dirty_rect = None;
+        }
+
+        // Map the scene-space dirty rect into buffer space, clipped to the
+        // buffer — used both to clip this render and to report damage below.
+        // `render_node_tree` draws the subtree with the root node at the canvas
+        // origin and the draw path then translates back by the root's *dynamic*
+        // offset (`render_position() − scene_origin`), so scene content lands at
+        // `scene − scene_origin − viewport`. Subtracting the root's full
+        // `render_position()` here instead would double-count the workspace
+        // scroll: on any workspace but the first, the windows/background plane
+        // roots sit a full output width to the left, and every dirty rect
+        // clamped to a sliver at the buffer edge — a window on workspace 2
+        // stopped repainting (Chrome scrolling froze on screen).
+        //
+        // `None` means the damage lies entirely outside this buffer, which is
+        // the normal case for a window on a workspace scrolled off screen:
+        // nothing visible changed, so the plane must not redraw at all. Letting
+        // it through would repaint (and report FB_DAMAGE_CLIPS for) an edge
+        // sliver on every frame a background workspace animates.
+        let (w, h) = inner.size;
+        let (ox, oy) = inner.scene_origin;
+        let (vx, vy) = inner.viewport;
+        let visible_damage = dirty_rect.and_then(|r| {
+            let x = (r.left().floor() as i32 - ox - vx).clamp(0, w);
+            let y = (r.top().floor() as i32 - oy - vy).clamp(0, h);
+            let x2 = (r.right().ceil() as i32 - ox - vx).clamp(0, w);
+            let y2 = (r.bottom().ceil() as i32 - oy - vy).clamp(0, h);
+            if x2 <= x || y2 <= y {
+                return None;
+            }
+            Some(Rectangle::<i32, Physical>::new(
+                (x, y).into(),
+                (x2 - x, y2 - y).into(),
+            ))
+        });
+        if has_dmabuf && visible_damage.is_none() && !backdrop_changed && !force_full {
+            return false;
         }
 
         let swapchain = match inner.swapchain.as_mut() {
@@ -399,32 +431,10 @@ impl SceneDmabufElement {
             }
         }
 
-        // Map the scene-space dirty rect into buffer space and clamp to buffer
-        // bounds — used both to clip this render and to report damage below.
-        // `render_node_tree` draws the subtree with the root node at the canvas
-        // origin and the draw path then translates back by the root's *dynamic*
-        // offset (`render_position() − scene_origin`), so scene content lands at
-        // `scene − scene_origin − viewport`. Subtracting the root's full
-        // `render_position()` here instead would double-count the workspace
-        // scroll: on any workspace but the first, the windows/background plane
-        // roots sit a full output width to the left, and every dirty rect
-        // clamped to a 1px sliver at the buffer edge — a window on workspace 2
-        // stopped repainting (Chrome scrolling froze on screen).
-        let (w, h) = inner.size;
-        let (ox, oy) = inner.scene_origin;
-        let (vx, vy) = inner.viewport;
-        let damage_rect = dirty_rect
+        // Full buffer when the backdrop changed (blur can repaint anywhere),
+        // on a forced redraw, or on this element's first render.
+        let damage_rect = visible_damage
             .filter(|_| !backdrop_changed && !force_full)
-            .map(|r| {
-                let x = (r.left().floor() as i32 - ox - vx).clamp(0, w);
-                let y = (r.top().floor() as i32 - oy - vy).clamp(0, h);
-                let x2 = (r.right().ceil() as i32 - ox - vx).clamp(0, w);
-                let y2 = (r.bottom().ceil() as i32 - oy - vy).clamp(0, h);
-                Rectangle::<i32, Physical>::new(
-                    (x, y).into(),
-                    ((x2 - x).max(1), (y2 - y).max(1)).into(),
-                )
-            })
             .unwrap_or_else(|| Rectangle::new((0, 0).into(), (w, h).into()));
 
         // Render into the slot's Skia surface.

--- a/src/render_elements/scene_dmabuf_element.rs
+++ b/src/render_elements/scene_dmabuf_element.rs
@@ -401,22 +401,25 @@ impl SceneDmabufElement {
 
         // Map the scene-space dirty rect into buffer space and clamp to buffer
         // bounds — used both to clip this render and to report damage below.
-        // The canvas is translated by the root node's render_position(), so
-        // buffer coords = scene coords − root_pos − viewport.
+        // `render_node_tree` draws the subtree with the root node at the canvas
+        // origin and the draw path then translates back by the root's *dynamic*
+        // offset (`render_position() − scene_origin`), so scene content lands at
+        // `scene − scene_origin − viewport`. Subtracting the root's full
+        // `render_position()` here instead would double-count the workspace
+        // scroll: on any workspace but the first, the windows/background plane
+        // roots sit a full output width to the left, and every dirty rect
+        // clamped to a 1px sliver at the buffer edge — a window on workspace 2
+        // stopped repainting (Chrome scrolling froze on screen).
         let (w, h) = inner.size;
-        let root_pos = inner
-            .node_ref
-            .and_then(|r| inner.engine.get_layer(&r))
-            .map(|l| l.render_position())
-            .unwrap_or_default();
+        let (ox, oy) = inner.scene_origin;
         let (vx, vy) = inner.viewport;
         let damage_rect = dirty_rect
             .filter(|_| !backdrop_changed && !force_full)
             .map(|r| {
-                let x = ((r.left() - root_pos.x) as i32 - vx).clamp(0, w);
-                let y = ((r.top() - root_pos.y) as i32 - vy).clamp(0, h);
-                let x2 = ((r.right() - root_pos.x) as i32 - vx).clamp(0, w);
-                let y2 = ((r.bottom() - root_pos.y) as i32 - vy).clamp(0, h);
+                let x = (r.left().floor() as i32 - ox - vx).clamp(0, w);
+                let y = (r.top().floor() as i32 - oy - vy).clamp(0, h);
+                let x2 = (r.right().ceil() as i32 - ox - vx).clamp(0, w);
+                let y2 = (r.bottom().ceil() as i32 - oy - vy).clamp(0, h);
                 Rectangle::<i32, Physical>::new(
                     (x, y).into(),
                     ((x2 - x).max(1), (y2 - y).max(1)).into(),


### PR DESCRIPTION
## Problem

A window on any workspace other than the first stopped updating the screen — most visibly, scrolling a Chrome window on workspace 2 left the screen frozen.

## Cause

`SceneDmabufElement::render` maps the subtree's scene-space damage rect into buffer coordinates. It subtracted the subtree root's `render_position()`:

```rust
let x = ((r.left() - root_pos.x) as i32 - vx).clamp(0, w);
```

But `render_node_tree` draws the subtree with the root at the canvas origin and the draw path then translates back by `render_position() - scene_origin`, so scene content lands at `scene − scene_origin − viewport`. Subtracting the root's full `render_position()` double-counted the workspace scroll: `workspaces_layer` is translated by `-(index * width)` to show workspace N, so the windows/background plane roots sit a full output width to the left on workspace 2+. Every dirty rect then mapped off the right edge and clamped to a 1px sliver, which became the render clip and the reported FB_DAMAGE_CLIPS — the plane effectively stopped repainting. Workspace 1 (offset 0) was unaffected, which is why the bug looked workspace-specific.

## Fix

Map with the output's `scene_origin` (and the element viewport) instead of the root position, matching what the draw path actually does. Also floor/ceil the float damage bounds instead of truncating, so a sub-pixel edge isn't dropped.

Spec `specs/plane-scanout.md` gained a bullet stating the coordinate rule.

## Follow-up: don't render for off-workspace damage

With the mapping corrected, damage from a workspace scrolled off screen still
clamped to a 1px sliver at the buffer edge and forced a repaint (and an
FB_DAMAGE_CLIPS entry) on every frame such a window animated. The mapping now
returns `None` when the damage falls entirely outside the buffer, and the plane
skips its render — nothing visible changed. Scrolling that workspace back into
view damages the moved subtree itself, so it repaints then.

## Verification

- `cargo fmt --all` and `cargo clippy --features "default" -- -D warnings` both clean.
- Derived the mapping from the lay-rs source (`render_node_tree` does not apply the root node's own transform; `render_position()` returns global scene coords; `subtree_damage` returns global scene coords) and from the element's own draw translate.
- **Verified on hardware**: booted the branch build on the `--tty-udev` backend from a dedicated greeter session and confirmed a Chrome window on workspace 2 now repaints while scrolling.

https://claude.ai/code/session_01XkjJdZYQ3ZwTAXg8EUqvoz

