### PR TITLE
fix(portal): no screen chooser when there is only one screen

### DIFF
--- a/components/xdg-desktop-portal-otto/src/portal/interface.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/interface.rs
@@ -171,6 +171,11 @@ impl ScreenCastPortal {
             return Ok(None);
         };
 
+        // One source is not a choice — a single-monitor session sharing its
+        // only screen gets the plain grant/deny prompt, not a radio list with
+        // nothing to pick. The answer is then implied by the grant.
+        let single_source = options.len() == 1;
+
         let title = "Share your screen";
         let subtitle = format!("{} wants to share your screen", display_app_name(app_id));
         let body = "The selected source will be visible to the application.";
@@ -188,12 +193,16 @@ impl ScreenCastPortal {
                     "Share",
                     "Cancel",
                     true,
-                    vec![(
-                        "source".to_string(),
-                        "Choose what to share".to_string(),
-                        options.clone(),
-                        default_id.clone(),
-                    )],
+                    if single_source {
+                        Vec::new()
+                    } else {
+                        vec![(
+                            "source".to_string(),
+                            "Choose what to share".to_string(),
+                            options.clone(),
+                            default_id.clone(),
+                        )]
+                    },
                 )
                 .await
         }
@@ -224,12 +233,16 @@ impl ScreenCastPortal {
                         "Share",
                         "Cancel",
                         true,
-                        vec![(
-                            "source".to_string(),
-                            "Choose what to share".to_string(),
-                            plain,
-                            default_id,
-                        )],
+                        if single_source {
+                            Vec::new()
+                        } else {
+                            vec![(
+                                "source".to_string(),
+                                "Choose what to share".to_string(),
+                                plain,
+                                default_id.clone(),
+                            )]
+                        },
                     )
                     .await?
             }
@@ -239,9 +252,15 @@ impl ScreenCastPortal {
             return Ok(None);
         }
 
