### PR TITLE
fix(config): keep dock defaults and hand-edited keys intact

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -297,6 +297,12 @@ fn backend_override_candidates(backend: &str) -> Vec<String> {
 ///
 /// The caller is responsible for passing the authoritative in-memory state.
 /// Only the `[dock]` table is touched; all other sections are left unchanged.
+///
+/// Within `[dock]`, only the keys the dock UI can actually change are written.
+/// The rest (`size`, `genie_*`, `colorize_*`) belongs to whoever hand-edited the
+/// config: rewriting the whole table would materialize a copy of every inherited
+/// value into the writable file, where it shadows the same key in a lower-priority
+/// config for good and silently reverts edits made while Otto is running.
 pub fn save_dock_config(dock: &DockConfig) {
     let path = writable_config_path();
     let raw = std::fs::read_to_string(&path).unwrap_or_default();
@@ -304,18 +310,47 @@ pub fn save_dock_config(dock: &DockConfig) {
         .parse()
         .unwrap_or(toml::Value::Table(Default::default()));
 
-    if let Ok(dock_value) = toml::Value::try_from(dock) {
-        doc.as_table_mut()
-            .unwrap()
-            .insert("dock".to_string(), dock_value);
-    }
+    merge_dock_config(&mut doc, dock);
 
     if let Ok(serialized) = toml::to_string_pretty(&doc) {
         let _ = std::fs::write(&path, serialized);
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// Write the dock-owned keys of `dock` into the `[dock]` table of `doc`,
+/// leaving every other key in that table (and every other section) alone.
+fn merge_dock_config(doc: &mut toml::Value, dock: &DockConfig) {
+    let Some(table) = doc.as_table_mut() else {
+        return;
+    };
+    let dock_table = table
+        .entry("dock".to_string())
+        .or_insert_with(|| toml::Value::Table(Default::default()));
+    let Some(dock_table) = dock_table.as_table_mut() else {
+        return;
+    };
+
+    dock_table.insert("autohide".to_string(), toml::Value::Boolean(dock.autohide));
+    dock_table.insert(
+        "magnification".to_string(),
+        toml::Value::Boolean(dock.magnification),
+    );
+    if let Ok(bookmarks) = toml::Value::try_from(SerializedBookmarks(&dock.bookmarks)) {
+        dock_table.insert("bookmarks".to_string(), bookmarks);
+    }
+}
+
+/// Newtype so the bookmark list can be serialized on its own with the same
+/// compact representation `DockConfig` uses.
+struct SerializedBookmarks<'a>(&'a [DockBookmark]);
+
+impl Serialize for SerializedBookmarks<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serialize_dock_bookmarks(self.0, serializer)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DockConfig {
     #[serde(default = "default_dock_size")]
     pub size: f64,
@@ -339,6 +374,26 @@ pub struct DockConfig {
         deserialize_with = "deserialize_dock_bookmarks"
     )]
     pub bookmarks: Vec<DockBookmark>,
+}
+
+/// Must stay in sync with the `#[serde(default = ...)]` functions above:
+/// `Config::init` seeds the merge from `Config::default()` serialized to TOML,
+/// so a derived (all-zero) `Default` would shadow those functions and silently
+/// give a `size` of 0 (clamped to 0.5) whenever the key is absent.
+impl Default for DockConfig {
+    fn default() -> Self {
+        Self {
+            size: default_dock_size(),
+            genie_scale: default_genie_scale(),
+            genie_span: default_genie_span(),
+            colorize_icons: false,
+            colorize_color: default_dock_colorize_color(),
+            colorize_intensity: default_dock_colorize_intensity(),
+            autohide: false,
+            magnification: default_magnification(),
+            bookmarks: Vec::new(),
+        }
+    }
 }
 
 /// App switcher (cmd-tab panel) configuration
@@ -1150,6 +1205,69 @@ mod tests {
         assert_eq!(
             config.dock.bookmarks[1].exec_args,
             vec!["--single-instance".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_dock_defaults_match_serde_defaults() {
+        // `Config::init` seeds the config merge from `Config::default()` serialized
+        // to TOML, so `DockConfig::default()` — not the `#[serde(default = ...)]`
+        // functions — is what a config file without a `[dock] size` ends up with.
+        let dock = DockConfig::default();
+        assert_eq!(dock.size, default_dock_size());
+        assert_eq!(dock.genie_scale, default_genie_scale());
+        assert_eq!(dock.genie_span, default_genie_span());
+        assert_eq!(dock.colorize_color, default_dock_colorize_color());
+        assert_eq!(dock.colorize_intensity, default_dock_colorize_intensity());
+        assert_eq!(dock.magnification, default_magnification());
+
+        let merged =
+            toml::Value::try_from(Config::default()).expect("default config is valid toml");
+        let from_defaults: Config = merged.try_into().expect("default config round-trips");
+        assert_eq!(from_defaults.dock.size, default_dock_size());
+    }
+
+    #[test]
+    fn test_save_dock_config_keeps_hand_edited_keys() {
+        let raw = r#"
+            [dock]
+            size = 1.6
+            genie_scale = 0.3
+            autohide = false
+        "#;
+        let mut doc: toml::Value = raw.parse().expect("config should parse");
+
+        let dock = DockConfig {
+            size: 1.0,
+            genie_scale: 0.5,
+            autohide: true,
+            bookmarks: vec![DockBookmark {
+                desktop_id: "firefox.desktop".to_string(),
+                label: None,
+                exec_args: Vec::new(),
+            }],
+            ..DockConfig::default()
+        };
+        merge_dock_config(&mut doc, &dock);
+
+        let saved = doc.get("dock").expect("dock table is present");
+        // Dock-owned keys are written…
+        assert_eq!(
+            saved.get("autohide").and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            saved
+                .get("bookmarks")
+                .and_then(toml::Value::as_array)
+                .map(|b| b.len()),
+            Some(1)
+        );
+        // …while keys only the user sets keep whatever the file said.
+        assert_eq!(saved.get("size").and_then(toml::Value::as_float), Some(1.6));
+        assert_eq!(
+            saved.get("genie_scale").and_then(toml::Value::as_float),
+            Some(0.3)
         );
     }
 


### PR DESCRIPTION
Investigating "the dock ignores `[dock] size`".

## What I measured first

`size` **is** honoured end-to-end on a fresh start. Running the winit backend
with only the multiplier changed (screen_scale 2.0, 8 bookmarks), instrumented
to log the dock's rendered bounds:

| `[dock] size` | dock bar | icon |
|---|---|---|
| 0.5 | 600x79 | 64 |
| 1.0 | 1122x157 | 128 |
| 2.0 | 2146x314 | 256 |

So the value reaches `DockView` and scales every dock dimension. The instrumentation was removed again; nothing in `src/workspaces/dock/` is touched by this PR.

## What is actually broken

Two config-plumbing bugs that make `size` unreliable in practice:

1. `DockConfig` derived `Default`, so `DockConfig::default()` was all zeros.
   `Config::init` seeds the merge from `Config::default()` serialized to TOML,
   which means the `#[serde(default = "…")]` functions never ran for a missing
   key — a config without `[dock] size` got `0.0`, clamped to **0.5** (half
   size) instead of the documented 1.0, and `genie_scale`/`genie_span` became 0,
   silently disabling magnification. `DockConfig` now implements `Default` by
   hand from the same default functions, like `LayerShellConfig` does.

2. `save_dock_config` replaced the entire `[dock]` table with the in-memory
   struct. Any dock action (autohide/magnification toggle, adding a bookmark)
   therefore wrote a full copy of every inherited value into the writable
   config — where it permanently shadows the same key in a lower-priority file
   and reverts edits made while Otto is running. It now writes only the keys the
   dock UI can change (`autohide`, `magnification`, `bookmarks`) and leaves
   `size`, `genie_*` and `colorize_*` as the file had them.

Evidence for (2) on this machine: `/etc/otto/config.toml` carries
`colorize_color = ""`, `colorize_intensity = 0.0`, `size = 0.5` — the zeroed
defaults from (1), written back by Otto.

## Note for existing installs

This does not clean up tables old builds already wrote. Here
`~/.config/otto/config.toml` has `size = 1.0` and `/etc/otto/config.toml` has
`size = 0.5`; the user file wins, so editing the system config still appears to
do nothing until that stale line is removed. There is also no config reload —
`size` is read at startup only.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --features "default" -- -D warnings`: clean.
- `cargo test --lib config::`: 24 pass, including two new tests — one pinning
  `DockConfig::default()` to the serde defaults (and round-tripping
  `Config::default()` through TOML), one asserting a save preserves hand-edited
  `size`/`genie_scale`.
- Behaviour above measured under the winit backend. I did **not** re-verify
  visually on tty-udev; a greeter session is installed for that: **Otto (PR #132 dock config fix)**.

https://claude.ai/code/session_0181Qc4urWCpLvsUFqN2aYRt