### PR TITLE
fix(portal): stop asking twice for the same screencast source

### DIFF
--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_io::Timer;
 use tokio::sync::Mutex;
@@ -15,9 +15,9 @@ use zbus::zvariant::{OwnedFd, OwnedObjectPath, OwnedValue};
 use crate::otto_client::screencast::WindowSource;
 use crate::otto_client::OttoClient;
 use crate::portal::{
-    build_streams_value_from_descriptors, make_output_mapping_id, PortalState, Request,
-    SelectedWindow, Session, SessionState, StreamDescriptor, CURSOR_MODE_EMBEDDED,
-    SOURCE_TYPE_MONITOR, SOURCE_TYPE_WINDOW, SUPPORTED_CURSOR_MODES,
+    build_streams_value_from_descriptors, make_output_mapping_id, PortalState, RecentGrant,
+    Request, SelectedWindow, Session, SessionState, SourceSelection, StreamDescriptor,
+    CURSOR_MODE_EMBEDDED, SOURCE_TYPE_MONITOR, SOURCE_TYPE_WINDOW, SUPPORTED_CURSOR_MODES,
 };
 use zbus::zvariant::Str;
 
@@ -25,6 +25,12 @@ use zbus::zvariant::Str;
 const NODE_ID_MAX_RETRIES: u32 = 100;
 /// Delay between retries when polling for PipeWire node ID.
 const NODE_ID_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+/// How long an approved source stays reusable for the same app without asking
+/// again. Long enough to cover an app that opens a preview session and then a
+/// real one for a single user action (Chrome), short enough that a share the
+/// user stopped a while ago cannot be silently resumed.
+const GRANT_REUSE_TTL: Duration = Duration::from_secs(60);
 
 /// Creates a fallback mapping ID when output name is empty or unavailable.
 pub fn fallback_mapping_id(output: &str) -> String {
@@ -101,13 +107,6 @@ fn fallback_output(available: &[String]) -> Option<String> {
         }
         None => available.first().cloned(),
     }
-}
-
-/// What the user picked in the source dialog.
-#[derive(Clone, Debug)]
-pub enum SourceSelection {
-    Monitor(String),
-    Window(WindowSource),
 }
 
 #[derive(Clone)]
@@ -255,6 +254,94 @@ impl ScreenCastPortal {
                 None
             }
         })
+    }
+
+    /// Store the resolved source on the session, ready for `Start`.
+    async fn store_selection(
+        &self,
+        session_handle: &OwnedObjectPath,
+        selection: &SourceSelection,
+        cursor_mode: u32,
+        persist_mode: Option<u32>,
+    ) -> fdo::Result<()> {
+        let mut state = self.state.lock().await;
+        let entry = state
+            .sessions
+            .get_mut(session_handle.as_str())
+            .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
+
+        match selection {
+            SourceSelection::Monitor(connector) => {
+                entry.selected_outputs = vec![connector.clone()];
+                entry.selected_window = None;
+            }
+            SourceSelection::Window(window) => {
+                entry.selected_outputs = Vec::new();
+                entry.selected_window = Some(SelectedWindow {
+                    id: window.id.clone(),
+                    title: window.title.clone(),
+                });
+            }
+        }
+        entry.cursor_mode = cursor_mode;
+        entry.persist_mode = persist_mode;
+        entry.next_stream_id = 0;
+
+        Ok(())
+    }
+
+    /// The source this app was just granted, if it may be reused without
+    /// asking again.
+    ///
+    /// A grant is only reused for the same app id, while it is younger than
+    /// [`GRANT_REUSE_TTL`], and while the very same source is still among the
+    /// ones we would have offered — so a closed window or an unplugged output
+    /// sends the user back to the picker. Apps that report no id at all are
+    /// never matched: an empty id identifies nobody, so one app's grant must
+    /// not answer another's request.
+    async fn reusable_grant(
+        &self,
+        app_id: &str,
+        outputs: &[String],
+        windows: &[WindowSource],
+    ) -> Option<SourceSelection> {
+        if app_id.is_empty() {
+            return None;
+        }
+
+        let state = self.state.lock().await;
+        let grant = state.recent_grants.get(app_id)?;
+        if grant.granted_at.elapsed() > GRANT_REUSE_TTL {
+            return None;
+        }
+
+        match &grant.source {
+            SourceSelection::Monitor(connector) => outputs
+                .contains(connector)
+                .then(|| SourceSelection::Monitor(connector.clone())),
+            SourceSelection::Window(window) => windows
+                .iter()
+                .find(|available| available.id == window.id)
+                .cloned()
+                .map(SourceSelection::Window),
+        }
+    }
+
+    /// Remember what the user just approved, so a follow-up session from the
+    /// same app doesn't ask again. Only called for answers the user actually
+    /// gave — the no-renderer fallback never records a grant.
+    async fn record_grant(&self, app_id: &str, source: &SourceSelection) {
+        if app_id.is_empty() {
+            return;
+        }
+
+        self.state.lock().await.recent_grants.insert(
+            app_id.to_string(),
+            RecentGrant {
+                source: source.clone(),
+                granted_at: Instant::now(),
+            },
+        );
     }
 
     /// Export a temporary Request object in dbus so the frontend can listen for the response signal.
