### PR TITLE
fix(tiling): widen drag side snap zones

### DIFF
--- a/src/workspaces/tiling_overlay.rs
+++ b/src/workspaces/tiling_overlay.rs
@@ -40,26 +40,25 @@ pub fn zone_from_pointer(
 ) -> Option<TileZone> {
     // Top maximize band, in logical pixels.
     const TOP_BAND: f64 = 80.0;
-    // Left/right zones span a generous fraction of the width (with a floor) so
-    // they're easy to hit, not just a thin strip at the very edge.
-    let edge_band = (usable.size.w as f64 * 0.15).max(120.0);
 
     let left = usable.loc.x as f64;
     let right = (usable.loc.x + usable.size.w) as f64;
     let top = usable.loc.y as f64;
 
-    // Central horizontal band (middle 50% of the usable width) for maximize.
-    let center_lo = left + usable.size.w as f64 * 0.25;
-    let center_hi = right - usable.size.w as f64 * 0.25;
+    // Central horizontal band (middle third of the usable width): the only
+    // place that doesn't arm a side zone, and where the top maximize band
+    // lives. Anything clearly left or right of centre tiles to that half.
+    let center_lo = left + usable.size.w as f64 / 3.0;
+    let center_hi = right - usable.size.w as f64 / 3.0;
 
     // Top-center → maximize wins over the side bands at the upper corners.
     if pointer.y <= top + TOP_BAND && pointer.x >= center_lo && pointer.x <= center_hi {
         return Some(TileZone::Maximize);
     }
-    if pointer.x <= left + edge_band {
+    if pointer.x < center_lo {
         return Some(TileZone::LeftHalf);
     }
-    if pointer.x >= right - edge_band {
+    if pointer.x > center_hi {
         return Some(TileZone::RightHalf);
     }
     None

--- a/src/workspaces/tiling_overlay.rs
+++ b/src/workspaces/tiling_overlay.rs
@@ -45,14 +45,17 @@ pub fn zone_from_pointer(
     let right = (usable.loc.x + usable.size.w) as f64;
     let top = usable.loc.y as f64;
 
-    // Central horizontal band (middle third of the usable width): the only
-    // place that doesn't arm a side zone, and where the top maximize band
-    // lives. Anything clearly left or right of centre tiles to that half.
-    let center_lo = left + usable.size.w as f64 / 3.0;
-    let center_hi = right - usable.size.w as f64 / 3.0;
+    // Narrow neutral column around the centre (middle 20% of the usable
+    // width): the only place that doesn't arm a side zone. Nudging a window
+    // off centre is enough to tile it to that half.
+    let center_lo = left + usable.size.w as f64 * 0.4;
+    let center_hi = right - usable.size.w as f64 * 0.4;
 
-    // Top-center → maximize wins over the side bands at the upper corners.
-    if pointer.y <= top + TOP_BAND && pointer.x >= center_lo && pointer.x <= center_hi {
+    // The top maximize band is wider than the neutral column (middle 50%) so
+    // it stays easy to hit, and wins over the side bands at the upper corners.
+    let max_lo = left + usable.size.w as f64 * 0.25;
+    let max_hi = right - usable.size.w as f64 * 0.25;
+    if pointer.y <= top + TOP_BAND && pointer.x >= max_lo && pointer.x <= max_hi {
         return Some(TileZone::Maximize);
     }
     if pointer.x < center_lo {


### PR DESCRIPTION
Dragging a window with Ctrl held only armed the left/right half zones when the
pointer was almost at the screen edge (`edge_band = max(15% of usable width, 120px)`).

`zone_from_pointer` now leaves only a narrow neutral column around the centre —
the middle 20% of the usable width. Anything left of 40% tiles to the left half,
anything right of 60% tiles to the right half, so a small nudge off centre is
enough. The top maximize band is deliberately wider than that column (middle 50%,
top 80 logical px) so it stays easy to hit, and it still wins over the side zones
at the upper corners.

Verified: `cargo fmt --all`, `cargo clippy --features "default" -- -D warnings`
clean, release build succeeds. I could not drive the compositor interactively
from this environment, so the zone behaviour has not been visually tested — boot
the session below to try it.

Test session: **Otto (PR #135 tiling drag zones)** — `/usr/local/bin/otto-session-pr135`,
logs to `~/.local/state/otto/session-pr135.log`

https://claude.ai/code/session_01B2WCtCnJB7MwFZbCqdDgQG