### PR TITLE
fix(portal): restore an approved screencast source instead of asking twice

### DIFF
--- a/components/xdg-desktop-portal-otto/src/main.rs
+++ b/components/xdg-desktop-portal-otto/src/main.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use tokio::signal;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
+use zbus::export::futures_util::StreamExt;
+use zbus::fdo::{DBusProxy, RequestNameFlags, RequestNameReply};
 use zbus::ConnectionBuilder;
 
 use xdg_desktop_portal_otto::otto_client::OttoClient;
@@ -21,10 +23,7 @@ const DBUS_NAME: &str = "org.freedesktop.impl.portal.desktop.otto";
 async fn main() -> Result<()> {
     init_tracing();
 
-    let connection = ConnectionBuilder::session()?
-        .name(DBUS_NAME)?
-        .build()
-        .await?;
+    let connection = ConnectionBuilder::session()?.build().await?;
 
     let sc_client = OttoClient::new(connection.clone()).await?;
     info!("Connected to D-Bus session bus");
@@ -47,16 +46,53 @@ async fn main() -> Result<()> {
         .at(desktop_path(), access_portal)
         .await?;
 
+    // Claim the name only once every interface is exported, and claim it even
+    // when someone already holds it. The session bus outlives the graphical
+    // session, so a backend left over from an earlier login — or from before an
+    // upgrade — otherwise keeps the name forever and every later instance dies
+    // on startup while the desktop silently talks to the stale one.
+    let dbus = DBusProxy::new(&connection).await?;
+    let mut name_lost = dbus.receive_name_lost().await?;
+    let reply = dbus
+        .request_name(
+            DBUS_NAME.try_into()?,
+            RequestNameFlags::AllowReplacement
+                | RequestNameFlags::ReplaceExisting
+                | RequestNameFlags::DoNotQueue,
+        )
+        .await?;
+    if reply != RequestNameReply::PrimaryOwner {
+        // Only reachable against an owner that refuses replacement — a backend
+        // predating this flag. Say so plainly: the symptom on the desktop is
+        // this build's behaviour simply not showing up.
+        anyhow::bail!(
+            "{DBUS_NAME} is held by another portal backend that refuses replacement \
+             ({reply:?}); kill it and start this one again"
+        );
+    }
+
     info!(
         name = DBUS_NAME,
         "ScreenCast, Settings and Access portal backends running"
     );
 
-    // Wait for shutdown signal
-    signal::ctrl_c().await?;
-    info!("Shutdown requested");
-
-    Ok(())
+    // Wait for a shutdown signal, or for a newer instance to take the name —
+    // staying alive without it would leave a portal nothing can reach.
+    loop {
+        tokio::select! {
+            result = signal::ctrl_c() => {
+                result?;
+                info!("Shutdown requested");
+                return Ok(());
+            }
+            Some(signal) = name_lost.next() => {
+                if signal.args()?.name.as_str() == DBUS_NAME {
+                    info!(name = DBUS_NAME, "Name taken over by another instance; exiting");
+                    return Ok(());
+                }
+            }
+        }
+    }
 }
 
 fn init_tracing() {

--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -15,9 +15,10 @@ use zbus::zvariant::{OwnedFd, OwnedObjectPath, OwnedValue};
 use crate::otto_client::screencast::WindowSource;
 use crate::otto_client::OttoClient;
 use crate::portal::{
-    build_streams_value_from_descriptors, make_output_mapping_id, PortalState, Request,
-    SelectedWindow, Session, SessionState, StreamDescriptor, CURSOR_MODE_EMBEDDED,
-    SOURCE_TYPE_MONITOR, SOURCE_TYPE_WINDOW, SUPPORTED_CURSOR_MODES,
+    build_streams_value_from_descriptors, decode_restore_data, encode_restore_data,
+    make_output_mapping_id, resolve_restored, PortalState, Request, RestoredSource, SelectedWindow,
+    Session, SessionState, StreamDescriptor, CURSOR_MODE_EMBEDDED, SOURCE_TYPE_MONITOR,
+    SOURCE_TYPE_WINDOW, SUPPORTED_CURSOR_MODES,
 };
 use zbus::zvariant::Str;
 
@@ -257,6 +258,40 @@ impl ScreenCastPortal {
         })
     }
 
