### PR TITLE
feat(outputs): log output topology on every output-set change

### DIFF
--- a/specs/multi-output.md
+++ b/specs/multi-output.md
@@ -101,6 +101,12 @@ Otto can drive more than one output (physical monitor or virtual/screenshare out
 - When the pointer moves from inside an output's geometry to outside it, that output renders exactly one further frame with the cursor omitted (a "farewell" frame) so its hardware cursor plane is cleared instead of continuing to display the cursor at its last position. No further cursor-related frames are forced after that single farewell frame while the pointer remains outside.
 - An output whose geometry the pointer re-enters resumes drawing the cursor on the next frame, with no farewell frame needed on entry (only on exit).
 
+### Output Topology Diagnostics
+
+- Every transition that changes the live output set — mapping a new output, re-mapping an existing one (mode/resize/resume), unmapping, suspending (lid close), resuming the session after a VT switch, and the scale/rotation keybindings — logs a dump of the whole topology on the `otto::outputs` target at `info` level. Enable it with `RUST_LOG=otto::outputs=info`.
+- The dump names the transition that triggered it and then, per live output: its logical geometry as returned by `Workspaces::output_geometry` (the same value maximize geometry and pointer clamping consume), current mode, fractional scale, transform, whether it is physical / virtual-interactive / virtual-non-interactive, and which one is primary. Suspended outputs are listed with the position and primary status they will be restored to.
+- Two inconsistencies are called out explicitly, because they are states no caller expects and both are silent otherwise: `MISSING-GEOMETRY` for a live output with no space mapped (any `output_geometry(..).unwrap()` on it would panic), and `ORPHANED` for workspace data belonging to an output that is neither live nor suspended.
+
 ## Constraints & Edge Cases
 
 - **Config position is honored for physical outputs, with overlap rejection:** a configured position for a physical display is used as-is as long as it doesn't overlap any already-mapped output's geometry; if it would overlap, the configured position is ignored (with a warning) and that output falls back to automatic left-to-right placement instead. Outputs can never be made to overlap through configuration alone.

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -56,6 +56,7 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
 
                     crate::shell::fixup_positions(&mut self.workspaces, current_location);
                     self.backend_data.reset_buffers(&output);
+                    self.workspaces.log_output_topology("scale up");
                     #[cfg(feature = "xwayland")]
                     self.update_xwayland_scale();
                 }
@@ -79,6 +80,7 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
                     let current_location = self.pointer.current_location();
                     crate::shell::fixup_positions(&mut self.workspaces, current_location);
                     self.backend_data.reset_buffers(&output);
+                    self.workspaces.log_output_topology("scale down");
                     #[cfg(feature = "xwayland")]
                     self.update_xwayland_scale();
                 }
@@ -104,6 +106,7 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
 
                     crate::shell::fixup_positions(&mut self.workspaces, current_location);
                     self.backend_data.reset_buffers(&output);
