### PR TITLE
Live config reload

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -26,6 +26,20 @@ Otto searches for configuration files in the following order (later files overri
 
 Values from higher-priority files are merged recursively into lower-priority ones, so you only need to specify the options you want to override.
 
+## Live Reload
+
+Otto watches these files while it runs. Save an edit and it applies to the
+running session within a couple of seconds — no logout, no restart. That covers
+the dock, the wallpaper, keyboard layout and repeat, touchpad and pointer
+settings, cursor theme, scaling, theme colours and fonts.
+
+A few things still need a restart because they only exist at startup:
+`exec_once` and XDG autostart entries (programs already launched are left
+alone), `systemd_notify`, and the `--login` greeter command.
+
+If a file has a syntax error, Otto logs it and keeps the values it could read;
+the session is never left without a configuration.
+
 ## Getting Started
 
 ```bash

--- a/specs/config-reload.md
+++ b/specs/config-reload.md
@@ -1,0 +1,96 @@
+# Live Configuration Reload
+
+**Status:** draft
+**Related specs:** [multi-output](multi-output.md), [topbar](topbar.md)
+
+## Summary
+
+Editing an Otto configuration file applies to the running session. The
+compositor notices the edit on its own and re-applies the settings; restarting
+the session is not required to see a change take effect.
+
+## Goals
+
+- An edit to any config file in the load order (system, user, local override,
+  backend override) is picked up while Otto runs.
+- Creating a config file that did not exist before counts as an edit.
+- Re-applied settings take effect on the live session, not only on things
+  created afterwards: dock appearance and bookmarks, wallpaper and background
+  colour, keyboard layout and repeat, cursor theme and size, touchpad and
+  pointer settings, global scale, theme colours and fonts.
+- A reload never resets unrelated session state: open windows keep their
+  position and stacking, the current workspace stays current, and clients are
+  not disconnected.
+- Settings Otto itself writes back to the config file (the dock's autohide,
+  magnification and bookmarks) do not cause the dock to visibly reset when the
+  write is read back.
+
+## Non-Goals
+
+- Watching config files of separate components (the top bar reads
+  `otto_topbar.toml` itself).
+- Applying settings that only exist at process start: the wayland socket,
+  `exec_once` and XDG autostart entries (already-launched programs are not
+  restarted or killed), `systemd_notify`, and the login-mode greeter command.
+- Reverting runtime changes made through the UI that were never persisted.
+- Reacting to an output scale change by re-reading the config files — output
+  scale is applied from config to outputs, not the other way round.
+
+## Behavior
+
+- When a watched config file's content changes on disk, Otto re-reads the whole
+  load order and merges it exactly as it does at startup.
+- When the merged result is identical to the running configuration, nothing is
+  applied and nothing is redrawn.
+- When the merged result differs:
+  - Touchpad and pointer settings are re-applied to every input device present,
+    including devices plugged in after startup.
+  - Keyboard layout, variant, options, repeat delay and repeat rate are
+    re-applied to the seat. If the new layout fails to compile the previous one
+    stays in effect and a warning is logged.
+  - A changed cursor theme or size is loaded and the cursor is drawn with it.
+  - A changed `[dock]` section is adopted by the dock: size, magnification,
+    autohide, icon colorisation and bookmarks all take effect. Bookmarks are
+    re-resolved only when the bookmark list itself changed.
+  - A changed background image or colour replaces the wallpaper on every
+    workspace of every output. A background image that fails to load leaves the
+    background colour showing and logs a warning.
+  - A changed global scale is applied to every output, and window and layer
+    positions are fixed up as they are when the scale keybinding is used.
+  - Everything read while drawing (theme scheme, accent colour, font family,
+    layer-shell zones, shortcut bindings, sound settings) applies on the next
+    frame.
+- A malformed config file is reported and ignored: the values that were parsed
+  successfully still apply, and the session keeps running.
+
+## Constraints & Edge Cases
+
+- Detection is polled, not instantaneous: an edit applies within a couple of
+  seconds.
+- A file that is rewritten in place and a file that is replaced by a rename
+  must both be detected, as editors do both.
+- Config files are also read from the working directory. A relative path is
+  resolved the same way at reload as at startup.
+- Shortcut bindings are compiled from the config; a reload recompiles them, so
+  a rebound key works on the next press without a restart.
+- Reload runs on the compositor's event loop, so applying it must not block:
+  work that can be deferred to the next frame is.
+
+## Rationale
+
+- Polling file metadata rather than subscribing to filesystem events keeps the
+  feature dependency-free and behaves the same for every way an editor writes a
+  file; a stat of a handful of paths every couple of seconds is far cheaper than
+  the reload it guards.
+- Only the sections that changed are re-applied, because re-applying everything
+  would, for example, re-resolve dock bookmarks (an async lookup per bookmark)
+  every time the dock persists its own settings.
+- Global scale reuses the existing runtime scale-change path rather than a
+  second one, so a config-driven scale change behaves exactly like the
+  keybinding.
+
+## Open Questions
+
+- Should a reload be requestable explicitly (a keybinding or a D-Bus call) in
+  addition to being detected?
+- Should `exec_once` entries added to the config while Otto runs be launched?

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, RwLock};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod default_apps;
 pub mod shortcuts;
+pub mod watcher;
 
 use shortcuts::{build_bindings, RunCommandConfig, ShortcutBinding, ShortcutMap};
 use toml::map::Entry;
@@ -66,7 +67,13 @@ pub struct Config {
     shortcut_bindings: Vec<ShortcutBinding>,
 }
 
-static CONFIG: OnceLock<Config> = OnceLock::new();
+/// The live configuration. Swappable: `Config::reload` re-reads every config
+/// file and publishes the result, so an edit applies without a restart.
+static CONFIG: OnceLock<RwLock<Arc<Config>>> = OnceLock::new();
+
+fn config_cell() -> &'static RwLock<Arc<Config>> {
+    CONFIG.get_or_init(|| RwLock::new(Arc::new(Config::init())))
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -109,11 +116,46 @@ impl Default for Config {
 pub const WINIT_DISPLAY_ID: &str = "winit";
 
 impl Config {
-    pub fn with<R>(f: impl FnOnce(&Config) -> R) -> R {
-        let config = CONFIG.get_or_init(Config::init);
-        f(config)
+    /// A snapshot of the live configuration. Cheap (one `Arc` clone) and
+    /// stable for as long as the returned handle is held — a reload swaps the
+    /// shared pointer, it never mutates a config in place.
+    pub fn current() -> Arc<Config> {
+        config_cell().read().unwrap().clone()
     }
+
+    pub fn with<R>(f: impl FnOnce(&Config) -> R) -> R {
+        // Take a snapshot and drop the lock before running `f`: `Config::with`
+        // calls nest all over the codebase, and holding a read guard across a
+        // nested call deadlocks as soon as a reload waits for the write lock.
+        let config = Self::current();
+        f(&config)
+    }
+
+    /// Re-read every config file and publish the result.
+    ///
+    /// Returns the previous and the new config when the merged result actually
+    /// changed, so callers can re-apply only the parts that moved.
+    pub fn reload() -> Option<(Arc<Config>, Arc<Config>)> {
+        let previous = Self::current();
+        let next = Arc::new(Self::load());
+        if !section_changed(previous.as_ref(), next.as_ref()) {
+            return None;
+        }
+        *config_cell().write().unwrap() = next.clone();
+        Some((previous, next))
+    }
+
     fn init() -> Self {
+        let config = Self::load();
+
+        // Environment variables for Wayland session
+        std::env::set_var("XDG_SESSION_TYPE", "wayland");
+        std::env::set_var("XDG_CURRENT_DESKTOP", "otto");
+
+        config
+    }
+
+    fn load() -> Self {
         let mut merged =
             toml::Value::try_from(Self::default()).expect("default config is always valid toml");
 
@@ -192,11 +234,7 @@ impl Config {
 
         config.rebuild_shortcut_bindings();
 
-        // Environment variables for Wayland session
-        std::env::set_var("XDG_SESSION_TYPE", "wayland");
-        std::env::set_var("XDG_CURRENT_DESKTOP", "otto");
-
-        tracing::info!("Config initialized: {:#?}", config.theme_scheme);
+        tracing::info!("Config loaded: {:#?}", config.theme_scheme);
         config
     }
 
@@ -215,6 +253,42 @@ impl Config {
     ) -> Option<DisplayProfile> {
         self.displays.resolve(name, descriptor)
     }
+}
+
+/// Whether two config values differ, compared through their serialized form.
+///
+/// Used to keep reloads cheap: only the sections that actually moved are
+/// re-applied. Serializing avoids spreading `PartialEq` derives over every
+/// config type (`Config` also carries compiled shortcut bindings, which are
+/// derived state and not comparable).
+pub(crate) fn section_changed<T: Serialize>(previous: &T, next: &T) -> bool {
+    match (toml::Value::try_from(previous), toml::Value::try_from(next)) {
+        (Ok(a), Ok(b)) => a != b,
+        // Unserializable either way: assume it changed rather than miss an edit.
+        _ => true,
+    }
+}
+
+/// Every path a config value can come from, in merge order, whether or not it
+/// exists right now — a file that appears later is a config change too.
+pub fn watched_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from("/etc/otto/config.toml")];
+
+    if let Some(dir) = user_config_dir() {
+        paths.push(dir.join("otto").join("config.toml"));
+    }
+
+    paths.push(PathBuf::from("otto_config.toml"));
+
+    if let Ok(backend) = std::env::var("OTTO_BACKEND") {
+        paths.extend(
+            backend_override_candidates(&backend)
+                .into_iter()
+                .map(PathBuf::from),
+        );
+    }
+
+    paths
 }
 
 fn merge_value(base: &mut toml::Value, overrides: toml::Value) {
@@ -244,15 +318,19 @@ fn get_system_config_path() -> Option<PathBuf> {
     }
 }
 
-fn get_user_config_path() -> Option<PathBuf> {
-    let config_dir = std::env::var("XDG_CONFIG_HOME")
+fn user_config_dir() -> Option<PathBuf> {
+    std::env::var("XDG_CONFIG_HOME")
         .ok()
         .map(PathBuf::from)
         .or_else(|| {
             std::env::var("HOME")
                 .ok()
                 .map(|home| PathBuf::from(home).join(".config"))
-        })?;
+        })
+}
+
+fn get_user_config_path() -> Option<PathBuf> {
+    let config_dir = user_config_dir()?;
 
     let path = config_dir.join("otto").join("config.toml");
     if path.exists() {

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -1,0 +1,121 @@
+//! Detects edits to the config files backing [`crate::config::Config`].
+//!
+//! The watcher stats the config paths and compares (mtime, size) — no inotify,
+//! no extra dependency. Editors that write in place, editors that
+//! rename-replace, and a file that only appears later all look the same to it,
+//! and a poll of a handful of paths is far cheaper than the reload it guards.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+/// How often the compositor re-stats the config files.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Identity of a config file: missing, or (mtime, size).
+type Stamp = Option<(SystemTime, u64)>;
+
+#[derive(Debug, Default)]
+pub struct ConfigWatcher {
+    stamps: BTreeMap<PathBuf, Stamp>,
+}
+
+impl ConfigWatcher {
+    /// Start watching from the current state on disk, so the first poll only
+    /// reports edits made after the compositor read its config.
+    pub fn new() -> Self {
+        Self { stamps: snapshot() }
+    }
+
+    /// Whether any watched file changed since the previous poll.
+    pub fn poll(&mut self) -> bool {
+        let next = snapshot();
+        if next == self.stamps {
+            return false;
+        }
+        self.stamps = next;
+        true
+    }
+}
+
+fn snapshot() -> BTreeMap<PathBuf, Stamp> {
+    super::watched_paths()
+        .into_iter()
+        .map(|path| {
+            let stamp = std::fs::metadata(&path).ok().and_then(|meta| {
+                let modified = meta.modified().ok()?;
+                Some((modified, meta.len()))
+            });
+            (path, stamp)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Point the user config at a temp dir so the watcher watches a file the
+    /// test owns. `XDG_CONFIG_HOME` is process-global, hence `#[serial]`.
+    fn with_config_home<R>(dir: &std::path::Path, f: impl FnOnce() -> R) -> R {
+        let previous = std::env::var("XDG_CONFIG_HOME").ok();
+        std::env::set_var("XDG_CONFIG_HOME", dir);
+        let result = f();
+        match previous {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        result
+    }
+
+    #[test]
+    #[serial]
+    fn quiet_when_nothing_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        with_config_home(dir.path(), || {
+            let mut watcher = ConfigWatcher::new();
+            assert!(!watcher.poll());
+            assert!(!watcher.poll());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn reports_a_created_config() {
+        let dir = tempfile::tempdir().unwrap();
+        with_config_home(dir.path(), || {
+            let mut watcher = ConfigWatcher::new();
+            assert!(!watcher.poll());
+
+            let config_dir = dir.path().join("otto");
+            std::fs::create_dir_all(&config_dir).unwrap();
+            std::fs::write(config_dir.join("config.toml"), "screen_scale = 1.0\n").unwrap();
+
+            assert!(watcher.poll(), "a new config file is a change");
+            assert!(!watcher.poll(), "and only reported once");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn reports_an_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("otto");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = config_dir.join("config.toml");
+        std::fs::write(&config, "screen_scale = 1.0\n").unwrap();
+
+        with_config_home(dir.path(), || {
+            let mut watcher = ConfigWatcher::new();
+            assert!(!watcher.poll());
+
+            // Rewrite with a different length: filesystems with coarse mtime
+            // granularity would otherwise hide an edit made in the same tick.
+            std::fs::write(&config, "screen_scale = 1.25\n").unwrap();
+
+            assert!(watcher.poll(), "an edited config file is a change");
+            assert!(!watcher.poll());
+        });
+    }
+}

--- a/src/state/config_reload.rs
+++ b/src/state/config_reload.rs
@@ -1,0 +1,161 @@
+//! Live configuration reload.
+//!
+//! Most of the compositor reads its settings through `Config::with` every time
+//! it needs them, so swapping the published config (see
+//! [`crate::config::Config::reload`]) is enough for them. This module covers
+//! the rest: the values something copied out of the config at startup and now
+//! owns — input devices, the keyboard map, the cursor theme, the dock, the
+//! wallpaper — plus the redraw that makes a purely visual change show up.
+
+use smithay::input::keyboard::XkbConfig;
+use smithay::reexports::calloop::{
+    timer::{TimeoutAction, Timer},
+    LoopHandle,
+};
+use tracing::{info, warn};
+
+use crate::config::{section_changed, watcher::ConfigWatcher, Config};
+use crate::state::{Backend, Otto};
+
+impl<BackendData: Backend + 'static> Otto<BackendData> {
+    /// Watch the config files and re-apply them when they change.
+    pub fn start_config_watcher(handle: &LoopHandle<'static, Self>) {
+        let mut watcher = ConfigWatcher::new();
+        let interval = crate::config::watcher::POLL_INTERVAL;
+
+        if handle
+            .insert_source(Timer::from_duration(interval), move |_, _, data| {
+                if watcher.poll() {
+                    data.reload_config();
+                }
+                TimeoutAction::ToDuration(interval)
+            })
+            .is_err()
+        {
+            warn!("Failed to start the config watcher; config changes need a restart");
+        }
+    }
+
+    /// Re-read the config files and apply what changed. A no-op when the
+    /// merged result is the same as the running one — a file can be touched,
+    /// or rewritten by Otto itself (the dock persists its own settings),
+    /// without anything actually moving.
+    pub fn reload_config(&mut self) {
+        let Some((previous, config)) = Config::reload() else {
+            return;
+        };
+        info!("Config changed on disk, applying it to the running session");
+
+        if section_changed(&previous.input, &config.input) {
+            self.backend_data.apply_input_config(&config);
+            self.apply_keyboard_config(&config);
+        } else if previous.keyboard_repeat_delay != config.keyboard_repeat_delay
+            || previous.keyboard_repeat_rate != config.keyboard_repeat_rate
+        {
+            self.apply_keyboard_config(&config);
+        }
+
+        if previous.cursor_theme != config.cursor_theme
+            || previous.cursor_size != config.cursor_size
+        {
+            self.cursor_manager
+                .reload(&config.cursor_theme, config.cursor_size as u8);
+            self.cursor_texture_cache.clear();
+        }
+
+        self.workspaces.dock.apply_config(&config.dock);
+
+        if previous.background_image != config.background_image
+            || previous.background_color != config.background_color
+        {
+            self.apply_background_config(&config);
+        }
+
+        if section_changed(&previous.layer_shell, &config.layer_shell) {
+            for output in self.workspaces.outputs().cloned().collect::<Vec<_>>() {
+                self.recalculate_exclusive_zones(&output);
+            }
+        }
+
+        if previous.screen_scale != config.screen_scale {
+            self.apply_screen_scale(config.screen_scale);
+        }
+
+        // Fonts, theme colours and the rest are read while drawing: they only
+        // need the scene to be drawn again.
+        self.backend_data.request_redraw();
+    }
+
+    fn apply_keyboard_config(&mut self, config: &Config) {
+        let Some(keyboard) = self.seat.get_keyboard() else {
+            return;
+        };
+
+        keyboard.change_repeat_info(config.keyboard_repeat_rate, config.keyboard_repeat_delay);
+
+        let layout = config.input.xkb_layout.clone().unwrap_or_default();
+        let variant = config.input.xkb_variant.clone().unwrap_or_default();
+        let options = if config.input.xkb_options.is_empty() {
+            None
+        } else {
+            Some(config.input.xkb_options.join(","))
+        };
+        let xkb_config = XkbConfig {
+            layout: &layout,
+            variant: &variant,
+            options,
+            ..Default::default()
+        };
+        if let Err(err) = keyboard.set_xkb_config(self, xkb_config) {
+            warn!("Keeping the previous keyboard layout, the new one failed: {err}");
+        }
+    }
+
+    fn apply_background_config(&mut self, config: &Config) {
+        let color = crate::utils::parse_hex_color(&config.background_color);
+        let image = crate::utils::image_from_path(&config.background_image, (2048, 2048));
+        if image.is_none() && !config.background_image.is_empty() {
+            warn!(
+                "Failed to load background image from path: {}",
+                config.background_image
+            );
+        }
+
+        for output_workspaces in self.workspaces.output_workspaces.values() {
+            for workspace in output_workspaces.workspace_views.iter() {
+                workspace
+                    .background_view
+                    .set_background(image.clone(), color);
+            }
+        }
+    }
+
+    /// Apply a new global scale to every output, the same way the scale
+    /// keybinding does.
+    fn apply_screen_scale(&mut self, scale: f64) {
+        use smithay::output::Scale;
+
+        let outputs: Vec<_> = self.workspaces.outputs().cloned().collect();
+        for output in &outputs {
+            output.change_current_state(None, None, Some(Scale::Fractional(scale)), None);
+        }
+        let pointer_location = self.pointer.current_location();
+        crate::shell::fixup_positions(&mut self.workspaces, pointer_location);
+
+        // The workspaces model caches the scale alongside the physical screen
+        // size, and the size did not change — re-set it so the scene is laid
+        // out at the new scale.
+        let (width, height) = self
+            .workspaces
+            .with_model(|model| (model.width, model.height));
+        if width > 0 && height > 0 {
+            self.workspaces.set_screen_dimension(width, height);
+        }
+
+        for output in &outputs {
+            self.backend_data.reset_buffers(output);
+        }
+        #[cfg(feature = "xwayland")]
+        self.update_xwayland_scale();
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -341,6 +341,7 @@ pub struct Otto<BackendData: Backend + 'static> {
 }
 
 pub mod app_management;
+pub mod config_reload;
 pub mod data_device_handler;
 pub mod dnd_grab_handler;
 pub mod foreign_toplevel_list_handler;
@@ -758,6 +759,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
 
         // No-op unless `lock.auto_lock_timeout` is set.
         Self::start_auto_lock_timer(&handle);
+        Self::start_config_watcher(&handle);
 
         // Get backend name before moving backend_data
         #[cfg(feature = "metrics")]
@@ -2371,6 +2373,9 @@ pub trait Backend {
     fn set_cursor(&mut self, image: &CursorImageStatus); //, renderer: &mut SkiaRenderer);
     fn renderer_context(&mut self) -> Option<layers::skia::gpu::DirectContext>;
     fn request_redraw(&mut self) {}
+    /// Re-apply the `[input]` settings to the devices the backend owns after a
+    /// config reload. Only backends driving libinput have anything to do.
+    fn apply_input_config(&mut self, _config: &Config) {}
     /// Invalidate any pre-computed (vblank-prefetched) scene update. Called
     /// on client commits: a commit can create scene layers (e.g. a popup)
     /// AFTER the prefetch ran, and drawing from the stale prefetch renders

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -53,8 +53,15 @@ fn looks_like_display_underrun(line: &str) -> bool {
             || l.contains("display"))
 }
 
-/// Configures all libinput devices based on Otto's configuration
-fn configure_libinput_devices(libinput: &mut Libinput, config: &Config) {
+/// Configures all libinput devices based on Otto's configuration.
+///
+/// Returns the devices it saw: these `DeviceAdded` events are consumed here,
+/// before the smithay backend exists, so this is the only chance to record
+/// them for a later config reload.
+fn configure_libinput_devices(
+    libinput: &mut Libinput,
+    config: &Config,
+) -> Vec<smithay::reexports::input::Device> {
     use smithay::reexports::input::{
         event::{DeviceEvent, EventTrait},
         Event,
@@ -63,16 +70,19 @@ fn configure_libinput_devices(libinput: &mut Libinput, config: &Config) {
     // Process initial devices
     libinput.dispatch().ok();
 
+    let mut devices = Vec::new();
     for event in libinput.by_ref() {
         if let Event::Device(DeviceEvent::Added(added_event)) = event {
             let mut device = added_event.device();
             apply_device_config(&mut device, config);
+            devices.push(device);
         }
     }
+    devices
 }
 
 /// Applies configuration to an individual input device
-fn apply_device_config(device: &mut smithay::reexports::input::Device, config: &Config) {
+pub(super) fn apply_device_config(device: &mut smithay::reexports::input::Device, config: &Config) {
     // Only configure pointer devices (touchpads)
     if !device.has_capability(smithay::reexports::input::DeviceCapability::Pointer) {
         return;
@@ -276,6 +286,7 @@ pub fn run_udev() {
         primary_gpu,
         gpus,
         backends: HashMap::new(),
+        input_devices: Vec::new(),
         #[cfg(feature = "fps_ticker")]
         fps_texture: None,
 
@@ -308,9 +319,8 @@ pub fn run_udev() {
     libinput_context.udev_assign_seat(&state.seat_name).unwrap();
 
     // Configure input devices based on config
-    Config::with(|config| {
-        configure_libinput_devices(&mut libinput_context, config);
-    });
+    state.backend_data.input_devices =
+        Config::with(|config| configure_libinput_devices(&mut libinput_context, config));
 
     let libinput_backend = LibinputInputBackend::new(libinput_context.clone());
 
@@ -320,6 +330,21 @@ pub fn run_udev() {
     event_loop
         .handle()
         .insert_source(libinput_backend, move |event, _, data| {
+            // Track the device set so a config reload can re-apply the input
+            // settings, and configure devices plugged in after startup.
+            match &event {
+                smithay::backend::input::InputEvent::DeviceAdded { device } => {
+                    let mut device = device.clone();
+                    Config::with(|config| apply_device_config(&mut device, config));
+                    if !data.backend_data.input_devices.contains(&device) {
+                        data.backend_data.input_devices.push(device);
+                    }
+                }
+                smithay::backend::input::InputEvent::DeviceRemoved { device } => {
+                    data.backend_data.input_devices.retain(|d| d != device);
+                }
+                _ => {}
+            }
             let dh = data.backend_data.dh.clone();
             data.process_input_event(&dh, event);
             // Input may move the cursor or trigger visual changes — request a render.

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -106,6 +106,12 @@ impl Backend for UdevData {
         "udev"
     }
 
+    fn apply_input_config(&mut self, config: &crate::config::Config) {
+        for device in self.input_devices.iter_mut() {
+            crate::udev::init::apply_device_config(device, config);
+        }
+    }
+
     fn reset_buffers(&mut self, output: &Output) {
         if let Some(id) = output.user_data().get::<UdevOutputId>() {
             if let Some(gpu) = self.backends.get_mut(&id.device_id) {

--- a/src/udev/types.rs
+++ b/src/udev/types.rs
@@ -78,6 +78,9 @@ pub struct UdevData {
     pub(super) primary_gpu: DrmNode,
     pub(super) gpus: GpuManager<GbmGlesBackend<SkiaRenderer, DrmDeviceFd>>,
     pub backends: HashMap<DrmNode, BackendData>,
+    /// Libinput devices currently present. Kept so a config reload can
+    /// re-apply the `[input]` settings without waiting for a replug.
+    pub(super) input_devices: Vec<smithay::reexports::input::Device>,
     #[cfg(feature = "fps_ticker")]
     pub(super) fps_texture: Option<smithay::backend::renderer::multigpu::MultiTexture>,
     pub context_id: Option<ContextId<MultiTexture>>,

--- a/src/workspaces/background.rs
+++ b/src/workspaces/background.rs
@@ -63,6 +63,17 @@ impl BackgroundView {
             ..self.view.get_state()
         });
     }
+
+    /// Replace both the wallpaper and the colour drawn when there is none.
+    /// Used when the config is reloaded: dropping the image is meaningful
+    /// (the wallpaper was removed from the config), so it takes an `Option`.
+    pub fn set_background(&self, image: Option<skia::Image>, fallback_color: skia::Color4f) {
+        self.view.update_state(&BackgroundViewState {
+            image,
+            fallback_color,
+            ..self.view.get_state()
+        });
+    }
 }
 
 // static mut COUNTER: f32 = 1.0;

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -1598,6 +1598,36 @@ impl DockView {
         }
     }
 
+    /// Adopt a `[dock]` section that was re-read from disk.
+    ///
+    /// The dock owns its config at runtime (the handle menu writes it back to
+    /// the file), so a reload that merely reflects Otto's own write is a no-op
+    /// — bookmarks are resolved asynchronously and re-rendering on every dock
+    /// interaction would be churn for nothing.
+    pub fn apply_config(&self, config: &crate::config::DockConfig) {
+        {
+            let current = self.dock_config.read().unwrap();
+            if !crate::config::section_changed(&*current, config) {
+                return;
+            }
+        }
+        let bookmarks_changed = crate::config::section_changed(
+            &self.dock_config.read().unwrap().bookmarks,
+            &config.bookmarks,
+        );
+
+        *self.dock_config.write().unwrap() = config.clone();
+        self.magnification_enabled
+            .store(config.magnification, std::sync::atomic::Ordering::SeqCst);
+        if !config.magnification {
+            self.update_magnification_position(-500.0);
+        }
+        if bookmarks_changed {
+            self.load_configured_bookmarks();
+        }
+        self.render_dock();
+    }
+
     /// Persist the current in-memory dock config to the writable config file.
     pub(super) fn save_config(&self) {
         crate::config::save_dock_config(&self.dock_config.read().unwrap());


### PR DESCRIPTION
Editing a config file now applies to the running session instead of waiting for a restart.

## What changed

- `CONFIG` is a swappable `Arc<Config>` instead of a `OnceLock<Config>`. `Config::with` takes a snapshot and drops the lock before running its closure, so the ~90 existing call sites keep working — and nested `Config::with` calls can't deadlock against a reload.
- `Config::reload()` re-reads the whole load order (system → user → `./otto_config.toml` → backend override), merges it exactly as at startup, and publishes it. It returns the old and new config only when the merged result actually differs.
- A calloop timer stats the config paths every 2s (`src/config/watcher.rs`) — mtime + size, so in-place writes, rename-replace, and a file that appears later are all detected. No new dependency and no unsafe.
- `Otto::reload_config` re-applies what consumers copied at startup, section by section:
  - touchpad/pointer settings to every libinput device (udev now tracks the device set, so devices plugged in after startup get configured too — previously only the ones present at startup were),
  - xkb layout/variant/options and repeat delay/rate on the seat (a layout that fails to compile keeps the old one and logs),
  - cursor theme/size (cursor texture cache cleared),
  - the `[dock]` section — skipped when it matches what the dock already has, so the dock persisting its own settings doesn't make it re-resolve bookmarks,
  - wallpaper image/colour on every workspace of every output,
  - layer-shell exclusive-zone limits,
  - `screen_scale`, through the same path the scale keybinding uses (outputs, `fixup_positions`, workspaces model scale, buffer reset).
- Everything read while drawing (theme, accent colour, fonts, shortcut bindings, sound) applies on the next frame — shortcut bindings are recompiled by the reload, so a rebound key works on the next press.

Startup-only settings still need a restart and are documented as such: `exec_once`/XDG autostart, `systemd_notify`, the login greeter command.

Spec: `specs/config-reload.md`. User docs: `docs/user/configuration.md`.

## Verification

- `cargo fmt --all`, `cargo clippy --features "default" -- -D warnings` clean.
- `cargo test --features "default" --lib config::` — 25 passed, including three new tests for the watcher (quiet when nothing changes, detects a created file, detects an edit).
- I could **not** run the full compositor to check this visually — no interactive session from here. The behaviour is untested on real hardware; boot the session below to try it (edit `~/.config/otto/config.toml` and watch the dock/wallpaper change).

## Test session

Installed as **Otto (PR #134 live config reload)** — `/usr/local/bin/otto-session-pr134`, logs to `~/.local/state/otto/session-pr134.log`.

https://claude.ai/code/session_013BbxP8vKAas9RZcDqR4CjM