+    /// Record the source this session will capture, however it was chosen.
+    async fn store_selection(
+        &self,
+        session_handle: &OwnedObjectPath,
+        selection: &SourceSelection,
+        cursor_mode: u32,
+        persist_mode: Option<u32>,
+    ) -> fdo::Result<()> {
+        let mut state = self.state.lock().await;
+        let entry = state
+            .sessions
+            .get_mut(session_handle.as_str())
+            .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
+
+        match selection {
+            SourceSelection::Monitor(connector) => {
+                entry.selected_outputs = vec![connector.clone()];
+                entry.selected_window = None;
+            }
+            SourceSelection::Window(window) => {
+                entry.selected_outputs = Vec::new();
+                entry.selected_window = Some(SelectedWindow {
+                    id: window.id.clone(),
+                    title: window.title.clone(),
+                });
+            }
+        }
+        entry.cursor_mode = cursor_mode;
+        entry.persist_mode = persist_mode;
+        entry.next_stream_id = 0;
+
+        Ok(())
+    }
+
     /// Export a temporary Request object in dbus so the frontend can listen for the response signal.
     async fn register_request(
         &self,
@@ -445,6 +480,38 @@ impl ScreenCastPortal {
                 );
             }
 
+            // A session the app is re-creating (Chrome does exactly that
+            // between the preview in its own picker and the real capture)
+            // carries the source the user already approved. Restoring it is
+            // what keeps the picker from opening a second time.
+            let restored = options
+                .get("restore_data")
+                .and_then(decode_restore_data)
+                .and_then(|source| {
+                    resolve_restored(
+                        source,
+                        requested_types,
+                        &available_outputs,
+                        &available_windows,
+                    )
+                });
+
+            if let Some(selection) = restored {
+                info!(
+                    session = %session_handle,
+                    ?selection,
+                    "Restored the previously approved source; not prompting"
+                );
+                self.store_selection(&session_handle, &selection, cursor_mode, persist_mode)
+                    .await?;
+
+                let mut results = HashMap::new();
+                if let Some(pm) = persist_mode {
+                    results.insert("persist_mode".to_string(), OwnedValue::from(pm));
+                }
+                return Ok((0, results));
+            }
+
             let selection = match self
                 .pick_source(&app_id, &available_outputs, &available_windows)
                 .await
@@ -467,30 +534,8 @@ impl ScreenCastPortal {
                 }
             };
 