+                    self.workspaces.log_output_topology("rotate output");
                 }
                 KeyAction::ApplicationSwitchNext => {
                     self.handle_app_switcher_next();
@@ -286,6 +289,7 @@ impl Otto<UdevData> {
                         );
                         pointer.frame(self);
                         self.backend_data.reset_buffers(&output);
+                        self.workspaces.log_output_topology("scale up");
                     }
                 }
                 KeyAction::ScaleDown => {
@@ -331,6 +335,7 @@ impl Otto<UdevData> {
                         );
                         pointer.frame(self);
                         self.backend_data.reset_buffers(&output);
+                        self.workspaces.log_output_topology("scale down");
                     }
                 }
                 KeyAction::RotateOutput => {
@@ -354,6 +359,7 @@ impl Otto<UdevData> {
                         let current_location = self.pointer.current_location();
                         crate::shell::fixup_positions(&mut self.workspaces, current_location);
                         self.backend_data.reset_buffers(&output);
+                        self.workspaces.log_output_topology("rotate output");
                     }
                 }
                 KeyAction::ApplicationSwitchNext => {

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -351,6 +351,7 @@ pub fn run_udev() {
                 if let Err(err) = libinput_context.resume() {
                     error!("Failed to resume libinput context: {:?}", err);
                 }
+                data.workspaces.log_output_topology("session activate");
 
                 // Coming back from another VT, the primary plane has no content
                 // and nothing in the scene has changed — so resetting the DRM

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -3358,6 +3358,87 @@ impl Workspaces {
         self.outputs.iter()
     }
 
+    /// Dump every output's geometry, mode, scale and transform to the log.
+    ///
+    /// Called whenever the output set changes (map / unmap / suspend /
+    /// restore) so a log captured while the pointer or maximize geometry goes
+    /// wrong pins down which transition corrupted the layout. Both bugs read
+    /// [`Workspaces::output_geometry`], so this prints exactly what that
+    /// returns, plus the raw output state it is derived from.
+    ///
+    /// Anything the derived state cannot explain is flagged inline:
+    /// `MISSING-GEOMETRY` for an output that is live but has no space mapped
+    /// (an `output_geometry(..).unwrap()` on that output would panic), and
+    /// `ORPHANED` for workspace data left behind by an output that is no
+    /// longer live.
+    pub fn log_output_topology(&self, reason: &str) {
+        let primary = self.primary_output.as_ref().map(|o| o.name());
+        tracing::info!(
+            target: "otto::outputs",
+            "output set changed ({reason}): {} live, {} suspended, primary={}",
+            self.outputs.len(),
+            self.suspended_outputs.len(),
+            primary.as_deref().unwrap_or("<none>"),
+        );
+
+        for output in &self.outputs {
+            let name = output.name();
+            let geo = self.output_geometry(output);
+            let geo_str = match geo {
+                Some(g) => format!(
+                    "loc=({},{}) size={}x{}",
+                    g.loc.x, g.loc.y, g.size.w, g.size.h
+                ),
+                None => "MISSING-GEOMETRY".to_string(),
+            };
+            let mode = output
+                .current_mode()
+                .map(|m| format!("{}x{}@{}", m.size.w, m.size.h, m.refresh))
+                .unwrap_or_else(|| "<no mode>".to_string());
+            let kind = if crate::virtual_output::is_virtual_output(output) {
+                if crate::virtual_output::is_unreachable_virtual_output(output) {
+                    "virtual/non-interactive"
+                } else {
+                    "virtual/interactive"
+                }
+            } else {
+                "physical"
+            };
+            tracing::info!(
+                target: "otto::outputs",
+                "  {name}{}: {kind} logical[{geo_str}] mode={mode} scale={:.2} transform={:?}",
+                if primary.as_deref() == Some(name.as_str()) {
+                    " (primary)"
+                } else {
+                    ""
+                },
+                output.current_scale().fractional_scale(),
+                output.current_transform(),
+            );
+        }
+
+        for (name, suspended) in &self.suspended_outputs {
+            tracing::info!(
+                target: "otto::outputs",
+                "  {name}: suspended at ({},{}) was_primary={}",
+                suspended.location.x,
+                suspended.location.y,
+                suspended.was_primary,
+            );
+        }
+
+        for name in self.output_workspaces.keys() {
+            if !self.outputs.iter().any(|o| o.name() == *name)
+                && !self.suspended_outputs.contains_key(name)
+            {
+                tracing::warn!(
+                    target: "otto::outputs",
+                    "  {name}: ORPHANED workspace data (no live or suspended output)",
+                );
+            }
+        }
+    }
+
     /// Attach a new output to every workspace
     pub fn map_output(
         &mut self,
@@ -3409,6 +3490,7 @@ impl Workspaces {
             }
             self.sync_model_from_primary();
             self.update_workspaces_layout();
+            self.log_output_topology(&format!("remap {}", output.name()));
             return;
         }
 
@@ -3698,6 +3780,7 @@ impl Workspaces {
         self.sync_model_from_primary();
         self.update_workspaces_layout();
         self.with_model(|m| self.notify_observers(m));
+        self.log_output_topology(&format!("map {}", output.name()));
     }
 
     /// Returns the primary output (used for dock placement and hot zone).
@@ -3751,6 +3834,7 @@ impl Workspaces {
             }
         }
         self.sync_model_from_primary();
+        self.log_output_topology(&format!("unmap {}", output.name()));
     }
 
     /// Suspend an output without destroying its workspace data.
@@ -3788,6 +3872,7 @@ impl Workspaces {
         }
         // Intentionally do NOT remove from output_workspaces — keep windows alive.
         self.sync_model_from_primary();
+        self.log_output_topology(&format!("suspend {}", output.name()));
     }
 
     /// Take (consume) a previously suspended output, if any.


### PR DESCRIPTION
TODO item (from the "Bug: pointer coordinates break after some event" section):

> - [ ] Add a log line dumping every output's geometry/location/scale whenever the
>       output set changes, to catch the moment it goes wrong

This is the *second* item in that section. The first one — "Identify the trigger" — cannot be done without this logging in place: the bug has no known repro, so there is nothing to observe until every output transition leaves a trace. Doing the dependency first, as instructed.

## Approach

New `Workspaces::log_output_topology(reason)` in `src/workspaces/mod.rs`. It logs on the `otto::outputs` target at `info` (these transitions are rare, so no spam), and prints per live output:

- the logical geometry returned by `Workspaces::output_geometry` — deliberately the same call maximize geometry and `clamp_coords` consume, so the log shows exactly the value the bug reads
- current mode, fractional scale, transform
- physical / virtual-interactive / virtual-non-interactive, and which output is primary

Suspended outputs are listed with the position and primary flag they would be restored to. Two silent inconsistencies are flagged inline: `MISSING-GEOMETRY` for a live output with no space mapped (where an `output_geometry(..).unwrap()` would panic — the section's later item about those unwraps) and `ORPHANED` for workspace data whose output is neither live nor suspended.

Call sites cover the suspect list in the TODO section:

- `map_output_with_primary` — both the fresh-map and the re-map (mode change / resume) paths
- `unmap_output`, `suspend_output` (lid close)
- `SessionEvent::ActivateSession` in `src/udev/init.rs` (VT switch back)
- the scale-up / scale-down / rotate keybindings in `src/input_handler.rs`, in both handler variants

Virtual outputs (RDP connect, screenshare start/stop) go through `map_output` / `unmap_output`, so they are covered by those.

Behavior is otherwise unchanged — this adds logging only.

## Verification

- `cargo fmt --all` and `cargo clippy --features "default" -- -D warnings` both clean.
- I could not exercise the compositor visually from here; the log content is by construction the values the buggy paths read, and no code path was altered beyond the added log calls.
- Spec updated: `specs/multi-output.md` gains an "Output Topology Diagnostics" section documenting the `otto::outputs` target and the two flagged inconsistencies.

## Test session

Installed as **Otto (PR #138 output topology logging)** — pick it in the greeter, then read `~/.local/state/otto/session-pr138.log`. `RUST_LOG` should include `otto::outputs=info`.
