### PR TITLE
feat(islands): music island with MPRIS and PipeWire

### DIFF
--- a/components/otto-islands/Cargo.toml
+++ b/components/otto-islands/Cargo.toml
@@ -15,3 +15,5 @@ smithay-client-toolkit = { version = "0.19", default-features = false }
 wayland-client = "0.31"
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 libc = "0.2"
+pipewire = "0.9"
+ureq = "3"

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod dbus_service;
 mod dialog;
+mod music;
 mod notifications;
 mod renderer;
 mod state;
@@ -18,9 +19,10 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_shell_v1::Layer, zwlr_layer_surface_v1::Anchor,
 };
 
-use crate::activity::Activity;
+use crate::activity::{Activity, ActivitySource, PresentationMode};
 use crate::dbus_service::{DialogService, IslandService, DBUS_NAME};
 use crate::dialog::{DialogHit, DialogId, DialogResponse, DialogView};
+use crate::music::MusicMonitor;
 use crate::renderer::{
     animate_to, apply_island_style, draw_centered, set_size_and_position, COMPACT_H, MINI_H, MINI_W,
 };
@@ -38,6 +40,19 @@ const GAP: f32 = 6.0;
 const DIALOG_TOP: f32 = BAR_HEIGHT + 14.0;
 /// Seconds of inactivity before the focused island shrinks to Mini.
 const FOCUS_TIMEOUT_SECS: f64 = 4.0;
+/// Top edge of the expanded music panel, in layer coordinates. Pinned to the
+/// top and never above it: `COMPACT_H` is taller than `BAR_HEIGHT`, so centring
+/// the panel on the bar puts its top edge off-screen, where the layer clips it.
+fn expanded_music_top() -> f32 {
+    ((BAR_HEIGHT - COMPACT_H) / 2.0).max(0.0)
+}
+
+/// Corner radius of the expanded music panel — a card, not a pill.
+const EXPANDED_MUSIC_RADIUS: f64 = 16.0;
+/// How long a pressed music control stays highlighted.
+const PRESS_FEEDBACK_MS: u128 = 300;
+/// Equalizer redraw interval while a track plays (~24fps).
+const EQ_REDRAW_MS: u64 = 42;
 /// Seconds a destroyed surface is kept alive so its exit animation can play.
 const DESTROY_DELAY_SECS: f64 = 0.8;
 
@@ -52,9 +67,20 @@ enum IslandMode {
     Expanded,
 }
 