-            {
-                let mut state = self.state.lock().await;
-                let entry = state
-                    .sessions
-                    .get_mut(session_handle.as_str())
-                    .ok_or_else(|| fdo::Error::Failed("Session not found".to_string()))?;
-
-                match &selection {
-                    SourceSelection::Monitor(connector) => {
-                        entry.selected_outputs = vec![connector.clone()];
-                        entry.selected_window = None;
-                    }
-                    SourceSelection::Window(window) => {
-                        entry.selected_outputs = Vec::new();
-                        entry.selected_window = Some(SelectedWindow {
-                            id: window.id.clone(),
-                            title: window.title.clone(),
-                        });
-                    }
-                }
-                entry.cursor_mode = cursor_mode;
-                entry.persist_mode = persist_mode;
-                entry.next_stream_id = 0;
-            }
+            self.store_selection(&session_handle, &selection, cursor_mode, persist_mode)
+                .await?;
 
             info!(
                 session = %session_handle,
@@ -725,8 +770,25 @@ impl ScreenCastPortal {
             let mut results = HashMap::new();
             results.insert("streams".to_string(), streams_value);
 
-            if let Some(pm) = persist_mode {
+            // Persistence is the frontend's to manage: it hands the app a token
+            // for whatever `restore_data` we return here and gives the tuple
+            // back on the app's next SelectSources. Nothing to return when the
+            // app didn't ask for any persistence (mode 0 or absent).
+            if let Some(pm) = persist_mode.filter(|mode| *mode != 0) {
                 results.insert("persist_mode".to_string(), OwnedValue::from(pm));
+
+                let restorable = match &selected_source {
+                    SourceSelection::Monitor(connector) => {
+                        RestoredSource::Monitor(connector.clone())
+                    }
+                    SourceSelection::Window(window) => RestoredSource::Window(window.id.clone()),
+                };
+                match encode_restore_data(&restorable) {
+                    Ok(value) => {
+                        results.insert("restore_data".to_string(), value);
+                    }
+                    Err(err) => warn!(?err, "Failed to encode restore_data; session won't persist"),
+                }
             }
 
             Ok((0, results))
@@ -776,7 +838,7 @@ impl ScreenCastPortal {
 
     #[zbus(property)]
     fn available_source_types(&self) -> u32 {
-        SOURCE_TYPE_MONITOR
+        SOURCE_TYPE_MONITOR | SOURCE_TYPE_WINDOW
     }
 
     #[zbus(property)]
@@ -786,8 +848,10 @@ impl ScreenCastPortal {
 
     /// The impl portal spec spells this property lowercase. zbus would
     /// derive `Version` from the method name, and xdg-desktop-portal then
-    /// reads 0 — which makes it skip the `AvailableCursorModes` binding
-    /// entirely and reject every cursor mode but the unset one.
+    /// reads 0 — which gates off everything the spec added after interface
+    /// version 1: the `AvailableCursorModes` binding (so every cursor mode
+    /// but the unset one is rejected) and the `restore_data` round-trip this
+    /// backend relies on to not prompt twice.
     #[zbus(property, name = "version")]
     fn version(&self) -> u32 {
         5

--- a/components/xdg-desktop-portal-otto/src/portal/mod.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/mod.rs
@@ -7,6 +7,7 @@
 mod access;
 mod interface;
 mod request;
+mod restore;
 mod session;
 mod settings;
 mod state;
@@ -16,6 +17,7 @@ pub use access::AccessPortal;
 pub use interface::{
     fallback_mapping_id, validate_cursor_mode, validate_persist_mode, ScreenCastPortal,
 };
+pub use restore::{decode_restore_data, encode_restore_data, resolve_restored, RestoredSource};
 pub use settings::SettingsPortal;
 pub use state::{PortalState, SelectedWindow, SessionState};
 pub use stream::{build_streams_value_from_descriptors, StreamDescriptor};

--- a/components/xdg-desktop-portal-otto/src/portal/restore.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/restore.rs
@@ -1,0 +1,247 @@
+//! `restore_data` encoding for the ScreenCast impl portal.
+//!
+//! The spec's session-persistence handshake runs entirely through the
+//! frontend: the backend returns `restore_data` — `(vendor, version, data)` —
+//! from `Start`, xdg-desktop-portal hands the app an opaque token for it, and
+//! on a later `SelectSources` the same tuple comes back to us. Only this
+//! backend has to understand `data`, so it carries the picked source verbatim
+//! and needs no state kept in the portal process.
+//!
+//! Without this, an app that re-creates its session (Chrome does, between the
+//! preview it renders in its own picker and the real capture) is prompted
+//! again for a source the user already approved.
+
+use std::collections::HashMap;
+
+use zbus::zvariant::{OwnedValue, Str, Value};
+
+use crate::portal::interface::SourceSelection;
+use crate::portal::{SOURCE_TYPE_MONITOR, SOURCE_TYPE_WINDOW};
+
+/// Vendor name in the `(suv)` tuple. Data written by another desktop's portal
+/// carries its own name and is rejected on sight.
+pub const RESTORE_VENDOR: &str = "otto";
+
+/// Version of this backend's private `data` payload.
+pub const RESTORE_VERSION: u32 = 1;
+
+/// A source selection as it survives across sessions.
+///
+/// Only the identity is stored. Sizes, outputs and titles are resolved afresh
+/// on restore, because the window may have moved or been resized since.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RestoredSource {
+    Monitor(String),
+    Window(String),
+}
+
+impl RestoredSource {
+    /// The `SOURCE_TYPE_*` bit this source answers to.
+    pub fn source_type(&self) -> u32 {
+        match self {
+            RestoredSource::Monitor(_) => SOURCE_TYPE_MONITOR,
+            RestoredSource::Window(_) => SOURCE_TYPE_WINDOW,
+        }
+    }
+}
+
+/// Build the `(suv)` value to return from `Start`.
+pub fn encode_restore_data(source: &RestoredSource) -> Result<OwnedValue, zbus::zvariant::Error> {
+    let (source_type, id) = match source {
+        RestoredSource::Monitor(connector) => (SOURCE_TYPE_MONITOR, connector.clone()),
+        RestoredSource::Window(id) => (SOURCE_TYPE_WINDOW, id.clone()),
+    };
+
+    let mut data: HashMap<&str, Value<'_>> = HashMap::new();
+    data.insert("source-type", Value::U32(source_type));
+    data.insert("id", Value::Str(Str::from(id)));
+
+    // The third field is a *variant*, not the dict itself — the tuple has to
+    // marshal as `(suv)` or the frontend rejects it.
+    let tuple = Value::from((
+        Str::from_static(RESTORE_VENDOR),
+        RESTORE_VERSION,
+        Value::Value(Box::new(Value::from(data))),
+    ));
+    OwnedValue::try_from(tuple)
+}
+
+/// Peel any number of variant wrappers off a value.
+///
+/// How deeply a value ends up nested depends on who marshalled it — the dict
+/// values in an `a{sv}` are variants, and the frontend re-wraps the payload
+/// when it stores and replays it — so unwrap until something concrete appears.
+fn unwrap_variants<'a>(value: &'a Value<'a>) -> &'a Value<'a> {
+    let mut current = value;
+    while let Value::Value(inner) = current {
+        current = inner.as_ref();
+    }
+    current
+}
+
+/// Read back a `(suv)` produced by [`encode_restore_data`].
+///
+/// Returns `None` for anything this backend did not write — another desktop's
+/// portal, a future payload version, or a malformed tuple. The spec requires
+/// exactly that: an unreadable restore payload falls back to prompting.
+pub fn decode_restore_data(value: &OwnedValue) -> Option<RestoredSource> {
+    let Value::Structure(structure) = &**value else {
+        return None;
+    };
+    let fields = structure.fields();
+    let [vendor, version, data] = fields else {
+        return None;
+    };
+
+    if <&str>::try_from(vendor).ok()? != RESTORE_VENDOR {
+        return None;
+    }
+    if u32::try_from(version).ok()? != RESTORE_VERSION {
+        return None;
+    }
+
+    let Value::Dict(dict) = unwrap_variants(data) else {
+        return None;
+    };
+    let source_type = match unwrap_variants(&dict.get::<_, Value<'_>>(&"source-type").ok()??) {
+        Value::U32(value) => *value,
+        _ => return None,
+    };
+    let id = match unwrap_variants(&dict.get::<_, Value<'_>>(&"id").ok()??) {
+        Value::Str(value) => value.to_string(),
+        _ => return None,
+    };
+    if id.is_empty() {
+        return None;
+    }
+
+    match source_type {
+        SOURCE_TYPE_MONITOR => Some(RestoredSource::Monitor(id)),
+        SOURCE_TYPE_WINDOW => Some(RestoredSource::Window(id)),
+        _ => None,
+    }
+}
+
+/// Turn a restored source back into a live selection.
+///
+/// The source is only accepted when the app is still allowed to ask for that
+/// type *and* the source is still there — a monitor that was unplugged or a
+/// window that was closed must fall through to the picker rather than fail the
+/// request.
+pub fn resolve_restored(
+    source: RestoredSource,
+    requested_types: u32,
+    outputs: &[String],
+    windows: &[crate::otto_client::screencast::WindowSource],
+) -> Option<SourceSelection> {
+    if requested_types & source.source_type() == 0 {
+        return None;
+    }
+
+    match source {
+        RestoredSource::Monitor(connector) if outputs.contains(&connector) => {
+            Some(SourceSelection::Monitor(connector))
+        }
+        RestoredSource::Monitor(_) => None,
+        RestoredSource::Window(id) => windows
+            .iter()
+            .find(|window| window.id == id)
+            .cloned()
+            .map(SourceSelection::Window),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::otto_client::screencast::WindowSource;
+
+    fn window(id: &str) -> WindowSource {
+        WindowSource {
+            id: id.to_string(),
+            app_id: "app".to_string(),
+            title: "title".to_string(),
+        }
+    }
+
+    #[test]
+    fn round_trips_a_window() {
+        let source = RestoredSource::Window("toplevel-1".to_string());
+        let encoded = encode_restore_data(&source).unwrap();
+        assert_eq!(decode_restore_data(&encoded), Some(source));
+    }
+
+    #[test]
+    fn marshals_as_the_signature_the_spec_asks_for() {
+        let encoded =
+            encode_restore_data(&RestoredSource::Window("toplevel-1".to_string())).unwrap();
+        assert_eq!(encoded.value_signature().to_string(), "(suv)");
+    }
+
+    #[test]
+    fn round_trips_a_monitor() {
+        let source = RestoredSource::Monitor("eDP-1".to_string());
+        let encoded = encode_restore_data(&source).unwrap();
+        assert_eq!(decode_restore_data(&encoded), Some(source));
+    }
+
+    #[test]
+    fn rejects_another_vendor() {
+        let mut data: HashMap<&str, Value<'_>> = HashMap::new();
+        data.insert("source-type", Value::U32(SOURCE_TYPE_WINDOW));
+        data.insert("id", Value::Str(Str::from_static("toplevel-1")));
+        let tuple = Value::from((Str::from_static("GNOME"), 1u32, Value::from(data)));
+        let encoded = OwnedValue::try_from(tuple).unwrap();
+        assert_eq!(decode_restore_data(&encoded), None);
+    }
+
+    #[test]
+    fn rejects_a_future_payload_version() {
+        let mut data: HashMap<&str, Value<'_>> = HashMap::new();
+        data.insert("source-type", Value::U32(SOURCE_TYPE_WINDOW));
+        data.insert("id", Value::Str(Str::from_static("toplevel-1")));
+        let tuple = Value::from((
+            Str::from_static(RESTORE_VENDOR),
+            RESTORE_VERSION + 1,
+            Value::from(data),
+        ));
+        let encoded = OwnedValue::try_from(tuple).unwrap();
+        assert_eq!(decode_restore_data(&encoded), None);
+    }
+
+    #[test]
+    fn resolves_a_window_that_is_still_open() {
+        let selection = resolve_restored(
+            RestoredSource::Window("toplevel-1".to_string()),
+            SOURCE_TYPE_WINDOW,
+            &[],
+            &[window("toplevel-1")],
+        );
+        assert!(matches!(
+            selection,
+            Some(SourceSelection::Window(w)) if w.id == "toplevel-1"
+        ));
+    }
+
+    #[test]
+    fn drops_a_window_that_is_gone() {
+        let selection = resolve_restored(
+            RestoredSource::Window("toplevel-1".to_string()),
+            SOURCE_TYPE_WINDOW,
+            &[],
+            &[window("toplevel-2")],
+        );
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn drops_a_source_of_an_unrequested_type() {
+        let selection = resolve_restored(
+            RestoredSource::Monitor("eDP-1".to_string()),
+            SOURCE_TYPE_WINDOW,
+            &["eDP-1".to_string()],
+            &[],
+        );
+        assert!(selection.is_none());
+    }
+}

--- a/docs/developer/screenshare.md
+++ b/docs/developer/screenshare.md
@@ -406,6 +406,13 @@ and still matches the requested `types`. Chrome relies on this — its window pi
 preview in one session and then re-creates the session for the real capture, so without a
 restorable token the dialog opened a second time on top of a live share.
 
+When testing a portal build, remember the backend's bus name is user-wide and the session bus
+outlives the graphical session: a backend from an earlier login keeps
+`org.freedesktop.impl.portal.desktop.otto` until it is killed. The backend now claims the
+name with `ReplaceExisting | AllowReplacement` and exits when a newer instance takes it over,
+so starting the new build is enough — but a *pre-fix* backend refuses replacement and has to
+be killed by hand (the new one then exits with a message saying so).
+
 Two things gate that path and are easy to break: the impl interface must export `version`
 under exactly that lowercase name (`#[zbus(property, name = "version")]`, or the frontend
 reads 0 and drops every option added after interface version 1), and `AvailableSourceTypes`

--- a/docs/developer/screenshare.md
+++ b/docs/developer/screenshare.md
@@ -398,6 +398,19 @@ behaviour: `$XDG_CONFIG_HOME/otto/screencast-output` (falling back to
 call, else the first output. A window is never auto-selected in that path. Full behavior:
 `specs/screenshare.md`.
 
+An approved source survives into a new session through the spec's `restore_data` handshake
+(`components/xdg-desktop-portal-otto/src/portal/restore.rs`): `Start` returns
+`("otto", 1, {source-type, id})`, the frontend hands the app a token for it, and a
+`SelectSources` that replays the tuple skips the picker as long as the source is still there
+and still matches the requested `types`. Chrome relies on this — its window picker builds the
+preview in one session and then re-creates the session for the real capture, so without a
+restorable token the dialog opened a second time on top of a live share.
+
+Two things gate that path and are easy to break: the impl interface must export `version`
+under exactly that lowercase name (`#[zbus(property, name = "version")]`, or the frontend
+reads 0 and drops every option added after interface version 1), and `AvailableSourceTypes`
+must include the `WINDOW` bit.
+
 ### Known Issues and Fixes
 
 #### Framerate Compatibility (January 2026)

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -138,6 +138,28 @@ documented in `docs/developer/screenshare.md`.
 - `Start` calls `RecordMonitor` or `RecordWindow` according to the stored selection, and the
   resulting portal stream carries `source_type` = 1 or 2 to match.
 
+### Session persistence (`restore_data`)
+
+- `AvailableSourceTypes` advertises `MONITOR | WINDOW`, and the impl interface exports its
+  `version` property under that exact (lowercase) name. zbus would otherwise derive
+  `Version` from the method name; xdg-desktop-portal reads a missing property as `0` and
+  then gates off everything the spec added after version 1 — `restore_data` included.
+- When the app asked for persistence (`persist_mode` 1 or 2), `Start` returns `restore_data`
+  as `("otto", 1, <a{sv}>)` where the payload carries `source-type` (1 or 2) and `id` (the
+  connector name or the foreign-toplevel identifier), plus the effective `persist_mode`. The
+  portal keeps no state of its own: the frontend hands the app a token for that tuple and
+  gives the tuple back on a later `SelectSources`.
+- A `SelectSources` carrying `restore_data` skips the picker when **all** of the following
+  hold; otherwise the user is prompted normally:
+  - the vendor field is `otto` and the payload version is one this build understands;
+  - the source's type is among the `types` the app requested on this call;
+  - the source is still available — the connector is still in `ListOutputs`, or the window
+    identifier is still in `ListWindows`.
+- This is what keeps a single approval from being asked twice. Chrome's own picker creates
+  one session to render the preview thumbnail, then closes it and creates a second session
+  for the real capture; without a restorable token the second one re-opened the dialog on
+  top of an already-running share, and dismissing it tore the share down.
+
 ### Window capture
 
 - A window stream renders the window's **own surface tree** (toplevel + subsurfaces, plus

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -138,12 +138,25 @@ documented in `docs/developer/screenshare.md`.
 - `Start` calls `RecordMonitor` or `RecordWindow` according to the stored selection, and the
   resulting portal stream carries `source_type` = 1 or 2 to match.
 
+### Portal bus name ownership
+
+- The backend claims `org.freedesktop.impl.portal.desktop.otto` with
+  `ReplaceExisting | AllowReplacement | DoNotQueue`, and only after every interface is
+  exported. A running backend that loses the name to a newer instance exits.
+- The reason is that the **session bus outlives the graphical session**: a backend left
+  running by an earlier login, or one started before an upgrade, otherwise holds the name
+  for as long as the user is logged in. Every later instance died on startup while the
+  desktop kept talking to the stale one — an installed fix simply never took effect.
+- A backend predating this flag still cannot be replaced (replacement needs the current
+  owner's consent). Startup then fails with an explicit message naming the conflict rather
+  than continuing without the name.
+
 ### Session persistence (`restore_data`)
 
-- `AvailableSourceTypes` advertises `MONITOR | WINDOW`, and the impl interface exports its
-  `version` property under that exact (lowercase) name. zbus would otherwise derive
-  `Version` from the method name; xdg-desktop-portal reads a missing property as `0` and
-  then gates off everything the spec added after version 1 — `restore_data` included.
+- `AvailableSourceTypes` advertises `MONITOR | WINDOW`. Persistence additionally depends on
+  the lowercase `version` property above: the frontend reads a missing property as `0` and
+  then gates off everything the spec added after interface version 1, `restore_data`
+  (version 4) included.
 - When the app asked for persistence (`persist_mode` 1 or 2), `Start` returns `restore_data`
   as `("otto", 1, <a{sv}>)` where the payload carries `source-type` (1 or 2) and `id` (the
   connector name or the foreign-toplevel identifier), plus the effective `persist_mode`. The


### PR DESCRIPTION
## What was broken

Sharing a window from Chrome opened Otto's source picker **twice**. Chrome's own
picker builds the "Window" tab preview from one portal session, then closes it
and creates a second session for the real capture:

```
SelectSources  ... {"types": 2, "multiple": false, "persist_mode": 1}   ← picker
Start          ... node_id=69
Session.Close
CreateSession  ... (new session, same app)
SelectSources  ... {"types": 2, "persist_mode": 1}                      ← picker AGAIN
```

The second dialog lands on top of a share that has already started, and there is
nothing to say what it is — dismissing it tears the share straight back down
(verified live: cancelling the second dialog removed Chrome's "sharing a window"
bar and the tab's recording dot).

Chrome asks for persistence (`persist_mode: 1`) and would skip that second prompt
if the backend handed back something to restore. Otto's portal never returned
`restore_data`, so there was nothing for Chrome to replay.

## The fix

`components/xdg-desktop-portal-otto/src/portal/restore.rs` implements the spec's
`restore_data` handshake:

- `Start` returns `("otto", 1, {"source-type": u, "id": s})` plus the effective
  `persist_mode`. No state is kept in the portal — the frontend mints the token
  and replays the tuple.
- `SelectSources` restores that source and skips the picker only when the vendor
  and payload version are ours, the source type is among the `types` this call
  requested, and the source still exists (connector still in `ListOutputs`, window
  identifier still in `ListWindows`). Anything else falls through to prompting,
  as the spec requires.

Two things gated the path and are fixed with it:

- the impl interface exported `Version`, not `version` — zbus derives PascalCase
  from the method name. xdg-desktop-portal reads a missing property as `0` and then
  gates off everything added after interface version 1, `restore_data` included.
  (This is the same one-line change as #123, which is still open; whichever lands
  first, the other's diff is trivially resolvable.)
- `AvailableSourceTypes` advertised `MONITOR` only, so the frontend told apps this
  desktop cannot share windows at all.

This supersedes the timing heuristic in #124, which was written from a log where
`persist_mode` never arrived — precisely because of the `Version` bug above. With
the property name fixed, the spec mechanism is available and no 60s grant window,
app-id keying or portal-side state is needed.

## Verification

- `cargo fmt --all`, `cargo clippy --features "default" -- -D warnings`: clean.
  8 unit tests cover the `(suv)` round-trip, the marshalled signature, rejecting
  another desktop's vendor / a future payload version, and dropping a source that
  is gone or of an unrequested type. (`clippy -p xdg-desktop-portal-otto --lib`
  still reports 2 pre-existing warnings in `settings.rs`, untouched here.)
- **Verified live on the running session**, driving Chrome through
  `getDisplayMedia` with `wlrctl` and reading the portal log:
  - before: picker → pick window → Chrome shows the preview → confirm → **second
    picker** over a live share; cancelling it stopped the share.
  - after: same flow, `restore_data` comes back on the second `SelectSources`,
    the log says `Restored the previously approved source; not prompting`, and the
    share runs with **one** dialog.
  - the compositor side was independently confirmed to capture a Chrome window
    correctly (frames dumped from the PipeWire node).
- The runtime portal was put back to `/usr/local/bin/xdg-desktop-portal-otto`
  afterwards; the running session is unchanged.

## Follow-up: the fix couldn't reach the desktop

First hardware test still showed two prompts — the PR portal never ran:

```
~/.local/state/otto/session-pr125-portal.log:  Error: name already taken on the bus
```

The session bus outlives the graphical session, so a backend left running by an
earlier login held `org.freedesktop.impl.portal.desktop.otto` across every
subsequent login; each new instance died on startup while the desktop kept
talking to the stale one. Second commit fixes that: the name is claimed with
`ReplaceExisting | AllowReplacement | DoNotQueue` after the interfaces are
exported, and an instance that loses the name exits. An owner predating the flag
still can't be replaced, so startup fails with a message naming the conflict
instead of the bare "name already taken". Verified live: a second instance takes
the name and the first logs `Name taken over by another instance; exiting`.

**Confirmed working on hardware** after that — sharing a Chrome window prompts once.

## Test on hardware

Boot the **Otto (PR #125 screencast source restore)** session and share a window
from Chrome — the picker should appear once. Note the portal is a single user-wide
D-Bus name, so this session's wrapper claims it with the PR build
(`/usr/local/bin/xdg-desktop-portal-otto-pr125`) before starting the compositor,
and restarts the xdg-desktop-portal frontend once Otto is up (the frontend caches
the backend's `version` at startup). Logs: `~/.local/state/otto/session-pr125.log`
and `session-pr125-portal.log`.

https://claude.ai/code/session_016YonjhZB6ydiU58qCRkmMt
