### PR TITLE
fix(portal): lowercase impl portal version property (screencast cursor mode)

### DIFF
--- a/components/xdg-desktop-portal-otto/ScreenCast-backend-spec.md
+++ b/components/xdg-desktop-portal-otto/ScreenCast-backend-spec.md
@@ -47,7 +47,10 @@ Bitmask of supported cursor presentation modes:
 
 ### `version` (readable `u`)
 
-Must return `5` to indicate compliance with the latest upstream definition.
+Must return `5` to indicate compliance with the latest upstream definition. The property
+name is lowercase — xdg-desktop-portal reads `version` and, when it comes back as 0, stops
+propagating `AvailableCursorModes` to the client-facing portal, which then rejects every
+`cursor_mode` with `Unavailable cursor mode`.
 
 ## Methods
 

--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -784,7 +784,11 @@ impl ScreenCastPortal {
         SUPPORTED_CURSOR_MODES
     }
 
-    #[zbus(property)]
+    /// The impl portal spec spells this property lowercase. zbus would
+    /// derive `Version` from the method name, and xdg-desktop-portal then
+    /// reads 0 — which makes it skip the `AvailableCursorModes` binding
+    /// entirely and reject every cursor mode but the unset one.
+    #[zbus(property, name = "version")]
     fn version(&self) -> u32 {
         5
     }

--- a/components/xdg-desktop-portal-otto/src/portal/settings.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/settings.rs
@@ -131,7 +131,8 @@ impl SettingsPortal {
         self.get_setting(&namespace, &key).await
     }
 
-    #[zbus(property)]
+    /// Lowercase per the impl portal spec — see the ScreenCast interface.
+    #[zbus(property, name = "version")]
     fn version(&self) -> u32 {
         1
     }

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -93,6 +93,25 @@ documented in `docs/developer/screenshare.md`.
 - An identifier that no longer resolves (window closed or unmapped between the picker and
   `Start`) fails `RecordWindow` rather than falling back to any other window.
 
+### Portal implementation properties and cursor modes
+
+- `xdg-desktop-portal-otto` exports the `org.freedesktop.impl.portal.ScreenCast` properties
+  exactly as the impl portal interface spells them: `AvailableSourceTypes`,
+  `AvailableCursorModes`, and **`version`** in lowercase. The same lowercase `version`
+  applies to every impl interface Otto exports (e.g. `…impl.portal.Settings`).
+- The name matters: xdg-desktop-portal reads `version` from the backend and only binds
+  `AvailableCursorModes` through to the client-facing portal when that version is ≥ 2. A
+  backend that spells it `Version` is seen as version 0, the frontend's
+  `AvailableCursorModes` stays 0, and every `SelectSources` carrying a `cursor_mode` is
+  rejected with `Unavailable cursor mode <n>` before it ever reaches Otto.
+- Otto advertises `AvailableCursorModes` = `HIDDEN | EMBEDDED` (3). `METADATA` is not
+  implemented and is not advertised.
+- Cursor modes keep the portal's bitmask numbering end to end — `HIDDEN` = 1, `EMBEDDED` = 2,
+  `METADATA` = 4. The portal forwards the requested value verbatim as the compositor-side
+  `cursor-mode` property of `CreateSession` / `RecordMonitor` / `RecordWindow`, and a missing
+  `cursor-mode` defaults to `EMBEDDED` on both sides. Only `EMBEDDED` draws the cursor into
+  the stream; any other value (including `METADATA`) leaves it out.
+
 ### Portal source selection (`SelectSources`)
 
 - `SelectSources` accepts `types` containing `MONITOR` (1), `WINDOW` (2), or both. A request

--- a/src/screenshare/dbus_service.rs
+++ b/src/screenshare/dbus_service.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, warn};
 use zbus::zvariant::{ObjectPath, OwnedFd, OwnedObjectPath, OwnedValue, Value};
 use zbus::{interface, Connection};
 