+impl IslandMode {
+    fn to_presentation_mode(self) -> PresentationMode {
+        match self {
+            IslandMode::Mini => PresentationMode::Minimal,
+            IslandMode::Compact => PresentationMode::Compact,
+            IslandMode::Expanded => PresentationMode::Expanded,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IslandKind {
     Notification,
+    Music,
 }
 
 /// Signature of what a pill buffer currently shows — redraw only on change.
@@ -87,6 +113,10 @@ struct Island {
     icon: String,
     /// The pill/circle subsurface.
     surface: SubsurfaceSurface,
+    /// Equalizer overlay subsurface (child of the pill, music islands only).
+    eq_surface: Option<SubsurfaceSurface>,
+    /// Last equalizer target (w, h, cx, cy) — skip re-animating when unchanged.
+    last_eq_layout: Option<(f32, f32, f32, f32)>,
     /// Lazily-created card subsurfaces (only when Expanded, notifications only).
     cards: Vec<CardSurface>,
     /// Current mode.
@@ -150,10 +180,18 @@ struct IslandApp {
     last_input_region: Option<Vec<(i32, i32, i32, i32)>>,
     /// The currently-presented Access-style dialog, if any.
     dialog: Option<DialogPanel>,
+    /// Music monitor — MPRIS playback plus PipeWire audio levels.
+    music_monitor: MusicMonitor,
+    /// Currently pressed music control (for press feedback).
+    music_pressed: Option<(music::MusicAction, std::time::Instant)>,
+    /// Last equalizer redraw (throttled to ~24fps).
+    music_last_redraw: std::time::Instant,
+    /// Last full music pill redraw (progress bar and clock, ~1fps).
+    music_last_full_redraw: std::time::Instant,
 }
 
 impl IslandApp {
-    fn new(state: SharedState) -> Self {
+    fn new(state: SharedState, music_monitor: MusicMonitor) -> Self {
         Self {
             state,
             layer_surface: None,
@@ -166,6 +204,10 @@ impl IslandApp {
             last_layer_size: None,
             last_input_region: None,
             dialog: None,
+            music_monitor,
+            music_pressed: None,
+            music_last_redraw: std::time::Instant::now(),
+            music_last_full_redraw: std::time::Instant::now(),
         }
     }
 
@@ -235,7 +277,13 @@ impl IslandApp {
         // Build the set of app_ids that should exist as islands.
         let mut desired: Vec<(String, IslandKind, String)> = Vec::new(); // (app_id, kind, icon)
         for (activity, _count) in &grouped {
-            let kind = IslandKind::Notification;
+            let kind = if activity.app_id == music::MUSIC_APP_ID
+                || activity.source == ActivitySource::Internal
+            {
+                IslandKind::Music
+            } else {
+                IslandKind::Notification
+            };
             if !desired.iter().any(|(id, _, _)| id == &activity.app_id) {
                 desired.push((activity.app_id.clone(), kind, activity.icon.clone()));
             }
@@ -273,6 +321,9 @@ impl IslandApp {
                 for card in island.cards.drain(..) {
                     self.defer_destroy(card.surface);
                 }
+                if let Some(eq) = island.eq_surface.take() {
+                    self.defer_destroy(eq);
+                }
                 self.defer_destroy(island.surface);
                 removed_island = true;
             }
@@ -283,11 +334,40 @@ impl IslandApp {
             if !self.islands.iter().any(|i| i.app_id == *app_id) {
                 if let Some(surface) = self.create_pill_subsurface() {
                     tracing::info!(%app_id, ?kind, %icon, "island created");
+                    // The equalizer lives on its own child subsurface so it can
+                    // redraw at ~24fps without touching the pill buffer. Clip the
+                    // pill so the bars stay inside its shape while it animates.
+                    let eq_surface = if *kind == IslandKind::Music {
+                        if let Some(ss) = surface.base_surface().surface_style() {
+                            use otto_kit::protocols::otto_surface_style_v1::ClipMode;
+                            ss.set_masks_to_bounds(ClipMode::Enabled);
+                        }
+                        let eq = SubsurfaceSurface::new(
+                            surface.wl_surface(),
+                            0,
+                            0,
+                            music::EQ_BUF_W,
+                            music::EQ_BUF_H,
+                        )
+                        .ok();
+                        if let Some(ref eq) = eq {
+                            if let Some(ss) = eq.base_surface().surface_style() {
+                                ss.set_contents_gravity(ContentsGravity::Center);
+                                ss.set_anchor_point(0.5, 0.5);
+                            }
+                            eq.place_above(surface.wl_surface());
+                        }
+                        eq
+                    } else {
+                        None
+                    };
                     self.islands.push(Island {
                         app_id: app_id.clone(),
                         kind: *kind,
                         icon: icon.clone(),
                         surface,
+                        eq_surface,
+                        last_eq_layout: None,
                         cards: Vec::new(),
                         mode: IslandMode::Mini,
                         created_at: std::time::Instant::now(),
@@ -373,6 +453,9 @@ impl IslandApp {
 
         // Compute element sizes for layout.
         let island_size = |island: &Island, mode: IslandMode| -> (f32, f32) {
+            if island.kind == IslandKind::Music {
+                return music::MusicActivityRenderer::mode_size(mode.to_presentation_mode());
+            }
             let entry = grouped.iter().find(|(a, _)| a.app_id == island.app_id);
             let count = entry.map(|(_, c)| *c).unwrap_or(1);
             let title = entry.map(|(a, _)| a.title.as_str()).unwrap_or("");
@@ -405,6 +488,8 @@ impl IslandApp {
         let mut pulse_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
         let mut layout_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new(); // (idx, w, h, x, y)
         let mut content_updates: Vec<(usize, PillContent)> = Vec::new();
+        // (idx, w, h, cx, cy) for the equalizer child surfaces.
+        let mut eq_updates: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
 
         for (idx, island) in self.islands.iter().enumerate() {
             let count = grouped
@@ -427,7 +512,46 @@ impl IslandApp {
             let h = base_h + grow;
             // Center coordinates for anchor_point(0.5, 0.5).
             let cx = x + w / 2.0;
-            let cy = BAR_HEIGHT / 2.0;
+            // The expanded music panel is pinned to the top of the layer and
+            // grows downward: it is taller than the bar, so centring it on
+            // BAR_HEIGHT would push its top edge off the top of the screen.
+            let cy = if island.kind == IslandKind::Music && island.mode == IslandMode::Expanded {
+                expanded_music_top() + h / 2.0
+            } else {
+                BAR_HEIGHT / 2.0
+            };
+
+            if island.kind == IslandKind::Music {
+                let pmode = island.mode.to_presentation_mode();
+                if let Some(mut mr) = self.music_monitor.renderer() {
+                    if let Some((action, instant)) = &self.music_pressed {
+                        if instant.elapsed().as_millis() < PRESS_FEEDBACK_MS {
+                            mr.pressed = Some(*action);
+                        }
+                    }
+                    // The equalizer redraws on its own surface; the pill buffer
+                    // only changes when the track or the layout does.
+                    let content = PillContent {
+                        mode: island.mode,
+                        icon: format!("music:{}", mr.artist),
+                        title: mr.title.clone(),
+                        count: 0,
+                        w,
+                        h,
+                    };
+                    if island.last_content.as_ref() != Some(&content) {
+                        draw_centered(&island.surface, w, h, |canvas| {
+                            mr.draw_without_eq(canvas, pmode, w, h);
+                        });
+                        content_updates.push((idx, content));
+                    }
+                    let (eq_w, eq_h, eq_ox, eq_oy) = mr.eq_layout(pmode, w, h);
+                    eq_updates.push((idx, eq_w, eq_h, eq_ox + eq_w / 2.0, eq_oy + eq_h / 2.0));
+                }
+                layout_targets.push((idx, w, h, cx, cy));
+                x += w + GAP;
+                continue;
+            }
 
             // Detect new notification: count increased or representative activity changed.
             let current_activity_id = grouped
@@ -532,10 +656,35 @@ impl IslandApp {
         for (idx, w, h, x, y) in layout_targets {
             let target = (w, h, x, y);
             if self.islands[idx].last_layout != target {
-                let radius = h as f64 / 2.0;
+                // The expanded music panel is a card, not a pill.
+                let radius = if self.islands[idx].kind == IslandKind::Music
+                    && self.islands[idx].mode == IslandMode::Expanded
+                {
+                    EXPANDED_MUSIC_RADIUS
+                } else {
+                    h as f64 / 2.0
+                };
                 animate_to(&self.islands[idx].surface, w, h, x, y, radius, layout_delay);
                 self.islands[idx].last_layout = target;
             }
+        }
+
+        // Move the equalizer with its pill. Snapping it to the target while the
+        // pill is still springing leaves the bars outside the pill.
+        for (idx, eq_w, eq_h, eq_cx, eq_cy) in eq_updates {
+            let first_placement = self.islands[idx].last_eq_layout.is_none();
+            let target = (eq_w, eq_h, eq_cx, eq_cy);
+            if self.islands[idx].last_eq_layout == Some(target) {
+                continue;
+            }
+            if let Some(eq) = &self.islands[idx].eq_surface {
+                if first_placement {
+                    set_size_and_position(eq, eq_w, eq_h, eq_cx, eq_cy);
+                } else {
+                    animate_to(eq, eq_w, eq_h, eq_cx, eq_cy, 0.0, layout_delay);
+                }
+            }
+            self.islands[idx].last_eq_layout = Some(target);
         }
 
         // Apply pulse and peek as Compact for new notifications.
@@ -770,6 +919,10 @@ impl IslandApp {
 
         for island in &self.islands {
             if island.mode == IslandMode::Expanded {
+                if island.kind == IslandKind::Music {
+                    max_h = max_h.max(expanded_music_top() + island.last_layout.1 + 4.0);
+                    continue;
+                }
                 let card_count = island.cards.len().min(5) as f32;
                 let pill_h = COMPACT_H;
                 let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
@@ -818,17 +971,31 @@ impl IslandApp {
         if !self.islands.is_empty() {
             // One rect per island, derived from last_layout (center coords).
             for island in &self.islands {
-                let (w, _h, cx, _cy) = island.last_layout;
-                let pill_h = match island.mode {
-                    IslandMode::Mini => MINI_H,
-                    IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+                let (w, h, cx, _cy) = island.last_layout;
+                let music_expanded =
+                    island.kind == IslandKind::Music && island.mode == IslandMode::Expanded;
+                let pill_h = if music_expanded {
+                    h
+                } else {
+                    match island.mode {
+                        IslandMode::Mini => MINI_H,
+                        IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+                    }
                 };
-                let pill_w = match island.mode {
-                    IslandMode::Expanded => w.max(renderer::CARD_W),
-                    _ => w.max(MINI_H),
+                let pill_w = if music_expanded {
+                    w
+                } else {
+                    match island.mode {
+                        IslandMode::Expanded => w.max(renderer::CARD_W),
+                        _ => w.max(MINI_H),
+                    }
                 };
                 let x = cx - pill_w / 2.0;
-                let y = (BAR_HEIGHT - pill_h) / 2.0;
+                let y = if music_expanded {
+                    expanded_music_top()
+                } else {
+                    (BAR_HEIGHT - pill_h) / 2.0
+                };
                 rects.push((
                     x.max(0.0) as i32,
                     y as i32,
@@ -908,17 +1075,31 @@ impl IslandApp {
     /// activity_id is Some when a card is hit.
     fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>)> {
         for island in &self.islands {
-            let (w, _h, cx, _cy) = island.last_layout;
-            let pill_h = match island.mode {
-                IslandMode::Mini => MINI_H,
-                IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+            let (w, h, cx, _cy) = island.last_layout;
+            let music_expanded =
+                island.kind == IslandKind::Music && island.mode == IslandMode::Expanded;
+            let pill_h = if music_expanded {
+                h
+            } else {
+                match island.mode {
+                    IslandMode::Mini => MINI_H,
+                    IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
+                }
             };
-            let pill_w = match island.mode {
-                IslandMode::Expanded => w.max(renderer::CARD_W),
-                _ => w.max(MINI_H),
+            let pill_w = if music_expanded {
+                w
+            } else {
+                match island.mode {
+                    IslandMode::Expanded => w.max(renderer::CARD_W),
+                    _ => w.max(MINI_H),
+                }
             };
             let x = cx - pill_w / 2.0;
-            let y = (BAR_HEIGHT - pill_h) / 2.0;
+            let y = if music_expanded {
+                expanded_music_top()
+            } else {
+                (BAR_HEIGHT - pill_h) / 2.0
+            };
 
             // Hit test cards first (they sit below the pill).
             if island.mode == IslandMode::Expanded {
@@ -1019,6 +1200,28 @@ impl IslandApp {
                 }
             }
         } else {
+            // An expanded music panel has transport controls: a click on one of
+            // them acts on the player instead of collapsing the panel.
+            if let Some(island) = self.islands.iter().find(|i| i.app_id == app_id) {
+                if island.kind == IslandKind::Music && island.mode == IslandMode::Expanded {
+                    let (w, h, cx, cy) = island.last_layout;
+                    let lx = px - (cx - w / 2.0);
+                    let ly = py - (cy - h / 2.0);
+                    if let Some(action) = self
+                        .music_monitor
+                        .renderer()
+                        .and_then(|mr| mr.hit_test_expanded(lx, ly, w, h))
+                    {
+                        tracing::info!(?action, "music control clicked");
+                        self.music_pressed = Some((action, std::time::Instant::now()));
+                        music::execute_action(action);
+                        self.last_interaction = std::time::Instant::now();
+                        self.state.lock().unwrap().dirty = true;
+                        return;
+                    }
+                }
+            }
+
             // Clicked a pill/circle.
             // Close any other expanded island first — only one can be expanded at a time.
             for island in self.islands.iter_mut().filter(|i| i.app_id != app_id) {
@@ -1220,6 +1423,73 @@ impl IslandApp {
     }
 }
 
+impl IslandApp {
+    /// Whether a track is currently playing (drives the equalizer tick rate).
+    fn music_playing(&self) -> bool {
+        self.music_monitor
+            .playback
+            .lock()
+            .ok()
+            .is_some_and(|info| info.is_playing)
+    }
+
+    /// Redraw the live parts of a music island: the equalizer at ~24fps on its
+    /// own subsurface, and — while expanded — the whole pill once a second so
+    /// the progress bar and clock advance. Everything else is retained.
+    fn redraw_music(&mut self, now: std::time::Instant) {
+        if !self.music_playing() {
+            return;
+        }
+
+        if now.duration_since(self.music_last_redraw) >= Duration::from_millis(EQ_REDRAW_MS) {
+            self.music_last_redraw = now;
+            for island in &self.islands {
+                if island.kind != IslandKind::Music {
+                    continue;
+                }
+                let (Some(eq_surf), Some(mr)) = (&island.eq_surface, self.music_monitor.renderer())
+                else {
+                    continue;
+                };
+                let pmode = island.mode.to_presentation_mode();
+                let (w, h, _, _) = island.last_layout;
+                let (eq_w, eq_h, _, _) = mr.eq_layout(pmode, w, h);
+                let buf_w = music::EQ_BUF_W as f32;
+                let buf_h = music::EQ_BUF_H as f32;
+                eq_surf.draw(|canvas| {
+                    canvas.save();
+                    canvas.translate(((buf_w - eq_w) / 2.0, (buf_h - eq_h) / 2.0));
+                    mr.draw_eq_only(canvas, pmode, eq_w, eq_h);
+                    canvas.restore();
+                });
+            }
+        }
+
+        if now.duration_since(self.music_last_full_redraw) >= Duration::from_secs(1) {
+            self.music_last_full_redraw = now;
+            for island in &self.islands {
+                if island.kind != IslandKind::Music || island.mode != IslandMode::Expanded {
+                    continue;
+                }
+                let Some(mut mr) = self.music_monitor.renderer() else {
+                    continue;
+                };
+                if let Some((action, instant)) = &self.music_pressed {
+                    if instant.elapsed().as_millis() < PRESS_FEEDBACK_MS {
+                        mr.pressed = Some(*action);
+                    }
+                }
+                let (w, h, _, _) = island.last_layout;
+                if w > 0.0 && h > 0.0 {
+                    draw_centered(&island.surface, w, h, |canvas| {
+                        mr.draw_without_eq(canvas, PresentationMode::Expanded, w, h);
+                    });
+                }
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // App trait implementation
 // ---------------------------------------------------------------------------
@@ -1311,6 +1581,10 @@ impl App for IslandApp {
             }
         }
 
+        // Create, update or dismiss the music activity from MPRIS state.
+        self.music_monitor.sync_to_island(&self.state);
+        self.redraw_music(now);
+
         // Poll for withdrawn dialogs (caller aborted the request). This marks
         // state dirty when one is pruned so the panel is dismissed below.
         if self.dialog.is_some() {
@@ -1348,6 +1622,10 @@ impl App for IslandApp {
             if let Some(until) = island.peek_until {
                 deadlines.push(until);
             }
+        }
+        // A playing track animates the equalizer, so the loop has to tick.
+        if self.music_playing() {
+            deadlines.push(self.music_last_redraw + Duration::from_millis(EQ_REDRAW_MS));
         }
         // While a dialog is up, poll periodically to detect caller withdrawal
         // (the D-Bus method future being dropped closes the response channel).
@@ -1618,7 +1896,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::future::pending::<()>().await;
     });
 
-    let app = IslandApp::new(state);
+    otto_kit::utils::focus_watcher::spawn_focus_watcher();
+
+    let playback = music::start_playerctl_monitor();
+    let audio_level = music::start_pipewire_level_monitor();
+    let music_monitor = MusicMonitor::new(playback, audio_level);
+
+    let app = IslandApp::new(state, music_monitor);
     AppRunner::new(app).run()?;
 
     Ok(())

--- a/components/otto-islands/src/music.rs
+++ b/components/otto-islands/src/music.rs
@@ -1,0 +1,1489 @@
+//! Music activity — MPRIS bridge via playerctl + PipeWire audio levels.
+//!
+//! Spawns background threads that poll playerctl and capture PipeWire audio.
+//! When music is playing, creates/updates an island activity. When stopped,
+//! dismisses it.
+
+use std::fs;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use otto_kit::typography::TextStyle;
+use otto_kit::AppContext;
+use otto_kit::utils::extract_accent_color;
+use skia_safe::{Canvas, Color, Data, Image, Paint, RRect, Rect};
+
+use crate::activity::{ActivityRenderer, PresentationMode};
+use crate::state::SharedState;
+
+// ---------------------------------------------------------------------------
+// Music player actions
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MusicAction {
+    PlayPause,
+    SkipNext,
+    SkipPrev,
+    /// Seek to a position (0.0–1.0).
+    Seek(f32),
+}
+
+const BAR_COUNT: usize = 8;
+
+/// Title reported when nothing is loaded; the island treats it as "no track".
+const NO_MEDIA: &str = "No media";
+
+/// `app_id` the music activity is published under.
+pub const MUSIC_APP_ID: &str = "org.otto.music";
+/// Buffer for the equalizer child subsurface, sized for the largest EQ mode.
+pub const EQ_BUF_W: i32 = 220;
+pub const EQ_BUF_H: i32 = 32;
+
+// ---------------------------------------------------------------------------
+// MusicActivityRenderer
+// ---------------------------------------------------------------------------
+
+pub struct MusicActivityRenderer {
+    pub title: String,
+    pub artist: String,
+    pub album_art: Option<Image>,
+    pub is_playing: bool,
+    pub progress: f32,
+    pub duration_secs: f32,
+    pub accent: Color,
+    pub levels: [f32; BAR_COUNT],
+    /// Currently pressed control (for visual feedback).
+    pub pressed: Option<MusicAction>,
+}
+
+impl MusicActivityRenderer {
+    /// Size for a given presentation mode — no instance needed.
+    pub fn mode_size(mode: PresentationMode) -> (f32, f32) {
+        match mode {
+            PresentationMode::Compact => (220.0, 30.0),
+            PresentationMode::Banner => (298.0, 36.0),
+            PresentationMode::Expanded => (340.0, 120.0),
+            PresentationMode::Minimal | PresentationMode::Idle => (28.0, 28.0),
+        }
+    }
+}
+
+impl ActivityRenderer for MusicActivityRenderer {
+    fn size(&self, mode: PresentationMode) -> (f32, f32) {
+        Self::mode_size(mode)
+    }
+
+    fn draw(&self, canvas: &Canvas, mode: PresentationMode, w: f32, h: f32) {
+        // Note: don't clear here — draw_slot_centered already clears the buffer
+        match mode {
+            PresentationMode::Compact | PresentationMode::Banner => self.draw_compact(canvas, w, h),
+            PresentationMode::Expanded => self.draw_open(canvas, w, h),
+            PresentationMode::Minimal => self.draw_minimal(canvas, w, h),
+            PresentationMode::Idle => self.draw_minimal(canvas, w, h),
+        }
+    }
+}
+
+impl MusicActivityRenderer {
+    /// Draw everything except the EQ bars (for the main pill surface).
+    /// The EQ is rendered on a separate child subsurface.
+    pub fn draw_without_eq(&self, canvas: &Canvas, mode: PresentationMode, w: f32, h: f32) {
+        match mode {
+            PresentationMode::Compact | PresentationMode::Banner => {
+                self.draw_compact_without_eq(canvas, w, h)
+            }
+            PresentationMode::Expanded => self.draw_open_without_eq(canvas, w, h),
+            PresentationMode::Minimal | PresentationMode::Idle => {
+                // Mini: EQ IS the content, nothing else to draw.
+            }
+        }
+    }
+
+    /// Return the EQ subsurface size and offset (relative to pill top-left) for each mode.
+    /// Returns (eq_w, eq_h, offset_x, offset_y).
+    pub fn eq_layout(&self, mode: PresentationMode, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        match mode {
+            PresentationMode::Minimal | PresentationMode::Idle => {
+                // Mini: EQ fills the whole pill
+                (w, h, 0.0, 0.0)
+            }
+            PresentationMode::Compact | PresentationMode::Banner => {
+                // Compact: EQ on the right side, padded vertically
+                let v_pad = 7.0;
+                let compact_bars = 4;
+                let eq_w = compact_bars as f32 * 3.0 + (compact_bars as f32 - 1.0) * 2.0;
+                let h_pad = 8.0;
+                let eq_h = h - v_pad * 2.0;
+                let eq_x = w - h_pad - eq_w;
+                (eq_w, eq_h, eq_x, v_pad)
+            }
+            PresentationMode::Expanded => {
+                // Expanded: EQ below title/artist, right column
+                let pad = 12.0;
+                let art_size = h - pad * 2.0;
+                let rx = pad + art_size + pad;
+                let eq_y = pad + 34.0;
+                let eq_h = 22.0;
+                let eq_w = w - rx - pad;
+                (eq_w, eq_h, rx, eq_y)
+            }
+        }
+    }
+
+    /// Draw only the EQ bars into a standalone surface.
+    /// Canvas origin (0,0) is the top-left of the EQ area.
+    pub fn draw_eq_only(&self, canvas: &Canvas, mode: PresentationMode, w: f32, h: f32) {
+        match mode {
+            PresentationMode::Minimal | PresentationMode::Idle => {
+                self.draw_minimal(canvas, w, h);
+            }
+            PresentationMode::Compact | PresentationMode::Banner => {
+                self.draw_equalizer_n(canvas, 0.0, 0.0, w, h, 4);
+            }
+            PresentationMode::Expanded => {
+                self.draw_equalizer_large(canvas, 0.0, 0.0, w, h);
+            }
+        }
+    }
+
+    /// Hit test within the expanded player. `lx`, `ly` are local coords
+    /// relative to the top-left of the expanded island content.
+    pub fn hit_test_expanded(&self, lx: f32, ly: f32, w: f32, h: f32) -> Option<MusicAction> {
+        let pad = 12.0;
+        let art_size = h - pad * 2.0;
+        let rx = pad + art_size + pad;
+        let rw = w - rx - pad;
+
+        // Progress bar — generous vertical hit zone (±8px around the bar).
+        let prog_y = h - pad - 26.0;
+        if lx >= rx && lx <= rx + rw && (ly - prog_y).abs() <= 8.0 {
+            let frac = ((lx - rx) / rw).clamp(0.0, 1.0);
+            return Some(MusicAction::Seek(frac));
+        }
+
+        // Controls
+        let ctrl_y = h - pad - 6.0;
+        let ctrl_cx = rx + rw / 2.0;
+        let icon_gap = 36.0;
+        let hit_r = 18.0;
+
+        // Skip prev
+        let dx = lx - (ctrl_cx - icon_gap);
+        let dy = ly - ctrl_y;
+        if dx * dx + dy * dy <= hit_r * hit_r {
+            return Some(MusicAction::SkipPrev);
+        }
+        // Play/pause
+        let dx = lx - ctrl_cx;
+        let dy = ly - ctrl_y;
+        if dx * dx + dy * dy <= hit_r * hit_r {
+            return Some(MusicAction::PlayPause);
+        }
+        // Skip next
+        let dx = lx - (ctrl_cx + icon_gap);
+        let dy = ly - ctrl_y;
+        if dx * dx + dy * dy <= hit_r * hit_r {
+            return Some(MusicAction::SkipNext);
+        }
+        None
+    }
+
+    fn draw_compact(&self, canvas: &Canvas, w: f32, h: f32) {
+        let v_pad = 7.0;
+        let h_pad = 10.0;
+        let art_size = h - v_pad * 2.0;
+        let art_x = h_pad;
+        let art_y = v_pad;
+
+        // Album art
+        self.draw_art(canvas, art_x, art_y, art_size);
+
+        // Equalizer on the far right (4 bars for compact)
+        let compact_bars = 4;
+        let eq_area_w = compact_bars as f32 * 3.0 + (compact_bars as f32 - 1.0) * 2.0;
+        let eq_x = w - h_pad - eq_area_w;
+        let eq_y = v_pad;
+        let eq_h = h - v_pad * 2.0;
+        self.draw_equalizer_n(canvas, eq_x, eq_y, eq_area_w, eq_h, compact_bars);
+
+        // Title + artist between art and equalizer
+        let text_x = art_x + art_size + h_pad;
+        let text_max_w = eq_x - text_x - h_pad;
+
+        let mid = h / 2.0;
+        Self::draw_text(
+            canvas,
+            &self.title,
+            text_x,
+            mid - 1.0,
+            11.0,
+            220,
+            text_max_w,
+        );
+
+        let af = font(9.5);
+        let mut ap = Paint::default();
+        ap.set_anti_alias(true);
+        ap.set_color(Color::from_argb(140, 170, 170, 170));
+        let artist = trim_to_width(&self.artist, &af, text_max_w.max(20.0));
+        canvas.draw_str(artist, (text_x, mid + 10.0), &af, &ap);
+    }
+
+    fn draw_open(&self, canvas: &Canvas, w: f32, h: f32) {
+        let pad = 12.0;
+        let art_size = h - pad * 2.0;
+
+        // --- Album art (left) ---
+        self.draw_art(canvas, pad, pad, art_size);
+
+        // --- Right column: title, artist, EQ, progress, controls ---
+        let rx = pad + art_size + pad;
+        let rw = w - rx - pad;
+
+        // Title + artist
+        Self::draw_text(canvas, &self.title, rx, pad + 13.0, 13.0, 255, rw);
+        let af = font(10.0);
+        let mut ap = Paint::default();
+        ap.set_anti_alias(true);
+        ap.set_color(Color::from_argb(150, 180, 180, 180));
+        let artist = trim_to_width(&self.artist, &af, rw.max(20.0));
+        canvas.draw_str(artist, (rx, pad + 27.0), &af, &ap);
+
+        // Equalizer (between text and progress)
+        let eq_y = pad + 34.0;
+        let eq_h = 22.0;
+        self.draw_equalizer_large(canvas, rx, eq_y, rw, eq_h);
+
+        // Progress bar
+        let prog_y = h - pad - 26.0;
+        self.draw_progress_large(canvas, rx, prog_y, rw);
+
+        // Controls
+        let ctrl_y = h - pad - 6.0;
+        let ctrl_cx = rx + rw / 2.0;
+        let icon_gap = 36.0;
+        let icon_size = 12.0;
+
+        let prev_alpha = if self.pressed == Some(MusicAction::SkipPrev) {
+            100
+        } else {
+            200
+        };
+        let pp_alpha = if self.pressed == Some(MusicAction::PlayPause) {
+            150
+        } else {
+            255
+        };
+        let next_alpha = if self.pressed == Some(MusicAction::SkipNext) {
+            100
+        } else {
+            200
+        };
+
+        self.draw_skip_prev_a(canvas, ctrl_cx - icon_gap, ctrl_y, icon_size, prev_alpha);
+        self.draw_play_pause_a(canvas, ctrl_cx, ctrl_y, icon_size + 4.0, pp_alpha);
+        self.draw_skip_next_a(canvas, ctrl_cx + icon_gap, ctrl_y, icon_size, next_alpha);
+    }
+
+    fn draw_compact_without_eq(&self, canvas: &Canvas, w: f32, h: f32) {
+        let v_pad = 7.0;
+        let h_pad = 10.0;
+        let art_size = h - v_pad * 2.0;
+        let art_x = h_pad;
+        let art_y = v_pad;
+
+        self.draw_art(canvas, art_x, art_y, art_size);
+
+        let compact_bars = 4;
+        let eq_area_w = compact_bars as f32 * 3.0 + (compact_bars as f32 - 1.0) * 2.0;
+        let eq_x = w - h_pad - eq_area_w;
+
+        let text_x = art_x + art_size + h_pad;
+        let text_max_w = eq_x - text_x - h_pad;
+
+        let mid = h / 2.0;
+        Self::draw_text(
+            canvas,
+            &self.title,
+            text_x,
+            mid - 1.0,
+            11.0,
+            220,
+            text_max_w,
+        );
+
+        let af = font(9.5);
+        let mut ap = Paint::default();
+        ap.set_anti_alias(true);
+        ap.set_color(Color::from_argb(140, 170, 170, 170));
+        let artist = trim_to_width(&self.artist, &af, text_max_w.max(20.0));
+        canvas.draw_str(artist, (text_x, mid + 10.0), &af, &ap);
+    }
+
+    fn draw_open_without_eq(&self, canvas: &Canvas, w: f32, h: f32) {
+        let pad = 12.0;
+        let art_size = h - pad * 2.0;
+
+        self.draw_art(canvas, pad, pad, art_size);
+
+        let rx = pad + art_size + pad;
+        let rw = w - rx - pad;
+
+        Self::draw_text(canvas, &self.title, rx, pad + 13.0, 13.0, 255, rw);
+        let af = font(10.0);
+        let mut ap = Paint::default();
+        ap.set_anti_alias(true);
+        ap.set_color(Color::from_argb(150, 180, 180, 180));
+        let artist = trim_to_width(&self.artist, &af, rw.max(20.0));
+        canvas.draw_str(artist, (rx, pad + 27.0), &af, &ap);
+
+        // Progress bar
+        let prog_y = h - pad - 26.0;
+        self.draw_progress_large(canvas, rx, prog_y, rw);
+
+        // Controls
+        let ctrl_y = h - pad - 6.0;
+        let ctrl_cx = rx + rw / 2.0;
+        let icon_gap = 36.0;
+        let icon_size = 12.0;
+
+        let prev_alpha = if self.pressed == Some(MusicAction::SkipPrev) {
+            120
+        } else {
+            200
+        };
+        self.draw_skip_prev_a(canvas, ctrl_cx - icon_gap, ctrl_y, icon_size, prev_alpha);
+
+        let pp_alpha = if self.pressed == Some(MusicAction::PlayPause) {
+            120
+        } else {
+            255
+        };
+        self.draw_play_pause_a(canvas, ctrl_cx, ctrl_y, icon_size + 2.0, pp_alpha);
+
+        let next_alpha = if self.pressed == Some(MusicAction::SkipNext) {
+            120
+        } else {
+            200
+        };
+        self.draw_skip_next_a(canvas, ctrl_cx + icon_gap, ctrl_y, icon_size, next_alpha);
+    }
+
+    fn draw_minimal(&self, canvas: &Canvas, w: f32, h: f32) {
+        // 3-bar mini equalizer centered in the circle
+        let bar_count = 3;
+        let bar_w = 3.0f32;
+        let bar_gap = 2.5f32;
+        let bars_total = bar_count as f32 * bar_w + (bar_count - 1) as f32 * bar_gap;
+        let start_x = (w - bars_total) / 2.0;
+        let center_y = h / 2.0;
+        let max_h = h * 0.5;
+
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        let ac = self.accent;
+        paint.set_color(Color::from_argb(220, ac.r(), ac.g(), ac.b()));
+
+        for i in 0..bar_count {
+            let level = self.levels[i].clamp(0.1, 1.0);
+            let bar_h = level * max_h;
+            let bx = start_x + i as f32 * (bar_w + bar_gap);
+            let by = center_y - bar_h / 2.0;
+            canvas.draw_rrect(
+                RRect::new_rect_xy(Rect::from_xywh(bx, by, bar_w, bar_h), 1.0, 1.0),
+                &paint,
+            );
+        }
+    }
+
+    fn draw_equalizer_large(&self, canvas: &Canvas, x: f32, y: f32, w: f32, h: f32) {
+        let bar_w = 6.0f32;
+        let bar_gap = 4.0f32;
+        let bars_total = BAR_COUNT as f32 * bar_w + (BAR_COUNT - 1) as f32 * bar_gap;
+        let start_x = x + (w - bars_total) / 2.0;
+        let bottom = y + h;
+
+        let ac = self.accent;
+        for i in 0..BAR_COUNT {
+            let level = self.levels[i].clamp(0.08, 1.0);
+            let bar_h = level * h;
+            let bx = start_x + i as f32 * (bar_w + bar_gap);
+            let by = bottom - bar_h;
+
+            // Gradient-like effect: brighter at top
+            let alpha_top = (180.0 + level * 75.0) as u8;
+            let alpha_bot = (80.0 + level * 40.0) as u8;
+
+            // Bottom portion (dimmer)
+            let mut paint_bot = Paint::default();
+            paint_bot.set_anti_alias(true);
+            paint_bot.set_color(Color::from_argb(alpha_bot, ac.r(), ac.g(), ac.b()));
+            let bot_h = bar_h * 0.6;
+            canvas.draw_rrect(
+                RRect::new_rect_xy(Rect::from_xywh(bx, bottom - bot_h, bar_w, bot_h), 2.0, 2.0),
+                &paint_bot,
+            );
+
+            // Top portion (brighter)
+            let mut paint_top = Paint::default();
+            paint_top.set_anti_alias(true);
+            paint_top.set_color(Color::from_argb(alpha_top, ac.r(), ac.g(), ac.b()));
+            let top_h = bar_h * 0.5;
+            canvas.draw_rrect(
+                RRect::new_rect_xy(Rect::from_xywh(bx, by, bar_w, top_h), 2.0, 2.0),
+                &paint_top,
+            );
+        }
+    }
+
+    fn draw_progress_large(&self, canvas: &Canvas, x: f32, y: f32, w: f32) {
+        let h = 4.0f32;
+        let r = h / 2.0;
+
+        // Track background
+        let mut bg = Paint::default();
+        bg.set_anti_alias(true);
+        bg.set_color(Color::from_argb(50, 255, 255, 255));
+        canvas.draw_rrect(RRect::new_rect_xy(Rect::from_xywh(x, y, w, h), r, r), &bg);
+
+        // Fill
+        let fill_w = (w * self.progress).max(h);
+        let mut fg = Paint::default();
+        fg.set_anti_alias(true);
+        fg.set_color(self.accent);
+        canvas.draw_rrect(
+            RRect::new_rect_xy(Rect::from_xywh(x, y, fill_w, h), r, r),
+            &fg,
+        );
+
+        // Time labels
+        let time_y = y + h + 14.0;
+        let tf = font(9.5);
+        let mut tp = Paint::default();
+        tp.set_anti_alias(true);
+        tp.set_color(Color::from_argb(140, 200, 200, 200));
+
+        let elapsed = format_time_secs(self.progress * self.duration_secs);
+        canvas.draw_str(&elapsed, (x, time_y), &tf, &tp);
+
+        let remaining = format_time_secs((1.0 - self.progress) * self.duration_secs);
+        let neg = format!("-{remaining}");
+        let (rw, _) = tf.measure_str(&neg, None);
+        canvas.draw_str(&neg, (x + w - rw, time_y), &tf, &tp);
+    }
+
+    fn draw_art(&self, canvas: &Canvas, x: f32, y: f32, size: f32) {
+        let r = size * 0.18;
+        let dst = Rect::from_xywh(x, y, size, size);
+        if let Some(art) = &self.album_art {
+            canvas.save();
+            canvas.clip_rrect(
+                RRect::new_rect_xy(dst, r, r),
+                skia_safe::ClipOp::Intersect,
+                true,
+            );
+            let src = Rect::from_xywh(0.0, 0.0, art.width() as f32, art.height() as f32);
+            canvas.draw_image_rect(
+                art,
+                Some((&src, skia_safe::canvas::SrcRectConstraint::Strict)),
+                dst,
+                &Paint::default(),
+            );
+            canvas.restore();
+        } else {
+            let mut ph = Paint::default();
+            ph.set_anti_alias(true);
+            ph.set_color(Color::from_argb(55, 255, 255, 255));
+            canvas.draw_rrect(RRect::new_rect_xy(dst, r, r), &ph);
+            let nf = font(size * 0.42);
+            let mut np = Paint::default();
+            np.set_anti_alias(true);
+            np.set_color(Color::from_argb(130, 255, 255, 255));
+            canvas.draw_str("\u{266A}", (x + size * 0.2, y + size * 0.68), &nf, &np);
+        }
+    }
+
+    fn draw_equalizer_n(&self, canvas: &Canvas, x: f32, y: f32, w: f32, h: f32, count: usize) {
+        let bar_w = 3.0f32;
+        let bar_gap = 2.0f32;
+        let bars_total = count as f32 * bar_w + (count as f32 - 1.0) * bar_gap;
+        let start_x = x + (w - bars_total) / 2.0;
+        let center_y = y + h / 2.0;
+
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        let ac = self.accent;
+        paint.set_color(Color::from_argb(220, ac.r(), ac.g(), ac.b()));
+
+        for i in 0..count {
+            let level = self.levels[i % BAR_COUNT].clamp(0.05, 1.0);
+            let bar_h = level * h;
+            let bx = start_x + i as f32 * (bar_w + bar_gap);
+            let by = center_y - bar_h / 2.0;
+            let r = RRect::new_rect_xy(Rect::from_xywh(bx, by, bar_w, bar_h), 1.0, 1.0);
+            canvas.draw_rrect(r, &paint);
+        }
+    }
+
+    fn draw_text(canvas: &Canvas, text: &str, x: f32, y: f32, size: f32, alpha: u8, max_w: f32) {
+        let f = font_bold(size);
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::from_argb(alpha, 255, 255, 255));
+        let label = trim_to_width(text, &f, max_w.max(20.0));
+        canvas.draw_str(label, (x, y), &f, &paint);
+    }
+
+    fn draw_play_pause_a(&self, canvas: &Canvas, cx: f32, cy: f32, size: f32, alpha: u8) {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::from_argb(alpha, 255, 255, 255));
+
+        if self.is_playing {
+            let bar_w = size * 0.28;
+            let bar_h = size * 0.8;
+            let gap = size * 0.22;
+            let lx = cx - gap / 2.0 - bar_w;
+            let rx = cx + gap / 2.0;
+            let ty = cy - bar_h / 2.0;
+            canvas.draw_rect(Rect::from_xywh(lx, ty, bar_w, bar_h), &paint);
+            canvas.draw_rect(Rect::from_xywh(rx, ty, bar_w, bar_h), &paint);
+        } else {
+            let mut b = skia_safe::PathBuilder::new();
+            let h = size * 0.85;
+            let w = h * 0.866;
+            b.move_to((cx - w / 2.0, cy - h / 2.0));
+            b.line_to((cx + w / 2.0, cy));
+            b.line_to((cx - w / 2.0, cy + h / 2.0));
+            b.close();
+            canvas.draw_path(&b.detach(), &paint);
+        }
+    }
+
+    fn draw_skip_prev_a(&self, canvas: &Canvas, cx: f32, cy: f32, size: f32, alpha: u8) {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::from_argb(alpha, 255, 255, 255));
+
+        let h = size * 0.75;
+        let w = h * 0.866;
+        let bar_w = size * 0.18;
+        let tx = cx + bar_w / 2.0;
+        let mut b = skia_safe::PathBuilder::new();
+        b.move_to((tx, cy - h / 2.0));
+        b.line_to((tx - w, cy));
+        b.line_to((tx, cy + h / 2.0));
+        b.close();
+        canvas.draw_path(&b.detach(), &paint);
+        canvas.draw_rect(
+            Rect::from_xywh(cx - w - bar_w / 2.0, cy - h / 2.0, bar_w, h),
+            &paint,
+        );
+    }
+
+    fn draw_skip_next_a(&self, canvas: &Canvas, cx: f32, cy: f32, size: f32, alpha: u8) {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::from_argb(alpha, 255, 255, 255));
+
+        let h = size * 0.75;
+        let w = h * 0.866;
+        let bar_w = size * 0.18;
+        let tx = cx - bar_w / 2.0;
+        let mut b = skia_safe::PathBuilder::new();
+        b.move_to((tx, cy - h / 2.0));
+        b.line_to((tx + w, cy));
+        b.line_to((tx, cy + h / 2.0));
+        b.close();
+        canvas.draw_path(&b.detach(), &paint);
+        canvas.draw_rect(
+            Rect::from_xywh(cx + w - bar_w / 2.0, cy - h / 2.0, bar_w, h),
+            &paint,
+        );
+    }
+
+    fn draw_progress(&self, canvas: &Canvas, x: f32, y: f32, w: f32) {
+        let h = 3.0f32;
+        let r = h / 2.0;
+
+        let mut bg = Paint::default();
+        bg.set_anti_alias(true);
+        bg.set_color(Color::from_argb(60, 255, 255, 255));
+        canvas.draw_rrect(RRect::new_rect_xy(Rect::from_xywh(x, y, w, h), r, r), &bg);
+
+        let fill_w = (w * self.progress).max(h);
+        let mut fg = Paint::default();
+        fg.set_anti_alias(true);
+        fg.set_color(self.accent);
+        canvas.draw_rrect(
+            RRect::new_rect_xy(Rect::from_xywh(x, y, fill_w, h), r, r),
+            &fg,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PlaybackInfo — shared between playerctl monitor and island
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct PlaybackInfo {
+    pub track_title: String,
+    pub track_artist: String,
+    pub art_url: String,
+    pub is_playing: bool,
+    pub progress: f32,
+    pub duration_secs: f32,
+    /// MPRIS player name (e.g. "spotify", "firefox") — typically matches Wayland app_id.
+    pub player_name: String,
+    /// Every player the current track was read from. A browser publishes the
+    /// same track twice (engine + integration shim), and either name can be
+    /// the one that matches the focused window's app_id.
+    pub player_names: Vec<String>,
+}
+
+pub type SharedPlayback = Arc<Mutex<PlaybackInfo>>;
+
+// ---------------------------------------------------------------------------
+// MusicMonitor — polls playerctl + captures PipeWire audio
+// ---------------------------------------------------------------------------
+
+pub struct MusicMonitor {
+    pub playback: SharedPlayback,
+    pub audio_level: Arc<Mutex<f32>>,
+    /// Cached album art image + the URL it was loaded from
+    album_art: Option<Image>,
+    last_art_url: String,
+    accent_color: Color,
+    /// Equalizer state
+    phase: f32,
+    levels: [f32; BAR_COUNT],
+    offsets: [f32; BAR_COUNT],
+    last_track_name: String,
+    /// Grace period: when the track disappears, wait before dismissing.
+    gone_since: Option<std::time::Instant>,
+    /// Island activity ID (None when no music activity exists)
+    activity_id: Option<u64>,
+}
+
+impl MusicMonitor {
+    pub fn new(playback: SharedPlayback, audio_level: Arc<Mutex<f32>>) -> Self {
+        Self {
+            playback,
+            audio_level,
+            album_art: None,
+            last_art_url: String::new(),
+            accent_color: Color::from_rgb(180, 180, 180),
+            phase: 0.0,
+            levels: [0.12; BAR_COUNT],
+            offsets: [0.0; BAR_COUNT],
+            last_track_name: String::new(),
+            activity_id: None,
+            gone_since: None,
+        }
+    }
+
+    /// Tick the music monitor. Returns a renderer if music is playing.
+    pub fn tick(&mut self) -> Option<MusicActivityRenderer> {
+        let info = self.playback.lock().ok()?.clone();
+
+        // Update album art if URL changed
+        if info.art_url != self.last_art_url {
+            self.last_art_url = info.art_url.clone();
+            self.album_art = load_album_art(&info.art_url);
+            if let Some(art) = &self.album_art {
+                self.accent_color = extract_accent_color(art);
+            } else {
+                self.accent_color = Color::from_rgb(180, 180, 180);
+            }
+        }
+
+        // Update equalizer
+        self.phase += if info.is_playing { 0.35 } else { 0.08 };
+        let base_level = self
+            .audio_level
+            .lock()
+            .map(|v| *v)
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        let playing_gain = if info.is_playing { 1.4 } else { 0.35 };
+        let envelope = (base_level * playing_gain).clamp(0.0, 1.0);
+
+        // Spread frequencies widely so each bar moves independently.
+        const FREQ: [f32; BAR_COUNT] = [0.6, 1.1, 0.8, 1.4, 0.5, 1.25, 0.7, 1.0];
+
+        for i in 0..BAR_COUNT {
+            let wave = ((self.phase * FREQ[i] + self.offsets[i]).sin() * 0.5) + 0.5;
+            // Minimum idle shimmer so bars are never invisible.
+            let idle = if info.is_playing {
+                0.08 + wave * 0.07
+            } else {
+                0.03 + wave * 0.03
+            };
+            // Volume-driven height — scales with actual audio level.
+            let driven = envelope * (0.4 + wave * 0.5);
+            let target = (idle + driven).clamp(0.0, 1.0);
+            let current = self.levels[i];
+            // Smooth heavily for 5fps — ease toward target.
+            self.levels[i] =
+                current + (target - current) * if target > current { 0.45 } else { 0.30 };
+        }
+
+        if info.track_title != self.last_track_name {
+            self.offsets = track_offsets(&info.track_title);
+            self.last_track_name = info.track_title.clone();
+        }
+
+        // Keep island visible as long as there's a real track loaded.
+        let has_track = !info.track_title.is_empty() && info.track_title != NO_MEDIA;
+        if has_track {
+            Some(MusicActivityRenderer {
+                title: info.track_title,
+                artist: info.track_artist,
+                album_art: self.album_art.clone(),
+                is_playing: info.is_playing,
+                progress: info.progress,
+                duration_secs: info.duration_secs,
+                accent: self.accent_color,
+                levels: self.levels,
+                pressed: None,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Check whether the music player app is currently focused.
+    fn is_music_app_focused(&self) -> bool {
+        let focused = otto_kit::utils::focus_watcher::current_focused_app();
+        if focused.app_id.is_empty() {
+            return false;
+        }
+        if let Ok(info) = self.playback.lock() {
+            // MPRIS player names and Wayland app_ids typically match
+            // (e.g. "spotify", "firefox"). Compare case-insensitively, against
+            // every player the track was read from — for a browser the app_id
+            // matches the engine player, not the integration shim.
+            info.player_names
+                .iter()
+                .any(|name| !name.is_empty() && focused.app_id.eq_ignore_ascii_case(name))
+        } else {
+            false
+        }
+    }
+
+    /// Sync with the island state: create/update/dismiss the music activity.
+    /// The island is shown when the music player loses focus and hidden when
+    /// it gains focus. Uses a 3-second grace period before dismissing to
+    /// survive track changes.
+    pub fn sync_to_island(&mut self, state: &SharedState) {
+        let renderer = self.tick();
+        let music_app_focused = self.is_music_app_focused();
+
+        let mut island = state.lock().unwrap();
+        match (&renderer, self.activity_id) {
+            (Some(_renderer), None) => {
+                if music_app_focused {
+                    // Music app is focused — don't show the island yet.
+                    return;
+                }
+                // Music playing and app not focused — create activity
+                let id = island.create_activity(
+                    MUSIC_APP_ID.to_string(),
+                    "Now Playing".to_string(),
+                    "audio-headphones".to_string(),
+                    None,
+                    0, // persistent
+                    crate::activity::Priority::Normal,
+                    true, // live
+                );
+                // Mark as Internal so the island system recognizes it as music.
+                if let Some(a) = island.activities.iter_mut().find(|a| a.id == id) {
+                    a.source = crate::activity::ActivitySource::Internal;
+                }
+                self.activity_id = Some(id);
+                self.gone_since = None;
+            }
+            (Some(_renderer), Some(id)) => {
+                if music_app_focused {
+                    // Music app gained focus — dismiss the island.
+                    island.dismiss_activity(id);
+                    self.activity_id = None;
+                    self.gone_since = None;
+                    return;
+                }
+                // Music still playing, app not focused — update title
+                self.gone_since = None;
+                if let Ok(info) = self.playback.lock() {
+                    island.update_activity(id, &info.track_title, -1.0);
+                }
+            }
+            (None, Some(id)) => {
+                // Track gone — start or check grace period.
+                let now = std::time::Instant::now();
+                match self.gone_since {
+                    None => {
+                        self.gone_since = Some(now);
+                    }
+                    Some(since) if now.duration_since(since).as_secs_f64() >= 3.0 => {
+                        island.dismiss_activity(id);
+                        self.activity_id = None;
+                        self.gone_since = None;
+                    }
+                    _ => {} // still within grace period
+                }
+            }
+            (None, None) => {
+                self.gone_since = None;
+            }
+        }
+    }
+
+    /// Get a renderer for the current state (if music is playing).
+    pub fn renderer(&self) -> Option<MusicActivityRenderer> {
+        let info = self.playback.lock().ok()?.clone();
+        let has_track = !info.track_title.is_empty() && info.track_title != NO_MEDIA;
+        if !has_track {
+            return None;
+        }
+        Some(MusicActivityRenderer {
+            title: info.track_title,
+            artist: info.track_artist,
+            album_art: self.album_art.clone(),
+            is_playing: info.is_playing,
+            progress: info.progress,
+            duration_secs: info.duration_secs,
+            accent: self.accent_color,
+            levels: self.levels,
+            pressed: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background threads
+// ---------------------------------------------------------------------------
+
+/// Field separator for the `playerctl` format string. ASCII unit separator, so
+/// it cannot collide with a track title.
+const FIELD_SEP: char = '\u{1f}';
+
+/// One MPRIS player as reported by `playerctl --all-players`.
+#[derive(Debug, Clone, Default, PartialEq)]
+struct PlayerEntry {
+    name: String,
+    status: String,
+    title: String,
+    artist: String,
+    art_url: String,
+    position: f64,
+    length: f64,
+}
+
+impl PlayerEntry {
+    fn parse(line: &str) -> Option<Self> {
+        let f: Vec<&str> = line.split(FIELD_SEP).collect();
+        if f.len() < 7 {
+            return None;
+        }
+        Some(Self {
+            name: f[0].to_string(),
+            status: f[1].to_string(),
+            title: f[2].to_string(),
+            artist: f[3].to_string(),
+            art_url: f[4].to_string(),
+            position: f[5].parse().unwrap_or(0.0),
+            length: f[6].parse().unwrap_or(0.0),
+        })
+    }
+
+    fn is_playing(&self) -> bool {
+        self.status.eq_ignore_ascii_case("playing")
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.status.eq_ignore_ascii_case("stopped")
+    }
+
+    /// How much of the track this player actually describes. Browsers publish
+    /// the same track from two players: the engine (title only, everything
+    /// mashed into one string) and an integration shim that carries the art and
+    /// a separate artist. The richer one is the one worth showing.
+    fn richness(&self) -> u8 {
+        u8::from(!self.art_url.is_empty()) * 2
+            + u8::from(!self.artist.is_empty())
+            + u8::from(!self.title.is_empty())
+    }
+}
+
+/// Pick the player to display, merging duplicate entries for the same track.
+///
+/// `playerctl` without `--player` picks whichever player sorts first, which for
+/// a browser is the metadata-poor engine player — that is why album art went
+/// missing. Prefer a playing player, then the one describing the track best,
+/// then fill any gaps from the other entries for the same track.
+fn select_player(entries: Vec<PlayerEntry>) -> Option<PlayerEntry> {
+    let mut candidates: Vec<PlayerEntry> = if entries.iter().any(|e| e.is_playing()) {
+        entries.into_iter().filter(|e| e.is_playing()).collect()
+    } else {
+        entries
+    };
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let best_idx = candidates
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, e)| e.richness())
+        .map(|(i, _)| i)?;
+    let mut best = candidates.swap_remove(best_idx);
+    let mut names = vec![best.name.clone()];
+
+    for other in candidates {
+        // Same duration means the same track, published twice.
+        if other.length != best.length || best.length == 0.0 {
+            continue;
+        }
+        if best.title.is_empty() {
+            best.title = other.title.clone();
+        }
+        if best.artist.is_empty() {
+            best.artist = other.artist.clone();
+        }
+        if best.art_url.is_empty() {
+            best.art_url = other.art_url.clone();
+        }
+        // The shim's position often does not advance; trust whichever is ahead.
+        best.position = best.position.max(other.position);
+        names.push(other.name);
+    }
+
+    best.name = names.join(",");
+    Some(best)
+}
+
+pub fn start_playerctl_monitor() -> SharedPlayback {
+    let shared = Arc::new(Mutex::new(PlaybackInfo {
+        track_title: NO_MEDIA.to_string(),
+        track_artist: String::new(),
+        art_url: String::new(),
+        is_playing: false,
+        progress: 0.0,
+        duration_secs: 0.0,
+        player_name: String::new(),
+        player_names: Vec::new(),
+    }));
+    let shared_for_thread = shared.clone();
+
+    let format = format!(
+        "{{{{playerName}}}}{s}{{{{status}}}}{s}{{{{title}}}}{s}{{{{artist}}}}{s}\
+         {{{{mpris:artUrl}}}}{s}{{{{position}}}}{s}{{{{mpris:length}}}}",
+        s = FIELD_SEP
+    );
+
+    thread::spawn(move || loop {
+        // Single playerctl call covering every player's metadata + status.
+        let output = Command::new("playerctl")
+            .args(["--all-players", "metadata", "--format", &format])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string());
+
+        let selected = output.as_deref().and_then(|out| {
+            select_player(
+                out.lines()
+                    .filter_map(PlayerEntry::parse)
+                    .collect::<Vec<_>>(),
+            )
+        });
+
+        // The island's event loop is fully retained — it sleeps until something
+        // wakes it. Nothing else knows a track appeared, changed or stopped, so
+        // this thread has to. Waking only on change keeps an idle desktop with
+        // no player asleep.
+        let mut wake = false;
+
+        if let Some(entry) = selected {
+            // When status is "Stopped", report "No media" so the island is
+            // dismissed after the grace period. Paused tracks keep their title.
+            let track_title = if entry.is_stopped() || entry.title.is_empty() {
+                NO_MEDIA.to_string()
+            } else {
+                entry.title.clone()
+            };
+            let length = if entry.length > 0.0 {
+                entry.length
+            } else {
+                1.0
+            };
+            let progress = (entry.position / length).clamp(0.0, 1.0) as f32;
+            let is_playing = entry.is_playing();
+
+            if let Ok(mut info) = shared_for_thread.lock() {
+                // A live track keeps the island's clock and progress bar moving,
+                // so keep waking while one is loaded, not only on change.
+                wake = info.track_title != track_title
+                    || info.track_artist != entry.artist
+                    || info.art_url != entry.art_url
+                    || info.is_playing != is_playing
+                    || track_title != NO_MEDIA;
+                info.track_title = track_title;
+                info.track_artist = entry.artist;
+                info.art_url = entry.art_url;
+                info.is_playing = is_playing;
+                info.progress = progress;
+                info.duration_secs = (length / 1_000_000.0) as f32;
+                info.player_names = entry.name.split(',').map(str::to_string).collect();
+                info.player_name = entry.name;
+            }
+        } else if let Ok(mut info) = shared_for_thread.lock() {
+            // playerctl failed — no player running. Clear track info so the
+            // island is dismissed after the grace period.
+            wake = info.track_title != NO_MEDIA;
+            info.is_playing = false;
+            info.track_title = NO_MEDIA.to_string();
+            info.track_artist.clear();
+            info.player_name.clear();
+            info.player_names.clear();
+        }
+
+        if wake {
+            AppContext::request_wakeup();
+        }
+        thread::sleep(Duration::from_millis(1500));
+    });
+
+    shared
+}
+
+pub fn start_pipewire_level_monitor() -> Arc<Mutex<f32>> {
+    let shared_level = Arc::new(Mutex::new(0.0f32));
+    let level_for_thread = shared_level.clone();
+
+    thread::spawn(move || {
+        if let Err(err) = run_pipewire_level_loop(level_for_thread) {
+            tracing::error!("PipeWire level monitor failed: {err}");
+        }
+    });
+
+    shared_level
+}
+
+fn run_pipewire_level_loop(shared_level: Arc<Mutex<f32>>) -> Result<(), pipewire::Error> {
+    use pipewire as pw;
+    use pw::properties::properties;
+    use pw::spa;
+    use spa::param::format::{MediaSubtype, MediaType};
+    use spa::param::format_utils;
+    use spa::pod::Pod;
+
+    pw::init();
+
+    let mainloop = pw::main_loop::MainLoopRc::new(None)?;
+    let context = pw::context::ContextRc::new(&mainloop, None)?;
+    let core = context.connect_rc(None)?;
+
+    struct UserData {
+        channels: u32,
+        level: Arc<Mutex<f32>>,
+        skip_count: u32,
+    }
+
+    let user_data = UserData {
+        channels: 2,
+        level: shared_level,
+        skip_count: 0,
+    };
+
+    let stream = pw::stream::StreamBox::new(
+        &core,
+        "otto-islands-audio-capture",
+        properties! {
+            *pw::keys::MEDIA_TYPE => "Audio",
+            *pw::keys::MEDIA_CATEGORY => "Capture",
+            *pw::keys::MEDIA_ROLE => "Music",
+            *pw::keys::STREAM_CAPTURE_SINK => "true",
+        },
+    )?;
+
+    let _listener = stream
+        .add_local_listener_with_user_data(user_data)
+        .param_changed(|_, user_data, id, param| {
+            let Some(param) = param else { return };
+            if id != pw::spa::param::ParamType::Format.as_raw() {
+                return;
+            }
+            let Ok((media_type, media_subtype)) = format_utils::parse_format(param) else {
+                return;
+            };
+            if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
+                return;
+            }
+            let mut audio_info = spa::param::audio::AudioInfoRaw::default();
+            if audio_info.parse(param).is_ok() {
+                user_data.channels = audio_info.channels().max(1);
+            }
+        })
+        .process(|stream, user_data| {
+            let Some(mut buffer) = stream.dequeue_buffer() else {
+                return;
+            };
+            // Skip computation on throttled frames — only process every 6th buffer.
+            user_data.skip_count += 1;
+            if user_data.skip_count < 6 {
+                return;
+            }
+            user_data.skip_count = 0;
+
+            let datas = buffer.datas_mut();
+            if datas.is_empty() {
+                return;
+            }
+            let data = &mut datas[0];
+            let n_channels = user_data.channels.max(1) as usize;
+            let chunk = data.chunk();
+            let chunk_offset = chunk.offset() as usize;
+            let chunk_size = chunk.size() as usize;
+            let Some(samples) = data.data() else { return };
+            let start = chunk_offset;
+            let end = start.saturating_add(chunk_size).min(samples.len());
+            if end <= start {
+                return;
+            }
+            let bytes = &samples[start..end];
+            let sample_count = bytes.len() / std::mem::size_of::<f32>();
+            if sample_count == 0 {
+                return;
+            }
+            let mut peak = 0.0f32;
+            let mut sum_sq = 0.0f32;
+            let mut seen = 0usize;
+            for n in (0..sample_count).step_by(n_channels) {
+                let s = n * std::mem::size_of::<f32>();
+                let e = s + std::mem::size_of::<f32>();
+                if e > bytes.len() {
+                    break;
+                }
+                let val =
+                    f32::from_le_bytes([bytes[s], bytes[s + 1], bytes[s + 2], bytes[s + 3]]).abs();
+                peak = peak.max(val);
+                sum_sq += val * val;
+                seen += 1;
+            }
+            if seen == 0 {
+                return;
+            }
+            let rms = (sum_sq / seen as f32).sqrt();
+            let normalized = (peak * 1.35 + rms * 0.65).clamp(0.0, 1.0);
+            if let Ok(mut level) = user_data.level.lock() {
+                *level = normalized;
+            }
+        })
+        .register()?;
+
+    let mut audio_info = spa::param::audio::AudioInfoRaw::new();
+    audio_info.set_format(spa::param::audio::AudioFormat::F32LE);
+    let obj = spa::pod::Object {
+        type_: spa::utils::SpaTypes::ObjectParamFormat.as_raw(),
+        id: spa::param::ParamType::EnumFormat.as_raw(),
+        properties: audio_info.into(),
+    };
+    let values: Vec<u8> = spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &spa::pod::Value::Object(obj),
+    )
+    .unwrap()
+    .0
+    .into_inner();
+    let mut params = [Pod::from_bytes(&values).unwrap()];
+
+    let target_object = std::env::var("OTTO_ISLANDS_PW_TARGET")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .or_else(detect_default_sink_node_id);
+
+    stream.connect(
+        spa::utils::Direction::Input,
+        target_object,
+        pw::stream::StreamFlags::AUTOCONNECT
+            | pw::stream::StreamFlags::MAP_BUFFERS
+            | pw::stream::StreamFlags::RT_PROCESS,
+        &mut params,
+    )?;
+
+    mainloop.run();
+    Ok(())
+}
+
+fn detect_default_sink_node_id() -> Option<u32> {
+    let output = Command::new("wpctl")
+        .args(["inspect", "@DEFAULT_AUDIO_SINK@"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let first_line = text.lines().next()?.trim();
+    let id_token = first_line
+        .strip_prefix("id ")?
+        .split(',')
+        .next()
+        .map(str::trim)?;
+    id_token.parse::<u32>().ok()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Execute a music player action via playerctl.
+pub fn execute_action(action: MusicAction) {
+    match action {
+        MusicAction::Seek(frac) => {
+            thread::spawn(move || {
+                // Get track length, compute absolute position, seek.
+                let length = Command::new("playerctl")
+                    .args(["metadata", "mpris:length"])
+                    .output()
+                    .ok()
+                    .filter(|o| o.status.success())
+                    .and_then(|o| {
+                        String::from_utf8_lossy(&o.stdout)
+                            .trim()
+                            .parse::<f64>()
+                            .ok()
+                    })
+                    .unwrap_or(0.0);
+                if length > 0.0 {
+                    // length is in microseconds; playerctl position takes seconds.
+                    let secs = frac as f64 * length / 1_000_000.0;
+                    let _ = Command::new("playerctl")
+                        .args(["position", &format!("{secs:.1}")])
+                        .status();
+                }
+            });
+        }
+        action => {
+            let arg = match action {
+                MusicAction::PlayPause => "play-pause",
+                MusicAction::SkipNext => "next",
+                MusicAction::SkipPrev => "previous",
+                MusicAction::Seek(_) => unreachable!(),
+            };
+            thread::spawn(move || {
+                let _ = Command::new("playerctl").arg(arg).status();
+            });
+        }
+    }
+}
+
+fn font(size: f32) -> skia_safe::Font {
+    TextStyle {
+        family: "Inter",
+        weight: 400,
+        size,
+    }
+    .font()
+}
+
+fn font_bold(size: f32) -> skia_safe::Font {
+    TextStyle {
+        family: "Inter",
+        weight: 600,
+        size,
+    }
+    .font()
+}
+
+/// Decode `%XX` escapes in a URL path. MPRIS `file://` art URLs are proper
+/// URLs, so any path with a space or a non-ASCII character (accented artist
+/// names, for instance) arrives percent-encoded and must be decoded before it
+/// can be opened.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3])
+                .ok()
+                .and_then(|h| u8::from_str_radix(h, 16).ok());
+            if let Some(byte) = hex {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Extract the filesystem path from a `file://` URL, decoding percent escapes.
+/// Accepts both `file:///path` and `file://localhost/path`.
+fn file_url_to_path(url: &str) -> Option<String> {
+    let rest = url.strip_prefix("file://")?;
+    let path = rest.strip_prefix("localhost").unwrap_or(rest);
+    if !path.starts_with('/') {
+        return None;
+    }
+    Some(percent_decode(path))
+}
+
+fn load_album_art(url: &str) -> Option<Image> {
+    if url.is_empty() {
+        return None;
+    }
+
+    let bytes = if url.starts_with("file://") {
+        let path = file_url_to_path(url)?;
+        match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                tracing::warn!(path, error = %e, "failed to read album art");
+                return None;
+            }
+        }
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        // Bounded: this runs on the island's update thread, so an unreachable
+        // host must not stall the UI.
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .build()
+            .new_agent();
+        match agent.get(url).call() {
+            Ok(resp) => resp.into_body().read_to_vec().ok()?,
+            Err(e) => {
+                tracing::warn!(url, error = %e, "failed to fetch album art");
+                return None;
+            }
+        }
+    } else {
+        tracing::warn!(url, "unsupported album art URL scheme");
+        return None;
+    };
+
+    let data = Data::new_copy(&bytes);
+    Image::from_encoded(data)
+}
+
+fn trim_to_width<'a>(text: &'a str, font: &skia_safe::Font, max_width: f32) -> &'a str {
+    let (width, _) = font.measure_str(text, None);
+    if width <= max_width {
+        return text;
+    }
+    // Find the longest prefix that fits (byte-boundary safe)
+    for end in (1..text.len()).rev() {
+        if !text.is_char_boundary(end) {
+            continue;
+        }
+        let sub = &text[..end];
+        let (w, _) = font.measure_str(sub, None);
+        if w <= max_width {
+            return sub;
+        }
+    }
+    ""
+}
+
+fn format_time_secs(total_secs: f32) -> String {
+    let secs = total_secs.max(0.0) as u32;
+    format!("{}:{:02}", secs / 60, secs % 60)
+}
+
+fn track_offsets(track: &str) -> [f32; BAR_COUNT] {
+    let mut hash: u32 = 2166136261;
+    for b in track.bytes() {
+        hash ^= b as u32;
+        hash = hash.wrapping_mul(16777619);
+    }
+    let mut out = [0.0f32; BAR_COUNT];
+    for item in out.iter_mut() {
+        let normalized = (hash & 0xFFFF) as f32 / 65535.0;
+        hash = hash.wrapping_mul(1664525).wrapping_add(1013904223);
+        *item = normalized * std::f32::consts::TAU;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(name: &str, status: &str, title: &str, artist: &str, art: &str, len: &str) -> String {
+        format!("{name}\u{1f}{status}\u{1f}{title}\u{1f}{artist}\u{1f}{art}\u{1f}0\u{1f}{len}")
+    }
+
+    #[test]
+    fn percent_escapes_are_decoded() {
+        assert_eq!(
+            file_url_to_path("file:///home/u/art%20dir/Beyonc%C3%A9.png").as_deref(),
+            Some("/home/u/art dir/Beyoncé.png")
+        );
+        assert_eq!(
+            file_url_to_path("file://localhost/tmp/cover.png").as_deref(),
+            Some("/tmp/cover.png")
+        );
+        assert_eq!(file_url_to_path("https://example.com/a.png"), None);
+    }
+
+    #[test]
+    fn browser_duplicate_players_are_merged() {
+        // Chromium publishes the track twice: the engine player has no art and
+        // no artist, the integration shim has both.
+        let entries = vec![
+            PlayerEntry::parse(&line(
+                "chromium",
+                "Playing",
+                "On Hold • The xx",
+                "",
+                "",
+                "224179773",
+            ))
+            .unwrap(),
+            PlayerEntry::parse(&line(
+                "plasma-browser-integration",
+                "Playing",
+                "On Hold",
+                "The xx",
+                "file:///tmp/art.png",
+                "224179773",
+            ))
+            .unwrap(),
+        ];
+        let picked = select_player(entries).unwrap();
+        assert_eq!(picked.art_url, "file:///tmp/art.png");
+        assert_eq!(picked.artist, "The xx");
+        assert_eq!(picked.title, "On Hold");
+        assert_eq!(picked.name, "plasma-browser-integration,chromium");
+    }
+
+    #[test]
+    fn playing_player_wins_over_paused() {
+        let entries = vec![
+            PlayerEntry::parse(&line("vlc", "Paused", "Old", "A", "file:///a.png", "100")).unwrap(),
+            PlayerEntry::parse(&line("spotify", "Playing", "New", "B", "", "200")).unwrap(),
+        ];
+        let picked = select_player(entries).unwrap();
+        assert_eq!(picked.title, "New");
+        assert_eq!(picked.name, "spotify");
+    }
+
+    #[test]
+    fn unrelated_tracks_are_not_merged() {
+        let entries = vec![
+            PlayerEntry::parse(&line("a", "Playing", "One", "", "", "100")).unwrap(),
+            PlayerEntry::parse(&line("b", "Playing", "Two", "X", "file:///b.png", "999")).unwrap(),
+        ];
+        let picked = select_player(entries).unwrap();
+        assert_eq!(picked.title, "Two");
+        assert_eq!(picked.name, "b");
+    }
+}

--- a/components/otto-kit/src/utils/focus_watcher.rs
+++ b/components/otto-kit/src/utils/focus_watcher.rs
@@ -1,0 +1,214 @@
+//! Foreign toplevel focus tracker.
+//!
+//! Spawns a background thread with its own Wayland connection that binds
+//! `zwlr_foreign_toplevel_manager_v1` and watches for activated state changes.
+//! The focused app's title and app_id are stored in a global `Mutex` for the
+//! main thread to read.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+
+use wayland_client::{protocol::wl_registry, Connection, Dispatch, Proxy, QueueHandle};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::{
+    zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1},
+    zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+};
+
+/// Info about the currently focused (activated) toplevel.
+#[derive(Clone, Debug, Default)]
+pub struct FocusedApp {
+    pub app_id: String,
+    pub title: String,
+}
+
+/// Global state: the currently focused app.
+static FOCUSED_APP: LazyLock<Mutex<FocusedApp>> =
+    LazyLock::new(|| Mutex::new(FocusedApp::default()));
+
+/// Generation counter — bumped on every focus change.
+static FOCUS_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Read the current focused app info.
+pub fn current_focused_app() -> FocusedApp {
+    FOCUSED_APP.lock().unwrap().clone()
+}
+
+/// Read the generation counter.
+pub fn generation() -> u64 {
+    FOCUS_GENERATION.load(Ordering::Relaxed)
+}
+
+/// Spawn the focus watcher on a background thread.
+pub fn spawn_focus_watcher() {
+    std::thread::spawn(|| {
+        if let Err(e) = run_watcher() {
+            tracing::warn!("focus watcher stopped: {e}");
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Internal Wayland client state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct ToplevelInfo {
+    app_id: Option<String>,
+    title: Option<String>,
+    activated: bool,
+}
+
+struct FocusState {
+    toplevels: std::collections::HashMap<u32, ToplevelInfo>,
+}
+
+impl FocusState {
+    fn new() -> Self {
+        Self {
+            toplevels: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Called after a `done` event — check if activated state changed globally.
+    fn update_focused(&self) {
+        let focused = self.toplevels.values().find(|t| t.activated);
+
+        let app = match focused {
+            Some(t) => FocusedApp {
+                app_id: t.app_id.clone().unwrap_or_default(),
+                title: t.title.clone().unwrap_or_default(),
+            },
+            None => FocusedApp::default(),
+        };
+
+        let mut current = FOCUSED_APP.lock().unwrap();
+        if current.app_id != app.app_id || current.title != app.title {
+            *current = app;
+            FOCUS_GENERATION.fetch_add(1, Ordering::Relaxed);
+            crate::AppContext::request_wakeup();
+        }
+    }
+}
+
+// --- Registry dispatch ---
+
+impl Dispatch<wl_registry::WlRegistry, ()> for FocusState {
+    fn event(
+        _state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            if interface == "zwlr_foreign_toplevel_manager_v1" {
+                registry.bind::<ZwlrForeignToplevelManagerV1, _, _>(name, version.min(3), qh, ());
+            }
+        }
+    }
+}
+
+// --- Manager dispatch ---
+
+impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for FocusState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZwlrForeignToplevelManagerV1,
+        event: zwlr_foreign_toplevel_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_foreign_toplevel_manager_v1::Event::Toplevel { toplevel } => {
+                let id = toplevel.id().protocol_id();
+                _state.toplevels.insert(
+                    id,
+                    ToplevelInfo {
+                        app_id: None,
+                        title: None,
+                        activated: false,
+                    },
+                );
+            }
+            zwlr_foreign_toplevel_manager_v1::Event::Finished => {}
+            _ => {}
+        }
+    }
+
+    wayland_client::event_created_child!(FocusState, ZwlrForeignToplevelManagerV1, [
+        0 => (ZwlrForeignToplevelHandleV1, ())
+    ]);
+}
+
+// --- Handle dispatch ---
+
+impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for FocusState {
+    fn event(
+        state: &mut Self,
+        proxy: &ZwlrForeignToplevelHandleV1,
+        event: zwlr_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        let id = proxy.id().protocol_id();
+        match event {
+            zwlr_foreign_toplevel_handle_v1::Event::Title { title } => {
+                if let Some(info) = state.toplevels.get_mut(&id) {
+                    info.title = Some(title);
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
+                if let Some(info) = state.toplevels.get_mut(&id) {
+                    info.app_id = Some(app_id);
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::State { state: raw_state } => {
+                if let Some(info) = state.toplevels.get_mut(&id) {
+                    let activated = raw_state.chunks_exact(4).any(|chunk| {
+                        let val = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                        val == zwlr_foreign_toplevel_handle_v1::State::Activated as u32
+                    });
+                    info.activated = activated;
+
+                    if activated {
+                        for (&other_id, other) in state.toplevels.iter_mut() {
+                            if other_id != id {
+                                other.activated = false;
+                            }
+                        }
+                    }
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::Done => {
+                state.update_focused();
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::Closed => {
+                if state.toplevels.remove(&id).is_some() {
+                    state.update_focused();
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn run_watcher() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = Connection::connect_to_env()?;
+    let display = conn.display();
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+    let _registry = display.get_registry(&qh, ());
+    let mut state = FocusState::new();
+
+    loop {
+        event_queue.blocking_dispatch(&mut state)?;
+    }
+}

--- a/components/otto-kit/src/utils/mod.rs
+++ b/components/otto-kit/src/utils/mod.rs
@@ -1,4 +1,8 @@
 //! Utility functions for otto-kit.
 
 pub mod color_extraction;
+pub mod focus_watcher;
 pub use color_extraction::extract_accent_color;
+pub use focus_watcher::{
+    current_focused_app, generation as focus_generation, spawn_focus_watcher, FocusedApp,
+};

--- a/specs/dynamic-island.md
+++ b/specs/dynamic-island.md
@@ -159,6 +159,13 @@ When music is playing (detected via `playerctl`), the island automatically creat
 
 Album art accent color is extracted and used for equalizer bars and progress fill.
 
+Art comes from the MPRIS `mpris:artUrl` field, which is a URL, not a path:
+- `file://` (optionally `file://localhost/`) — percent escapes are decoded before
+  the file is opened, so paths with spaces or non-ASCII characters still load.
+- `http://` / `https://` — fetched with a bounded timeout so an unreachable host
+  cannot stall the island's update thread.
+- Anything else is logged and falls back to the ♪ placeholder.
+
 ### Positioning
 
 - The layer shell surface is anchored to `Top` with a small margin (matching topbar).

--- a/specs/notification-island.md
+++ b/specs/notification-island.md
@@ -154,6 +154,12 @@ Music is another island in the same row. It follows the same Mini/Compact/Expand
 - When a notification group is clicked to Compact, music shrinks to Mini.
 - Music Mini: 3-bar equalizer in a circle.
 - Music Compact: album art + title + artist + equalizer.
+- Music Expanded: a card pinned to the top of the layer (y = 0) that grows
+  downward. It is never centred on `BAR_HEIGHT` — `COMPACT_H` is taller than the
+  bar, so centring puts the top of the panel above the layer, where it is clipped.
+- The equalizer is a child subsurface of the music pill, redrawn at ~24fps while
+  a track plays. It animates with the pill rather than snapping to its target, so
+  the bars stay inside the pill for the whole transition.
 
 ## D-Bus Integration
 


### PR DESCRIPTION
Ports the music activity from #87 onto the current island code, so it sits on top of the retained-mode rendering and the portal dialog that landed on main since that branch forked. #87 cannot be merged as-is: it is 26 commits behind and both sides rewrote `layout()`, `update_layer_size`, `on_update` and the pointer handling.

## What's here

- **Music activity** — MPRIS metadata and transport via `playerctl`, audio levels via PipeWire, album art with an extracted accent colour. Mini / Compact / Expanded like any other island.
- **Equalizer on its own child subsurface**, redrawn at ~24fps while a track plays so the retained pill buffer is untouched. It animates *with* the pill; snapping it to its target left the bars outside the pill for the length of the expand animation. The pill sets `masks_to_bounds`, so the compositor clips it.
- **Album art actually loads.** `mpris:artUrl` is a URL, not a path:
  - `file://` (and `file://localhost/`) is percent-decoded — art under a path with a space or an accented character silently failed before;
  - `http(s)` is fetched with a 5s timeout so an unreachable host can't stall the update thread.
- **Player selection.** A browser publishes the same track twice: the engine player (`chromium`) has no `mpris:artUrl` and mashes the artist into the title, while the integration player next to it carries art, artist and album. Bare `playerctl` picks the first one, which is why covers were missing with Spotify in a browser. Every player is now queried in one call, a playing one is preferred, the richest entry wins and entries for the same track are merged.
- **Expanded panel pinned to the top** of the layer. It is taller than `BAR_HEIGHT`, so centring it there put its top edge above the layer, where it was clipped off-screen.
- **Stays retained-mode.** The monitor thread wakes the loop on change instead of adding a periodic tick, so a desktop with no player is still fully idle.

## Verified

Built and run against a live session on hardware (`--release`, installed as `/usr/local/bin/otto-islands-music`):

- Cover art loads from a percent-encoded `file://` path and from Spotify's `https://i.scdn.co/...`, with the accent colour picked up by the equalizer.
- Expanded panel is fully on screen, corners and all; transport controls and seek respond.
- Notification island and music island coexist side by side; a notification peeks Compact without shrinking music.
- Clicks pass through to otto-bar where there is no island (tray menus open normally).
- `cargo test -p otto-islands` green, including 4 new tests for the player picker and URL decoding; `cargo clippy` adds no new warnings.

Not exercised: the portal Access dialog, which this does not touch.