### PR TITLE
fix(blur): tone-map the backdrop blur so panels stay readable

### DIFF
--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -34,6 +34,12 @@ vibrancy even though the content behind it lives on other planes.
   blurred }` handed to a layer carries a `blurred` flag; in-scene blur
   consumers with no external backdrop (context menus, OSD) still run the real
   blur against live scene content.
+- The whole-image blur carries a vibrancy tone map (saturation boost plus a
+  gentle downward gain and a small bias), because skipping the layer's own blur
+  pass also skips lay-rs' tone map. Without it a frosted panel over a flat
+  white window composites back to white and its boundary disappears; the tone
+  map shifts the backdrop a few percent darker and a little more saturated so
+  the material stays distinguishable on any background.
 - The blur composite is rebuilt only when a lower plane recorded damage
   that intersects an active blur consumer's region (the dock strip, the
   switcher strip, or the full output while overlay UI or expose is shown),

--- a/src/udev/backdrop.rs
+++ b/src/udev/backdrop.rs
@@ -42,9 +42,45 @@ const BACKDROP_SCALE: f32 = 0.25;
 /// blur (which leaves a faded, seed-exposing rim at the layer edge).
 const BACKDROP_BLUR_SIGMA: f32 = 10.0;
 
-/// Gaussian-blur `image` into a fresh same-size GPU surface and return the
-/// snapshot. Returns `None` if the surface or filter can't be built (caller
-/// falls back to the raw image).
+/// Vibrancy tone map applied to the blurred backdrop, so a frosted panel stays
+/// distinguishable from what is behind it. A plain Gaussian blur of a flat
+/// white window is still flat white: the dock's translucent material over it
+/// composites back to white and the panel disappears. Saturation boost plus a
+/// gentle downward gain gives the material a slight, consistent colour shift —
+/// bright backdrops read a few percent darker (a visible boundary on white),
+/// coloured ones keep more of their hue, and the small bias keeps dark
+/// backdrops from crushing.
+///
+/// Consumers seeding a pre-blurred backdrop skip lay-rs' own blur pass — and
+/// with it lay-rs' vibrancy filter — so this is the only place the plane path
+/// gets a tone map. Kept mild in the same spirit; the composite fallback path
+/// (no external backdrop) still uses lay-rs' slightly weaker one.
+const VIBRANCY_SATURATION: f32 = 1.25;
+const VIBRANCY_GAIN: f32 = 0.85;
+const VIBRANCY_BIAS: f32 = 0.04;
+
+/// The saturation + gain/bias colour matrix described on [`VIBRANCY_SATURATION`],
+/// as a colour filter. Rows are the standard luma-preserving saturation matrix
+/// scaled by the gain, with the bias in the translation column.
+fn vibrancy_filter() -> layers::skia::ColorFilter {
+    let s = VIBRANCY_SATURATION;
+    let g = VIBRANCY_GAIN;
+    let b = VIBRANCY_BIAS;
+    // Rec. 709 luma coefficients, matching lay-rs' backdrop tone map.
+    let (lr, lg, lb) = (0.213, 0.715, 0.072);
+    #[rustfmt::skip]
+    let matrix = layers::skia::ColorMatrix::new(
+        g * (lr + (1.0 - lr) * s), g * (lg - lg * s),         g * (lb - lb * s),         0.0, b,
+        g * (lr - lr * s),         g * (lg + (1.0 - lg) * s), g * (lb - lb * s),         0.0, b,
+        g * (lr - lr * s),         g * (lg - lg * s),         g * (lb + (1.0 - lb) * s), 0.0, b,
+        0.0,                       0.0,                       0.0,                       1.0, 0.0,
+    );
+    layers::skia::color_filters::matrix(&matrix, None)
+}
+
+/// Gaussian-blur `image` into a fresh same-size GPU surface, apply the vibrancy
+/// tone map, and return the snapshot. Returns `None` if the surface or filter
+/// can't be built (caller falls back to the raw image).
 fn blur_image(
     image: &layers::skia::Image,
     ctx: &mut layers::skia::gpu::DirectContext,
@@ -72,8 +108,10 @@ fn blur_image(
         None,
         None,
     )?;
+    // Tone map on top of the blur: one filter chain, one pass.
+    let filter = layers::skia::image_filters::color_filter(vibrancy_filter(), blur, None)?;
     let mut paint = layers::skia::Paint::default();
-    paint.set_image_filter(blur);
+    paint.set_image_filter(filter);
     {
         let canvas = surface.canvas();
         canvas.clear(layers::skia::Color4f::new(0.0, 0.0, 0.0, 1.0));


### PR DESCRIPTION
Frosted panels (dock, app switcher, menus, expose) lost all vibrancy on the
plane-scanout path: consumers that seed a pre-blurred external backdrop skip
lay-rs' own blur `save_layer`, and that is also where lay-rs applies its
tone map. The result was a plain Gaussian blur — so over a flat white window
the dock material (`#F6F6F67A`, ~48% alpha) composited straight back to
white and the panel boundary vanished.

`blur_image()` in `src/udev/backdrop.rs` now chains a colour matrix onto the
blur: luma-preserving saturation 1.25, gain 0.85, bias 0.04. Every consumer
of the whole-image blur gets it (dock, switcher, overlay/popups, expose),
in one filter chain and one pass.

What that does to the numbers: white → 0.89, black → 0.04, mid-grey 0.5 →
0.465. The dock over a white window lands at ~0.93 instead of 1.0 — a
visible edge — while coloured backdrops keep a bit more hue and dark ones
are left essentially alone.

Note the composite fallback path (no external backdrop: in-scene context
menus, OSD, the winit backend) still uses lay-rs' own, slightly weaker tone
map — that one lives in the `layers` crate and is out of scope here.

Spec `specs/plane-scanout.md` updated.

## Verification

- `cargo build` and `cargo clippy --features "default" -- -D warnings` clean;
  `cargo fmt --all` applied.
- **Not verified visually** — I could not launch the compositor from this
  agent. Please boot the session below and check the dock/menus against a
  white window and against a colourful wallpaper.

Test session: **Otto (PR #126 backdrop blur tone map)** in the greeter session
list.

https://claude.ai/code/session_01UuVFyJ23ZRXL9ZudJgKrnX
