### PR TITLE
fix(lock): lock screen buttons are not clickable

### DIFF
--- a/specs/lock-screen.md
+++ b/specs/lock-screen.md
@@ -89,7 +89,10 @@ user. Any other `ext-session-lock-v1` client works too.
   An output whose lock surface is destroyed reverts to the blank.
 - Keyboard focus goes to the lock surface of the output that has pointer focus,
   and follows the pointer between outputs. Pointer and touch events go only to
-  lock surfaces.
+  lock surfaces, and arrive surface-local — a lock surface covers its output, so
+  the pointer's position within it is the position on that output. A locker lays
+  its controls out in that space and would otherwise be unable to tell where a
+  click landed.
 - The cursor is drawn from the locker's own cursor surface, or Otto's default if
   it sets none.
 

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -318,16 +318,22 @@ impl<BackendData: Backend> Otto<BackendData> {
         // when this output has no lock surface is deliberate: the click must
         // land nowhere rather than fall through to the desktop.
         if self.is_session_locked() {
+            // The offset is where the surface *is*, not where the pointer is
+            // inside it: Smithay subtracts it from the event location to get
+            // surface-local coordinates. A lock surface covers its output, so
+            // that is the output's origin — passing the local point instead
+            // made every click arrive at (0, 0) and miss every control.
             let origin = self
                 .workspaces
                 .output_geometry(output)
                 .map(|g| g.loc)
                 .unwrap_or_default();
-            let local =
-                Point::<f64, Logical>::from((pos.x - origin.x as f64, pos.y - origin.y as f64));
-            return self
-                .lock_surface_for_output(output)
-                .map(|surface| (PointerFocusTarget::from(surface), local));
+            return self.lock_surface_for_output(output).map(|surface| {
+                (
+                    PointerFocusTarget::from(surface),
+                    Point::<f64, Logical>::from((origin.x as f64, origin.y as f64)),
+                )
+            });
         }
 
         // App switcher check


### PR DESCRIPTION
## What was broken

On the lock screen, the panel's controls (suspend / restart / shut down / "use
password") did nothing. The greeter's identical panel worked, because the
greeter is an ordinary client.

## Cause

`Otto::surface_under` (src/input/pointer.rs) returns `(focus_target, offset)`,
where the offset is the surface's **global position** — Smithay subtracts it
from the event location to get surface-local coordinates. Every other branch
returns a position; the locked-session branch returned the pointer's position
*within* the output instead. On a single output at the scene origin that made
the delivered surface-local coordinate `pos - pos == (0, 0)`, so every press
otto-lock saw was at the top-left corner and hit no control. Keyboard input was
unaffected, which is why typing a password still worked.

## Fix

Return the output's origin as the offset, matching the workspace-selector branch
just below it.

## Verification

`cargo fmt --all` and `cargo clippy --features "default" -- -D warnings` pass.
I could not lock the screen and click the buttons myself from this environment —
not visually verified.

Installed for hardware testing as the session **Otto (PR #128 lock click fix)**
(`/usr/local/bin/otto-session-pr128`); pick it in the greeter's session list, then
lock the session and click a power button.

## Spec

`specs/lock-screen.md` now states that lock-surface pointer events arrive
surface-local.
