### PR TITLE
perf(planes): sync once per frame, and fix expose gesture flicker

### DIFF
--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -157,10 +157,23 @@ vibrancy even though the content behind it lives on other planes.
   test is outset by the blur sigma so damage just outside the shape still
   triggers it). This matches the whole-scene expansion. (The blur layer's
   own damage is already sigma-outset when it is drawn.)
-- Plane renders submit to the GPU without a CPU-blocking wait on devices
-  with implicit dmabuf fencing (the kernel's atomic commit waits on the
-  buffer's reservation fences); on the NVIDIA proprietary driver, which
-  has no implicit fencing, the CPU wait is kept.
+- Plane buffers are offscreen EGLImage render targets, which Mesa iris does
+  not attach implicit dma-fences to, so the atomic commit does not wait for
+  their GL writes on its own — something must, or planes flip half-drawn.
+  That wait happens **once per frame**, after the last plane render and
+  before the buffers are handed to the DRM compositor: every plane's slot
+  surface is built from the renderer's single shared Skia `DirectContext`,
+  so one sync covers all of them. The per-plane flushes submit without
+  blocking (they still submit rather than merely record, because the
+  backdrop composite samples an earlier plane's snapshot from the same
+  context and the queued order is the correct order).
+  Waiting per plane instead serialised CPU against GPU once per plane, and
+  that blocked time — nearly all of a plane render — was the dominant term
+  in the frame budget.
+  Delivering the fence to KMS as `IN_FENCE_FD` instead would be better
+  still, but is not currently possible: smithay populates `PlaneConfig.sync`
+  only from a `ScanoutBuffer::Wayland` acquire point, so a dmabuf-backed
+  plane element cannot carry a sync point without extending smithay.
 - A promoted (scanned-out) window's commits skip the scene import
   entirely — importing would only re-render its hidden content layer into
   the windows plane. The skip sets a pending flag that forces the next
@@ -173,6 +186,21 @@ vibrancy even though the content behind it lives on other planes.
 - When expose is active, the expose buffer replaces the windows buffer in
   the plane stack; its blur samples the downscaled background-only stage of
   the composite, and the overlay's backdrop then includes expose content.
+  The windows buffer is rendered once on the expose entry edge to keep its
+  swapchain warm for the expose→windows transition, and not again while
+  expose is up: it is not pushed as a plane element there, so per-frame
+  re-rendering spent a substantial share of each expose frame on pixels
+  that never reach the screen. Content that changed during expose is still correct on
+  exit — the damage history no longer reaches the reacquired slot's commit,
+  which forces a full re-render on the first composited frame.
+- Expose counts as active for the whole of a finger gesture, from
+  `expose_gesture_start` until the gesture commits, regardless of what the
+  gesture accumulator reads. The accumulator is reset to exactly 0 (or 1000
+  when closing) at gesture start, and a fast swipe saturates at the clamp
+  and stays there, so a rule based on the accumulator alone reads "not
+  transitioning" for those frames while `show_all` is not yet committed —
+  the expose plane leaves the stack, the windows plane is pushed, and the
+  screen flicks back to the normal layout mid-gesture.
 - When a lower plane records damage, the composite is rebuilt and the
   blur-bearing planes re-render once with the new backdrop (triggered by
   the fresh snapshot's unique id).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod render;
 pub mod render_elements;
 #[cfg(feature = "metrics")]
 pub mod render_metrics;
+pub mod render_phase_stats;
 pub mod renderer;
 pub mod screenshare;
 pub mod settings_service;

--- a/src/render_elements/scene_dmabuf_element.rs
+++ b/src/render_elements/scene_dmabuf_element.rs
@@ -308,6 +308,19 @@ impl SceneDmabufElement {
     /// Returns `true` if a new frame was rendered, `false` if skipped
     /// (no subtree damage, no swapchain, no free slot, or surface creation failed).
     pub fn render(&self, renderer: &mut SkiaRenderer) -> bool {
+        // Timing wrapper: under plane decomposition this call is where the
+        // Skia work for a plane buffer happens, so it's the only place the
+        // per-plane cost is visible. Only a real re-render is recorded — the
+        // early-out paths below are cheap and would dilute the mean.
+        let started = std::time::Instant::now();
+        let rendered = self.render_inner(renderer);
+        if rendered {
+            crate::render_phase_stats::record_plane_render(self.label, started.elapsed());
+        }
+        rendered
+    }
+
+    fn render_inner(&self, renderer: &mut SkiaRenderer) -> bool {
         let mut inner = self.inner.lock().unwrap();
 
         // Skip re-render when a valid dmabuf already exists and there is nothing
@@ -536,18 +549,30 @@ impl SceneDmabufElement {
             }
 
             canvas.restore_to_count(save_point);
-            // CPU-blocking sync is REQUIRED before the buffer reaches KMS:
-            // Mesa iris does not attach implicit dma-fences to offscreen
+            // A CPU-side sync IS required before any of these buffers reaches
+            // KMS: Mesa iris does not attach implicit dma-fences to offscreen
             // EGLImage render targets (EXEC_OBJECT_ASYNC on everything but
-            // winsys buffers), so the atomic commit does NOT wait for these
-            // GL writes — without this wait every plane flip visibly
-            // flickers with an unfinished buffer. Removing the wait needs
-            // an explicit fence instead: export an EGL native fence here
-            // and deliver it as the plane's IN_FENCE_FD (follow-up).
+            // winsys buffers), so the atomic commit does NOT wait for these GL
+            // writes — without a wait, plane flips show unfinished buffers.
+            //
+            // But that wait does NOT belong here. Every plane's slot surface is
+            // built from the renderer's single shared `DirectContext`, so one
+            // wait after the last plane covers all of them. Waiting per plane
+            // instead serialised CPU against GPU once per plane and measured
+            // ~15 ms of blocked time each — 95-100% of a plane render, and the
+            // dominant term in the frame budget. Submit without blocking here;
+            // `flush_planes_for_scanout` does the single wait before the commit.
+            //
+            // Submitting (rather than merely recording) still matters for
+            // ordering: the backdrop composite samples an earlier plane's
+            // snapshot, and both live in the same GL context, so the queued
+            // order is the correct order.
+            let flush_started = std::time::Instant::now();
             skia_surface.gr_context.flush_and_submit_surface(
                 &mut skia_surface.surface,
-                layers::skia::gpu::SyncCpu::Yes,
+                layers::skia::gpu::SyncCpu::No,
             );
+            crate::render_phase_stats::record_plane_flush(self.label, flush_started.elapsed());
         }
 
         // Update damage and commit counter. The tight damage rect keeps

--- a/src/render_elements/scene_element.rs
+++ b/src/render_elements/scene_element.rs
@@ -400,6 +400,7 @@ impl RenderElement<SkiaRenderer> for SceneElement {
         // whole untouched subtrees instead of re-walking them per frame.
         let damage_ref = damage_region.as_ref();
 
+        let scene_draw_t = std::time::Instant::now();
         scene.with_arena(|arena| {
             scene.with_renderable_arena(|renderable_arena| {
                 if let Some(root_id) = root_id {
@@ -417,6 +418,7 @@ impl RenderElement<SkiaRenderer> for SceneElement {
                 self.engine.clear_damage();
             });
         });
+        crate::render_phase_stats::record_scene_draw(scene_draw_t.elapsed());
         canvas.restore_to_count(save_point);
 
         Ok(())

--- a/src/render_phase_stats.rs
+++ b/src/render_phase_stats.rs
@@ -1,0 +1,285 @@
+//! Per-phase render timing stats, gated behind the `perf-counters` feature.
+//!
+//! Splits the udev compose path into four phases so we can see whether the
+//! cost lives in the lay-rs engine tick, the smithay element walk, the Skia
+//! scene traversal, or the Skia GPU flush:
+//!
+//! 1. `engine_update` — `SceneElement::update` (lay-rs animation/layout tick)
+//! 2. `render_frame` — `DrmCompositor::render_frame` (smithay walk + GPU dispatch)
+//! 3. `scene_draw` — `render_node_tree` inside `SceneElement::draw`
+//!    (CPU traversal that records Skia draw ops)
+//! 4. `skia_flush` — `SkiaFrame::finish`'s `flush_and_submit_surface`
+//!    (Skia resolves and submits GL commands; on EGL this can include
+//!    implicit waits)
+//!
+//! Phases (3) and (4) are recorded from shared rendering code and only
+//! drained/logged from the udev path. The recording is a single relaxed
+//! atomic add per phase per frame.
+
+#[cfg(feature = "perf-counters")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "perf-counters")]
+use std::sync::Mutex;
+#[cfg(feature = "perf-counters")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "perf-counters")]
+struct Phase {
+    total_ns: AtomicU64,
+    count: AtomicU64,
+    max_ns: AtomicU64,
+}
+
+#[cfg(feature = "perf-counters")]
+impl Phase {
+    const fn new() -> Self {
+        Self {
+            total_ns: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+            max_ns: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, ns: u64) {
+        self.total_ns.fetch_add(ns, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        // Lock-free max via CAS.
+        let mut current = self.max_ns.load(Ordering::Relaxed);
+        while ns > current {
+            match self.max_ns.compare_exchange_weak(
+                current,
+                ns,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Atomically read and reset the accumulators.
+    fn drain(&self) -> (u64, u64, u64) {
+        let total = self.total_ns.swap(0, Ordering::Relaxed);
+        let count = self.count.swap(0, Ordering::Relaxed);
+        let max = self.max_ns.swap(0, Ordering::Relaxed);
+        (count, total, max)
+    }
+}
+
+#[cfg(feature = "perf-counters")]
+static ENGINE_UPDATE: Phase = Phase::new();
+#[cfg(feature = "perf-counters")]
+static RENDER_FRAME: Phase = Phase::new();
+#[cfg(feature = "perf-counters")]
+static SCENE_DRAW: Phase = Phase::new();
+#[cfg(feature = "perf-counters")]
+static SKIA_FLUSH: Phase = Phase::new();
+
+/// Per-plane render timings, keyed by `SceneDmabufElement::label`
+/// ("bg", "windows", "expose", "overlay", "dock", "switcher").
+///
+/// Under plane decomposition this is where the Skia work actually happens —
+/// `render_frame` only hands Smithay already-rendered dmabufs, so the four
+/// phases above show a near-empty compose path and say nothing about which
+/// buffer is expensive. Recorded only when a plane really re-rendered
+/// (`render()` returned true), so a skipped plane doesn't dilute the mean.
+///
+/// A `Mutex<Vec<_>>` rather than atomics: the label set is small and only
+/// discovered at runtime, and this is locked a handful of times per frame.
+/// Fields per label: (label, count, total_ns, max_ns, flush_ns).
+///
+/// `flush_ns` accumulates just the `flush_and_submit_surface(.., SyncCpu::Yes)`
+/// call, which blocks the CPU until that plane's GPU work retires. Subtracting
+/// it from `total_ns` gives the CPU-side draw-recording cost, so the two
+/// questions — "is the GPU work expensive?" vs "are we merely waiting for it?"
+/// — can be told apart. Only the second is recoverable by handing the plane an
+/// IN_FENCE_FD instead of blocking (see the note at the call site).
+#[cfg(feature = "perf-counters")]
+type PlaneStat = (&'static str, u64, u64, u64, u64);
+
+#[cfg(feature = "perf-counters")]
+static PLANES: Mutex<Vec<PlaneStat>> = Mutex::new(Vec::new());
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_plane_render(label: &'static str, elapsed: Duration) {
+    let ns = elapsed.as_nanos() as u64;
+    let mut planes = PLANES.lock().unwrap();
+    match planes.iter_mut().find(|(l, ..)| *l == label) {
+        Some((_, count, total, max, _)) => {
+            *count += 1;
+            *total += ns;
+            *max = (*max).max(ns);
+        }
+        None => planes.push((label, 1, ns, ns, 0)),
+    }
+}
+
+/// Record the blocking-flush portion of a plane render. Called from inside the
+/// render, before `record_plane_render` closes out the same frame's entry.
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_plane_flush(label: &'static str, elapsed: Duration) {
+    let ns = elapsed.as_nanos() as u64;
+    let mut planes = PLANES.lock().unwrap();
+    match planes.iter_mut().find(|(l, ..)| *l == label) {
+        Some((_, _, _, _, flush)) => *flush += ns,
+        None => planes.push((label, 0, 0, 0, ns)),
+    }
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_plane_render(_label: &'static str, _elapsed: std::time::Duration) {}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_plane_flush(_label: &'static str, _elapsed: std::time::Duration) {}
+
+/// The single per-frame CPU wait for all plane buffers
+/// (`SkiaRenderer::flush_planes_for_scanout`). This replaced one blocking
+/// wait per plane, so it should be compared against the *sum* of the old
+/// per-plane flush times, not against any single one.
+#[cfg(feature = "perf-counters")]
+static PLANE_SYNC: Phase = Phase::new();
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_plane_sync(elapsed: Duration) {
+    PLANE_SYNC.record(elapsed.as_nanos() as u64);
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_plane_sync(_elapsed: std::time::Duration) {}
+
+#[cfg(feature = "perf-counters")]
+static LAST_LOG: Mutex<Option<Instant>> = Mutex::new(None);
+
+#[cfg(feature = "perf-counters")]
+const LOG_INTERVAL: Duration = Duration::from_secs(1);
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_engine_update(elapsed: Duration) {
+    ENGINE_UPDATE.record(elapsed.as_nanos() as u64);
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_engine_update(_elapsed: std::time::Duration) {}
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_render_frame(elapsed: Duration) {
+    RENDER_FRAME.record(elapsed.as_nanos() as u64);
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_render_frame(_elapsed: std::time::Duration) {}
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_scene_draw(elapsed: Duration) {
+    SCENE_DRAW.record(elapsed.as_nanos() as u64);
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_scene_draw(_elapsed: std::time::Duration) {}
+
+#[cfg(feature = "perf-counters")]
+#[inline]
+pub fn record_skia_flush(elapsed: Duration) {
+    SKIA_FLUSH.record(elapsed.as_nanos() as u64);
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn record_skia_flush(_elapsed: std::time::Duration) {}
+
+/// If at least `LOG_INTERVAL` has passed since the previous log, drain the
+/// counters and emit a single `tracing::debug!` line summarising each phase
+/// over that window. Cheap to call every frame.
+#[cfg(feature = "perf-counters")]
+pub fn log_if_due() {
+    let mut last = LAST_LOG.lock().unwrap();
+    let now = Instant::now();
+    let due = match *last {
+        Some(t) => now.duration_since(t) >= LOG_INTERVAL,
+        None => {
+            *last = Some(now);
+            false
+        }
+    };
+    if !due {
+        return;
+    }
+    *last = Some(now);
+
+    let (eu_n, eu_total, eu_max) = ENGINE_UPDATE.drain();
+    let (rf_n, rf_total, rf_max) = RENDER_FRAME.drain();
+    let (sd_n, sd_total, sd_max) = SCENE_DRAW.drain();
+    let (sf_n, sf_total, sf_max) = SKIA_FLUSH.drain();
+    let (ps_n, ps_total, ps_max) = PLANE_SYNC.drain();
+
+    let mean_us = |n: u64, total: u64| -> f32 {
+        if n == 0 {
+            0.0
+        } else {
+            (total as f32 / n as f32) / 1_000.0
+        }
+    };
+    let max_us = |max: u64| -> f32 { max as f32 / 1_000.0 };
+
+    tracing::debug!(
+        target: "otto::perf.compose",
+        engine_update_n = eu_n,
+        engine_update_mean_us = mean_us(eu_n, eu_total),
+        engine_update_max_us = max_us(eu_max),
+        render_frame_n = rf_n,
+        render_frame_mean_us = mean_us(rf_n, rf_total),
+        render_frame_max_us = max_us(rf_max),
+        scene_draw_n = sd_n,
+        scene_draw_mean_us = mean_us(sd_n, sd_total),
+        scene_draw_max_us = max_us(sd_max),
+        skia_flush_n = sf_n,
+        skia_flush_mean_us = mean_us(sf_n, sf_total),
+        skia_flush_max_us = max_us(sf_max),
+        plane_sync_n = ps_n,
+        plane_sync_mean_us = mean_us(ps_n, ps_total),
+        plane_sync_max_us = max_us(ps_max),
+        "compose phase timings (per-second window)",
+    );
+
+    // One line per plane that re-rendered in this window. Separate lines
+    // rather than fields on the line above: the label set is dynamic, and a
+    // plane that never redrew should be absent rather than logged as zero.
+    let drained: Vec<_> = {
+        let mut planes = PLANES.lock().unwrap();
+        let snapshot = planes.clone();
+        planes.clear();
+        snapshot
+    };
+    for (label, count, total, max, flush) in drained {
+        // draw = everything that is not the blocking flush: Skia op recording,
+        // swapchain acquire, surface setup.
+        let draw = total.saturating_sub(flush);
+        tracing::debug!(
+            target: "otto::perf.compose",
+            plane = label,
+            n = count,
+            mean_us = mean_us(count, total),
+            draw_mean_us = mean_us(count, draw),
+            flush_mean_us = mean_us(count, flush),
+            max_us = max_us(max),
+            "plane render timings (per-second window)",
+        );
+    }
+}
+
+#[cfg(not(feature = "perf-counters"))]
+#[inline]
+pub fn log_if_due() {}

--- a/src/renderer/frame.rs
+++ b/src/renderer/frame.rs
@@ -196,9 +196,11 @@ impl Frame for SkiaFrame<'_> {
         // this, the EGL fence we create below may be inserted *before* Skia has
         // actually emitted the GL draw calls for this frame's content — causing
         // the GPU to scan out a partially/un-rendered buffer (black frame).
+        let flush_t = std::time::Instant::now();
         surface
             .gr_context
             .flush_and_submit_surface(&mut surface.surface, None);
+        crate::render_phase_stats::record_skia_flush(flush_t.elapsed());
 
         let sync = SkiaSync::create(self.renderer.egl_context().display())
             .map(SyncPoint::from)

--- a/src/skia_renderer.rs
+++ b/src/skia_renderer.rs
@@ -246,6 +246,24 @@ impl SkiaRenderer {
         self.gl_renderer.egl_context()
     }
 
+    /// Block until every plane buffer rendered this frame has actually been
+    /// written by the GPU.
+    ///
+    /// Plane slot surfaces are offscreen EGLImage render targets, which Mesa
+    /// iris does not attach implicit dma-fences to, so the atomic commit will
+    /// not wait for them — something must, or planes flip with half-drawn
+    /// buffers. Every plane shares this one `DirectContext`, so a single wait
+    /// here covers all of them; the per-plane renders submit without blocking
+    /// (see `SceneDmabufElement::render_inner`).
+    ///
+    /// Call once per frame, after the last plane render and before handing the
+    /// buffers to the DRM compositor.
+    pub fn flush_planes_for_scanout(&mut self) {
+        if let Some(context) = self.context.as_mut() {
+            context.flush_submit_and_sync_cpu();
+        }
+    }
+
     /// Create a Skia surface backed by the GL texture we import from
     /// `dmabuf`. Used by [`SceneDmabufElement`](crate::render_elements::scene_dmabuf_element::SceneDmabufElement)
     /// to render the lay-rs scene into a dmabuf the DRM compositor can

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -664,6 +664,7 @@ impl Otto<UdevData> {
                 overlay_last_active: None,
                 overlay_was_active: false,
                 switcher_was_active: false,
+                windows_warmed_for_expose: false,
                 popup_teardown_seen: 0,
                 dock_menu_teardown_seen: 0,
                 promote_candidates: Vec::new(),

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -209,7 +209,9 @@ impl Otto<UdevData> {
             //
             // `scene_element` and `backend_data` are distinct fields of `self`,
             // so Rust's field-projection rules allow concurrent access here.
+            let engine_t = Instant::now();
             let scene_has_damage = self.scene_element.update();
+            crate::render_phase_stats::record_engine_update(engine_t.elapsed());
             if scene_has_damage {
                 // Damage ticks are counted globally: the flag is consumed by
                 // whichever output ticks first, so other surfaces detect the
@@ -711,7 +713,10 @@ impl Otto<UdevData> {
             // now to apply it before compositing, and force a draw — otherwise
             // the first composited frame after demotion shows the stale,
             // shadow-only scene (a one-frame flicker).
-            if self.scene_element.update() {
+            let engine_t = Instant::now();
+            let updated = self.scene_element.update();
+            crate::render_phase_stats::record_engine_update(engine_t.elapsed());
+            if updated {
                 self.backend_data.damage_generation += 1;
             }
             true
@@ -719,7 +724,9 @@ impl Otto<UdevData> {
             match prefetched_scene_damage {
                 Some(damage) => damage,
                 None => {
+                    let engine_t = Instant::now();
                     let damage = self.scene_element.update();
+                    crate::render_phase_stats::record_engine_update(engine_t.elapsed());
                     if damage {
                         self.backend_data.damage_generation += 1;
                     }
@@ -767,6 +774,8 @@ impl Otto<UdevData> {
                 .is_animating
                 .load(std::sync::atomic::Ordering::Relaxed),
         );
+
+        crate::render_phase_stats::log_if_due();
 
         #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
         let occluded_ids = self.workspaces.occluded_window_ids();
@@ -2285,12 +2294,24 @@ pub(super) fn render_output_frame<'a>(
                     &surface.expose_dmabuf_element,
                     &mut workspace_render_elements,
                 );
-                // Keep the windows swapchain warm for the expose→windows
-                // transition so closing expose doesn't flash a cold frame.
-                if let Some(el) = &surface.windows_dmabuf_element {
-                    el.render(renderer.as_mut());
+                // Warm the windows swapchain ONCE per expose session, not every
+                // frame. The buffer is not pushed as a plane element above, so
+                // nothing it contains reaches the screen while expose is up —
+                // but `render()` blocks the CPU on a GPU sync, which measured
+                // ~109 ms per second of expose (a fifth of the frame budget) for
+                // invisible pixels. Rendering on the entry edge alone keeps the
+                // warm expose→windows transition this was added for. Content
+                // that changes during expose is still correct on exit: the
+                // damage history no longer reaches the reacquired slot's commit,
+                // which forces a full re-render on the first composited frame.
+                if !surface.windows_warmed_for_expose {
+                    if let Some(el) = &surface.windows_dmabuf_element {
+                        el.render(renderer.as_mut());
+                    }
+                    surface.windows_warmed_for_expose = true;
                 }
             } else {
+                surface.windows_warmed_for_expose = false;
                 // Top-window direct scanout: the client's Wayland buffer goes
                 // to Smithay as a `ScanoutCandidate`. Smithay tries to bind
                 // it to an overlay; if that fails it composites the client
@@ -2489,6 +2510,15 @@ pub(super) fn render_output_frame<'a>(
             | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY
             | smithay::backend::drm::compositor::FrameFlags::ALLOW_OVERLAY_PLANE_SCANOUT
     };
+    // Single CPU wait for every plane buffer rendered above. The per-plane
+    // renders submit without blocking, so this is the one point where the GPU
+    // is guaranteed to have finished writing them — required because the
+    // atomic commit will not wait for offscreen EGLImage targets itself.
+    let plane_sync_t = std::time::Instant::now();
+    renderer.as_mut().flush_planes_for_scanout();
+    crate::render_phase_stats::record_plane_sync(plane_sync_t.elapsed());
+
+    let render_frame_t = std::time::Instant::now();
     let render_frame_result = surface
         .compositor
         .render_frame(renderer, &output_elements, clear_color, frame_flags)
@@ -2505,6 +2535,7 @@ pub(super) fn render_output_frame<'a>(
                 ))))
             }
         })?;
+    crate::render_phase_stats::record_render_frame(render_frame_t.elapsed());
 
     #[cfg(feature = "renderer_sync")]
     {

--- a/src/udev/types.rs
+++ b/src/udev/types.rs
@@ -249,6 +249,13 @@ pub struct SurfaceData {
     /// flashing ghost content (`SceneDmabufElement::request_full_render`).
     pub(super) overlay_was_active: bool,
     pub(super) switcher_was_active: bool,
+    /// Whether the windows plane has already been warmed for the current
+    /// expose session. While expose is up the windows buffer is rendered but
+    /// never pushed as a plane element, so re-rendering it per frame blocks
+    /// the CPU on a GPU sync for pixels that never reach the screen (measured
+    /// at ~109 ms per second of expose). One render on the entry edge keeps
+    /// the warm expose→windows transition; reset when expose ends.
+    pub(super) windows_warmed_for_expose: bool,
     /// Last `PopupOverlayView::teardown_generation()` this surface has drawn.
     /// A popup teardown removes nodes that painted outside the bounds damage
     /// is derived from (drop shadow, blur rim), so the frame after a teardown

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -878,9 +878,22 @@ impl Workspaces {
         let is_animating = self.is_animating.load(std::sync::atomic::Ordering::Relaxed);
 
         // We're transitioning if:
-        // 1. Gesture value is between 0 and 1000 (not fully closed or fully open), OR
-        // 2. Animation is in progress AND we're not at a stable state (0 or 1000)
-        (gesture_value > 0 && gesture_value < 1000)
+        // 1. A finger gesture is in flight, whatever the accumulator reads, OR
+        // 2. Gesture value is between 0 and 1000 (not fully closed or fully open), OR
+        // 3. Animation is in progress AND we're not at a stable state (0 or 1000)
+        //
+        // (1) is not redundant with (2): `expose_gesture_start` sets the active
+        // flag and resets the accumulator to exactly 0 (or 1000 when closing) in
+        // the same breath — the two values (2) excludes — and a fast swipe then
+        // saturates at the clamp and stays there for a run of frames. Without
+        // (1), `expose_active` reads false for those frames while `show_all` has
+        // not been committed yet, so the expose plane leaves the plane stack and
+        // the windows plane is pushed instead: mid-gesture the screen flicks back
+        // to the normal layout, then snaps to expose when the gesture ends. A slow
+        // gesture hides the bug by spending most frames strictly inside (0,1000).
+        self.expose_gesture_active
+            .load(std::sync::atomic::Ordering::Relaxed)
+            || (gesture_value > 0 && gesture_value < 1000)
             || (is_animating && gesture_value != 0 && gesture_value != 1000)
     }
 


### PR DESCRIPTION
Reduces blocked CPU time in the per-output plane render path, and fixes an
expose gesture glitch found while measuring it.

## Sync once per frame instead of once per plane

Every plane buffer flushed with `SyncCpu::Yes`, blocking the CPU until that
plane's GPU work retired before the next plane could start recording — so a
frame cost the sum of every plane's CPU and GPU time, with the CPU idle for
most of it.

The wait is still required (plane buffers are offscreen EGLImage render
targets, which Mesa iris does not attach implicit dma-fences to, so the
atomic commit does not wait for their GL writes on its own), but it does not
belong per plane: every plane's slot surface is built from the renderer's
single shared Skia `DirectContext`, so one wait after the last plane covers
all of them. Per-plane flushes now submit without blocking, and CPU and GPU
overlap instead of serialising.

They still *submit* rather than merely record, because the backdrop composite
samples an earlier plane's snapshot from the same context and the queued order
is the correct order.

Delivering the fence to KMS as `IN_FENCE_FD` would be better still, and is
noted in the spec as follow-up: it is not reachable today because smithay
populates `PlaneConfig.sync` only from a `ScanoutBuffer::Wayland` acquire
point, so a dmabuf-backed plane element cannot carry a sync point without
extending the smithay fork.

## Don't re-render the windows plane during expose

While expose is up the windows buffer was rendered every frame but never
pushed as a plane element — the expose buffer replaces it in the stack — so
none of that work reached the screen. It is now warmed once on the expose
entry edge, which is all the `expose -> windows` transition needed it for.

Content that changed during expose is still correct on exit: the damage
history no longer reaches the reacquired swapchain slot's commit, which
forces a full re-render on the first composited frame.

## Keep expose active for the whole gesture

`expose_gesture_start` sets the gesture-active flag and resets the accumulator
to exactly 0 (or 1000 when closing) — the two values `is_expose_transitioning`
excluded — and a fast swipe then saturates at the clamp and stays there. So
`expose_active` read false for those frames while `show_all` was not yet
committed: the expose plane left the plane stack and the windows plane was
pushed instead, and mid-gesture the screen flicked back to the normal layout
before snapping to expose when the gesture ended. A slow gesture hid the bug
by spending most frames strictly inside (0, 1000).

## Instrumentation

Adds `render_phase_stats`, behind the existing `perf-counters` feature (off by
default, no-op stubs when disabled). It splits the compose path into engine
update / `render_frame` / Skia scene draw / Skia flush, and times each plane
buffer's render separately as draw vs blocking flush — the compose-path phases
alone show almost nothing under plane decomposition, because `render_frame` is
handed already-rendered dmabufs and the real work is inside each plane's
render.

## Testing

Built with and without `perf-counters`; `cargo clippy` clean. Exercised on tty
(udev) on Intel/i915: idle desktop, window drag, and expose open/close
including fast gestures. No plane tearing observed, which was the correctness
risk of moving the sync — watched the dock and overlay during animations.

`specs/plane-scanout.md` is updated. Its previous claim that plane renders
"submit to the GPU without a CPU-blocking wait on devices with implicit dmabuf
fencing" did not match the code, which blocked unconditionally; that bullet is
corrected.