-        let Some((_, choice)) = results.into_iter().find(|(group, _)| group == "source") else {
-            warn!("Picker returned no selection for the source group");
-            return Ok(None);
+        let choice = match results.into_iter().find(|(group, _)| group == "source") {
+            Some((_, choice)) => choice,
+            // No group was sent when there was only one source, so the grant
+            // is the answer.
+            None if single_source => default_id,
+            None => {
+                warn!("Picker returned no selection for the source group");
+                return Ok(None);
+            }
         };
 
         Ok(match choice.split_once(':') {

--- a/docs/user/screen-sharing.md
+++ b/docs/user/screen-sharing.md
@@ -64,21 +64,29 @@ In a browser, click "Share screen"; in a video call, pick screen sharing. The
 portal takes over from there:
 
 1. A **permission dialog** appears in the
-   [dynamic island](dynamic-island.md) — who is asking, and what for.
-2. You grant or deny.
-3. On grant, Otto starts a PipeWire stream of the chosen monitor and hands the
+   [dynamic island](dynamic-island.md) — who is asking, and what for, with a
+   list of everything you can share.
+2. You pick a source and grant, or deny.
+3. On grant, Otto starts a PipeWire stream of the chosen source and hands the
    node to the application.
 
-`otto-islands` is what renders that dialog. **If it is not running, the request
-is denied** rather than left hanging — a screenshare that cannot ask fails
-closed.
+`otto-islands` is what renders that dialog. If it is not running, Otto asks
+another desktop's portal dialog instead (GTK, GNOME or KDE, in that order) —
+the same list, without app icons.
 
-### Choosing which monitor
+### Choosing what to share
 
-There is no graphical source picker yet. Without one, Otto shares the first
-monitor it enumerates.
+The dialog lists every connected monitor and, when the application asks for
+windows too, every open window — one list, one choice. With a single monitor
+and no windows on offer there is nothing to choose, so the dialog is just the
+grant/deny prompt.
 
-To override, write the connector name into a file:
+If no dialog renderer answers at all, monitor sharing still works: Otto shares
+the first monitor it enumerates rather than failing. Windows are never picked
+for you on that path.
+
+To choose which monitor that fallback lands on, write the connector name into a
+file:
 
 ```sh
 echo "HDMI-A-1" > ~/.config/otto/screencast-output
@@ -89,7 +97,8 @@ without restarting anything. Use a name from `otto --probe`, or a virtual output
 name like `virtual-1`.
 
 If the name does not match any available output, Otto logs a warning and falls
-back to the first one.
+back to the first one. The file is only consulted when no dialog renderer
+answers — when the dialog appears, your choice in it wins.
 
 ### Cursor
 
@@ -159,8 +168,10 @@ the very portal you just configured:
 
 1. Set up a non-interactive virtual output (AirPlay mirroring has no input
    channel — it is view-only).
-2. Point `~/.config/otto/screencast-output` at it.
-3. Run doubletake and pick your receiver.
+2. Run doubletake and pick your receiver.
+3. Otto's share dialog lists every monitor, the virtual output included — pick
+   the one you want to cast. With a single monitor there is nothing to choose
+   and casting starts on it.
 
 Otto does not implement the AirPlay protocol itself. The sender side requires
 Apple's FairPlay handshake, which no clean-room implementation exists for.

--- a/specs/screenshare.md
+++ b/specs/screenshare.md
@@ -128,6 +128,10 @@ documented in `docs/developer/screenshare.md`.
 - The list is presented through the `org.otto.Dialog1` renderer (otto-islands), the same
   Access-style permission/choice dialog used by the portal's Access implementation. Option
   ids are namespaced `monitor:<connector>` and `window:<identifier>`.
+- When exactly **one** source is on offer (the common single-monitor, monitors-only case)
+  no choice group is sent at all: the dialog is the plain grant/deny permission prompt, and
+  a grant implies that one source. A radio list the user cannot change is noise, and it made
+  every cast — AirPlay included — look like it needed a screen picked.
 - The user's answer resolves as:
   - **Chose a source** → stored on the session; response `0`.
   - **Dismissed the dialog** → response `1` (cancelled). Nothing is captured.


### PR DESCRIPTION
Bug: *"AirPlay has no output chooser with multiple screens — starting a cast picks a screen implicitly; with a single output, keep casting straight away with no prompt."*

## What I found

The multi-output half of this is already shipped: `SelectSources` builds a radio
list of every output (and window) and renders it through otto-islands
(`org.otto.Dialog1`), falling back to the GTK/GNOME/KDE `impl.portal.Access`
dialog when islands isn't running (#121, #125). AirPlay goes through this portal —
doubletake captures via xdg-desktop-portal — so a multi-screen cast does get a
chooser. Nothing implicit there any more.

What was still wrong is the single-output case: the choice group was sent
unconditionally, so a one-monitor cast got a permission dialog carrying a radio
list with exactly one entry and nothing to decide.

## What this changes

- `pick_source` omits the choice group entirely when only one source is on
  offer; the grant itself resolves to that source. Both renderer paths (native
  and the Access fallback) and the answer parsing handle it.
- Multi-source behaviour is untouched.
- `docs/user/screen-sharing.md` still claimed *"There is no graphical source
  picker yet"* and told AirPlay users to point `~/.config/otto/screencast-output`
  at the output they wanted — i.e. it documented exactly the implicit pick this
  bug reports. Rewritten to describe the picker, the GTK fallback, and the
  override file's actual role (no-renderer fallback only).
- `specs/screenshare.md` records the single-source rule.

## Verification

- `cargo fmt --all`; `cargo build --release` for both `otto` and
  `-p xdg-desktop-portal-otto`; `cargo clippy -p xdg-desktop-portal-otto` clean
  for the changed file (the two remaining warnings are pre-existing, in
  `portal/settings.rs` and `portal/mod.rs`, from a newer clippy than CI pins).
- Confirmed against the live session that the portal already contains the picker
  and that this machine enumerates a single output (`eDP-1`), so the
  single-source path is the one the hardware exercises.
- **Not verified visually**: I could not run the compositor interactively from
  here, and with one display connected the multi-output chooser cannot be
  exercised on this machine at all.

## Testing on hardware

Session installed as **Otto (PR #131 single-screen share prompt)** —
`otto-pr131.desktop` in the session list. The wrapper also starts the matching
portal build (`xdg-desktop-portal-otto-pr131`), since the fix lives in the
portal, not the compositor; it logs to `~/.local/state/otto/portal-pr131.log`.

Test: start a screen share (browser, OBS, or doubletake) and check the island
dialog is a plain grant/deny prompt with no one-item source list.

https://claude.ai/code/session_01Ue32eVFqQENbeBkDVd3DTc