-use super::{CompositorCommand, StreamTarget};
+use super::{CompositorCommand, StreamTarget, CURSOR_MODE_EMBEDDED};
 
 /// Global session counter for unique IDs.
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -57,7 +57,7 @@ impl ScreenCastInterface {
     /// Creates a new screencast session.
     ///
     /// Properties may include:
-    /// - `cursor-mode`: u32 (0 = hidden, 1 = embedded, 2 = metadata)
+    /// - `cursor-mode`: u32 (1 = hidden, 2 = embedded, 4 = metadata)
     async fn create_session(
         &self,
         properties: HashMap<&str, Value<'_>>,
@@ -65,7 +65,7 @@ impl ScreenCastInterface {
         let cursor_mode = properties
             .get("cursor-mode")
             .and_then(|v| u32::try_from(v).ok())
-            .unwrap_or(1); // Default to embedded cursor
+            .unwrap_or(CURSOR_MODE_EMBEDDED);
 
         let session_id = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
         let session_path = format!("/org/otto/ScreenCast/session/{session_id}");
@@ -287,7 +287,7 @@ impl SessionInterface {
         let cursor_mode = properties
             .get("cursor-mode")
             .and_then(|v| u32::try_from(v).ok())
-            .unwrap_or(1);
+            .unwrap_or(CURSOR_MODE_EMBEDDED);
 
         info!(%connector, cursor_mode, "Recording monitor");
 
@@ -335,7 +335,7 @@ impl SessionInterface {
         let cursor_mode = properties
             .get("cursor-mode")
             .and_then(|v| u32::try_from(v).ok())
-            .unwrap_or(1);
+            .unwrap_or(CURSOR_MODE_EMBEDDED);
 
         info!(%window_id, cursor_mode, "Recording window");
 

--- a/src/screenshare/mod.rs
+++ b/src/screenshare/mod.rs
@@ -49,6 +49,14 @@ use zbus::zvariant::OwnedFd;
 
 use crate::renderer::BlitCurrentFrame;
 
+/// Cursor mode values, matching the xdg-desktop-portal ScreenCast bitmask —
+/// the portal forwards its own value verbatim as the `cursor-mode` property.
+pub const CURSOR_MODE_HIDDEN: u32 = 1;
+/// The cursor is drawn into the streamed frames.
+pub const CURSOR_MODE_EMBEDDED: u32 = 2;
+/// The cursor is sent as PipeWire metadata — not implemented, treated as hidden.
+pub const CURSOR_MODE_METADATA: u32 = 4;
+
 /// Active screencast session state (compositor side).
 ///
 /// Tracks all active streams for a D-Bus session.

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -1099,12 +1099,10 @@ impl Otto<UdevData> {
                 // Get the source framebuffer that was just rendered to
                 // Blit to PipeWire buffers on main thread
                 for session in self.screenshare_sessions.values() {
-                    // Check if we should render cursor for this session
-                    // CURSOR_MODE_HIDDEN (1) = don't render cursor
-                    // CURSOR_MODE_EMBEDDED (2) = render cursor into video
-                    // CURSOR_MODE_METADATA (4) = send cursor as metadata (not in video) - NOT IMPLEMENTED, treat as hidden
-                    const CURSOR_MODE_EMBEDDED: u32 = 2;
-                    let should_render_cursor = session.cursor_mode == CURSOR_MODE_EMBEDDED;
+                    // Only EMBEDDED draws the cursor into the stream; METADATA
+                    // is not implemented and falls back to hidden.
+                    let should_render_cursor =
+                        session.cursor_mode == crate::screenshare::CURSOR_MODE_EMBEDDED;
 
                     tracing::trace!(
                         "Screenshare session {}: cursor_mode={}, should_render={}",


### PR DESCRIPTION
## What was broken

AirPlay mirroring (and anything else asking for an embedded cursor) failed at
`SelectSources` with:

```
screen capture failed: screencast portal: SelectSources: Unavailable cursor mode 2
```

That error comes from xdg-desktop-portal, not from Otto's backend. The frontend
reads the backend's `version` property, and only binds `AvailableCursorModes`
through to the client-facing portal when it is >= 2:

```c
xdp_dbus_screen_cast_set_version (…, MIN (xdp_dbus_impl_screen_cast_get_version (impl), 6));
if (xdp_dbus_impl_screen_cast_get_version (screen_cast->impl) >= 2)
  g_object_bind_property (impl, "available-cursor-modes", screen_cast, "available-cursor-modes", …);
```

zbus derives property names in PascalCase, so `fn version()` was exported as
`Version` while the impl portal spec spells it lowercase. The frontend read 0,
skipped the cursor-modes binding, and rejected every `cursor_mode` before the
request ever reached Otto.

## Fix

- `#[zbus(property, name = "version")]` on the `ScreenCast` and `Settings` impl
  interfaces.
- Compositor side: the portal forwards its own bitmask verbatim as `cursor-mode`
  (1 = hidden, 2 = embedded, 4 = metadata), but `dbus_service.rs` defaulted to
  `1` while commenting "default to embedded" — i.e. defaulted to *hidden*. Shared
  `CURSOR_MODE_*` constants now back both the defaults and the render-loop check.
- Spec sync: `specs/screenshare.md` and the component's backend spec now state
  the lowercase property name, why it matters, and the cursor-mode numbering.

## Verification

- `cargo fmt --all`, `cargo clippy --features "default" -- -D warnings`: clean.
  (The pre-existing clippy errors and the broken `tests/streams.rs` in
  `xdg-desktop-portal-otto` are untouched and unrelated.)
- Reproduced the root cause on the live session: the running backend answered
  `GetAll` with `Version`, and the frontend's
  `org.freedesktop.portal.ScreenCast` showed `version 0` /
  `AvailableCursorModes 0` while the backend advertised `3`. Restarting the
  frontend brought `AvailableSourceTypes` across (0 → 1) but left the cursor
  modes at 0, confirming the version-gated binding.
- Ran the rebuilt backend on a private bus (`dbus-run-session`): the interface
  now introspects as `.version property u 5` and `AvailableCursorModes u 3`.
- Verified end to end on the running session: with the fixed backend owning the
  bus name and the frontend restarted, `org.freedesktop.portal.ScreenCast` now
  reports `version 5` and `AvailableCursorModes 3` (both were 0), so
  `cursor_mode = 2` is accepted instead of rejected.
- Not verified against an actual Apple TV — I could not run a full AirPlay mirror
  session from here, so the rest of the mirroring path stays untested.

## Testing on hardware

Log in to the **Otto (PR #123 screencast cursor mode)** session. Note that
`/usr/local/bin/xdg-desktop-portal-otto` was replaced with the fixed build
(previous binary kept as `xdg-desktop-portal-otto.bak`), since the portal
backend is a single shared D-Bus name and cannot be installed per-PR. If an
xdg-desktop-portal frontend from before login is still running, restart it with
`systemctl --user restart xdg-desktop-portal` — it caches the backend version at
startup. The currently running session was already switched over to the fixed
backend this way.

Two caveats found while installing: zbus does not replace an already-owned bus
name (whichever backend instance starts first wins), and the D-Bus activation
fallback `/usr/libexec/xdg-desktop-portal-otto` is a stale root-owned build that
was left untouched. If that one wins the race at login, restart the frontend as
above once the session's own backend is up.

https://claude.ai/code/session_01LMWmjkiCCn9cpZ5FBKyXvJ