@@ -445,11 +532,35 @@ impl ScreenCastPortal {
                 );
             }
 
+            // An app that just got an answer for this very source doesn't get
+            // to ask again — that second dialog is the app's business (a
+            // preview session, say), not a second decision for the user.
+            if let Some(selection) = self
+                .reusable_grant(&app_id, &available_outputs, &available_windows)
+                .await
+            {
+                info!(
+                    session = %session_handle,
+                    selection = ?selection,
+                    "Reusing the source this app was just granted"
+                );
+                self.store_selection(&session_handle, &selection, cursor_mode, persist_mode)
+                    .await?;
+                let mut results = HashMap::new();
+                if let Some(pm) = persist_mode {
+                    results.insert("persist_mode".to_string(), OwnedValue::from(pm));
+                }
+                return Ok((0, results));
+            }
+
             let selection = match self
                 .pick_source(&app_id, &available_outputs, &available_windows)
                 .await
             {
-                Ok(Some(selection)) => selection,
+                Ok(Some(selection)) => {
+                    self.record_grant(&app_id, &selection).await;
+                    selection
+                }
                 // User dismissed the picker.
                 Ok(None) => {
                     info!(session = %session_handle, "User cancelled source selection");
@@ -467,30 +578,8 @@ impl ScreenCastPortal {
                 }
             };
 
-            {
-                let mut state = self.state.lock().await;
-                let entry = state
-                    .sessions
-                    .get_mut(session_handle.as_str())
-                    .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
-
-                match &selection {
-                    SourceSelection::Monitor(connector) => {
-                        entry.selected_outputs = vec![connector.clone()];
-                        entry.selected_window = None;
-                    }
-                    SourceSelection::Window(window) => {
-                        entry.selected_outputs = Vec::new();
-                        entry.selected_window = Some(SelectedWindow {
-                            id: window.id.clone(),
-                            title: window.title.clone(),
-                        });
-                    }
-                }
-                entry.cursor_mode = cursor_mode;
-                entry.persist_mode = persist_mode;
-                entry.next_stream_id = 0;
-            }
+            self.store_selection(&session_handle, &selection, cursor_mode, persist_mode)
+                .await?;
 
             info!(
                 session = %session_handle,

--- a/components/xdg-desktop-portal-otto/src/portal/mod.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/mod.rs
@@ -17,7 +17,7 @@ pub use interface::{
     fallback_mapping_id, validate_cursor_mode, validate_persist_mode, ScreenCastPortal,
 };
 pub use settings::SettingsPortal;
-pub use state::{PortalState, SelectedWindow, SessionState};
+pub use state::{PortalState, RecentGrant, SelectedWindow, SessionState, SourceSelection};
 pub use stream::{build_streams_value_from_descriptors, StreamDescriptor};
 
 pub(crate) use request::Request;

--- a/components/xdg-desktop-portal-otto/src/portal/state.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/state.rs
@@ -1,14 +1,41 @@
 //! Portal state management for tracking active sessions.
 
 use std::collections::HashMap;
+use std::time::Instant;
 
 use zbus::zvariant::OwnedObjectPath;
+
+use crate::otto_client::screencast::WindowSource;
 
 /// Global portal state tracking all active sessions.
 #[derive(Default)]
 pub struct PortalState {
     /// Map from portal session handle to session state.
     pub sessions: HashMap<String, SessionState>,
+    /// Last source each app was granted, keyed by app id. See [`RecentGrant`].
+    pub recent_grants: HashMap<String, RecentGrant>,
+}
+
+/// What the user picked in the source dialog.
+#[derive(Clone, Debug)]
+pub enum SourceSelection {
+    Monitor(String),
+    Window(WindowSource),
+}
+
+/// A source the user approved, remembered for a short while so the same app
+/// isn't asked twice in a row.
+///
+/// Chrome opens one screencast session to render the preview in its own picker
+/// and a second one to actually share, which without this would pop the source
+/// dialog twice for a single user action. The grant is only reused for the same
+/// app, for the same source, while it is still on offer, and its timestamp is
+/// never refreshed — an app cannot keep the window open by re-asking.
+pub struct RecentGrant {
+    /// The source the user approved.
+    pub source: SourceSelection,
+    /// When the user approved it.
+    pub granted_at: Instant,
 }
 
 /// State for a single screencast session.

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -119,6 +119,28 @@ documented in `docs/developer/screenshare.md`.
 - `Start` calls `RecordMonitor` or `RecordWindow` according to the stored selection, and the
   resulting portal stream carries `source_type` = 1 or 2 to match.
 
+### Re-asking the same app (recent grants)
+
+- When the user picks a source, the portal remembers it against the requesting app id for
+  60 seconds.
+- A later `SelectSources` from the **same app id** skips the dialog and reuses that source —
+  answering response `0` as if the user had picked it again — but only when *all* of the
+  following hold:
+  - the grant is younger than 60 seconds;
+  - the granted source is still among the ones this call would have offered (the output is
+    still in `ListOutputs`, or the window is still in `ListWindows`);
+  - the app reports a non-empty app id.
+- An empty app id never matches a grant, in either direction: it identifies nobody, so one
+  unidentified app's grant must not answer another's request.
+- A grant's timestamp is set once when the user answers and is **not** refreshed on reuse,
+  so an app cannot hold the window open by re-asking.
+- Only a real user answer creates a grant. The no-renderer fallback (override file / first
+  output) does not, and neither does a dismissed dialog.
+- Grants live in the portal process only; restarting the portal forgets them.
+
+This is what stops Chrome asking twice for a single share: Chrome opens one screencast
+session to render the preview inside its own picker and a second one to capture for real.
+
 ### Window capture
 
 - A window stream renders the window's **own surface tree** (toplevel + subsurfaces, plus
@@ -202,6 +224,14 @@ documented in `docs/developer/screenshare.md`.
 - **The picker is modal and blocking:** `SelectSources` does not return until the user
   answers. An app that times out its portal call will fail the session; this matches the
   behaviour of every other portal implementation's chooser.
+- **A recent grant is a silent re-capture window:** for up to 60 seconds after the user
+  approves a source, the same app can start capturing that same source again without a
+  prompt — including after the user stopped the first share. The window is deliberately
+  short and narrow (same app, same still-present source, no timestamp refresh); the
+  alternative, prompting per session, asks the user to make the same decision twice for one
+  action, which trains them to click through the dialog without reading it.
+- **Grants key on app id, which is empty for unsandboxed apps:** those apps get the old
+  behaviour (a dialog per session) rather than sharing a grant pool.
 
 ## Rationale
 
@@ -243,7 +273,16 @@ documented in `docs/developer/screenshare.md`.
   whatever happens to be stacked on top of the shared window to the remote viewer — the
   privacy property users assume when they pick "share a window" over "share a screen".
 
+- **Remembering the answer in the portal rather than relying on `persist_mode` /
+  `restore_token`** is what actually fixes the double prompt: Chrome's preview and capture
+  sessions both arrive with empty options — no `persist_mode`, no token — so there is
+  nothing for a spec-level persistence mechanism to key on. A short-lived per-app grant
+  needs no cooperation from the app.
+
 ## Open Questions
+
+- Should the grant window be configurable, or extended to an explicit per-app allow-list in
+  `otto_config.toml` ("always let this app share without asking")?
 
 - Should the SHM fallback path also be re-enabled as an *additional* pod when DMA-BUF pods
   are offered, so a client that can't negotiate `DMA_DRM` caps still gets a (CPU-copied)


### PR DESCRIPTION
## What was broken

Sharing the entire screen in Chrome popped Otto's source dialog twice: once
for the preview Chrome renders inside its own picker, once for the real
capture. The portal log shows Chrome creating two separate screencast
sessions seconds apart, both with empty options — no `persist_mode`, no
`restore_token` — so there is nothing spec-level to key persistence on.

## The fix

`xdg-desktop-portal-otto` now remembers the source the user approved, keyed
by app id, and reuses it on a later `SelectSources` instead of prompting
again. A grant is only reused when:

- it is younger than 60s (timestamp is set once and never refreshed on
  reuse, so an app can't hold the window open by re-asking);
- the granted source is still among the ones this call would have offered
  (output still in `ListOutputs`, window still in `ListWindows`);
- the app reports a non-empty app id — an empty id identifies nobody, so
  unsandboxed apps keep the old prompt-per-session behaviour.

Only a real user answer records a grant; the no-renderer fallback and a
dismissed dialog do not. Grants live in the portal process only.

The per-app allow-list from the bug report ("allow certain apps from the
config") is deliberately not implemented — it's noted as an open question
in the spec.

## Verification

- `cargo build --release` and `cargo clippy --features "default" -- -D warnings`
  both pass. (`cargo clippy -p xdg-desktop-portal-otto --all-targets` fails on
  a pre-existing break in `tests/streams.rs` — `StreamDescriptor` gained a
  `source_type` field earlier and the test wasn't updated; untouched here.)
- **Not verified visually** — I could not run the compositor and drive a real
  Chrome screenshare from this environment. The double-prompt sequence was
  confirmed from `~/.local/state/otto/session.log`, not reproduced live.
- `specs/screenshare.md` updated with the new behaviour, its constraints and
  the rationale.

## Test on hardware

Boot the **Otto (PR #124 screencast double-prompt fix)** session, then share
the entire screen from Chrome: the dialog should appear once.

https://claude.ai/code/session_01VbPpB9mwFbZs9oz2ehpPUR


The fix is in the portal, which is D-Bus activated from a single user-wide
service file, so installing this build over `/usr/local/bin/xdg-desktop-portal-otto`
would change the portal for every session. Instead the PR build lives at
`/usr/local/bin/xdg-desktop-portal-otto-pr124` and the session wrapper claims
the bus name with it before starting the compositor, so activation never fires
and only this session gets it. Logs: `~/.local/state/otto/session-pr124.log`
and `session-pr124-portal.log`.
