### PR TITLE
Apps: file browser, app launcher and settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,10 +162,15 @@ members = [
     "components/otto-lock",
     "components/otto-bar",
     "components/otto-islands",
+    "components/otto-launcher",
+    "components/otto-settings",
+    "components/otto-files",
+    "components/otto-quickview",
     "sample-clients/client-rainbow",
     "sample-clients/submenu",
     "sample-clients/submenu-gtk",
-    "sample-clients/deadlock-test",]
+    "sample-clients/deadlock-test",
+]
 
 
 [package.metadata.deb]

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "otto-files"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+otto-quickview = { path = "../otto-quickview" }
+smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
+wayland-client = "0.31"
+tracing = "0.1"
+libc = "0.2"
+zbus = { version = "4", default-features = false, features = ["tokio"] }
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dependencies.laye-rs]
+git = "https://github.com/nongio/layers"
+tag = "v1.13.0"
+features = ["export-taffy"]
+
+[dependencies.skia-safe]
+version = "=0.93"
+features = ["gl", "textlayout", "svg"]
+
+[dev-dependencies]
+khronos-egl = { version = "6", features = ["dynamic"] }
+wayland-egl = "0.32"
+
+[[bin]]
+name = "otto-files"
+path = "src/main.rs"
+
+[lib]
+name = "otto_files"
+path = "src/lib.rs"

--- a/components/otto-files/org.otto.FilePicker1.service
+++ b/components/otto-files/org.otto.FilePicker1.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.otto.FilePicker1
+Exec=/usr/local/bin/otto-files --picker

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1,0 +1,3627 @@
+use crate::{model, pane_surfaces, perf, picker, quickview, scene, view};
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use otto_kit::clipboard;
+use otto_kit::components::context_menu::ContextMenu;
+use otto_kit::components::scroll::{Axis, ScrollView};
+use otto_kit::components::titlebar::{WindowControl, WindowControlsState};
+use otto_kit::components::window::resize;
+use otto_kit::prelude::*;
+use otto_kit::CursorShape;
+use skia_safe::Contains;
+use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
+use smithay_client_toolkit::seat::keyboard::KeyEvent;
+use smithay_client_toolkit::seat::pointer::PointerEventKind;
+use smithay_client_toolkit::shell::xdg::window::WindowConfigure;
+use smithay_client_toolkit::shell::xdg::{XdgPositioner, XdgSurface};
+use wayland_client::protocol::wl_keyboard;
+
+/// `BTN_RIGHT` from `linux/input-event-codes.h` — a right-click opens the
+/// context menu instead of doing whatever the same spot does on the left
+/// button.
+const BTN_RIGHT: u32 = 0x111;
+
+use model::{Column, Entry, Place, SortKey};
+use view::ViewMode;
+
+/// How soon a second press on the same column divider must land to count as
+/// a double-click rather than the start of a fresh drag.
+const DOUBLE_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// The browser's whole state. Shared with the draw and input callbacks, which
+/// outlive any borrow this struct could hand out.
+struct Browser {
+    /// The path stack: `[root, …, deepest]`. Miller columns render all of it;
+    /// the list renders the last. Navigation pushes and pops in both views, so
+    /// switching between them keeps the user where they were.
+    columns: Vec<Column>,
+    /// Which column has the keyboard.
+    active: usize,
+    places: Vec<Place>,
+    mode: ViewMode,
+    sort: SortKey,
+    ascending: bool,
+    show_hidden: bool,
+    /// The list view's draggable Size/Kind/Modified column widths.
+    list_columns: view::ListColumnWidths,
+    /// A column divider currently being dragged: which one, the pointer x it
+    /// started at, and the width it started with.
+    column_resize: Option<(view::ColumnBoundary, f32, f32)>,
+    /// The Miller view's shared, draggable pane width.
+    miller_w: f32,
+    /// A Miller pane divider being dragged: its depth, the pointer x it
+    /// started at, and the width it started with.
+    miller_resize: Option<(usize, f32, f32)>,
+    /// The last Miller divider clicked and when, so a second click shortly
+    /// after reads as a double-click rather than a fresh drag.
+    last_miller_click: Option<(usize, std::time::Instant)>,
+    /// The last row/cell clicked (depth, index) and when — List and Grid have
+    /// no Miller-style eager descent, so a directory only opens on a second
+    /// click landing on the same one within the window.
+    last_row_click: Option<(usize, usize, std::time::Instant)>,
+    /// The last boundary clicked and when, so a second click on the same one
+    /// shortly after reads as a double-click rather than a fresh drag.
+    last_boundary_click: Option<(view::ColumnBoundary, std::time::Instant)>,
+    /// Horizontal pan of the Miller stack, as a scroll view of its own: the
+    /// stack is one continuous strip that happens to be divided into panes,
+    /// so panning it is a scroll, with the same momentum, rubber banding and
+    /// overlay bar the panes scroll vertically with. Its offset is how far
+    /// the strip is pushed left, in points.
+    ///
+    /// Navigation ([`view::miller_pan_for`]) drives it too, through
+    /// `scroll_to`, which lands on an exact column edge and drops whatever
+    /// fling was in flight.
+    pan: ScrollView,
+    /// Which axis the touchpad gesture in progress belongs to, decided by its
+    /// first delta and held until it ends. Deciding per event instead lets a
+    /// diagonal swipe flip-flop between panning the stack and scrolling a
+    /// pane, several times a second.
+    gesture_axis: Option<Axis>,
+    size: (f32, f32),
+    /// What a cut or copy put aside. Internal to this application — see
+    /// [`model::Clipboard`].
+    clipboard: model::Clipboard,
+    /// The last operation's outcome, shown in the header until the next action.
+    status: Option<String>,
+    /// The open preview, if one is up.
+    quickview: Option<quickview::Session>,
+    /// The docked preview column's state, for the entry currently under a
+    /// single-item selection. `None` both when the column is hidden (no
+    /// selection, or not enough room for it) and briefly while a fresh
+    /// selection's decode is still in flight — [`PreviewPaneState::pending`]
+    /// tells the two apart.
+    preview: Option<PreviewPaneState>,
+    /// Bumped for every preview decode started, independent of Quick View's
+    /// own generation counter — the two panels can be open at once.
+    preview_generation_seed: u64,
+    /// A decode is in flight. Keeps the frame loop alive so its result is
+    /// painted without waiting for the next input.
+    quickview_pending: bool,
+    /// A dismissed preview still on screen, shrinking back to its file.
+    quickview_closing: Option<quickview::Session>,
+    /// Open Quick View on the first entry as soon as one is listed, so the
+    /// panel can be looked at without anyone pressing a key. Driving the real
+    /// keyboard means injecting into whatever session the test runs in, which
+    /// is both unreliable and rude to whoever is using that desktop.
+    /// `OTTO_FILES_QV_AUTO=1`.
+    quickview_auto: bool,
+    /// Bumped for every decode started. A result arriving with a stale
+    /// generation is dropped: arrow-keying is much faster than decoding, and a
+    /// slow PDF must not land on top of a file the user moved off three keys
+    /// ago.
+    quickview_generation: u64,
+    /// The Get Info panel, when one is open. Not modal: it is a window of its
+    /// own that floats over the browser, and the browser goes on working
+    /// underneath it.
+    info: Option<model::FileInfo>,
+    /// Why the last permission change was refused, if it was.
+    info_error: Option<String>,
+    /// Pointer is over the panel's close dot, so its × glyph reveals — the
+    /// same hover behaviour as the window's own traffic lights.
+    info_close_hovered: bool,
+    /// Set when the panel's own window has something new to show — it is a
+    /// separate window with a separate buffer, so the browser's own `dirty`
+    /// says nothing about it.
+    info_dirty: bool,
+    /// Hover and press state of the traffic lights, so they reveal their
+    /// glyphs under the pointer the way the compositor's own decoration does.
+    controls: WindowControlsState,
+    /// The Back/Forward half being held down. Like the traffic lights, the
+    /// arrows arm on press and fire on release over the same half, so a press
+    /// dragged off the button changes nothing.
+    nav_pressed: Option<view::NavButton>,
+    /// An in-place rename in progress. List view only, for now.
+    rename: Option<RenameSession>,
+    /// A Back/Forward step landed and its panes are still being read. The
+    /// remembered cursor is an index into a list that does not exist until
+    /// those reads finish, so it is re-derived — and scrolled into view —
+    /// once they do.
+    pending_restore: bool,
+    /// Locations left behind by Back, most recent last. Forward pops them back.
+    back: Vec<Location>,
+    /// Locations left behind by Forward, most recent last. Back pops them back.
+    forward: Vec<Location>,
+    /// Set when something changed and the window needs repainting.
+    dirty: bool,
+    /// The portal request this window is serving, when it is a picker rather
+    /// than the browser. `None` is the browser, and every difference between
+    /// the two shells reads off this one field.
+    picker: Option<picker::Session>,
+    /// The action row's hover and press state, tracked like the traffic
+    /// lights': a button arms on press and fires on release over the same
+    /// button, so a press dragged off it changes nothing.
+    footer_hover: Option<view::FooterButton>,
+    footer_pressed: Option<view::FooterButton>,
+    /// Pointer is over Quick View's close button.
+    quickview_close_hovered: bool,
+    /// Where Quick View's panel actually is, in window coordinates.
+    ///
+    /// Written by the render path, read by the pointer handler, because the
+    /// two cannot otherwise agree: a panel centred on the *display* is placed
+    /// from an answer only [`pane_surfaces`] has, and the pointer callback
+    /// outlives any borrow of it. `None` falls back to the window's centre,
+    /// which is where the panel is when it is not centred on the display.
+    quickview_panel: Option<Rect>,
+    /// The pointer's last position over the Quick View panel, together with
+    /// the panel rect it was measured against.
+    ///
+    /// The two are stored as a pair because they are not always in the same
+    /// space: the panel takes its own input when it is centred on the display
+    /// and the toplevel takes it otherwise, and those two report positions in
+    /// two different coordinate systems. Whichever handler saw the pointer
+    /// records the panel *it* was hit-testing against, so a pinch can work in
+    /// that space without having to know which handler it came from.
+    quickview_focus: Option<(skia_safe::Point, Rect)>,
+    /// The zoom a pinch in progress started from, if one is.
+    ///
+    /// `zwp_pointer_gesture_pinch_v1` reports its scale against the start of
+    /// the gesture rather than against the last update, so the zoom it is
+    /// asking for is this times that — and applying it incrementally instead
+    /// would compound rounding across a gesture that can run for seconds.
+    quickview_pinch: Option<f32>,
+}
+
+/// A snapshot of the column stack, for the Back/Forward pair. The whole
+/// breadcrumb is kept, not just the deepest path, so returning to a Miller
+/// view location restores every pane that was open, not just the last one.
+struct Location {
+    columns: Vec<ColumnState>,
+    active: usize,
+}
+
+/// One pane of a remembered [`Location`]: where it was pointed and what was
+/// picked in it. Going back to a directory you were just in should put you
+/// back where you were standing in it, cursor and selection included — not
+/// at the top of an unselected list.
+struct ColumnState {
+    path: PathBuf,
+    selection: std::collections::BTreeSet<String>,
+    cursor: Option<usize>,
+    anchor: Option<usize>,
+}
+
+/// What the docked preview column is showing, for the entry at `path`.
+struct PreviewPaneState {
+    path: PathBuf,
+    generation: u64,
+    /// A decode for `path` is in flight.
+    pending: bool,
+    decoded: Option<otto_kit::preview::Preview>,
+}
+
+/// An in-place rename in progress: which row it belongs to and the text
+/// field editing its name.
+struct RenameSession {
+    depth: usize,
+    index: usize,
+    original: PathBuf,
+    input: TextInput,
+}
+
+/// The byte range an in-place rename should start with selected: the stem,
+/// so typing replaces the base name and leaves the extension alone — the way
+/// Finder and Explorer both do it. A directory has no extension to protect,
+/// and a leading dot (`.bashrc`) is not an extension separator, so both keep
+/// the whole name selected.
+fn rename_selection(name: &str, is_dir: bool) -> std::ops::Range<usize> {
+    if is_dir {
+        return 0..name.len();
+    }
+    match name.rfind('.') {
+        Some(0) | None => 0..name.len(),
+        Some(dot) => 0..dot,
+    }
+}
+
+impl Browser {
+    fn new(start: PathBuf) -> Self {
+        Self {
+            columns: vec![Column::new(start)],
+            active: 0,
+            places: model::places(),
+            mode: ViewMode::Columns,
+            sort: SortKey::Name,
+            ascending: true,
+            show_hidden: false,
+            list_columns: view::ListColumnWidths::default(),
+            column_resize: None,
+            miller_w: view::MILLER_W,
+            miller_resize: None,
+            last_miller_click: None,
+            last_row_click: None,
+            last_boundary_click: None,
+            rename: None,
+            pending_restore: false,
+            back: Vec::new(),
+            forward: Vec::new(),
+            nav_pressed: None,
+            pan: ScrollView::horizontal(view::content_viewport(
+                view::WINDOW_W,
+                view::WINDOW_H,
+                ViewMode::Columns,
+            )),
+            gesture_axis: None,
+            size: (view::WINDOW_W, view::WINDOW_H),
+            clipboard: model::Clipboard::default(),
+            quickview: None,
+            preview: None,
+            preview_generation_seed: 0,
+            quickview_pending: false,
+            quickview_closing: None,
+            quickview_auto: std::env::var_os("OTTO_FILES_QV_AUTO").is_some(),
+            quickview_generation: 0,
+            status: None,
+            info: None,
+            info_error: None,
+            info_close_hovered: false,
+            info_dirty: false,
+            controls: WindowControlsState::new(),
+            dirty: true,
+            picker: None,
+            footer_hover: None,
+            footer_pressed: None,
+            quickview_close_hovered: false,
+            quickview_panel: None,
+            quickview_focus: None,
+            quickview_pinch: None,
+        }
+    }
+
+    /// A picker window serving `session`, opened at the directory the request
+    /// asks for.
+    fn for_picker(session: picker::Session, start: PathBuf) -> Self {
+        let mut browser = Self::new(start);
+        // The picker is a dialog, not a document window: one directory at a
+        // time reads as a file dialog, where the Miller stack reads as the
+        // browser. The user can still switch views.
+        browser.mode = ViewMode::List;
+        browser.picker = Some(session);
+        browser.pan = ScrollView::horizontal(view::content_viewport(
+            browser.size.0,
+            browser.size.1 - view::FOOTER_H,
+            ViewMode::List,
+        ));
+        browser
+    }
+
+    /// How much of the window height the action row takes — zero in the
+    /// browser, which has none.
+    fn footer_h(&self) -> f32 {
+        if self.picker.is_some() {
+            view::FOOTER_H
+        } else {
+            0.0
+        }
+    }
+
+    /// The bottom of the *file area*, which is the window bottom less the
+    /// action row. Every piece of geometry in [`view`] takes this as its
+    /// `height`, so none of it has to know the row exists.
+    fn content_h(&self) -> f32 {
+        self.size.1 - self.footer_h()
+    }
+
+    /// The entries of column `depth`, filtered and sorted for display.
+    ///
+    /// Rebuilt per frame rather than cached: at the sizes a window shows this
+    /// is cheap, and a cache is one more thing to invalidate when the directory
+    /// changes underneath. The moment it stops being cheap it moves to the
+    /// model thread, which is where the spec puts it.
+    fn visible(&self, depth: usize) -> Vec<&Entry> {
+        let _t = perf::now();
+        let entries = self.visible_uncounted(depth);
+        perf::mark(perf::Stage::Visible, _t);
+        entries
+    }
+
+    /// How many entries the column shows, without materialising the list.
+    ///
+    /// `counts()` and the subtitle only ever wanted the length, and building
+    /// a `Vec` of twenty-five thousand references to throw away is the kind
+    /// of per-frame cost that is invisible until the directory is big.
+    fn visible_len(&self, depth: usize) -> usize {
+        self.ensure_sorted(depth);
+        self.columns[depth].sorted.borrow().order.len()
+    }
+
+    /// Bring the column's cached order in line with the listing and the
+    /// current sort settings, recomputing only if one of them moved.
+    fn ensure_sorted(&self, depth: usize) {
+        let column = &self.columns[depth];
+        // The picker's filter is part of the key: picking a different one
+        // re-filters in place, with no filesystem access, and picking the
+        // same one re-uses the order already computed.
+        let filter = self.picker.as_ref().map(|p| p.current_filter).unwrap_or(0);
+        let key = (
+            column.epoch,
+            self.sort,
+            self.ascending,
+            self.show_hidden,
+            filter,
+        );
+        if column.sorted.borrow().key == Some(key) {
+            return;
+        }
+        let entries = &column.snapshot.entries;
+        let mut order: Vec<usize> = (0..entries.len())
+            .filter(|&i| self.show_hidden || !entries[i].hidden)
+            .filter(|&i| match &self.picker {
+                Some(session) => session.shows(&entries[i].name, entries[i].is_dir),
+                None => true,
+            })
+            .collect();
+        order.sort_by(|&a, &b| self.compare(&entries[a], &entries[b]));
+        *column.sorted.borrow_mut() = model::SortCache {
+            key: Some(key),
+            order,
+        };
+    }
+
+    fn visible_uncounted(&self, depth: usize) -> Vec<&Entry> {
+        self.ensure_sorted(depth);
+        let column = &self.columns[depth];
+        let entries = &column.snapshot.entries;
+        column
+            .sorted
+            .borrow()
+            .order
+            .iter()
+            .map(|&i| &entries[i])
+            .collect()
+    }
+
+    /// The order two entries sort in, under the current settings.
+    fn compare(&self, a: &Entry, b: &Entry) -> std::cmp::Ordering {
+        let dirs_first = b.is_dir.cmp(&a.is_dir);
+        if dirs_first != std::cmp::Ordering::Equal {
+            return dirs_first;
+        }
+        let ord = match self.sort {
+            SortKey::Name => model::natural_cmp(&a.name, &b.name),
+            SortKey::Size => a.size.unwrap_or(0).cmp(&b.size.unwrap_or(0)),
+            SortKey::Kind => a
+                .kind_label()
+                .cmp(b.kind_label())
+                .then_with(|| model::natural_cmp(&a.name, &b.name)),
+            SortKey::Modified => a.modified.cmp(&b.modified),
+        };
+        if self.ascending {
+            ord
+        } else {
+            ord.reverse()
+        }
+    }
+
+    fn counts(&self) -> Vec<usize> {
+        (0..self.columns.len())
+            .map(|d| self.visible_len(d))
+            .collect()
+    }
+
+    /// Whether the preview pane has something to show: exactly one *file*
+    /// selected in the active column, in Miller view — a folder is where you
+    /// already are one click away from browsing, so previewing it as if it
+    /// were a document's content does not earn the pane, and List/Grid show
+    /// one directory at a time with nothing for a trailing pane to sit beside.
+    ///
+    /// No width check: the pane is a member of the horizontally-panned Miller
+    /// stack (see [`Self::preview_width`], [`Self::reveal_preview`]), not
+    /// something carved out of the listing's own space, so there is nothing
+    /// for a narrow window to run short of — it is simply off-screen until
+    /// panned into view, the same as any column would be.
+    fn preview_visible(&self) -> bool {
+        if self.mode != ViewMode::Columns {
+            return false;
+        }
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let single_selected = self
+            .columns
+            .get(depth)
+            .is_some_and(|c| c.selection.len() == 1);
+        single_selected && self.selected_entry().is_some_and(|e| !e.is_dir)
+    }
+
+    fn preview_width(&self) -> f32 {
+        if self.preview_visible() {
+            view::PREVIEW_W
+        } else {
+            0.0
+        }
+    }
+
+    /// Bring the preview pane's state in line with the current selection.
+    /// Returns the path and generation to decode when the target changed and
+    /// nothing is already in flight for it — the caller runs the decode off
+    /// the UI thread and reports back through [`Self::finish_preview`].
+    fn sync_preview_target(&mut self) -> Option<(PathBuf, u64)> {
+        if !self.preview_visible() {
+            if self.preview.take().is_some() {
+                self.dirty = true;
+            }
+            return None;
+        }
+        let entry = self.selected_entry()?;
+        if let Some(pane) = &self.preview {
+            if pane.path == entry.path {
+                return None; // Already showing (or decoding) this one.
+            }
+        }
+        self.preview_generation_seed += 1;
+        let generation = self.preview_generation_seed;
+        self.preview = Some(PreviewPaneState {
+            path: entry.path.clone(),
+            generation,
+            pending: true,
+            decoded: None,
+        });
+        self.reveal_preview();
+        self.dirty = true;
+        Some((entry.path, generation))
+    }
+
+    /// Pan the stack so the preview pane — sitting right after the last real
+    /// column, the same trailing position a freshly opened directory column
+    /// would occupy — is fully in view. Called whenever the preview's target
+    /// changes, the same way selecting a directory reveals its own column.
+    fn reveal_preview(&mut self) {
+        if !self.preview_visible() {
+            return;
+        }
+        self.sync_scroll_metrics();
+        let target = view::preview_pan_for(
+            self.columns.len(),
+            self.size.0,
+            self.pan.offset(),
+            self.miller_w,
+        );
+        if self.pan.scroll_to(target) {
+            self.dirty = true;
+        }
+    }
+
+    /// Show a preview decode that arrived, unless the selection has moved on
+    /// since — the same staleness guard Quick View uses.
+    fn finish_preview(&mut self, generation: u64, preview: otto_kit::preview::Preview) {
+        let Some(pane) = &mut self.preview else {
+            return;
+        };
+        if pane.generation != generation {
+            return;
+        }
+        pane.pending = false;
+        pane.decoded = Some(preview);
+        self.dirty = true;
+    }
+
+    /// Give every pane's scroll view its viewport and content height.
+    ///
+    /// Re-measured rather than cached, and before both drawing and scrolling:
+    /// the viewport moves with the window and the pan, and the content height
+    /// changes whenever a directory finishes loading, is re-sorted, or has
+    /// hidden files toggled. A scroll view with stale metrics clamps to the
+    /// wrong end.
+    fn sync_scroll_metrics(&mut self) {
+        let (width, height) = (self.size.0, self.content_h());
+        let mode = self.mode;
+        let miller_w = self.miller_w;
+        let depth_count = self.columns.len();
+        let counts = self.counts();
+
+        // The stack's own metrics first: the panes are laid out from its
+        // offset, so a stale pan would place every pane viewport wrong. The
+        // preview pane, when showing, is one more thing the stack must have
+        // room to pan to — it is folded into the same content length as the
+        // real columns rather than carved out of the viewport.
+        self.pan
+            .set_viewport(view::content_viewport(width, height, mode));
+        self.pan.set_content_length(view::miller_content_width(
+            depth_count,
+            miller_w,
+            self.preview_width(),
+        ));
+        let pan = self.pan.offset();
+
+        for depth in 0..depth_count {
+            let viewport = view::pane_viewport(width, height, mode, depth, pan, miller_w);
+            let content = view::pane_content_height(width, height, mode, counts[depth]);
+            let scroll = &mut self.columns[depth].scroll;
+            scroll.state.set_viewport(viewport);
+            scroll.set_content_length(content);
+        }
+    }
+
+    /// Pan the stack the shortest distance that brings pane `depth` fully into
+    /// view — what every navigation into a new column does.
+    ///
+    /// A no-op outside Miller view, where there is one pane and nothing to
+    /// pan. The metrics are re-synced first because the target is clamped to
+    /// the stack's content width, which grows and shrinks with the path.
+    fn reveal_pane(&mut self, depth: usize) {
+        if self.mode != ViewMode::Columns {
+            return;
+        }
+        self.sync_scroll_metrics();
+        let target = view::miller_pan_for(depth, self.size.0, self.pan.offset(), self.miller_w);
+        if self.pan.scroll_to(target) {
+            self.dirty = true;
+        }
+    }
+
+    /// Which pane the pointer is over — the one the wheel and the scrollbar
+    /// belong to. Only Miller view has more than one.
+    fn pane_under(&self, x: f32, y: f32) -> usize {
+        if self.mode != ViewMode::Columns {
+            return self.columns.len() - 1;
+        }
+        let counts = self.counts();
+        view::miller_at(
+            x,
+            y,
+            self.size.0,
+            self.content_h(),
+            &self.columns,
+            &counts,
+            self.pan.offset(),
+            self.miller_w,
+        )
+        .map(|(depth, _)| depth)
+        .unwrap_or(self.active)
+    }
+
+    /// Whether any pane still has motion to run — momentum, an overscroll
+    /// bounce, or a scrollbar fading out.
+    fn scroll_animating(&self) -> bool {
+        self.pan.is_animating() || self.columns.iter().any(|c| c.scroll.is_animating())
+    }
+
+    /// Advance every pane's scrolling by one tick. Returns whether anything
+    /// moved and therefore needs a repaint.
+    fn tick_scroll(&mut self) -> bool {
+        let mut moved = false;
+        if self.pan.is_animating() {
+            moved |= self.pan.tick();
+        }
+        for column in &mut self.columns {
+            if column.scroll.is_animating() {
+                moved |= column.scroll.tick();
+            }
+        }
+        moved
+    }
+
+    /// The directory the window is "at": the deepest column, or the selected
+    /// directory within it.
+    fn current_path(&self) -> PathBuf {
+        self.columns
+            .last()
+            .map(|c| c.path.clone())
+            .unwrap_or_default()
+    }
+
+    /// Select `index` in column `depth`, replacing whatever was selected.
+    ///
+    /// If it is a directory, push a column for it; if not, truncate the stack
+    /// so nothing stale hangs to the right.
+    fn select(&mut self, depth: usize, index: usize) {
+        if depth >= self.columns.len() {
+            return;
+        }
+        let entry = match self.visible(depth).get(index) {
+            Some(e) => (*e).clone(),
+            None => return,
+        };
+
+        // A directory descent is a real navigation, worth a Back entry;
+        // recorded here, before the stack changes underneath it.
+        let descending = entry.is_dir && self.mode == ViewMode::Columns;
+        if descending {
+            self.record_location();
+        }
+
+        let column = &mut self.columns[depth];
+        column.selection.clear();
+        column.selection.insert(entry.name.clone());
+        column.cursor = Some(index);
+        column.anchor = Some(index);
+
+        self.active = depth;
+        self.columns.truncate(depth + 1);
+
+        // Only Miller view reveals a directory's contents on a plain select —
+        // that eager next pane is the point of the view. List and Grid show
+        // one directory at a time, so selecting there must not also swap it
+        // out from under the click; opening is `open_selection`'s job there
+        // (a double-click, or Return), the same as a file.
+        if entry.is_dir && self.mode == ViewMode::Columns {
+            self.columns.push(Column::new(entry.path.clone()));
+            self.reveal_pane(depth + 1);
+        }
+        self.dirty = true;
+    }
+
+    /// Add or remove one entry, leaving the rest of the selection alone —
+    /// Ctrl+click. The cursor and the anchor both move to it, so a following
+    /// Shift+click ranges from here.
+    fn toggle_select(&mut self, depth: usize, index: usize) {
+        if depth >= self.columns.len() {
+            return;
+        }
+        let Some(name) = self.visible(depth).get(index).map(|e| e.name.clone()) else {
+            return;
+        };
+        let column = &mut self.columns[depth];
+        if !column.selection.remove(&name) {
+            column.selection.insert(name);
+        }
+        column.cursor = Some(index);
+        column.anchor = Some(index);
+        self.active = depth;
+        // A multi-selection has no single child, so nothing hangs to the right.
+        self.columns.truncate(depth + 1);
+        self.dirty = true;
+    }
+
+    /// Select the contiguous run from the anchor to `index` — Shift+click and
+    /// Shift+Arrow. Replaces the previous range rather than accumulating, so
+    /// dragging the far end back shrinks it.
+    fn extend_select(&mut self, depth: usize, index: usize) {
+        if depth >= self.columns.len() {
+            return;
+        }
+        let names: Vec<String> = self.visible(depth).iter().map(|e| e.name.clone()).collect();
+        if index >= names.len() {
+            return;
+        }
+        let anchor = self.columns[depth]
+            .anchor
+            .unwrap_or(index)
+            .min(names.len() - 1);
+        let (lo, hi) = if anchor <= index {
+            (anchor, index)
+        } else {
+            (index, anchor)
+        };
+
+        let column = &mut self.columns[depth];
+        column.selection.clear();
+        for name in &names[lo..=hi] {
+            column.selection.insert(name.clone());
+        }
+        column.cursor = Some(index);
+        self.active = depth;
+        self.columns.truncate(depth + 1);
+        self.dirty = true;
+    }
+
+    fn select_all(&mut self) {
+        let depth = self.active;
+        let names: Vec<String> = self.visible(depth).iter().map(|e| e.name.clone()).collect();
+        let column = &mut self.columns[depth];
+        column.selection = names.into_iter().collect();
+        self.columns.truncate(depth + 1);
+        self.dirty = true;
+    }
+
+    fn clear_selection(&mut self) {
+        let column = &mut self.columns[self.active];
+        column.selection.clear();
+        column.cursor = None;
+        column.anchor = None;
+        self.dirty = true;
+    }
+
+    /// Every selected entry in the active column, in view order.
+    fn selected_entries(&self) -> Vec<Entry> {
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let selection = &self.columns[depth].selection;
+        self.visible(depth)
+            .into_iter()
+            .filter(|e| selection.contains(&e.name))
+            .cloned()
+            .collect()
+    }
+
+    /// Start editing the cursor entry's name in place — Return's job, the way
+    /// it is Finder's, in every view mode.
+    fn start_rename(&mut self) {
+        if self.rename.is_some() {
+            return;
+        }
+        let depth = self.active;
+        let Some(index) = self.columns[depth].cursor else {
+            return;
+        };
+        let Some(entry) = self.visible(depth).get(index).map(|e| (*e).clone()) else {
+            return;
+        };
+        let theme = AppContext::current_theme();
+        let selection = rename_selection(&entry.name, entry.is_dir);
+        let mut input = TextInput::editing(entry.name, view::rename_field_style(theme));
+        input.state.select_range(selection);
+        self.rename = Some(RenameSession {
+            depth,
+            index,
+            original: entry.path,
+            input,
+        });
+        self.dirty = true;
+    }
+
+    /// Apply the field's text as the new name, if it actually changed.
+    fn commit_rename(&mut self) {
+        let Some(session) = self.rename.take() else {
+            return;
+        };
+        let new_name = session.input.value().trim().to_string();
+        let old_name = session
+            .original
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if new_name.is_empty() || new_name == old_name {
+            self.dirty = true;
+            return;
+        }
+        let target = session.original.with_file_name(&new_name);
+        match std::fs::rename(&session.original, &target) {
+            Ok(()) => {
+                if let Some(column) = self.columns.get_mut(session.depth) {
+                    column.selection.clear();
+                    column.selection.insert(new_name.clone());
+                }
+                self.status = Some(format!("Renamed to \u{201c}{new_name}\u{201d}"));
+                self.reload_all();
+            }
+            Err(err) => {
+                self.status = Some(format!("Couldn\u{2019}t rename: {err}"));
+            }
+        }
+        self.dirty = true;
+    }
+
+    /// Discard the field's text and leave the file as it was.
+    fn cancel_rename(&mut self) {
+        if self.rename.take().is_some() {
+            self.dirty = true;
+        }
+    }
+
+    /// Record a plain click on a row/cell, opening it if this is the second
+    /// one to land on the same row within the double-click window — List and
+    /// Grid's only mouse way to open a directory, since neither shows a
+    /// child eagerly the way Miller does.
+    fn note_row_click(&mut self, depth: usize, index: usize) {
+        let now = std::time::Instant::now();
+        let double_click = self.last_row_click.is_some_and(|(d, i, at)| {
+            d == depth && i == index && now.duration_since(at) < DOUBLE_CLICK_WINDOW
+        });
+        if double_click {
+            self.last_row_click = None;
+            self.open_selection();
+        } else {
+            self.last_row_click = Some((depth, index, now));
+        }
+    }
+
+    /// Descend into the selection: in Miller view the child column already
+    /// exists, so this only moves the keyboard into it.
+    fn open_selection(&mut self) {
+        let depth = self.active;
+        let Some(index) = self.columns[depth].cursor else {
+            return;
+        };
+        let Some(entry) = self.visible(depth).get(index).map(|e| (*e).clone()) else {
+            return;
+        };
+
+        if entry.is_dir {
+            match self.mode {
+                ViewMode::Columns => {
+                    if depth + 1 < self.columns.len() {
+                        self.active = depth + 1;
+                        if self.columns[self.active].cursor.is_none()
+                            && !self.visible(self.active).is_empty()
+                        {
+                            // Same path a click takes: if this first entry is
+                            // itself a directory, its column shows up too —
+                            // every directory on screen keeps the pane to its
+                            // right populated, not just the one last entered.
+                            self.select(self.active, 0);
+                        }
+                        self.reveal_pane(self.active);
+                    }
+                }
+                ViewMode::List | ViewMode::Grid => {
+                    // These show one directory, so descending replaces it.
+                    self.record_location();
+                    self.columns.truncate(depth + 1);
+                    self.columns.push(Column::new(entry.path.clone()));
+                    self.active = self.columns.len() - 1;
+                }
+            }
+            self.dirty = true;
+            return;
+        }
+
+        // A file. In the picker, activating one *is* the accept — double-click
+        // and Enter both land here, and both mean "this one". In the browser,
+        // opening a file in its default application is not wired up yet.
+        if self.picker.is_some() {
+            self.picker_accept();
+        }
+    }
+
+    // --- The picker's half of "activate" -----------------------------------
+
+    /// What the accept button would return, or `None` if it has nothing to
+    /// return and must stay disabled.
+    ///
+    /// Directory mode with nothing picked accepts the directory being
+    /// *viewed*, which is how a user says "this folder" without having to
+    /// step out of it and select it from its parent.
+    fn picker_selection(&self) -> Option<Vec<PathBuf>> {
+        let session = self.picker.as_ref()?;
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let column = self.columns.get(depth)?;
+
+        let picked: Vec<PathBuf> = self
+            .visible(depth)
+            .into_iter()
+            .filter(|e| column.selection.contains(&e.name))
+            .filter(|e| session.selectable(&e.name, e.is_dir))
+            .map(|e| e.path.clone())
+            .collect();
+
+        if picked.is_empty() {
+            if session.request.directory {
+                return Some(vec![column.path.clone()]);
+            }
+            return None;
+        }
+        // A single-select request returns exactly one file however many the
+        // pointer managed to gather.
+        if !session.request.multiple {
+            return picked.into_iter().next().map(|p| vec![p]);
+        }
+        Some(picked)
+    }
+
+    /// Return the current selection to the application and close the window.
+    fn picker_accept(&mut self) {
+        let Some(paths) = self.picker_selection() else {
+            return;
+        };
+        if let Some(session) = self.picker.as_mut() {
+            session.accept(&paths);
+        }
+        self.dirty = true;
+    }
+
+    /// Cancel the request. The window closes and the application is told the
+    /// user declined — which is a different answer from "it went wrong".
+    fn picker_cancel(&mut self) {
+        if let Some(session) = self.picker.as_mut() {
+            session.resolve(picker::Outcome::cancelled());
+        }
+        self.dirty = true;
+    }
+
+    /// Switch to filter `index` and re-filter in place.
+    fn set_filter(&mut self, index: usize) {
+        if let Some(session) = self.picker.as_mut() {
+            if index < session.filters.len() && index != session.current_filter {
+                session.current_filter = index;
+                // The cursor and selection are indices into an order that no
+                // longer exists once the filter moves.
+                for column in &mut self.columns {
+                    column.selection.clear();
+                    column.cursor = None;
+                    column.anchor = None;
+                }
+            }
+            session.filter_open = false;
+            self.dirty = true;
+        }
+    }
+
+    /// The action row's press half: arm the button under the pointer.
+    fn footer_press(&mut self, button: view::FooterButton) {
+        self.footer_pressed = Some(button);
+        self.dirty = true;
+    }
+
+    /// The action row's release half: fire only if the pointer is still over
+    /// the button that was armed.
+    fn footer_release(&mut self, over: Option<view::FooterButton>) {
+        let armed = self.footer_pressed.take();
+        self.dirty = true;
+        if armed.is_none() || armed != over {
+            return;
+        }
+        match armed {
+            Some(view::FooterButton::Accept) => self.picker_accept(),
+            Some(view::FooterButton::Cancel) => self.picker_cancel(),
+            Some(view::FooterButton::Filter) => {
+                if let Some(session) = self.picker.as_mut() {
+                    session.filter_open = !session.filter_open;
+                }
+            }
+            Some(view::FooterButton::FilterOption(index)) => self.set_filter(index),
+            None => {}
+        }
+    }
+
+    /// The column stack as a [`Location`], for the Back/Forward pair.
+    fn location(&self) -> Location {
+        Location {
+            columns: self
+                .columns
+                .iter()
+                .map(|c| ColumnState {
+                    path: c.path.clone(),
+                    selection: c.selection.clone(),
+                    cursor: c.cursor,
+                    anchor: c.anchor,
+                })
+                .collect(),
+            active: self.active,
+        }
+    }
+
+    /// Record where the browser is now, before a navigation moves it
+    /// somewhere else — Back's undo point. Any Forward history is dropped:
+    /// once the user branches off by navigating anew, the old "future" no
+    /// longer applies, the same rule a web browser follows.
+    fn record_location(&mut self) {
+        self.back.push(self.location());
+        self.forward.clear();
+    }
+
+    /// Replace the column stack with a remembered one, as Back and Forward
+    /// both do.
+    fn restore_location(&mut self, location: Location) {
+        self.columns = location
+            .columns
+            .into_iter()
+            .map(|state| {
+                let mut column = Column::new(state.path);
+                column.selection = state.selection;
+                column.cursor = state.cursor;
+                column.anchor = state.anchor;
+                column
+            })
+            .collect();
+        if self.columns.is_empty() {
+            self.columns.push(Column::new(self.current_path()));
+        }
+        self.active = location.active.min(self.columns.len() - 1);
+        self.pan.scroll_to(0.0);
+        self.reveal_pane(self.active);
+        self.pending_restore = true;
+        self.dirty = true;
+    }
+
+    /// Finish a Back/Forward step once its directories have been read.
+    ///
+    /// The selection is held by name, so it survives the reload untouched;
+    /// the cursor is an index, so it is re-derived from that selection rather
+    /// than trusted — a file added or removed while the user was away would
+    /// otherwise leave the keyboard one row off from the highlight. Then the
+    /// restored row is scrolled back into view, which needs the metrics of
+    /// the listing that just landed.
+    fn settle_restore(&mut self) {
+        if !self.pending_restore || self.loading() {
+            return;
+        }
+        self.pending_restore = false;
+        for depth in 0..self.columns.len() {
+            let Some(first) = self.columns[depth].selection.iter().next().cloned() else {
+                continue;
+            };
+            let index = self.visible(depth).iter().position(|e| e.name == first);
+            if let Some(index) = index {
+                self.columns[depth].cursor = Some(index);
+                self.columns[depth].anchor = Some(index);
+            }
+        }
+        self.reveal_cursor();
+        self.dirty = true;
+    }
+
+    /// The nav arrow under `(x, y)`, and only when it has somewhere to go: a
+    /// half with an empty history is drawn dimmed, and a dimmed control must
+    /// not light up under a press either.
+    fn nav_button_at(&self, x: f32, y: f32) -> Option<view::NavButton> {
+        let button = view::nav_button_at(x, y)?;
+        let live = match button {
+            view::NavButton::Back => !self.back.is_empty(),
+            view::NavButton::Forward => !self.forward.is_empty(),
+        };
+        live.then_some(button)
+    }
+
+    /// Step to the previous location, if there is one.
+    fn go_back(&mut self) {
+        let Some(location) = self.back.pop() else {
+            return;
+        };
+        self.forward.push(self.location());
+        self.restore_location(location);
+    }
+
+    /// Step to the location Back left, if there is one.
+    fn go_forward(&mut self) {
+        let Some(location) = self.forward.pop() else {
+            return;
+        };
+        self.back.push(self.location());
+        self.restore_location(location);
+    }
+
+    /// Go to the parent directory.
+    fn go_up(&mut self) {
+        if self.columns.len() > 1 {
+            self.record_location();
+            self.columns.truncate(self.columns.len() - 1);
+            self.active = self.columns.len() - 1;
+            self.reveal_pane(self.active);
+            self.dirty = true;
+            return;
+        }
+        // At the root of the stack: re-root one level up.
+        let path = self.columns[0].path.clone();
+        if let Some(parent) = path.parent() {
+            self.record_location();
+            self.columns = vec![Column::new(parent.to_path_buf())];
+            self.active = 0;
+            self.pan.scroll_to(0.0);
+            self.dirty = true;
+        }
+    }
+
+    /// Replace the whole stack, as clicking a place does.
+    fn navigate_to(&mut self, path: &Path) {
+        self.record_location();
+        self.columns = vec![Column::new(path.to_path_buf())];
+        self.active = 0;
+        self.pan.scroll_to(0.0);
+        self.dirty = true;
+    }
+
+    /// How far one Up/Down press moves. In the grid that is a whole row of
+    /// cells — the arrows walk the grid in two dimensions, so vertical motion
+    /// crosses a row and Left/Right steps one cell — and one entry everywhere
+    /// else, where the listing is a single column.
+    fn row_step(&self) -> i32 {
+        if self.mode != ViewMode::Grid {
+            return 1;
+        }
+        let area = view::content_viewport(self.size.0, self.content_h(), ViewMode::Grid);
+        view::grid_columns(area) as i32
+    }
+
+    /// Move the cursor within the active column. With `extend`, the selection
+    /// grows from the anchor instead of being replaced.
+    fn move_cursor(&mut self, delta: i32, extend: bool) {
+        let count = self.visible(self.active).len();
+        if count == 0 {
+            return;
+        }
+        // With nothing selected, the first press should land the cursor on an
+        // end, whatever the step: Down's obvious first stop is index 0, not
+        // one grid row in.
+        let next = match self.columns[self.active].cursor {
+            Some(cursor) => (cursor as i32 + delta).clamp(0, count as i32 - 1) as usize,
+            None if delta >= 0 => 0,
+            None => count - 1,
+        };
+        if extend {
+            self.extend_select(self.active, next);
+        } else {
+            self.select(self.active, next);
+        }
+        self.reveal_cursor();
+    }
+
+    /// Scroll the active pane the shortest distance that brings the cursor
+    /// fully into view, so walking a long directory with the arrow keys does
+    /// not leave the selection behind the edge of the viewport.
+    ///
+    /// Metrics come from the last [`Self::sync_scroll_metrics`], which runs at
+    /// the top of every frame — a key press always follows one.
+    fn reveal_cursor(&mut self) {
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let Some(index) = self.columns[depth].cursor else {
+            return;
+        };
+        let (width, height) = (self.size.0, self.content_h());
+        let viewport = view::pane_viewport(
+            width,
+            height,
+            self.mode,
+            depth,
+            self.pan.offset(),
+            self.miller_w,
+        );
+        if viewport.is_empty() {
+            return;
+        }
+        let (top, item_h) = view::item_span(width, height, self.mode, index);
+
+        let scroll = &mut self.columns[depth].scroll;
+        let offset = scroll.offset();
+        let target = if top < offset {
+            top
+        } else if top + item_h > offset + viewport.height() {
+            top + item_h - viewport.height()
+        } else {
+            return;
+        };
+        // A fling still in the air would undo this on the next tick.
+        scroll.stop();
+        if scroll.state.set_offset(target) {
+            self.dirty = true;
+        }
+    }
+
+    /// Left/right in Miller view: out of a column, or into its child.
+    fn move_lateral(&mut self, delta: i32) {
+        if self.mode != ViewMode::Columns {
+            if delta < 0 {
+                self.go_up();
+            } else {
+                self.open_selection();
+            }
+            return;
+        }
+        if delta < 0 {
+            if self.active > 0 {
+                self.active -= 1;
+                self.reveal_pane(self.active);
+                self.dirty = true;
+            }
+        } else {
+            self.open_selection();
+        }
+    }
+
+    /// The entry the cursor is on, if any.
+    fn selected_entry(&self) -> Option<Entry> {
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let index = self.columns[depth].cursor?;
+        self.visible(depth).get(index).map(|e| (*e).clone())
+    }
+
+    /// Open Get Info for the selection.
+    ///
+    /// The read is synchronous here, unlike a directory listing: it is one
+    /// `stat` plus two account lookups for one file the user just asked about,
+    /// and it happens on a keystroke rather than during scrolling. If the
+    /// account database turns out to block in practice this moves to a worker
+    /// like everything else.
+    fn open_info(&mut self) {
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        self.info = Some(model::read_info(&entry.path));
+        self.info_error = None;
+        self.info_dirty = true;
+    }
+
+    fn close_info(&mut self) {
+        self.info = None;
+        self.info_error = None;
+        self.info_close_hovered = false;
+        self.info_dirty = true;
+    }
+
+    /// Toggle one permission bit and apply it.
+    ///
+    /// Applied immediately rather than behind an OK button — there is no
+    /// pending state to get out of step, and a refusal is reported in place.
+    /// Only the toggled bit changes, so setuid/setgid/sticky survive.
+    fn toggle_permission(&mut self, who: usize, what: usize) {
+        let Some(info) = &self.info else { return };
+        let path = info.path.clone();
+        let next = info.mode ^ model::permission_bit(who, what);
+
+        match model::set_mode(&path, next) {
+            Ok(()) => {
+                // Re-read rather than assuming: the filesystem may have applied
+                // something other than what was asked (a mount's umask, an
+                // acl), and the sheet must show what is true.
+                self.info = Some(model::read_info(&path));
+                self.info_error = None;
+            }
+            Err(reason) => self.info_error = Some(reason),
+        }
+        self.info_dirty = true;
+    }
+
+    /// Put the selection on the system clipboard.
+    ///
+    /// A cut only *marks*: nothing moves until the paste, so an abandoned cut
+    /// costs nothing and cannot lose a file.
+    ///
+    /// `serial` must be from a real input event — the compositor refuses a
+    /// selection claimed without one.
+    fn copy_selection(&mut self, cut: bool, serial: u32) {
+        let paths: Vec<PathBuf> = self
+            .selected_entries()
+            .into_iter()
+            .map(|e| e.path)
+            .collect();
+        if paths.is_empty() {
+            return;
+        }
+        let count = paths.len();
+
+        // Kept locally as well as offered: the local copy is what draws the
+        // cut entries dimmed, and it means a paste back into this window does
+        // not have to round-trip through the compositor.
+        self.clipboard = model::Clipboard {
+            paths: paths.clone(),
+            cut,
+        };
+
+        let claimed = clipboard::set(clipboard::file_payloads(&paths, cut), serial);
+        self.status = Some(if claimed {
+            format!(
+                "{} {count} item{} to paste",
+                if cut { "Cut" } else { "Copied" },
+                if count == 1 { "" } else { "s" }
+            )
+        } else {
+            // Say so rather than pretending: the files are still pasteable
+            // here, just not anywhere else.
+            format!(
+                "{} {count} item{} (this window only)",
+                if cut { "Cut" } else { "Copied" },
+                if count == 1 { "" } else { "s" }
+            )
+        });
+        self.dirty = true;
+    }
+
+    /// Paste into the directory being viewed.
+    ///
+    /// Runs on the calling thread today, which is the UI thread — acceptable
+    /// only because it is a deliberate keystroke on a known selection, not
+    /// something that happens while scrolling. The spec puts this on the worker
+    /// pool with progress and cancellation, and that is the next change; the
+    /// `OpResult` it returns is already the shape that path reports.
+    fn paste(&mut self) {
+        // The system clipboard wins over our own copy: if another application
+        // has copied since, that is what the user means by "paste", and our
+        // local clipboard is stale.
+        let from_system = clipboard::first_available(clipboard::file_mime_preference())
+            .and_then(|mime| clipboard::read(&mime).map(|bytes| (mime, bytes)))
+            .map(|(mime, bytes)| clipboard::parse_file_payload(&mime, &bytes))
+            .filter(|(paths, _)| !paths.is_empty());
+
+        let clip = match from_system {
+            Some((paths, cut)) => model::Clipboard { paths, cut },
+            None => self.clipboard.clone(),
+        };
+        if clip.is_empty() {
+            return;
+        }
+        let dest = self.columns[self.active].path.clone();
+
+        // Keep Both rather than Replace: without a conflict sheet to ask with,
+        // the only safe default is the one that cannot destroy anything.
+        let result = model::paste(&clip, &dest, model::OnConflict::KeepBoth);
+
+        // A cut is consumed by its paste; a copy stays available to paste again.
+        if clip.cut && result.errors.is_empty() {
+            self.clipboard = model::Clipboard::default();
+        }
+
+        let summary = result.summary();
+        self.status = (!summary.is_empty()).then_some(summary);
+        self.reload_all();
+        self.dirty = true;
+    }
+
+    /// The entry under a point, if any — the same hit test the left-click
+    /// handler uses for the current view mode. `None` means empty space: the
+    /// background, a gap between rows, or (in List view) the header.
+    fn entry_at(&self, x: f32, y: f32) -> Option<(usize, usize)> {
+        let (width, height) = (self.size.0, self.content_h());
+        match self.mode {
+            ViewMode::Grid => {
+                let depth = self.columns.len() - 1;
+                let count = self.visible_len(depth);
+                let scroll = self.columns[depth].scroll.offset();
+                let area = view::content_viewport(width, height, ViewMode::Grid);
+                view::grid_cell_at(area, x, y, count, scroll).map(|i| (depth, i))
+            }
+            ViewMode::List => {
+                let depth = self.columns.len() - 1;
+                let count = self.visible_len(depth);
+                let scroll = self.columns[depth].scroll.offset();
+                view::row_at(x, y, width, height, count, scroll).map(|i| (depth, i))
+            }
+            ViewMode::Columns => {
+                let counts = self.counts();
+                match view::miller_at(
+                    x,
+                    y,
+                    width,
+                    height,
+                    &self.columns,
+                    &counts,
+                    self.pan.offset(),
+                    self.miller_w,
+                ) {
+                    Some((depth, Some(index))) => Some((depth, index)),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Point the browser at what a right-click at `(x, y)` should act on,
+    /// and build the menu for it.
+    ///
+    /// A hit not already part of the selection replaces it, the way a plain
+    /// click does; a hit that's already selected leaves a multi-selection
+    /// alone, so the menu acts on the whole group. An empty-space click just
+    /// moves the keyboard focus to that pane, for New Folder and Paste.
+    fn context_menu_items(&mut self, x: f32, y: f32) -> Vec<MenuItem> {
+        match self.entry_at(x, y) {
+            Some((depth, index)) => {
+                let already_selected = self
+                    .visible(depth)
+                    .get(index)
+                    .is_some_and(|e| self.columns[depth].selection.contains(&e.name));
+                if already_selected {
+                    self.active = depth;
+                } else {
+                    self.select(depth, index);
+                }
+            }
+            None => self.active = self.pane_under(x, y),
+        }
+
+        let entries = self.selected_entries();
+        let mut items = Vec::new();
+
+        if let [only] = entries.as_slice() {
+            if only.is_dir {
+                items.push(MenuItem::action("Open").with_action_id("open"));
+            }
+            items.push(MenuItem::action("Get Info").with_action_id("get_info"));
+            items.push(MenuItem::action("Rename").with_action_id("rename"));
+        }
+
+        if entries.is_empty() {
+            items.push(MenuItem::action("New Folder").with_action_id("new_folder"));
+            let can_paste = !self.clipboard.is_empty()
+                || clipboard::first_available(clipboard::file_mime_preference()).is_some();
+            if can_paste {
+                items.push(MenuItem::separator());
+                items.push(MenuItem::action("Paste").with_action_id("paste"));
+            }
+        } else {
+            if !items.is_empty() {
+                items.push(MenuItem::separator());
+            }
+            items.push(MenuItem::action("Cut").with_action_id("cut"));
+            items.push(MenuItem::action("Copy").with_action_id("copy"));
+            items.push(MenuItem::separator());
+            let label = if entries.len() == 1 {
+                "Move to Trash".to_string()
+            } else {
+                format!("Move {} Items to Trash", entries.len())
+            };
+            items.push(MenuItem::action(label).with_action_id("trash"));
+        }
+
+        items
+    }
+
+    /// Move the current selection to Trash.
+    fn move_selected_to_trash(&mut self) {
+        let paths: Vec<PathBuf> = self
+            .selected_entries()
+            .into_iter()
+            .map(|e| e.path)
+            .collect();
+        if paths.is_empty() {
+            return;
+        }
+        let result = model::move_to_trash(&paths);
+        let summary = result.summary();
+        self.status = (!summary.is_empty()).then_some(summary);
+        self.reload_all();
+        self.dirty = true;
+    }
+
+    /// Create "untitled folder" in the active pane and start renaming it in
+    /// place, the way Finder and Explorer's New Folder both do.
+    fn new_folder(&mut self) {
+        let dest = self.columns[self.active].path.clone();
+        match model::create_folder(&dest) {
+            Ok(path) => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                self.reload_all();
+                let depth = self.active;
+                if let Some(index) = self.visible(depth).iter().position(|e| e.name == name) {
+                    self.select(depth, index);
+                    self.start_rename();
+                }
+                self.status = Some(format!("New folder \u{201c}{name}\u{201d}"));
+            }
+            Err(err) => {
+                self.status = Some(format!("Couldn\u{2019}t create folder: {err}"));
+            }
+        }
+        self.dirty = true;
+    }
+
+    /// Re-read **every** column in the stack, keeping the user where they are.
+    ///
+    /// Not just the active one: a paste changes the destination *and* — for a
+    /// cut — the directory the files came from, which is a different column and
+    /// usually still on screen. Reloading only the destination leaves the source
+    /// column listing files that are no longer there.
+    ///
+    /// Reloading the whole stack is the blunt version. The directory watcher the
+    /// spec calls for makes this unnecessary: any directory on screen would
+    /// notice its own changes, whoever made them, including changes made by
+    /// another application. Until that exists this is what keeps the view
+    /// truthful.
+    fn reload_all(&mut self) {
+        for depth in 0..self.columns.len() {
+            let path = self.columns[depth].path.clone();
+            let keep = self.columns[depth].selection.clone();
+            let cursor = self.columns[depth].cursor;
+            let offset = self.columns[depth].scroll.offset();
+
+            let mut column = Column::new(path);
+            column.selection = keep;
+            column.cursor = cursor;
+            column.anchor = cursor;
+            // Only the position is carried over: the fresh view re-measures
+            // its own content, and any momentum belonged to the old listing.
+            column.scroll.state.set_offset(offset);
+            self.columns[depth] = column;
+        }
+    }
+
+    /// The rect Quick View grows its panel from, for the active column.
+    ///
+    /// Surface-local, and empty when there is nothing on screen to grow out of.
+    /// Both are usable now that the panel is drawn into this same surface.
+    fn quickview_anchor(&self) -> Rect {
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let entries = self.visible(depth);
+        let column = &self.columns[depth];
+        let pane = view::PaneData {
+            selected: entries
+                .iter()
+                .map(|e| column.selection.contains(&e.name))
+                .collect(),
+            cursor: column.cursor,
+            entries,
+            scroll: column.scroll.offset(),
+            bar: None,
+            loading: column.loading(),
+            error: None,
+        };
+        view::quickview_anchor(
+            self.size.0,
+            self.content_h(),
+            self.mode,
+            &pane,
+            depth,
+            self.pan.offset(),
+            self.miller_w,
+        )
+    }
+
+    /// Start previewing the cursor's file, replacing whatever is open.
+    ///
+    /// Returns the path to decode and the generation to tag it with, or `None`
+    /// when there is nothing to preview. The decode itself is the caller's to
+    /// run off the UI thread — this only moves the state.
+    fn begin_quickview(&mut self) -> Option<(PathBuf, u64, Rect)> {
+        let entry = self.selected_entry();
+        if std::env::var_os("OTTO_FILES_QV_TRACE").is_some() {
+            eprintln!("qv begin: selected={:?}", entry.as_ref().map(|e| &e.name));
+        }
+        let entry = entry?;
+        // A directory previews as a listing, which the decoder handles, so
+        // nothing is excluded here.
+        let anchor = self.quickview_anchor();
+        self.quickview_generation += 1;
+        self.quickview_pending = true;
+        // Clear any stale message so "Opening preview…" is not fighting the
+        // last operation's summary.
+        self.status = None;
+        self.dirty = true;
+        Some((entry.path, self.quickview_generation, anchor))
+    }
+
+    /// Show a decode that arrived, unless the user has moved on since.
+    fn finish_quickview(
+        &mut self,
+        generation: u64,
+        anchor: Rect,
+        name: String,
+        preview: otto_kit::preview::Preview,
+    ) {
+        if std::env::var_os("OTTO_FILES_QV_TRACE").is_some() {
+            eprintln!(
+                "qv finish: generation={generation} current={} anchor={anchor:?}",
+                self.quickview_generation
+            );
+        }
+        if generation != self.quickview_generation {
+            return; // Stale: the user arrow-keyed past this file mid-decode.
+        }
+        self.quickview_pending = false;
+        // Re-opening onto the same panel keeps its entrance rather than
+        // replaying it, so arrow-keying through a folder does not pulse.
+        let opened_at = match &self.quickview {
+            Some(session) => session.opened_at,
+            None => std::time::Instant::now(),
+        };
+        self.quickview = Some(quickview::Session {
+            preview,
+            name,
+            first_row: 0,
+            // Fit, whatever the last file was left at. A zoom belongs to the
+            // picture it was made on, not to the panel.
+            zoom: otto_kit::preview::Zoom::FIT,
+            anchor,
+            opened_at,
+            closing: None,
+        });
+        // Re-opening cancels whatever was on its way out: two panels in flight
+        // at once would cross over each other.
+        self.quickview_closing = None;
+        self.dirty = true;
+    }
+
+    /// Remember where the pointer is over the Quick View panel, and which
+    /// panel rect that position was measured against.
+    ///
+    /// A pinch carries no position of its own — only how far its focal point
+    /// has drifted since it began — so the only way to zoom about the fingers
+    /// is to have kept the last place the pointer was seen.
+    fn quickview_focus(&mut self, point: skia_safe::Point, panel: Rect) {
+        self.quickview_focus = Some((point, panel));
+    }
+
+    /// Zoom the open preview to `scale`, about the focal point: wherever the
+    /// pointer last was, carried along by `drift` — the focal point's travel
+    /// since the pinch began. Returns whether anything moved.
+    fn quickview_zoom_to(&mut self, scale: f32, drift: (f32, f32)) -> bool {
+        // With no remembered pointer — a pinch that began before the panel
+        // ever saw one — the panel's own centre is the honest focal point.
+        let (focus, panel) = match self.quickview_focus {
+            Some((point, panel)) => ((point.x + drift.0, point.y + drift.1), panel),
+            None => {
+                let panel = self
+                    .quickview_panel
+                    .unwrap_or_else(|| quickview::panel_rect(self.size.0, self.size.1));
+                let content = view::quickview_content_rect(panel);
+                ((content.center_x(), content.center_y()), panel)
+            }
+        };
+        let content = view::quickview_content_rect(panel);
+        let Some(session) = self.quickview.as_mut() else {
+            return false;
+        };
+        let moved = session.zoom_to(scale, focus, content);
+        self.dirty |= moved;
+        moved
+    }
+
+    /// Feed a two-finger scroll to the open preview: a pan when there is a
+    /// zoomed image to drag, and the scroll it has always been otherwise.
+    ///
+    /// One entry point for both handlers — the toplevel's and the panel's own
+    /// surface — because the choice between panning and scrolling has to come
+    /// out the same whichever of the two the compositor happened to deliver
+    /// the event to.
+    fn quickview_wheel(&mut self, dx: f32, dy: f32, panel: Rect) {
+        let content = view::quickview_content_rect(panel);
+        let pannable = self
+            .quickview
+            .as_ref()
+            .is_some_and(|session| session.pannable(content));
+        let Some(session) = self.quickview.as_mut() else {
+            return;
+        };
+        if pannable {
+            // The picture follows the fingers the way the content of a
+            // scrolled view does: pushing down brings what is below into
+            // view, which moves the image up.
+            //
+            // At the same speed, too. A Wayland axis delta is the finger's
+            // own travel in logical points, which every scroll view in the
+            // toolkit multiplies before it moves anything — applied raw here
+            // the picture crawled, and one two-finger gesture meant two
+            // different things depending on whether a preview was open.
+            let speed = otto_kit::components::scroll::wheel_scale();
+            session.pan_by(-dx * speed, -dy * speed, content);
+        } else {
+            // The content's box, not the card's: the rows are laid out below
+            // the title strip, so scrolling has to measure against the same
+            // rect the preview was drawn into.
+            let rows = (dy / otto_kit::preview::ROW_HEIGHT).round() as i32;
+            session.scroll_by(rows, content);
+        }
+        self.dirty = true;
+    }
+
+    /// Dismiss the preview. Returns whether one was open.
+    fn close_quickview(&mut self) -> bool {
+        // Bumping the generation orphans an in-flight decode, so a slow file
+        // cannot re-open a panel the user has already dismissed.
+        self.quickview_generation += 1;
+        self.quickview_pending = false;
+        // Where the file is *now*, not where it was when the panel opened: the
+        // selection may have arrow-keyed on, or the list scrolled, and the
+        // point of the exit is to say which file this was.
+        let anchor = self.quickview_anchor();
+        let Some(mut session) = self.quickview.take() else {
+            return false;
+        };
+        if !anchor.is_empty() {
+            session.anchor = anchor;
+        }
+        session.closing = Some(std::time::Instant::now());
+        // Moved aside rather than left in `quickview`, so everything that asks
+        // "is a preview open" — the key handling, the pointer routing — sees a
+        // closed window from this moment, while the panel is still on screen
+        // finishing its exit.
+        self.quickview_closing = Some(session);
+        self.dirty = true;
+        true
+    }
+
+    /// The panel on screen, whichever direction it is going.
+    fn quickview_visible(&self) -> Option<&quickview::Session> {
+        self.quickview.as_ref().or(self.quickview_closing.as_ref())
+    }
+
+    /// Whether a panel still has frames to run — arriving or leaving.
+    fn quickview_animating(&self) -> bool {
+        self.quickview_visible()
+            .is_some_and(quickview::Session::animating)
+    }
+
+    /// Retire a finished exit. Returns whether anything changed.
+    fn tick_quickview_exit(&mut self) -> bool {
+        let done = self
+            .quickview_closing
+            .as_ref()
+            .is_some_and(|session| !session.animating());
+        if done {
+            self.quickview_closing = None;
+        }
+        done
+    }
+
+    /// Poll every column's worker. Returns whether anything landed.
+    ///
+    /// A freshly loaded column starts with nothing selected — no eager pick
+    /// of its first entry. `move_cursor` already lands Down's first press on
+    /// index 0 from an empty cursor, so there is nowhere that needs one.
+    fn poll(&mut self) -> bool {
+        let mut changed = false;
+        for depth in 0..self.columns.len() {
+            if self.columns[depth].poll() {
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    fn loading(&self) -> bool {
+        self.columns.iter().any(|c| c.loading())
+    }
+
+    fn title(&self) -> String {
+        let path = if self.mode == ViewMode::Columns {
+            self.columns[self.active].path.clone()
+        } else {
+            self.current_path()
+        };
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned())
+    }
+
+    fn subtitle(&self) -> String {
+        // A first preview pays D-Bus activation, so this can be visible for a
+        // moment. Saying so beats a keystroke that appears to do nothing.
+        if self.quickview_pending {
+            return "Opening preview…".to_string();
+        }
+        if let Some(status) = &self.status {
+            return status.clone();
+        }
+        let depth = self.active.min(self.columns.len() - 1);
+        if self.columns[depth].loading() {
+            return "Loading…".to_string();
+        }
+        let selected = self.columns[depth].selection.len();
+        if selected > 1 {
+            return format!("{selected} of {} selected", self.visible_len(depth));
+        }
+        let count = self.visible_len(depth);
+        let hidden = self.columns[depth]
+            .snapshot
+            .entries
+            .iter()
+            .filter(|e| e.hidden)
+            .count();
+        let mut text = match count {
+            0 => "No items".to_string(),
+            1 => "1 item".to_string(),
+            n => format!("{n} items"),
+        };
+        if hidden > 0 && !self.show_hidden {
+            text.push_str(&format!(", {hidden} hidden"));
+        }
+        text
+    }
+
+    /// Build the per-frame view data.
+    fn frame<'a>(&'a self, theme: &'a Theme, title: &'a str) -> view::Frame<'a> {
+        let panes = (0..self.columns.len())
+            .map(|depth| {
+                let entries = self.visible(depth);
+                let column = &self.columns[depth];
+                view::PaneData {
+                    selected: entries
+                        .iter()
+                        .map(|e| column.selection.contains(&e.name))
+                        .collect(),
+                    cursor: column.cursor,
+                    entries,
+                    scroll: column.scroll.offset(),
+                    bar: Some(&column.scroll.state),
+                    loading: column.loading(),
+                    error: column.snapshot.error.as_deref(),
+                }
+            })
+            .collect();
+
+        let preview_entry: Option<&'a Entry> = self
+            .preview_visible()
+            .then(|| {
+                let depth = self.active.min(self.columns.len().saturating_sub(1));
+                self.columns[depth]
+                    .cursor
+                    .and_then(|index| self.visible(depth).get(index).copied())
+            })
+            .flatten();
+        let preview = preview_entry.map(|entry| view::PreviewData {
+            name: entry.name.as_str(),
+            icon_chain: entry.icon_chain(),
+            decoded: self.preview.as_ref().and_then(|p| p.decoded.as_ref()),
+            first_row: 0,
+            info: preview_info(entry),
+        });
+
+        view::Frame {
+            width: self.size.0,
+            // The *file area's* bottom, not the window's — see
+            // [`view::Frame::action_row`]. Every piece of geometry the frame
+            // carries stops short of the picker's action row because of this
+            // one line.
+            height: self.content_h(),
+            theme,
+            title,
+            subtitle: self.subtitle(),
+            places: &self.places,
+            selected_place: self
+                .places
+                .iter()
+                .position(|p| p.path == self.columns[0].path),
+            cut: if self.clipboard.cut {
+                self.clipboard.paths.clone()
+            } else {
+                Default::default()
+            },
+            mode: self.mode,
+            panes,
+            active: self.active,
+            pan: self.pan.offset(),
+            pan_bar: (self.mode == ViewMode::Columns).then_some(&self.pan.state),
+            miller_w: self.miller_w,
+            sort: self.sort,
+            ascending: self.ascending,
+            list_columns: self.list_columns,
+            renaming: self.rename.as_ref().map(|r| (r.depth, r.index)),
+            controls: self.controls,
+            can_go_back: !self.back.is_empty(),
+            can_go_forward: !self.forward.is_empty(),
+            nav_pressed: self.nav_pressed,
+            preview,
+            action_row: self.picker.as_ref().map(|session| view::FooterData {
+                accept_label: &session.accept_label,
+                accept_enabled: self.picker_selection().is_some(),
+                filters: &session.filter_labels,
+                current_filter: session.current_filter,
+                filter_open: session.filter_open,
+                hovered: self.footer_hover,
+                pressed: self.footer_pressed,
+            }),
+            footer: self.footer_h(),
+            quickview_close_hovered: self.quickview_close_hovered,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// App shell
+// ---------------------------------------------------------------------------
+
+struct FilesApp {
+    window: Option<Window>,
+    state: Arc<Mutex<Browser>>,
+    /// Control held. Tracked from the key stream rather than inferred from the
+    /// text a chord produces: Ctrl+I is historically a TAB character and Ctrl+H
+    /// a backspace, so reading `utf8` to detect them is both obscure and
+    /// unreliable — it depends on the keymap producing the control character at
+    /// all, which it may not.
+    ///
+    /// Shared rather than a plain field because the pointer callback needs them
+    /// too — Ctrl+click and Shift+click are the pointer half of the same
+    /// selection rules — and that callback outlives any borrow of `self`.
+    modifiers: Arc<Mutex<(bool, bool)>>,
+    /// The right-click menu, built once — see `ContextMenu::new`'s docs for
+    /// why it cannot be built lazily from inside a pointer handler. `None`
+    /// until `on_app_ready` constructs it, which is the earliest point
+    /// `AppContext` is set up.
+    context_menu: Option<ContextMenu>,
+    /// Quick View's surface and its card's rect within it, published by the
+    /// render path for the pointer callback below. See
+    /// [`pane_surfaces::PaneSurfaces::quickview_target`].
+    quickview_target: Arc<Mutex<Option<(wayland_client::backend::ObjectId, Rect)>>>,
+    /// The picker's request queue, when this process is serving
+    /// `org.otto.FilePicker1`. `None` in the browser.
+    picker_queue: Option<crate::dbus::SharedQueue>,
+    /// Per-column subsurfaces, when `OTTO_FILES_PANE_SUBS=1`. A scroll then
+    /// repaints one column's own buffer instead of the whole window.
+    pane_surfaces: Option<pane_surfaces::PaneSurfaces>,
+    /// The Get Info panel's window, while one is open.
+    ///
+    /// Shared with the pointer callback, which is registered once at startup
+    /// and looks the current window up rather than being re-registered for
+    /// each panel: callbacks cannot be taken off again, so registering one
+    /// per opening would pile them up for the life of the process.
+    info_window: Rc<RefCell<Option<Window>>>,
+}
+
+impl App for FilesApp {
+    fn on_app_ready(&mut self, _ctx: &AppContext) -> Result<(), Box<dyn std::error::Error>> {
+        self.context_menu = Some(ContextMenu::new(Vec::new()));
+
+        // Before the window: a surface builds its own root layer node at
+        // construction, and that node is what the scene hangs off.
+        AppContext::enable_layer_engine(view::WINDOW_W, view::WINDOW_H);
+
+        let mut window = Window::new("Files", view::WINDOW_W as i32, view::WINDOW_H as i32)?;
+        window.set_min_size(view::MIN_W as u32, view::MIN_H as u32);
+        // The window as a whole has no ground of its own: the sidebar, the
+        // header and the content area each carry their own material, and two
+        // of the three are translucent so the compositor's blur reads through
+        // them. Anything painted here would sit between that blur and them.
+        window.set_background(skia_safe::Color::TRANSPARENT);
+
+        // Name the window after its desktop entry, so the dock and the app
+        // switcher find `otto-files.desktop` — and its file-manager icon —
+        // directly. Without an app_id the compositor has to guess from the
+        // client's pid and executable name, which lands on the same entry only
+        // because the `Exec=` line happens to match.
+        if let Some(surface) = window.surface() {
+            surface.xdg_window().set_app_id("otto-files".to_string());
+        }
+
+        if let Some(style) = window.surface_style() {
+            style.set_corner_radius(view::CORNER as f64);
+            // otto-kit's materials are translucent by design — they expect a
+            // blurred backdrop behind them. Without this the desktop shows
+            // through the window rather than being frosted by it.
+            // `OTTO_FILES_NO_BLUR=1` drops the frosted backdrop, to test what
+            // it costs. The window's materials are translucent by design, so
+            // without it the desktop shows through unfrosted — ugly, but it
+            // isolates the compositor's blur work from everything else.
+            if std::env::var_os("OTTO_FILES_NO_BLUR").is_none() {
+                style.set_blend_mode(
+                    otto_kit::protocols::otto_surface_style_v1::BlendMode::BackgroundBlur,
+                );
+            }
+        }
+
+        // The panels' scene. `None` only where the engine could not be brought
+        // up, which is the case the immediate-mode chrome still covers: the
+        // window then draws without its grounds rather than not at all.
+        let scene = Arc::new(Mutex::new(window.layer_node().map(scene::Scene::new)));
+
+        let state = Arc::clone(&self.state);
+        window.on_draw(move |canvas| {
+            let mut browser = state.lock().unwrap();
+
+            // Drain finished directory reads. This is the UI thread by
+            // construction, which is what the poll needs — see
+            // `install_frame_loop` for why it cannot live on a worker.
+            let t_total = perf::now();
+            let t_prep = perf::now();
+            browser.poll();
+
+            let theme = AppContext::current_theme();
+            let title = browser.title();
+            // Panes measure themselves against the size this frame is drawn
+            // at, so their scroll views are re-fitted before anything reads
+            // an offset.
+            browser.sync_scroll_metrics();
+            // Needs those metrics, so it runs here rather than beside the poll.
+            browser.settle_restore();
+            perf::mark(perf::Stage::Prep, t_prep);
+            let t_frame = perf::now();
+            let frame = browser.frame(&theme, &title);
+            perf::mark(perf::Stage::FrameBuild, t_frame);
+            // The panels first, composited by the engine from cached pictures,
+            // then the chrome that sits over them.
+            let t0 = perf::now();
+            if let Some(scene) = scene.lock().unwrap().as_mut() {
+                scene.update(&frame);
+                perf::mark(perf::Stage::SceneUpdate, t0);
+                let t1 = perf::now();
+                scene.render(canvas);
+                perf::mark(perf::Stage::SceneRender, t1);
+            }
+            let t2 = perf::now();
+            view::draw(canvas, &frame);
+            perf::mark(perf::Stage::Chrome, t2);
+            perf::mark(perf::Stage::Total, t_total);
+            // Unless it has a surface of its own over the columns — drawn
+            // here it would be under them. See [`crate::pane_surfaces`].
+            if !pane_surfaces::quickview_on_surface() {
+                if let Some(session) = browser.quickview_visible() {
+                    // Centred on the *window*, not the file area: Quick View
+                    // is a card floating over the whole picker, and the
+                    // action row is behind it rather than beside it.
+                    let resting = quickview::panel_rect(frame.width, frame.height + frame.footer);
+                    view::draw_quickview(canvas, &frame, session, resting);
+                }
+            }
+            drop(frame);
+
+            if let Some(session) = browser.rename.as_ref() {
+                let (depth, index) = (session.depth, session.index);
+                let (width, height) = (browser.size.0, browser.content_h());
+                let count = browser.visible(depth).len();
+                let scroll = browser.columns[depth].scroll.offset();
+                let rect = match browser.mode {
+                    ViewMode::List => {
+                        view::list_rename_rect(width, browser.list_columns, count, scroll, index)
+                    }
+                    ViewMode::Columns => {
+                        let is_dir = browser.visible(depth).get(index).is_some_and(|e| e.is_dir);
+                        view::miller_rename_rect(
+                            height,
+                            browser.pan.offset(),
+                            browser.miller_w,
+                            depth,
+                            count,
+                            scroll,
+                            index,
+                            is_dir,
+                        )
+                    }
+                    ViewMode::Grid => view::grid_rename_rect(width, height, scroll, index),
+                };
+                let session = browser.rename.as_mut().unwrap();
+                session.input.set_size(rect.width(), rect.height());
+                canvas.save();
+                canvas.translate((rect.left, rect.top));
+                session.input.render_at(canvas, rect.width(), rect.height());
+                canvas.restore();
+            }
+        });
+
+        // Also when only Quick View wants a surface: the columns stay in the
+        // scene, and this carries the preview alone.
+        if pane_surfaces::quickview_on_surface() {
+            self.pane_surfaces = Some(pane_surfaces::PaneSurfaces::new(
+                AppContext::scale_factor() as f32
+            ));
+        }
+
+        self.install_quickview_pointer();
+        self.install_info_window_pointer();
+        self.install_pointer(&window, self.context_menu.clone().unwrap());
+        self.install_frame_loop(&window);
+        AppContext::register_window(window.clone());
+        self.window = Some(window);
+        Ok(())
+    }
+
+    /// Repaint whatever changed since the last pass, from wherever it changed.
+    ///
+    /// The frame-callback loop can only carry work that is already on screen:
+    /// it sustains itself by committing frames, so a window that is drawing
+    /// nothing new stops being called. A directory read or a decode finishing
+    /// on another thread wakes the loop instead — see
+    /// [`AppContext::request_wakeup`] — and this is where that wakeup turns
+    /// into a frame.
+    fn on_update(&mut self, _ctx: &AppContext) {
+        let (repaint, preview_target, scrolled_only) = {
+            let mut browser = self.state.lock().unwrap();
+            let changed = browser.poll();
+            // Momentum, the overscroll bounce and the scrollbar's fade all
+            // advance here rather than on input, since they keep running after
+            // the gesture ends.
+            let scrolled = browser.tick_scroll();
+            let animating = browser.quickview_animating() | browser.tick_quickview_exit();
+            // The docked preview column follows the selection wherever it
+            // moves — a click, an arrow key, a directory finishing a load
+            // that changes what "the selection" resolves to — so this is
+            // checked centrally here rather than threaded through every place
+            // the selection can change.
+            let preview_target = browser.sync_preview_target();
+            // A sideways pan moves the columns, and the hairlines between them
+            // are drawn in the window, not in the column surfaces — so while
+            // the stack is panning the window has to keep up or the dividers
+            // are left behind. The bar's fade is a good enough stand-in for
+            // "the stack is moving": it is up for exactly that long.
+            let pan_bar_visible =
+                browser.mode == ViewMode::Columns && browser.pan.state.scrollbar_opacity() > 0.0;
+            let scrolled_only = scrolled
+                && !changed
+                && !browser.dirty
+                && !animating
+                && preview_target.is_none()
+                && !pan_bar_visible;
+            let repaint = changed
+                || scrolled
+                || std::mem::take(&mut browser.dirty)
+                || animating
+                || preview_target.is_some();
+            (repaint, preview_target, scrolled_only)
+        };
+        if let Some((path, generation)) = preview_target {
+            self.start_preview(path, generation);
+        }
+
+        // One lock, taken once. A `self.state.lock()` in an `if` condition
+        // holds its guard for the whole `if`, so locking again inside the body
+        // deadlocks the update loop — which is exactly what it did.
+        let open_now = {
+            let mut browser = self.state.lock().unwrap();
+            let depth = browser.active;
+            let ready = browser.quickview_auto && !browser.visible(depth).is_empty();
+            if ready {
+                browser.quickview_auto = false;
+                browser.columns[depth].cursor = Some(0);
+            }
+            ready
+        };
+        if open_now {
+            let mut browser = self.state.lock().unwrap();
+            self.start_quickview(&mut browser);
+        }
+
+        // With the columns in their own surfaces, a scroll is repainted there
+        // and the window is left alone — which is the whole point, so the
+        // scroll must not also count towards a window repaint.
+        let mut repaint = repaint;
+        if self.pane_surfaces.is_some() {
+            let painted = self.sync_pane_surfaces();
+            if scrolled_only && painted {
+                repaint = false;
+            }
+            // A paint the throttle turned away is only ever retried by another
+            // pass, and passes stop when the content stops changing. Keeping
+            // the window repainting is what keeps them coming.
+            if self
+                .pane_surfaces
+                .as_ref()
+                .is_some_and(pane_surfaces::PaneSurfaces::pending)
+            {
+                repaint = true;
+            }
+        }
+
+        if repaint {
+            self.render();
+        }
+
+        self.sync_info_window();
+        self.advance_picker();
+    }
+
+    /// A hand laid on the touchpad stops whatever is gliding, the way a
+    /// finger on a spinning wheel does. Nothing else in the pointer stream
+    /// says so: a hold carries no motion and no button.
+    fn on_pointer_hold_begin(&mut self, _ctx: &AppContext, _fingers: u32) {
+        let mut browser = self.state.lock().unwrap();
+        browser.pan.stop();
+        browser.gesture_axis = None;
+        for column in &mut browser.columns {
+            column.scroll.stop();
+        }
+        drop(browser);
+        self.render();
+    }
+
+    /// A two-finger pinch zooms the open preview's picture.
+    ///
+    /// Only the preview: the browser's own views have no zoom, and a pinch
+    /// with no panel up is left alone rather than repurposed into something
+    /// the gesture does not mean anywhere else.
+    fn on_pointer_pinch_begin(&mut self, _ctx: &AppContext, fingers: u32) {
+        let mut browser = self.state.lock().unwrap();
+        // Where this gesture's scale is measured from. Taken at the start
+        // because the protocol reports scale against the start.
+        browser.quickview_pinch = (fingers == 2)
+            .then(|| browser.quickview.as_ref().map(|s| s.zoom.scale))
+            .flatten();
+    }
+
+    fn on_pointer_pinch_update(
+        &mut self,
+        _ctx: &AppContext,
+        dx: f64,
+        dy: f64,
+        scale: f64,
+        _rotation: f64,
+    ) {
+        let mut browser = self.state.lock().unwrap();
+        let Some(base) = browser.quickview_pinch else {
+            return;
+        };
+        let moved = browser.quickview_zoom_to(base * scale as f32, (dx as f32, dy as f32));
+        drop(browser);
+        if moved {
+            self.render();
+        }
+    }
+
+    fn on_pointer_pinch_end(&mut self, _ctx: &AppContext, _cancelled: bool) {
+        // Nothing to settle: every update already left the zoom clamped and
+        // snapped, so the fingers lifting only ends the gesture.
+        self.state.lock().unwrap().quickview_pinch = None;
+    }
+
+    /// While something is gliding the app needs a steady clock, not just the
+    /// next input event.
+    fn idle_timeout(&self) -> Option<std::time::Duration> {
+        let browser = self.state.lock().unwrap();
+        let animating = browser.scroll_animating() || browser.quickview_animating();
+        animating.then(|| std::time::Duration::from_millis(8))
+    }
+
+    fn on_configure(&mut self, _ctx: &AppContext, configure: WindowConfigure, _serial: u32) {
+        if let (Some(w), Some(h)) = (configure.new_size.0, configure.new_size.1) {
+            let mut browser = self.state.lock().unwrap();
+            browser.size = (w.get() as f32, h.get() as f32);
+            browser.dirty = true;
+        }
+        self.render();
+    }
+
+    fn on_key_event(
+        &mut self,
+        _ctx: &AppContext,
+        event: &KeyEvent,
+        key_state: wl_keyboard::KeyState,
+        serial: u32,
+    ) {
+        use smithay_client_toolkit::seat::keyboard::Keysym;
+
+        // Track the modifiers on both edges, before the press-only guard.
+        let pressed = key_state == wl_keyboard::KeyState::Pressed;
+        if matches!(event.keysym, Keysym::Control_L | Keysym::Control_R) {
+            self.modifiers.lock().unwrap().0 = pressed;
+            return;
+        }
+        if matches!(event.keysym, Keysym::Shift_L | Keysym::Shift_R) {
+            self.modifiers.lock().unwrap().1 = pressed;
+            return;
+        }
+        if !pressed {
+            return;
+        }
+        let (ctrl, shift) = *self.modifiers.lock().unwrap();
+
+        {
+            let mut browser = self.state.lock().unwrap();
+
+            // An in-place rename owns the keyboard outright: every key is
+            // text-field input, not a browser shortcut.
+            if browser.rename.is_some() {
+                let key = match event.keysym {
+                    Keysym::Return | Keysym::KP_Enter => Some(TextInputKey::Enter),
+                    Keysym::Escape => Some(TextInputKey::Escape),
+                    Keysym::Left => Some(TextInputKey::Left),
+                    Keysym::Right => Some(TextInputKey::Right),
+                    Keysym::Home => Some(TextInputKey::Home),
+                    Keysym::End => Some(TextInputKey::End),
+                    Keysym::BackSpace => Some(TextInputKey::Backspace),
+                    Keysym::Delete => Some(TextInputKey::Delete),
+                    Keysym::a if ctrl => Some(TextInputKey::SelectAll),
+                    _ => event
+                        .utf8
+                        .as_ref()
+                        .and_then(|s| s.chars().next())
+                        .map(TextInputKey::Char),
+                };
+                if let Some(key) = key {
+                    let mods = KeyMods { shift, ctrl };
+                    let response = browser
+                        .rename
+                        .as_mut()
+                        .map(|session| session.input.on_key(key, mods));
+                    match response {
+                        Some(TextInputResponse::Commit) => browser.commit_rename(),
+                        Some(TextInputResponse::Cancel) => browser.cancel_rename(),
+                        Some(_) => browser.dirty = true,
+                        None => {}
+                    }
+                }
+                drop(browser);
+                self.render();
+                return;
+            }
+
+            match event.keysym {
+                Keysym::Down => {
+                    let step = browser.row_step();
+                    browser.move_cursor(step, shift)
+                }
+                Keysym::Up => {
+                    let step = browser.row_step();
+                    browser.move_cursor(-step, shift)
+                }
+                // The grid is two-dimensional: sideways is the next cell, not
+                // a move in or out of a directory the way it is in the list
+                // and Miller views.
+                Keysym::Right if browser.mode == ViewMode::Grid => browser.move_cursor(1, shift),
+                Keysym::Left if browser.mode == ViewMode::Grid => browser.move_cursor(-1, shift),
+                Keysym::Right => browser.move_lateral(1),
+                Keysym::Left => browser.move_lateral(-1),
+                Keysym::Return | Keysym::KP_Enter => {
+                    // In the picker, Return means "this one" — descend into a
+                    // directory or accept a file. Renaming is file management,
+                    // which the picker does not do.
+                    if browser.picker.is_some() {
+                        browser.open_selection();
+                    } else {
+                        browser.start_rename();
+                    }
+                }
+                // The Linux convention, alongside Return: both rename.
+                Keysym::F2 => browser.start_rename(),
+                Keysym::BackSpace => browser.go_up(),
+                Keysym::Home => browser.move_cursor(-100_000, shift),
+                Keysym::End => browser.move_cursor(100_000, shift),
+                Keysym::Page_Down => {
+                    let step = browser.row_step();
+                    browser.move_cursor(15 * step, shift)
+                }
+                Keysym::Page_Up => {
+                    let step = browser.row_step();
+                    browser.move_cursor(-15 * step, shift)
+                }
+                // Select-all only means something when the request asked for
+                // more than one file.
+                Keysym::a if ctrl => {
+                    let multiple = browser.picker.as_ref().is_none_or(|p| p.request.multiple);
+                    if multiple {
+                        browser.select_all();
+                    }
+                }
+                // Cut, copy and paste are file management: browser only.
+                Keysym::c if ctrl && browser.picker.is_none() => {
+                    browser.copy_selection(false, serial)
+                }
+                Keysym::x if ctrl && browser.picker.is_none() => {
+                    browser.copy_selection(true, serial)
+                }
+                Keysym::v if ctrl && browser.picker.is_none() => browser.paste(),
+                // Space toggles: the second press dismisses what the first
+                // opened, which is the gesture people already have.
+                Keysym::space => {
+                    if !browser.close_quickview() {
+                        self.start_quickview(&mut browser);
+                    }
+                }
+                // Escape unwinds one layer at a time: the preview, then the
+                // filter menu, then — in the picker — the request itself.
+                Keysym::Escape => {
+                    let menu_open = browser.picker.as_ref().is_some_and(|p| p.filter_open);
+                    // The panel is not modal, so Escape does not belong to it
+                    // outright — it takes its turn in the same unwinding order
+                    // as everything else that is up.
+                    if browser.info.is_some() {
+                        browser.close_info();
+                    } else if browser.close_quickview() {
+                        // The preview took it.
+                    } else if menu_open {
+                        if let Some(session) = browser.picker.as_mut() {
+                            session.filter_open = false;
+                        }
+                        browser.dirty = true;
+                    } else if browser.picker.is_some() {
+                        browser.picker_cancel();
+                    } else {
+                        browser.clear_selection();
+                    }
+                }
+                // A second press closes it, the way Space does for Quick
+                // View: the shortcut that opened the panel is the one already
+                // under the user's fingers.
+                Keysym::i if ctrl => {
+                    if browser.info.is_some() {
+                        browser.close_info();
+                    } else {
+                        browser.open_info();
+                    }
+                }
+                Keysym::h if ctrl => {
+                    browser.show_hidden = !browser.show_hidden;
+                    browser.dirty = true;
+                }
+                Keysym::_1 => {
+                    browser.mode = ViewMode::List;
+                    browser.dirty = true;
+                }
+                Keysym::_2 => {
+                    browser.mode = ViewMode::Grid;
+                    browser.dirty = true;
+                }
+                Keysym::_3 => {
+                    browser.mode = ViewMode::Columns;
+                    browser.dirty = true;
+                }
+                _ => {}
+            }
+
+            // The preview follows the cursor: arrow-keying through a folder
+            // re-decodes in place rather than dismissing. The generation on
+            // each decode is what keeps a slow file from landing late.
+            let moved = matches!(
+                event.keysym,
+                Keysym::Down
+                    | Keysym::Up
+                    | Keysym::Left
+                    | Keysym::Right
+                    | Keysym::Home
+                    | Keysym::End
+                    | Keysym::Page_Down
+                    | Keysym::Page_Up
+            );
+            if moved && browser.quickview.is_some() {
+                self.start_quickview(&mut browser);
+            }
+        }
+        self.render();
+    }
+}
+
+impl FilesApp {
+    /// Move the picker on when its request is done with, and notice when the
+    /// portal withdraws the one on screen.
+    ///
+    /// A no-op in the browser, and on every pass where the window is still
+    /// serving a live request — which is nearly all of them.
+    fn advance_picker(&mut self) {
+        let Some(queue) = self.picker_queue.clone() else {
+            return;
+        };
+
+        {
+            let mut browser = self.state.lock().unwrap();
+            let Some(session) = browser.picker.as_mut() else {
+                return;
+            };
+            // Withdrawn by the portal — the requesting application went away,
+            // or gave up. The window goes immediately; there is nobody left
+            // to answer.
+            if !session.answered() && queue.take_withdrawn(&session.request.handle) {
+                session.resolve(picker::Outcome::ended());
+            }
+            if !session.answered() {
+                return;
+            }
+        }
+
+        // The request has been answered. Serve the next one in the same
+        // window, or leave — an idle picker holds no window and no Wayland
+        // connection, and the bus starts a fresh one when it is next needed.
+        match queue.next_session() {
+            Some(session) => {
+                let start = session.request.starting_directory(None);
+                let mut browser = self.state.lock().unwrap();
+                let size = browser.size;
+                *browser = Browser::for_picker(session, start);
+                browser.size = size;
+                browser.dirty = true;
+                drop(browser);
+                self.render();
+            }
+            None => AppContext::request_exit(),
+        }
+    }
+
+    /// Repaint whichever column subsurfaces are out of date. Returns whether
+    /// any of them actually painted.
+    fn sync_pane_surfaces(&mut self) -> bool {
+        let Some(window) = self.window.as_ref() else {
+            return false;
+        };
+        let Some(surface) = window.surface() else {
+            return false;
+        };
+        let parent = surface.wl_surface().clone();
+        let mut browser = self.state.lock().unwrap();
+        browser.sync_scroll_metrics();
+        let theme = AppContext::current_theme();
+        let title = browser.title();
+        let frame = browser.frame(&theme, &title);
+        let quickview = browser
+            .quickview_visible()
+            .map(|session| (session, browser.quickview_generation));
+        let painted = match self.pane_surfaces.as_mut() {
+            Some(panes) => panes.sync(&parent, &frame, quickview),
+            None => false,
+        };
+
+        // Hand the pointer handler the rect the panel was actually placed at.
+        // Doing it here, after the sync, is what keeps the hit test and the
+        // paint from disagreeing about where the card is.
+        drop(frame);
+        browser.quickview_panel = self
+            .pane_surfaces
+            .as_ref()
+            .and_then(pane_surfaces::PaneSurfaces::quickview_resting);
+        *self.quickview_target.lock().unwrap() = self
+            .pane_surfaces
+            .as_ref()
+            .and_then(pane_surfaces::PaneSurfaces::quickview_target);
+        painted
+    }
+
+    fn render(&self) {
+        if let Some(window) = &self.window {
+            window.request_frame();
+            // The runner renders dirty windows at the *top* of a loop
+            // iteration, before `on_update`, so a frame requested from
+            // `on_update` would sit unrendered until some other event happened
+            // to wake the loop. Asking for one more turn is what makes a
+            // repaint requested off the input path actually appear.
+            AppContext::request_wakeup();
+        }
+    }
+
+    /// Preview the cursor's file, decoding off the UI thread.
+    ///
+    /// [`quickview::decode`] blocks until the sandboxed worker answers or its
+    /// deadline expires — inline, that would stall the frame loop for as long
+    /// as the file takes.
+    fn start_quickview(&self, browser: &mut Browser) {
+        let Some((path, generation, anchor)) = browser.begin_quickview() else {
+            return;
+        };
+        let panel = quickview::panel_rect(browser.size.0, browser.size.1);
+        let scale = AppContext::scale_factor().max(1) as f32;
+        let state = Arc::clone(&self.state);
+
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        tokio::task::spawn_blocking(move || {
+            let preview = quickview::decode(&path, panel, scale);
+            state
+                .lock()
+                .unwrap()
+                .finish_quickview(generation, anchor, name, preview);
+            // Wake the UI thread: a window showing "Opening preview…" is not
+            // committing frames, so there is no frame callback to notice the
+            // decode landed.
+            AppContext::request_wakeup();
+        });
+    }
+
+    /// Decode the docked preview column's target, off the UI thread — the
+    /// same worker path Quick View's overlay uses, just landing in
+    /// [`Browser::finish_preview`] instead of [`Browser::finish_quickview`].
+    fn start_preview(&self, path: PathBuf, generation: u64) {
+        let panel = {
+            let browser = self.state.lock().unwrap();
+            Rect::from_wh(view::PREVIEW_W, browser.size.1)
+        };
+        let scale = AppContext::scale_factor().max(1) as f32;
+        let state = Arc::clone(&self.state);
+
+        tokio::task::spawn_blocking(move || {
+            let preview = quickview::decode(&path, panel, scale);
+            state.lock().unwrap().finish_preview(generation, preview);
+            AppContext::request_wakeup();
+        });
+    }
+
+    /// Keep repainting while a directory read is outstanding.
+    ///
+    /// Two constraints force this shape. A worker thread cannot ask for a
+    /// repaint at all — `AppContext::request_frame` dispatches through a
+    /// thread-local and is a silent no-op anywhere but the UI thread. And
+    /// asking from *inside* the draw does not reliably schedule another frame:
+    /// measured, a request made during a draw is honoured only when some other
+    /// event also triggers a render, so a read finishing after the last input
+    /// is never shown. The frame callback runs on the UI thread and after the
+    /// frame is acknowledged, which is the one place both hold.
+    ///
+    /// The loop sustains itself only while something is loading, so an idle
+    /// window costs nothing.
+    fn install_frame_loop(&self, window: &Window) {
+        use wayland_client::Proxy;
+
+        let Some(surface) = window.wl_surface() else {
+            return;
+        };
+        let state = Arc::clone(&self.state);
+        let window = window.clone();
+
+        AppContext::register_frame_callback(surface.id(), move || {
+            let repaint = {
+                let mut browser = state.lock().unwrap();
+                // A read that lands *here* is not in the frame just drawn, and
+                // clears `loading` — so without the `changed` arm the column
+                // that finished would sit empty until the next input event.
+                let changed = browser.poll();
+                // Also while a Quick View call is outstanding, so its result
+                // paints without waiting for the next keystroke.
+                // …and while the preview's entrance is still running, which is
+                // animated in this process now that the panel lives in this
+                // window's own surface.
+                let opening = browser.quickview_animating();
+                let preview_pending = browser.preview.as_ref().is_some_and(|p| p.pending);
+                changed
+                    || browser.loading()
+                    || browser.quickview_pending
+                    || opening
+                    || preview_pending
+            };
+            if repaint {
+                window.request_frame();
+            }
+        });
+    }
+
+    /// Quick View's panel handles its own pointer, because it is the one
+    /// surface of this window that is routinely *outside* it.
+    ///
+    /// Centred on the display, the card hangs past the toplevel's edges, and
+    /// the compositor delivers events over that part to this surface — never
+    /// to the toplevel. Hit-testing the button in window coordinates
+    /// therefore misses it exactly when the panel is placed correctly.
+    ///
+    /// The close button and the panel's own scrolling are handled here.
+    /// Both are things the pointer does *over* the card, and over the card is
+    /// exactly where the toplevel never hears about it. Dismissing on a click
+    /// outside the panel stays with the toplevel, where the rest of the
+    /// browser's hit-testing already lives — a click outside the card is a
+    /// click on the window.
+    fn install_quickview_pointer(&self) {
+        let state = Arc::clone(&self.state);
+        let target = Arc::clone(&self.quickview_target);
+
+        AppContext::register_pointer_callback(move |events| {
+            for event in events {
+                use wayland_client::Proxy;
+                let Some((surface, panel)) = target.lock().unwrap().clone() else {
+                    continue;
+                };
+                if event.surface.id() != surface {
+                    continue;
+                }
+                // Surface-local already: the compositor reports positions
+                // against the surface the pointer is over. Everything derived
+                // from `panel` below is in that same space.
+                let point = skia_safe::Point::new(event.position.0 as f32, event.position.1 as f32);
+                let over = view::quickview_close_rect(panel)
+                    .with_outset((4.0, 4.0))
+                    .contains(point);
+
+                let mut browser = state.lock().unwrap();
+                match event.kind {
+                    PointerEventKind::Press { .. } if over => {
+                        browser.close_quickview();
+                    }
+                    PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+                        browser.quickview_focus(point, panel);
+                        if browser.quickview_close_hovered != over {
+                            browser.quickview_close_hovered = over;
+                            browser.dirty = true;
+                        }
+                    }
+                    PointerEventKind::Leave { .. } => {
+                        browser.quickview_focus = None;
+                        if browser.quickview_close_hovered {
+                            browser.quickview_close_hovered = false;
+                            browser.dirty = true;
+                        }
+                    }
+                    PointerEventKind::Axis {
+                        vertical,
+                        horizontal,
+                        ..
+                    } => {
+                        browser.quickview_wheel(
+                            horizontal.absolute as f32,
+                            vertical.absolute as f32,
+                            panel,
+                        );
+                    }
+                    _ => {}
+                }
+                drop(browser);
+                AppContext::request_wakeup();
+            }
+        });
+    }
+
+    /// Bring the Get Info panel's window into line with the browser's state:
+    /// open one when there is something to show, take it away when there is
+    /// not, and repaint it when what it shows changes.
+    ///
+    /// The panel is a window of its own rather than a sheet drawn over this
+    /// one. It is dragged around, it stays put while the browser goes on
+    /// being used behind it, and it wants the shadow and the stacking every
+    /// other window gets — all of which the compositor already does for a
+    /// toplevel and none of which is worth rebuilding inside this window.
+    /// It carries the browser's own `app_id`, so it lands under the same dock
+    /// icon instead of adding one of its own.
+    fn sync_info_window(&mut self) {
+        let (wanted, dirty) = {
+            let mut browser = self.state.lock().unwrap();
+            (
+                browser.info.is_some(),
+                std::mem::take(&mut browser.info_dirty),
+            )
+        };
+        // Never with the cell borrowed: creating a window talks to the
+        // compositor, which dispatches events — the panel's own pointer
+        // callback among them — and that callback reads this same cell.
+        let open = self.info_window.borrow().is_some();
+        match (wanted, open) {
+            (true, false) => {
+                let window = self.create_info_window();
+                *self.info_window.borrow_mut() = window;
+            }
+            (false, true) => {
+                let window = self.info_window.borrow_mut().take();
+                if let Some(window) = window {
+                    window.close();
+                }
+            }
+            _ => {}
+        }
+        if dirty {
+            let window = self.info_window.borrow().clone();
+            if let Some(window) = window {
+                window.request_frame();
+                AppContext::request_wakeup();
+            }
+        }
+    }
+
+    fn create_info_window(&self) -> Option<Window> {
+        let mut window = Window::new("Info", view::INFO_W as i32, view::INFO_H as i32).ok()?;
+        // The layout inside is fixed, so the window does not resize.
+        window.set_min_size(view::INFO_W as u32, view::INFO_H as u32);
+        window.set_max_size(view::INFO_W as u32, view::INFO_H as u32);
+        // The card paints its own ground, and the compositor rounds and
+        // shadows the surface around it.
+        window.set_background(skia_safe::Color::TRANSPARENT);
+        if let Some(surface) = window.surface() {
+            // The browser's own app_id: this is another window of the file
+            // manager, not another application, and the dock and the app
+            // switcher should both read it that way.
+            surface.xdg_window().set_app_id("otto-files".to_string());
+        }
+        if let Some(style) = window.surface_style() {
+            style.set_corner_radius(14.0);
+        }
+
+        let state = Arc::clone(&self.state);
+        window.on_draw(move |canvas| {
+            let browser = state.lock().unwrap();
+            let Some(info) = browser.info.as_ref() else {
+                return;
+            };
+            let theme = AppContext::current_theme();
+            view::draw_info(
+                canvas,
+                &theme,
+                Rect::from_wh(view::INFO_W, view::INFO_H),
+                info,
+                browser.info_error.as_deref(),
+                browser.info_close_hovered,
+                false,
+            );
+        });
+
+        // A close asked for from outside — the app switcher, a keyboard
+        // shortcut, the dock's Quit — closes the panel. Without this the
+        // runner would take it for the application's own close request and
+        // end the process, which is a surprising way for Get Info to go away.
+        let state = Arc::clone(&self.state);
+        window.on_close_request(move || state.lock().unwrap().close_info());
+
+        Some(window)
+    }
+
+    /// The Get Info window's pointer. Registered once, for whichever panel is
+    /// open — see [`FilesApp::info_window`].
+    fn install_info_window_pointer(&self) {
+        let state = Arc::clone(&self.state);
+        let info_window = Rc::clone(&self.info_window);
+
+        AppContext::register_pointer_callback(move |events| {
+            use wayland_client::Proxy;
+            let window = info_window.borrow().clone();
+            let Some(window) = window else { return };
+            let Some(surface) = window.wl_surface() else {
+                return;
+            };
+            // The window is the card, so surface-local coordinates are the
+            // panel's own and nothing has to be converted.
+            let sheet = Rect::from_wh(view::INFO_W, view::INFO_H);
+
+            for event in events {
+                if event.surface.id() != surface.id() {
+                    continue;
+                }
+                let point = (event.position.0 as f32, event.position.1 as f32);
+                let drag = {
+                    let mut browser = state.lock().unwrap();
+                    info_pointer(&mut browser, &event.kind, sheet, point)
+                };
+                if drag {
+                    if let PointerEventKind::Press { serial, .. } = event.kind {
+                        if let Some(seat) = AppContext::seat_state().seats().next() {
+                            window.start_move(&seat, serial);
+                        }
+                    }
+                }
+                AppContext::request_wakeup();
+            }
+        });
+    }
+
+    fn install_pointer(&self, window: &Window, context_menu: ContextMenu) {
+        let state = Arc::clone(&self.state);
+        let window_for_events = window.clone();
+        let modifiers = Arc::clone(&self.modifiers);
+
+        window.on_pointer_event(move |events| {
+            for event in events {
+                let (x, y) = (event.position.0 as f32, event.position.1 as f32);
+                let (ctrl, shift) = *modifiers.lock().unwrap();
+                let mut browser = state.lock().unwrap();
+                // The file area's bottom, not the window's: every hit test
+                // below is against the listing, which stops short of the
+                // picker's action row. The row's own hit test uses the full
+                // window height and runs first.
+                let (width, height) = (browser.size.0, browser.content_h());
+
+                // An in-place rename owns the pointer while it is up: a click
+                // inside places the caret, a click anywhere else commits it
+                // the way clicking away from a Finder rename does.
+                if let Some(session) = browser.rename.as_ref() {
+                    if let PointerEventKind::Press { .. } = event.kind {
+                        let (depth, index) = (session.depth, session.index);
+                        let count = browser.visible(depth).len();
+                        let scroll = browser.columns[depth].scroll.offset();
+                        let rect = match browser.mode {
+                            ViewMode::List => view::list_rename_rect(
+                                width,
+                                browser.list_columns,
+                                count,
+                                scroll,
+                                index,
+                            ),
+                            ViewMode::Columns => {
+                                let is_dir =
+                                    browser.visible(depth).get(index).is_some_and(|e| e.is_dir);
+                                view::miller_rename_rect(
+                                    height,
+                                    browser.pan.offset(),
+                                    browser.miller_w,
+                                    depth,
+                                    count,
+                                    scroll,
+                                    index,
+                                    is_dir,
+                                )
+                            }
+                            ViewMode::Grid => view::grid_rename_rect(width, height, scroll, index),
+                        };
+                        if rect.contains(skia_safe::Point::new(x, y)) {
+                            if let Some(session) = browser.rename.as_mut() {
+                                session.input.on_pointer_down(x - rect.left, 1, shift);
+                            }
+                            browser.dirty = true;
+                        } else {
+                            browser.commit_rename();
+                        }
+                    }
+                    drop(browser);
+                    window_for_events.request_frame();
+                    continue;
+                }
+
+                // An open preview owns the pointer, the way the sheet does: a
+                // click outside dismisses it, the wheel scrolls its content, and
+                // nothing reaches the listing underneath.
+                if browser.quickview.is_some() {
+                    // Where the panel *is*, which is not where the window's
+                    // centre is once the compositor has centred it on the
+                    // display. The fallback is the window-centred rect, and
+                    // the window height is right for it: the panel floats
+                    // over the action row rather than beside it.
+                    let panel = browser
+                        .quickview_panel
+                        .unwrap_or_else(|| quickview::panel_rect(width, browser.size.1));
+                    let point = skia_safe::Point::new(x, y);
+                    let over_close = view::quickview_close_rect(panel)
+                        .with_outset((4.0, 4.0))
+                        .contains(point);
+                    match event.kind {
+                        PointerEventKind::Press { .. } => {
+                            // The button first: it sits inside the panel, so
+                            // the "click outside dismisses" rule below would
+                            // never reach it.
+                            if over_close || !panel.contains(point) {
+                                browser.close_quickview();
+                            }
+                        }
+                        PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+                            browser.quickview_focus(point, panel);
+                            if browser.quickview_close_hovered != over_close {
+                                browser.quickview_close_hovered = over_close;
+                                browser.dirty = true;
+                            }
+                        }
+                        PointerEventKind::Leave { .. } => {
+                            browser.quickview_focus = None;
+                            if browser.quickview_close_hovered {
+                                browser.quickview_close_hovered = false;
+                                browser.dirty = true;
+                            }
+                        }
+                        PointerEventKind::Axis {
+                            vertical,
+                            horizontal,
+                            ..
+                        } => {
+                            browser.quickview_wheel(
+                                horizontal.absolute as f32,
+                                vertical.absolute as f32,
+                                panel,
+                            );
+                        }
+                        _ => {}
+                    }
+                    drop(browser);
+                    continue;
+                }
+
+                // The picker's action row, and the filter menu it opens,
+                // take the pointer before the listing does. Their geometry is
+                // in *window* coordinates — `height` above is the file area's
+                // bottom, which is exactly where this strip begins.
+                if browser.picker.is_some() {
+                    let window_h = browser.size.1;
+                    let (filter_count, menu_open) = browser
+                        .picker
+                        .as_ref()
+                        .map(|p| (p.filters.len(), p.filter_open))
+                        .unwrap_or((0, false));
+                    let hit = view::footer_at(x, y, width, window_h, filter_count, menu_open);
+                    // A click anywhere outside the open menu closes it, the
+                    // way clicking away from any menu does — including a
+                    // click on the listing, which is then swallowed.
+                    let dismissing_menu = menu_open
+                        && !matches!(
+                            hit,
+                            Some(view::FooterButton::FilterOption(_))
+                                | Some(view::FooterButton::Filter)
+                        );
+
+                    match event.kind {
+                        PointerEventKind::Motion { .. } => {
+                            if browser.footer_hover != hit {
+                                browser.footer_hover = hit;
+                                browser.dirty = true;
+                            }
+                            if hit.is_some() {
+                                AppContext::set_cursor_shape(CursorShape::Default);
+                                drop(browser);
+                                continue;
+                            }
+                        }
+                        PointerEventKind::Leave { .. } => {
+                            if browser.footer_hover.take().is_some() {
+                                browser.dirty = true;
+                            }
+                        }
+                        PointerEventKind::Press { button, .. } if button != BTN_RIGHT => {
+                            if dismissing_menu {
+                                if let Some(session) = browser.picker.as_mut() {
+                                    session.filter_open = false;
+                                }
+                                browser.dirty = true;
+                                drop(browser);
+                                window_for_events.request_frame();
+                                continue;
+                            }
+                            if let Some(button) = hit {
+                                browser.footer_press(button);
+                                drop(browser);
+                                window_for_events.request_frame();
+                                continue;
+                            }
+                        }
+                        PointerEventKind::Release { button, .. } if button != BTN_RIGHT => {
+                            if browser.footer_pressed.is_some() {
+                                browser.footer_release(hit);
+                                drop(browser);
+                                window_for_events.request_frame();
+                                continue;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                match event.kind {
+                    PointerEventKind::Motion { .. } => {
+                        // A column divider being dragged owns the pointer
+                        // outright — nothing else on this move should react.
+                        if let Some((boundary, start_x, start_w)) = browser.column_resize {
+                            let dx = x - start_x;
+                            let new_w = (start_w - dx).clamp(view::COLUMN_MIN_W, 400.0);
+                            match boundary {
+                                view::ColumnBoundary::Size => browser.list_columns.size = new_w,
+                                view::ColumnBoundary::Kind => browser.list_columns.kind = new_w,
+                                view::ColumnBoundary::Modified => {
+                                    browser.list_columns.modified = new_w
+                                }
+                            }
+                            browser.dirty = true;
+                            AppContext::set_cursor_shape(CursorShape::ColResize);
+                            drop(browser);
+                            continue;
+                        }
+                        if let Some((depth, start_x, start_w)) = browser.miller_resize {
+                            let dx = (x - start_x) / (depth + 1) as f32;
+                            browser.miller_w =
+                                (start_w + dx).clamp(view::MILLER_MIN_W, view::MILLER_MAX_W);
+                            browser.dirty = true;
+                            AppContext::set_cursor_shape(CursorShape::ColResize);
+                            drop(browser);
+                            continue;
+                        }
+
+                        // Resize affordance at the window edges.
+                        let edge = resize::edge_at(Rect::from_wh(width, browser.size.1), x, y);
+                        let over_column_divider = (browser.mode == ViewMode::List
+                            && view::column_boundary_at(x, y, width, browser.list_columns)
+                                .is_some())
+                            || (browser.mode == ViewMode::Columns
+                                && view::miller_boundary_at(
+                                    x,
+                                    y,
+                                    width,
+                                    height,
+                                    browser.pan.offset(),
+                                    browser.columns.len(),
+                                    browser.miller_w,
+                                )
+                                .is_some());
+                        let shape = if over_column_divider {
+                            CursorShape::ColResize
+                        } else {
+                            edge.map_or(CursorShape::Default, |e| e.cursor())
+                        };
+                        AppContext::set_cursor_shape(shape);
+
+                        // A scrollbar drag follows the pointer wherever it
+                        // goes, so the dragged pane is asked first and the
+                        // hovered one only styles its bar.
+                        browser.sync_scroll_metrics();
+                        let hovered = browser.pane_under(x, y);
+                        let mut moved = browser.pan.on_pointer_drag(x, y);
+                        if browser.mode == ViewMode::Columns {
+                            moved |= browser.pan.on_pointer_move(x, y);
+                        } else {
+                            browser.pan.on_pointer_leave();
+                        }
+                        for (depth, column) in browser.columns.iter_mut().enumerate() {
+                            moved |= column.scroll.on_pointer_drag(x, y);
+                            if depth == hovered {
+                                // Hovering the scrollbar keeps it up and
+                                // widens it, the way the settings app does.
+                                moved |= column.scroll.on_pointer_move(x, y);
+                            } else {
+                                column.scroll.on_pointer_leave();
+                            }
+                        }
+                        browser.dirty |= moved;
+
+                        // The traffic lights reveal their glyphs while the
+                        // pointer is over the group.
+                        let control = view::control_at(x, y);
+                        browser.dirty |= browser.controls.on_motion(control);
+                    }
+                    PointerEventKind::Release { .. } => {
+                        browser.column_resize = None;
+                        browser.miller_resize = None;
+                        browser.pan.on_pointer_up();
+                        for column in &mut browser.columns {
+                            column.scroll.on_pointer_up();
+                        }
+
+                        // A nav arrow steps on release, and only over the half
+                        // the press landed on: a press dragged off it is a
+                        // cancelled click, and only clears the fill.
+                        if let Some(armed) = browser.nav_pressed.take() {
+                            browser.dirty = true;
+                            if browser.nav_button_at(x, y) == Some(armed) {
+                                match armed {
+                                    view::NavButton::Back => browser.go_back(),
+                                    view::NavButton::Forward => browser.go_forward(),
+                                }
+                            }
+                        }
+
+                        // A control fires on release, and only over the dot
+                        // the press landed on.
+                        let control = view::control_at(x, y);
+                        browser.dirty |= browser.controls.pressed().is_some();
+                        match browser.controls.on_release(control) {
+                            // In the picker, closing the window *is*
+                            // cancelling: exiting here would leave the
+                            // requesting application waiting on a reply that
+                            // no longer has a sender.
+                            Some(WindowControl::Close) => {
+                                if browser.picker.is_some() {
+                                    browser.picker_cancel();
+                                } else {
+                                    std::process::exit(0)
+                                }
+                            }
+                            Some(WindowControl::Minimize) => window_for_events.minimize(),
+                            Some(WindowControl::Zoom) => window_for_events.toggle_maximized(),
+                            None => {}
+                        }
+                    }
+                    PointerEventKind::Leave { .. } => {
+                        browser.column_resize = None;
+                        browser.miller_resize = None;
+                        browser.pan.on_pointer_leave();
+                        for column in &mut browser.columns {
+                            column.scroll.on_pointer_leave();
+                        }
+                        // Nothing in the header is hovered once the pointer is
+                        // off the window, or the glyphs stay drawn on it.
+                        browser.controls.on_leave();
+                        // Same for a held arrow: the release will never come.
+                        browser.nav_pressed = None;
+                        browser.dirty = true;
+                    }
+                    PointerEventKind::Press { serial, button, .. } if button == BTN_RIGHT => {
+                        let items = browser.context_menu_items(x, y);
+                        drop(browser);
+
+                        let Some(parent_xdg) = window_for_events
+                            .surface()
+                            .map(|s| s.xdg_window().xdg_surface().clone())
+                        else {
+                            continue;
+                        };
+                        let Ok(positioner) = XdgPositioner::new(AppContext::xdg_shell_state())
+                        else {
+                            continue;
+                        };
+
+                        context_menu.state().borrow_mut().set_items(items);
+                        let theme = AppContext::current_theme();
+                        context_menu
+                            .clone()
+                            .with_style(ContextMenuStyle::default().with_theme(theme));
+
+                        let (menu_w, menu_h) = context_menu.get_size_at_depth(0);
+                        positioner.set_size(menu_w as i32, menu_h as i32);
+                        positioner.set_anchor_rect(x as i32, y as i32, 1, 1);
+                        positioner.set_anchor(xdg_positioner::Anchor::TopLeft);
+                        positioner.set_gravity(xdg_positioner::Gravity::BottomRight);
+                        positioner.set_constraint_adjustment(
+                            xdg_positioner::ConstraintAdjustment::SlideX
+                                | xdg_positioner::ConstraintAdjustment::SlideY
+                                | xdg_positioner::ConstraintAdjustment::FlipX
+                                | xdg_positioner::ConstraintAdjustment::FlipY,
+                        );
+
+                        let click_state = Arc::clone(&state);
+                        let click_window = window_for_events.clone();
+                        context_menu.clone().on_item_click(move |action_id| {
+                            let mut browser = click_state.lock().unwrap();
+                            match action_id {
+                                "open" => browser.open_selection(),
+                                "get_info" => browser.open_info(),
+                                "rename" => browser.start_rename(),
+                                "cut" => browser.copy_selection(true, serial),
+                                "copy" => browser.copy_selection(false, serial),
+                                "paste" => browser.paste(),
+                                "trash" => browser.move_selected_to_trash(),
+                                "new_folder" => browser.new_folder(),
+                                _ => {}
+                            }
+                            drop(browser);
+                            click_window.request_frame();
+                        });
+
+                        context_menu.show(&parent_xdg, &positioner, serial);
+                        continue;
+                    }
+                    PointerEventKind::Press { serial, .. } => {
+                        if let Some(edge) = resize::edge_at(Rect::from_wh(width, height), x, y) {
+                            if let Some(seat) = AppContext::seat_state().seats().next() {
+                                window_for_events.start_resize(&seat, serial, edge);
+                            }
+                            return;
+                        }
+
+                        // Arming rather than acting: the control fires on
+                        // release, over the same dot.
+                        if browser.controls.on_press(view::control_at(x, y)) {
+                            browser.dirty = true;
+                            return;
+                        }
+
+                        // Dragging the header moves the window, in every view. The
+                        // sidebar's first place reaches into the header band, so a
+                        // click there belongs to the place, not to the drag.
+                        if view::is_drag_area(x, y, width)
+                            && view::place_at(x, y, browser.places.len()).is_none()
+                        {
+                            if let Some(seat) = AppContext::seat_state().seats().next() {
+                                window_for_events.start_move(&seat, serial);
+                            }
+                            return;
+                        }
+
+                        // A press on a scrollbar thumb grabs it and selects
+                        // nothing: the bar sits over the rows it scrolls, so
+                        // it has to win the click.
+                        browser.sync_scroll_metrics();
+                        // The stack's bar lies along the bottom of every
+                        // pane, crossing the foot of each pane's own gutter,
+                        // so it is asked first where the two overlap.
+                        let depth = browser.pane_under(x, y);
+                        let panning = browser.mode == ViewMode::Columns;
+                        if (panning && browser.pan.on_pointer_down(x, y))
+                            || browser.columns[depth].scroll.on_pointer_down(x, y)
+                        {
+                            browser.dirty = true;
+                            drop(browser);
+                            continue;
+                        }
+
+                        if let Some(button) = browser.nav_button_at(x, y) {
+                            // Armed, not acted on: the step happens on
+                            // release, over the same half, so the arrow can
+                            // sit visibly pressed in the meantime.
+                            browser.nav_pressed = Some(button);
+                            browser.dirty = true;
+                        } else if let Some(mode) = view::switcher_at(x, y, width) {
+                            browser.mode = mode;
+                            browser.dirty = true;
+                        } else if let Some(index) = view::place_at(x, y, browser.places.len()) {
+                            let path = browser.places[index].path.clone();
+                            browser.navigate_to(&path);
+                        } else if browser.mode == ViewMode::Grid {
+                            let depth = browser.columns.len() - 1;
+                            let count = browser.visible(depth).len();
+                            let scroll = browser.columns[depth].scroll.offset();
+                            let area = view::content_viewport(width, height, ViewMode::Grid);
+                            if let Some(index) = view::grid_cell_at(area, x, y, count, scroll) {
+                                if ctrl {
+                                    browser.toggle_select(depth, index);
+                                } else if shift {
+                                    browser.extend_select(depth, index);
+                                } else {
+                                    browser.select(depth, index);
+                                    browser.note_row_click(depth, index);
+                                }
+                            }
+                        } else if browser.mode == ViewMode::List
+                            && view::column_boundary_at(x, y, width, browser.list_columns).is_some()
+                        {
+                            let boundary =
+                                view::column_boundary_at(x, y, width, browser.list_columns)
+                                    .unwrap();
+                            let now = std::time::Instant::now();
+                            let double_click =
+                                browser.last_boundary_click.is_some_and(|(last, at)| {
+                                    last == boundary && now.duration_since(at) < DOUBLE_CLICK_WINDOW
+                                });
+                            if double_click && boundary == view::ColumnBoundary::Size {
+                                let depth = browser.columns.len() - 1;
+                                let longest = view::widest_name(
+                                    browser.visible(depth).iter().map(|e| e.name.as_str()),
+                                );
+                                browser.list_columns.size =
+                                    view::fit_size_column(width, browser.list_columns, longest);
+                                browser.last_boundary_click = None;
+                                browser.dirty = true;
+                            } else {
+                                let start = match boundary {
+                                    view::ColumnBoundary::Size => browser.list_columns.size,
+                                    view::ColumnBoundary::Kind => browser.list_columns.kind,
+                                    view::ColumnBoundary::Modified => browser.list_columns.modified,
+                                };
+                                browser.column_resize = Some((boundary, x, start));
+                                browser.last_boundary_click = Some((boundary, now));
+                            }
+                        } else if browser.mode == ViewMode::List {
+                            if let Some(key) = view::column_at(x, y, width, browser.list_columns) {
+                                if browser.sort == key {
+                                    browser.ascending = !browser.ascending;
+                                } else {
+                                    browser.sort = key;
+                                    browser.ascending = true;
+                                }
+                                browser.dirty = true;
+                            } else {
+                                let depth = browser.columns.len() - 1;
+                                let count = browser.visible(depth).len();
+                                let scroll = browser.columns[depth].scroll.offset();
+                                if let Some(index) =
+                                    view::row_at(x, y, width, height, count, scroll)
+                                {
+                                    if ctrl {
+                                        browser.toggle_select(depth, index);
+                                    } else if shift {
+                                        browser.extend_select(depth, index);
+                                    } else {
+                                        browser.select(depth, index);
+                                        browser.note_row_click(depth, index);
+                                    }
+                                }
+                            }
+                        } else if browser.mode == ViewMode::Columns
+                            && view::miller_boundary_at(
+                                x,
+                                y,
+                                width,
+                                height,
+                                browser.pan.offset(),
+                                browser.columns.len(),
+                                browser.miller_w,
+                            )
+                            .is_some()
+                        {
+                            let depth = view::miller_boundary_at(
+                                x,
+                                y,
+                                width,
+                                height,
+                                browser.pan.offset(),
+                                browser.columns.len(),
+                                browser.miller_w,
+                            )
+                            .unwrap();
+                            let now = std::time::Instant::now();
+                            let double_click =
+                                browser.last_miller_click.is_some_and(|(last, at)| {
+                                    last == depth && now.duration_since(at) < DOUBLE_CLICK_WINDOW
+                                });
+                            if double_click {
+                                let entries = browser.visible(depth);
+                                let longest =
+                                    view::widest_name(entries.iter().map(|e| e.name.as_str()));
+                                let has_dirs = entries.iter().any(|e| e.is_dir);
+                                browser.miller_w = view::fit_miller_width(longest, has_dirs);
+                                browser.last_miller_click = None;
+                                browser.dirty = true;
+                            } else {
+                                browser.miller_resize = Some((depth, x, browser.miller_w));
+                                browser.last_miller_click = Some((depth, now));
+                            }
+                        } else {
+                            let counts = browser.counts();
+                            let hit = view::miller_at(
+                                x,
+                                y,
+                                width,
+                                height,
+                                &browser.columns,
+                                &counts,
+                                browser.pan.offset(),
+                                browser.miller_w,
+                            );
+                            if let Some((depth, Some(index))) = hit {
+                                if ctrl {
+                                    browser.toggle_select(depth, index);
+                                } else if shift {
+                                    browser.extend_select(depth, index);
+                                } else {
+                                    browser.select(depth, index);
+                                }
+                            } else if let Some((depth, None)) = hit {
+                                browser.active = depth;
+                                browser.dirty = true;
+                            }
+                        }
+                    }
+                    PointerEventKind::Axis {
+                        vertical,
+                        horizontal,
+                        ..
+                    } => {
+                        let dy = vertical.absolute as f32;
+                        let dx = horizontal.absolute as f32;
+                        // Both axes clamp, band and fling themselves, so the
+                        // metrics have to be current before either is fed.
+                        browser.sync_scroll_metrics();
+
+                        let stop = vertical.stop || horizontal.stop;
+                        let discrete = vertical.discrete != 0 || horizontal.discrete != 0;
+                        // One gesture belongs to one axis, chosen by its first
+                        // delta and kept until it lifts.
+                        let leading = if browser.mode == ViewMode::Columns && dx.abs() > dy.abs() {
+                            Axis::Horizontal
+                        } else {
+                            Axis::Vertical
+                        };
+                        let axis = *browser.gesture_axis.get_or_insert(leading);
+                        let (delta, scroll) = match axis {
+                            // The stack pans as a whole …
+                            Axis::Horizontal => (dx, &mut browser.pan),
+                            // … while a vertical scroll belongs to the pane
+                            // under the pointer.
+                            Axis::Vertical => {
+                                let depth = browser.pane_under(x, y);
+                                (dy, &mut browser.columns[depth].scroll)
+                            }
+                        };
+
+                        // A notched wheel reports discrete steps and moves
+                        // exactly one step per click; a touchpad reports a
+                        // continuous stream, which is what momentum and
+                        // rubber banding are for.
+                        let moved = if stop {
+                            // Fingers off the touchpad: what the gesture
+                            // was carrying becomes a fling, and anything
+                            // pulled past an end springs back.
+                            scroll.on_wheel_end();
+                            true
+                        } else if discrete {
+                            scroll.on_wheel_discrete(delta)
+                        } else {
+                            scroll.on_wheel(delta)
+                        };
+                        if stop || discrete {
+                            // Nothing is in flight to keep an axis for: the
+                            // next delta picks afresh.
+                            browser.gesture_axis = None;
+                        }
+                        browser.dirty |= moved;
+                    }
+                    _ => {}
+                }
+
+                drop(browser);
+            }
+            window_for_events.request_frame();
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// What the preview column says about a file, under its name.
+///
+/// The same three facts the list view's columns show, in the same words: a
+/// preview that described the file differently from the row it grew out of
+/// would be describing a different file as far as the reader is concerned. A
+/// directory has no size worth showing — the listing does not count children
+/// either — so it gets two lines rather than three.
+fn preview_info(entry: &Entry) -> Vec<String> {
+    let mut info = vec![entry.kind_label().to_string()];
+    if let Some(size) = entry.size.filter(|_| !entry.is_dir) {
+        info.push(model::format_size(size));
+    }
+    if let Some(modified) = entry.modified {
+        info.push(model::format_time(modified));
+    }
+    info
+}
+
+/// Open a browser window at `start` and run until it is closed.
+pub fn run_browser(start: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    run_app(Browser::new(start), None)
+}
+
+/// Serve `org.otto.FilePicker1` until there is nothing left to serve.
+///
+/// No window exists until a request arrives: a bus-activated picker that
+/// nobody has asked anything of should not be showing a dialog. The first
+/// request builds the window; later ones re-use it as it is answered and
+/// freed.
+///
+/// **One request at a time in v1.** Two applications asking at once are
+/// served in turn rather than in two windows — the app shell is built around
+/// a single toplevel, and queueing is honest where a second, half-supported
+/// window would not be. Neither request is dropped and neither hangs.
+pub async fn run_picker() -> Result<(), Box<dyn std::error::Error>> {
+    let queue: crate::dbus::SharedQueue = Default::default();
+
+    let service_queue = Arc::clone(&queue);
+    tokio::spawn(async move {
+        if let Err(err) = crate::dbus::serve(service_queue).await {
+            tracing::error!(?err, "file picker D-Bus service failed");
+            // Nothing can reach us, and a picker nobody can call is a dialog
+            // that never opens. Better to die and be re-activated.
+            std::process::exit(1);
+        }
+    });
+
+    // Park until the bus hands us something to do. This is the whole of the
+    // idle picker: no Wayland connection, no window, no watchers.
+    let session = queue.next_session_async().await;
+
+    let start = session.request.starting_directory(None);
+    run_app(Browser::for_picker(session, start), Some(queue))
+}
+
+/// Run the app shell around an already-built [`Browser`].
+/// One pointer event inside the Get Info window.
+///
+/// `sheet` is the panel's rect in that window's own coordinates, which is the
+/// whole of it: the window *is* the card. Positions arrive in the same space,
+/// so nothing here converts anything.
+///
+/// Returns a drag request: the strip was pressed, and the compositor should
+/// take over and move the window. Moving is the compositor's job — it is the
+/// only party that knows where the window is on the display, and an
+/// interactive move it drives keeps the pointer and the window in step even
+/// when the client is busy.
+fn info_pointer(
+    browser: &mut Browser,
+    kind: &PointerEventKind,
+    sheet: Rect,
+    point: (f32, f32),
+) -> bool {
+    let (x, y) = point;
+    let point = skia_safe::Point::new(x, y);
+    let over_close = view::info_close_rect(sheet)
+        .with_outset((6.0, 6.0))
+        .contains(point);
+
+    match kind {
+        PointerEventKind::Press { .. } => {
+            if over_close {
+                browser.close_info();
+            } else if let Some((who, what)) = view::perm_box_at(sheet, x, y) {
+                browser.toggle_permission(who, what);
+            } else if view::info_titlebar_rect(sheet).contains(point) {
+                return true;
+            }
+            false
+        }
+        PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+            if browser.info_close_hovered != over_close {
+                browser.info_close_hovered = over_close;
+                browser.info_dirty = true;
+            }
+            false
+        }
+        PointerEventKind::Leave { .. } => {
+            if browser.info_close_hovered {
+                browser.info_close_hovered = false;
+                browser.info_dirty = true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn run_app(
+    browser: Browser,
+    picker_queue: Option<crate::dbus::SharedQueue>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state = Arc::new(Mutex::new(browser));
+
+    let app = FilesApp {
+        pane_surfaces: None,
+        window: None,
+        info_window: Rc::new(RefCell::new(None)),
+        state: Arc::clone(&state),
+        modifiers: Arc::new(Mutex::new((false, false))),
+        context_menu: None,
+        quickview_target: Arc::new(Mutex::new(None)),
+        picker_queue,
+    };
+
+    AppRunner::new(app).run()
+}
+
+#[cfg(test)]
+mod rename_tests {
+    use super::rename_selection;
+
+    #[test]
+    fn a_file_selects_the_stem_only() {
+        assert_eq!(rename_selection("photo.png", false), 0..5);
+    }
+
+    #[test]
+    fn a_multi_dot_name_splits_on_the_last_dot() {
+        assert_eq!(rename_selection("archive.tar.gz", false), 0..11);
+    }
+
+    #[test]
+    fn a_directory_selects_the_whole_name() {
+        assert_eq!(rename_selection("Documents", true), 0..9);
+        assert_eq!(rename_selection("my.folder", true), 0..9);
+    }
+
+    #[test]
+    fn a_dotfile_selects_the_whole_name() {
+        assert_eq!(rename_selection(".bashrc", false), 0..7);
+    }
+
+    #[test]
+    fn an_extensionless_file_selects_the_whole_name() {
+        assert_eq!(rename_selection("README", false), 0..6);
+    }
+}

--- a/components/otto-files/src/bench.rs
+++ b/components/otto-files/src/bench.rs
@@ -1,0 +1,862 @@
+//! Isolated micro-benchmarks for the scroll hot path.
+//!
+//! Not a correctness suite: each of these times one thing the browser does per
+//! frame (or per wheel event) against the alternative it could do instead, so
+//! "is this worth changing" is a number rather than an argument.
+//!
+//! ```sh
+//! cargo test --bin otto-files -- --ignored --nocapture bench
+//! ```
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime};
+
+use crate::model::{self, Entry, SortKey};
+use otto_kit::filetype::Kind;
+
+/// Rows a 1100pt-tall pane shows at ROW_H — what one frame actually draws.
+const VISIBLE: usize = 40;
+
+fn bench<F: FnMut()>(label: &str, iters: u32, mut f: F) -> Duration {
+    // One untimed pass so caches and lazy statics are not charged to the mean.
+    f();
+    let start = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    let total = start.elapsed();
+    let each = total / iters;
+    println!("  {label:<44} {:>9.1} µs", each.as_secs_f64() * 1e6);
+    each
+}
+
+fn ratio(label: &str, before: Duration, after: Duration) {
+    let b = before.as_secs_f64();
+    let a = after.as_secs_f64().max(1e-12);
+    println!("  → {label}: {:.1}× faster\n", b / a);
+}
+
+fn entries(count: usize) -> Vec<Entry> {
+    (0..count)
+        .map(|i| {
+            let name = match i % 5 {
+                0 => format!("Screenshot 2026-08-{:02} at {i}.png", i % 28 + 1),
+                1 => format!("report-{i}.pdf"),
+                2 => format!("src-{i}"),
+                3 => format!("a rather long file name that will not fit {i}.txt"),
+                _ => format!("IMG_{i:04}.jpeg"),
+            };
+            Entry {
+                path: PathBuf::from(format!("/home/u/files/{name}")),
+                is_dir: i % 5 == 2,
+                is_symlink: false,
+                hidden: i % 11 == 0,
+                kind: Kind::Other,
+                size: Some((i as u64 * 7919) % 4_000_000),
+                modified: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(i as u64 * 3600)),
+                name,
+            }
+        })
+        .collect()
+}
+
+/// `Browser::visible_uncounted`, lifted verbatim so the bench measures the
+/// real comparator and the real allocation rather than a stand-in.
+fn visible_uncounted(
+    all: &[Entry],
+    show_hidden: bool,
+    sort: SortKey,
+    ascending: bool,
+) -> Vec<&Entry> {
+    let mut entries: Vec<&Entry> = all.iter().filter(|e| show_hidden || !e.hidden).collect();
+    entries.sort_by(|a, b| {
+        let dirs_first = b.is_dir.cmp(&a.is_dir);
+        if dirs_first != std::cmp::Ordering::Equal {
+            return dirs_first;
+        }
+        let ord = match sort {
+            SortKey::Name => model::natural_cmp(&a.name, &b.name),
+            SortKey::Size => a.size.unwrap_or(0).cmp(&b.size.unwrap_or(0)),
+            SortKey::Kind => a
+                .kind_label()
+                .cmp(b.kind_label())
+                .then_with(|| model::natural_cmp(&a.name, &b.name)),
+            SortKey::Modified => a.modified.cmp(&b.modified),
+        };
+        if ascending {
+            ord
+        } else {
+            ord.reverse()
+        }
+    });
+    entries
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn bench_visible_sort() {
+    println!("\n=== 1. visible(): sort every frame vs. cached order ===");
+    for count in [200usize, 1_000, 5_000, 20_000] {
+        let all = entries(count);
+        println!("  -- {count} entries --");
+        let sorted = bench("sort_by (what happens today)", 200, || {
+            std::hint::black_box(visible_uncounted(&all, false, SortKey::Name, true));
+        });
+        let cached_vec: Vec<&Entry> = visible_uncounted(&all, false, SortKey::Name, true);
+        let cached = bench("clone a cached Vec<&Entry>", 200, || {
+            std::hint::black_box(cached_vec.clone());
+        });
+        let borrowed = bench("borrow a cached slice", 200, || {
+            std::hint::black_box(&cached_vec[..]);
+        });
+        ratio("cache + clone", sorted, cached);
+        ratio("cache + borrow", sorted, borrowed);
+    }
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn bench_selection_vec() {
+    println!("\n=== 2. PaneData.selected: whole listing vs. visible rows ===");
+    for count in [1_000usize, 20_000] {
+        let all = entries(count);
+        let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+        // A realistic multi-select: a run of 20 rows.
+        let selection: BTreeSet<String> = sorted
+            .iter()
+            .skip(300)
+            .take(20)
+            .map(|e| e.name.clone())
+            .collect();
+        println!("  -- {count} entries, 20 selected --");
+        let full = bench("Vec<bool> over all entries (today)", 500, || {
+            let v: Vec<bool> = sorted.iter().map(|e| selection.contains(&e.name)).collect();
+            std::hint::black_box(v);
+        });
+        let windowed = bench("Vec<bool> over the visible rows", 500, || {
+            let v: Vec<bool> = sorted[..VISIBLE.min(sorted.len())]
+                .iter()
+                .map(|e| selection.contains(&e.name))
+                .collect();
+            std::hint::black_box(v);
+        });
+        let lazy = bench("lookup per drawn row, no Vec", 500, || {
+            for e in &sorted[..VISIBLE.min(sorted.len())] {
+                std::hint::black_box(selection.contains(&e.name));
+            }
+        });
+        ratio("visible-range Vec", full, windowed);
+        ratio("no Vec at all", full, lazy);
+    }
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn bench_row_build() {
+    println!("\n=== 3. build_rows(): the cost of one re-record ===");
+    let all = entries(5_000);
+    let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+    let band = &sorted[..30];
+
+    let chains = bench("icon_chain() × 30 rows (mime lookup + Vec)", 500, || {
+        for e in band {
+            std::hint::black_box(e.icon_chain());
+        }
+    });
+    println!(
+        "  a band re-records on every row boundary crossed.\n\
+         \x20 at 1500 pt/s over a 24 pt row that is ~62 re-records/s:\n\
+         \x20   no overscan : {:>7.2} ms/s of scroll\n\
+         \x20   ±8 overscan : {:>7.2} ms/s of scroll (one per 8 rows)\n",
+        chains.as_secs_f64() * 62.0 * 1e3,
+        chains.as_secs_f64() * 62.0 / 8.0 * 1e3,
+    );
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn bench_text_shaping() {
+    use crate::view;
+    use otto_kit::typography::styles;
+    use skia_safe::{surfaces, Color, Paint, PictureRecorder, Rect};
+
+    println!("\n=== 4. list rows: immediate re-shape vs. cached picture ===");
+    println!("  both sides rasterise the same 40 rows into the same surface;");
+    println!("  only the measuring/shaping/formatting differs.");
+    let all = entries(5_000);
+    let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+    let band: Vec<&Entry> = sorted[..VISIBLE].to_vec();
+    let font = styles::BODY_MEDIUM.font();
+    let mut surface = surfaces::raster_n32_premul((900, 1000)).unwrap();
+
+    let draw_row = |canvas: &skia_safe::Canvas, i: usize, e: &Entry, font: &skia_safe::Font| {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(Color::BLACK);
+        let y = 20.0 + i as f32 * 24.0;
+        let name = view::ellipsize(font, &e.name, 320.0);
+        canvas.draw_str(&name, (14.0, y), font, &paint);
+        let size_text = if e.is_dir {
+            "--".to_string()
+        } else {
+            e.size.map(model::format_size).unwrap_or_default()
+        };
+        canvas.draw_str(&size_text, (400.0, y), font, &paint);
+        canvas.draw_str(e.kind_label(), (520.0, y), font, &paint);
+        let when = e.modified.map(model::format_time).unwrap_or_default();
+        canvas.draw_str(&when, (680.0, y), font, &paint);
+    };
+
+    let immediate = bench("shape + format + rasterise 40 rows", 200, || {
+        let canvas = surface.canvas();
+        canvas.clear(Color::WHITE);
+        for (i, e) in band.iter().enumerate() {
+            draw_row(canvas, i, e, &font);
+        }
+    });
+
+    let mut recorder = PictureRecorder::new();
+    let rec = recorder.begin_recording(Rect::from_wh(900.0, 1000.0), true);
+    for (i, e) in band.iter().enumerate() {
+        draw_row(rec, i, e, &font);
+    }
+    let picture = recorder.finish_recording_as_picture(None).unwrap();
+
+    let replay = bench("replay the cached picture (same pixels)", 200, || {
+        let canvas = surface.canvas();
+        canvas.clear(Color::WHITE);
+        canvas.draw_picture(&picture, None, None);
+    });
+    ratio("layerise list/grid rows", immediate, replay);
+}
+
+/// One frame of the real thing: what `Browser::frame()` costs before anything
+/// is drawn, for a Miller stack of three columns over a directory of `count`.
+#[test]
+#[ignore = "benchmark"]
+fn bench_frame_build() {
+    println!("\n=== 5. one frame's frame(): today vs. cached order ===");
+    for count in [500usize, 5_000, 20_000] {
+        let all = entries(count);
+        let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+        let selection: BTreeSet<String> = sorted
+            .iter()
+            .skip(3)
+            .take(2)
+            .map(|e| e.name.clone())
+            .collect();
+        println!("  -- {count} entries, 3 Miller columns --");
+
+        // frame() calls visible() once per column; subtitle() calls it twice
+        // more; sync_scroll_metrics()/counts() once per column again — and
+        // sync_scroll_metrics also runs on every wheel event.
+        let today = bench(
+            "3×visible + 2×subtitle + 3×counts + selected",
+            20,
+            || {
+                for _ in 0..3 {
+                    let v = visible_uncounted(&all, false, SortKey::Name, true);
+                    let sel: Vec<bool> = v.iter().map(|e| selection.contains(&e.name)).collect();
+                    std::hint::black_box((v, sel));
+                }
+                for _ in 0..2 {
+                    std::hint::black_box(visible_uncounted(&all, false, SortKey::Name, true).len());
+                }
+                for _ in 0..3 {
+                    std::hint::black_box(visible_uncounted(&all, false, SortKey::Name, true).len());
+                }
+            },
+        );
+        let cached = bench("same frame off a cached sorted order", 20, || {
+            for _ in 0..3 {
+                let v = &sorted[..];
+                let sel: Vec<bool> = v[..VISIBLE.min(v.len())]
+                    .iter()
+                    .map(|e| selection.contains(&e.name))
+                    .collect();
+                std::hint::black_box((v, sel));
+            }
+            for _ in 0..5 {
+                std::hint::black_box(sorted.len());
+            }
+        });
+        println!(
+            "    frame budget at 120 Hz is 8333 µs — today uses {:.0}% of it, cached {:.2}%",
+            today.as_secs_f64() * 1e6 / 8333.0 * 100.0,
+            cached.as_secs_f64() * 1e6 / 8333.0 * 100.0
+        );
+        ratio("cache the sorted order", today, cached);
+    }
+}
+
+/// A touchpad reports ~150 deltas a second, and each one runs
+/// `sync_scroll_metrics()` before it touches a scroll view.
+#[test]
+#[ignore = "benchmark"]
+fn bench_wheel_event() {
+    println!("\n=== 6. sync_scroll_metrics() on every wheel event ===");
+    for count in [500usize, 5_000, 20_000] {
+        let all = entries(count);
+        println!("  -- {count} entries, 3 Miller columns --");
+        let per_event = bench("counts() = 3 × visible()", 20, || {
+            for _ in 0..3 {
+                std::hint::black_box(visible_uncounted(&all, false, SortKey::Name, true).len());
+            }
+        });
+        println!(
+            "    at 150 events/s that is {:.0} ms of CPU per second of scrolling\n",
+            per_event.as_secs_f64() * 150.0 * 1e3
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. The architectural question: a scroll driven through lay-rs layers vs. a
+//    scroll repainted immediately, over the same pixels.
+// ---------------------------------------------------------------------------
+
+/// Row height both arms lay out at — [`crate::view::ROW_H`].
+const ROW_H: f32 = 24.0;
+const PANE_W: f32 = 900.0;
+const PANE_H: f32 = 1000.0;
+
+/// One row with everything already resolved: the shape of `scene::Row`, which
+/// is exactly the work the layer arm does once per re-record and the immediate
+/// arm does once per frame.
+struct BenchRow {
+    top: f32,
+    name: String,
+    size: String,
+    kind: String,
+    when: String,
+    selected: bool,
+}
+
+fn resolve_rows(
+    band: &[&Entry],
+    first: usize,
+    font: &skia_safe::Font,
+    band_relative: bool,
+) -> Vec<BenchRow> {
+    band.iter()
+        .enumerate()
+        .map(|(i, e)| BenchRow {
+            top: if band_relative {
+                i as f32 * ROW_H
+            } else {
+                (first + i) as f32 * ROW_H
+            },
+            name: crate::view::ellipsize(font, &e.name, 320.0),
+            size: if e.is_dir {
+                "--".to_string()
+            } else {
+                e.size.map(model::format_size).unwrap_or_default()
+            },
+            kind: e.kind_label().to_string(),
+            when: e.modified.map(model::format_time).unwrap_or_default(),
+            selected: false,
+        })
+        .collect()
+}
+
+fn paint_rows(
+    canvas: &skia_safe::Canvas,
+    rows: &[BenchRow],
+    font: &skia_safe::Font,
+    icon: &skia_safe::Image,
+) {
+    use skia_safe::{Color, Paint, RRect, Rect};
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    for row in rows {
+        let rect = Rect::from_xywh(0.0, row.top, PANE_W, ROW_H);
+        if row.selected {
+            paint.set_color(Color::from_argb(255, 60, 120, 220));
+            canvas.draw_rrect(RRect::new_rect_xy(rect, 6.0, 6.0), &paint);
+        }
+        canvas.draw_image_rect(
+            icon,
+            None,
+            Rect::from_xywh(14.0, rect.center_y() - 8.0, 16.0, 16.0),
+            &paint,
+        );
+        paint.set_color(Color::BLACK);
+        let y = rect.center_y() + 5.0;
+        canvas.draw_str(&row.name, (40.0, y), font, &paint);
+        canvas.draw_str(&row.size, (400.0, y), font, &paint);
+        canvas.draw_str(&row.kind, (520.0, y), font, &paint);
+        canvas.draw_str(&row.when, (680.0, y), font, &paint);
+    }
+}
+
+fn bench_icon() -> skia_safe::Image {
+    use skia_safe::{surfaces, Color, Paint, Rect};
+    let mut s = surfaces::raster_n32_premul((16, 16)).unwrap();
+    let mut p = Paint::default();
+    p.set_color(Color::from_argb(255, 90, 150, 240));
+    s.canvas().draw_rect(Rect::from_wh(16.0, 16.0), &p);
+    s.image_snapshot()
+}
+
+const FRAMES: usize = 240;
+/// 1500 pt/s at 120 Hz — a brisk fling.
+const PER_FRAME: f32 = 1500.0 / 120.0;
+
+fn rows_visible() -> usize {
+    (PANE_H / ROW_H).ceil() as usize + 1
+}
+
+/// Immediate mode: re-resolve and re-draw every visible row, every frame.
+fn scroll_immediate(
+    surface: &mut skia_safe::Surface,
+    sorted: &[&Entry],
+    font: &skia_safe::Font,
+    icon: &skia_safe::Image,
+    present: &mut dyn FnMut(&mut skia_safe::Surface),
+) -> Duration {
+    use skia_safe::Color;
+    let rows_visible = rows_visible();
+    let mut offset = 0.0f32;
+    let start = Instant::now();
+    for _ in 0..FRAMES {
+        let first = (offset / ROW_H).floor() as usize;
+        let last = (first + rows_visible).min(sorted.len());
+        let rows = resolve_rows(&sorted[first..last], first, font, false);
+        {
+            let canvas = surface.canvas();
+            canvas.clear(Color::WHITE);
+            canvas.save();
+            canvas.translate((0.0, -offset));
+            paint_rows(canvas, &rows, font, icon);
+            canvas.restore();
+        }
+        present(surface);
+        offset += PER_FRAME;
+    }
+    start.elapsed() / FRAMES as u32
+}
+
+/// Layer mode: a `picture_cached` strip the engine moves, re-recorded only
+/// when the scroll leaves the recorded band.
+#[allow(clippy::too_many_arguments)]
+fn scroll_layers(
+    surface: &mut skia_safe::Surface,
+    sorted: &[&Entry],
+    font: &skia_safe::Font,
+    icon: &skia_safe::Image,
+    overscan: usize,
+    image_cached: bool,
+    frozen: bool,
+    present: &mut dyn FnMut(&mut skia_safe::Surface),
+) -> (Duration, usize) {
+    use layers::prelude::*;
+    use layers::types::{Point as LayerPoint, Size as LayerSize};
+    use skia_safe::Color;
+
+    let rows_visible = rows_visible();
+    let engine = Engine::create(PANE_W, PANE_H);
+    let root = engine.new_layer();
+    root.set_layout_style(taffy::Style {
+        position: taffy::style::Position::Absolute,
+        ..Default::default()
+    });
+    root.set_size(LayerSize::points(PANE_W, PANE_H), None);
+    root.set_clip_content(true, None);
+    root.set_clip_children(true, None);
+    engine.scene_set_root(root.clone());
+
+    let strip = engine.new_layer();
+    strip.set_layout_style(taffy::Style {
+        position: taffy::style::Position::Absolute,
+        ..Default::default()
+    });
+    strip.set_picture_cached(true);
+    strip.set_image_cached(image_cached);
+    let _ = root.add_sublayer(&strip);
+
+    let mut recorded: Option<(usize, usize)> = None;
+    let mut rerecords = 0usize;
+    let mut offset = 0.0f32;
+    let start = Instant::now();
+    for _ in 0..FRAMES {
+        let first_visible = (offset / ROW_H).floor() as usize;
+        let need = (
+            first_visible,
+            (first_visible + rows_visible).min(sorted.len()),
+        );
+        let covered = recorded.is_some_and(|(lo, hi)| need.0 >= lo && need.1 <= hi);
+        if !covered {
+            let lo = first_visible.saturating_sub(overscan);
+            let hi = (first_visible + rows_visible + overscan).min(sorted.len());
+            let rows = resolve_rows(&sorted[lo..hi], lo, font, true);
+            let icon = icon.clone();
+            let font = font.clone();
+            strip.set_size(LayerSize::points(PANE_W, (hi - lo) as f32 * ROW_H), None);
+            strip.set_draw_content(move |canvas: &skia_safe::Canvas, w: f32, h: f32| {
+                paint_rows(canvas, &rows, &font, &icon);
+                skia_safe::Rect::from_wh(w, h)
+            });
+            recorded = Some((lo, hi));
+            rerecords += 1;
+        }
+        let (lo, _) = recorded.unwrap();
+        if !frozen {
+            strip.set_position(LayerPoint::new(0.0, lo as f32 * ROW_H - offset), None);
+        }
+        engine.update(0.0);
+        {
+            let canvas = surface.canvas();
+            canvas.clear(Color::WHITE);
+            draw_scene(canvas, engine.scene(), root.id());
+        }
+        present(surface);
+        if !frozen {
+            offset += PER_FRAME;
+        }
+    }
+    (start.elapsed() / FRAMES as u32, rerecords)
+}
+
+/// Run every arm against one surface and print the table.
+fn compare_arms(
+    surface: &mut skia_safe::Surface,
+    sorted: &[&Entry],
+    font: &skia_safe::Font,
+    icon: &skia_safe::Image,
+    floor: Duration,
+    present: &mut dyn FnMut(&mut skia_safe::Surface),
+) {
+    let rows_visible = rows_visible();
+    println!(
+        "  {FRAMES} frames, {PER_FRAME:.1} pt/frame (1500 pt/s), {rows_visible} rows on screen\n"
+    );
+    let net = |d: Duration| (d.saturating_sub(floor)).as_secs_f64() * 1e6;
+    // Best of N, not the mean of N: this machine runs a compositor that
+    // contends for the same GPU, so a slow repetition measures the contention
+    // and the fastest one measures the work.
+    const REPS: usize = 5;
+    let immediate = (0..REPS)
+        .map(|_| scroll_immediate(surface, sorted, font, icon, present))
+        .min()
+        .unwrap();
+    println!(
+        "  immediate: resolve + paint every row every frame  {:>9.1} µs   (net {:>8.1} µs)",
+        immediate.as_secs_f64() * 1e6,
+        net(immediate)
+    );
+    let arms: [(usize, bool, bool, &str); 8] = [
+        (0, false, false, "layers, picture cache: no overscan"),
+        (8, false, false, "layers, picture cache: ±8 rows"),
+        (
+            rows_visible,
+            false,
+            false,
+            "layers, picture cache: ±1 screen",
+        ),
+        (0, true, false, "layers, image cache: no overscan"),
+        (8, true, false, "layers, image cache: ±8 rows"),
+        (rows_visible, true, false, "layers, image cache: ±1 screen"),
+        (0, false, true, "CONTROL frozen, picture cache"),
+        (0, true, true, "CONTROL frozen, image cache"),
+    ];
+    let mut results = Vec::new();
+    for (overscan, image_cached, frozen, label) in arms {
+        let mut best = Duration::MAX;
+        let mut rerecords = 0;
+        for _ in 0..REPS {
+            let (each, n) = scroll_layers(
+                surface,
+                sorted,
+                font,
+                icon,
+                overscan,
+                image_cached,
+                frozen,
+                present,
+            );
+            best = best.min(each);
+            rerecords = n;
+        }
+        let each = best;
+        println!(
+            "  {label:<48} {:>9.1} µs   (net {:>8.1} µs, {rerecords} re-records)",
+            each.as_secs_f64() * 1e6,
+            net(each)
+        );
+        results.push((label, each));
+    }
+    println!();
+    for (label, each) in results {
+        // Ratios on the net figures: the frame-boundary floor is paid by every
+        // arm alike and including it would flatter whichever is slower.
+        ratio(
+            label,
+            Duration::from_secs_f64(net(immediate) / 1e6),
+            Duration::from_secs_f64(net(each).max(1.0) / 1e6),
+        );
+    }
+}
+
+/// Scroll a pane 240 frames at a realistic fling speed, both ways, and compare
+/// Scroll a pane 240 frames at a realistic fling speed, both ways, and compare
+/// what one frame of it costs.
+///
+/// Both arms end up with the same pixels in the same raster surface. The only
+/// difference is *who* holds the recorded content between frames: the immediate
+/// arm re-resolves and re-draws every visible row every frame; the layer arm
+/// resolves a band once, hands it to a `picture_cached` layer, and a frame of
+/// scrolling is a `set_position` plus an engine update plus a picture replay —
+/// with a re-record only when the scroll crosses out of the recorded band.
+#[test]
+#[ignore = "benchmark"]
+fn bench_layers_vs_immediate() {
+    use otto_kit::typography::styles;
+    use skia_safe::surfaces;
+
+    let all = entries(5_000);
+    let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+    let font = styles::BODY_MEDIUM.font();
+    let icon = bench_icon();
+    let mut surface = surfaces::raster_n32_premul((PANE_W as i32, PANE_H as i32)).unwrap();
+
+    println!("\n=== 7. layers vs. immediate — CPU raster surface ===");
+    compare_arms(
+        &mut surface,
+        &sorted,
+        &font,
+        &icon,
+        Duration::ZERO,
+        &mut |_| {},
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. The same comparison on the substrate the app actually runs on: a real
+//    Wayland surface with a real EGL window surface and Skia's GL backend.
+// ---------------------------------------------------------------------------
+
+/// A live EGL window, built the same way `otto_kit::rendering` builds one: a
+/// `wl_surface`, a `wl_egl_window` over it, a GLES2 context, and a Skia
+/// surface wrapping the window's own framebuffer.
+///
+/// The surface is never given an `xdg_surface`, so nothing is mapped and
+/// nothing is presented to a screen — but every drawing call goes through the
+/// same driver, the same glyph atlas and the same window-backed framebuffer a
+/// mapped otto-files window would use, which is what the measurement is about.
+/// Field order matters: the EGL surface must die before the `WlEglSurface`.
+#[cfg(test)]
+struct EglWindow {
+    skia_surface: skia_safe::Surface,
+    context: skia_safe::gpu::DirectContext,
+    egl: khronos_egl::DynamicInstance<khronos_egl::EGL1_4>,
+    display: khronos_egl::Display,
+    egl_surface: khronos_egl::Surface,
+    _wl_egl: wayland_egl::WlEglSurface,
+    _wl_surface: wayland_client::protocol::wl_surface::WlSurface,
+    _conn: wayland_client::Connection,
+}
+
+#[cfg(test)]
+struct EglWindowState;
+
+#[cfg(test)]
+mod egl_dispatch {
+    use wayland_client::protocol::{wl_compositor, wl_registry, wl_surface};
+    impl
+        wayland_client::Dispatch<
+            wl_registry::WlRegistry,
+            wayland_client::globals::GlobalListContents,
+        > for super::EglWindowState
+    {
+        fn event(
+            _: &mut Self,
+            _: &wl_registry::WlRegistry,
+            _: wl_registry::Event,
+            _: &wayland_client::globals::GlobalListContents,
+            _: &wayland_client::Connection,
+            _: &wayland_client::QueueHandle<Self>,
+        ) {
+        }
+    }
+    wayland_client::delegate_noop!(super::EglWindowState: ignore wl_compositor::WlCompositor);
+    wayland_client::delegate_noop!(super::EglWindowState: ignore wl_surface::WlSurface);
+}
+
+#[cfg(test)]
+impl EglWindow {
+    fn new(width: i32, height: i32) -> Result<Self, String> {
+        use wayland_client::protocol::wl_compositor::WlCompositor;
+        use wayland_client::{globals::registry_queue_init, Connection, Proxy};
+
+        let conn = Connection::connect_to_env().map_err(|e| format!("no wayland: {e}"))?;
+        let (globals, mut queue) =
+            registry_queue_init::<EglWindowState>(&conn).map_err(|e| format!("registry: {e}"))?;
+        let qh = queue.handle();
+        let compositor: WlCompositor = globals
+            .bind(&qh, 1..=6, ())
+            .map_err(|e| format!("wl_compositor: {e}"))?;
+        let wl_surface = compositor.create_surface(&qh, ());
+        queue.roundtrip(&mut EglWindowState).ok();
+
+        unsafe {
+            let egl = khronos_egl::DynamicInstance::<khronos_egl::EGL1_4>::load_required()
+                .map_err(|e| format!("load egl: {e}"))?;
+            let display = egl
+                .get_display(conn.backend().display_ptr() as *mut std::ffi::c_void)
+                .ok_or("no egl display")?;
+            egl.initialize(display).map_err(|e| format!("init: {e}"))?;
+
+            let config_attribs = [
+                khronos_egl::SURFACE_TYPE,
+                khronos_egl::WINDOW_BIT,
+                khronos_egl::RED_SIZE,
+                8,
+                khronos_egl::GREEN_SIZE,
+                8,
+                khronos_egl::BLUE_SIZE,
+                8,
+                khronos_egl::ALPHA_SIZE,
+                8,
+                khronos_egl::RENDERABLE_TYPE,
+                khronos_egl::OPENGL_ES2_BIT,
+                khronos_egl::NONE,
+            ];
+            let config = egl
+                .choose_first_config(display, &config_attribs)
+                .map_err(|e| format!("choose config: {e}"))?
+                .ok_or("no config")?;
+            egl.bind_api(khronos_egl::OPENGL_ES_API)
+                .map_err(|e| format!("bind api: {e}"))?;
+            let context_attribs = [khronos_egl::CONTEXT_CLIENT_VERSION, 2, khronos_egl::NONE];
+            let context = egl
+                .create_context(display, config, None, &context_attribs)
+                .map_err(|e| format!("context: {e}"))?;
+
+            let wl_egl = wayland_egl::WlEglSurface::new(wl_surface.id(), width, height)
+                .map_err(|e| format!("wl_egl: {e:?}"))?;
+            let egl_surface = egl
+                .create_window_surface(
+                    display,
+                    config,
+                    wl_egl.ptr() as khronos_egl::NativeWindowType,
+                    None,
+                )
+                .map_err(|e| format!("window surface: {e}"))?;
+            egl.make_current(display, Some(egl_surface), Some(egl_surface), Some(context))
+                .map_err(|e| format!("make current: {e}"))?;
+            // No vsync: the measurement is of work done, not of waiting for a
+            // vblank that an unmapped surface would never get anyway.
+            egl.swap_interval(display, 0).ok();
+
+            let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
+                egl.get_proc_address(name)
+                    .map(|p| p as *const std::ffi::c_void)
+                    .unwrap_or(std::ptr::null())
+            })
+            .ok_or("skia gl interface")?;
+            let mut skia_context = skia_safe::gpu::direct_contexts::make_gl(interface, None)
+                .ok_or("direct context")?;
+
+            let fb_info = skia_safe::gpu::gl::FramebufferInfo {
+                // A window-backed EGL surface renders to framebuffer 0.
+                fboid: 0,
+                format: skia_safe::gpu::gl::Format::RGBA8.into(),
+                protected: skia_safe::gpu::Protected::No,
+            };
+            let target =
+                skia_safe::gpu::backend_render_targets::make_gl((width, height), 0, 8, fb_info);
+            let skia_surface = skia_safe::gpu::surfaces::wrap_backend_render_target(
+                &mut skia_context,
+                &target,
+                skia_safe::gpu::SurfaceOrigin::BottomLeft,
+                skia_safe::ColorType::RGBA8888,
+                None,
+                None,
+            )
+            .ok_or("wrap render target")?;
+
+            Ok(Self {
+                skia_surface,
+                context: skia_context,
+                egl,
+                display,
+                egl_surface,
+                _wl_egl: wl_egl,
+                _wl_surface: wl_surface,
+                _conn: conn,
+            })
+        }
+    }
+
+    /// End a frame the way the app does — flush the recorded work to the GPU
+    /// and wait for it, so a frame's cost is the work and not the queueing.
+    fn present(&mut self, surface: &mut skia_safe::Surface) {
+        self.context
+            .flush_and_submit_surface(surface, skia_safe::gpu::SyncCpu::Yes);
+        self.egl.swap_buffers(self.display, self.egl_surface).ok();
+    }
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn bench_layers_vs_immediate_egl() {
+    use otto_kit::typography::styles;
+
+    println!("\n=== 8. layers vs. immediate — real EGL window, Skia GL backend ===");
+    let mut window = match EglWindow::new(PANE_W as i32, PANE_H as i32) {
+        Ok(w) => w,
+        Err(e) => {
+            println!("  skipped: {e}");
+            return;
+        }
+    };
+    println!("  EGL window up: {}×{} GLES2 RGBA8\n", PANE_W, PANE_H);
+
+    let mut floor;
+    // Floor: what a frame costs with no content at all. If this is close to
+    // the arms below, the frame boundary — not the drawing — is what is being
+    // measured, and the comparison means nothing.
+    {
+        let mut s = window.skia_surface.clone();
+        let start = Instant::now();
+        for _ in 0..FRAMES {
+            s.canvas().clear(skia_safe::Color::WHITE);
+            window
+                .context
+                .flush_and_submit_surface(&mut s, skia_safe::gpu::SyncCpu::Yes);
+        }
+        let flush_only = start.elapsed() / FRAMES as u32;
+        let start = Instant::now();
+        for _ in 0..FRAMES {
+            s.canvas().clear(skia_safe::Color::WHITE);
+            window.present(&mut s);
+        }
+        let with_swap = start.elapsed() / FRAMES as u32;
+        println!(
+            "  FLOOR empty frame, clear + flush + gpu sync       {:>9.1} µs/frame",
+            flush_only.as_secs_f64() * 1e6
+        );
+        println!(
+            "  FLOOR empty frame, + eglSwapBuffers               {:>9.1} µs/frame\n",
+            with_swap.as_secs_f64() * 1e6
+        );
+        floor = with_swap;
+    }
+
+    let all = entries(5_000);
+    let sorted = visible_uncounted(&all, false, SortKey::Name, true);
+    let font = styles::BODY_MEDIUM.font();
+    let icon = bench_icon();
+
+    // The surface is borrowed by the arms, so hand them a clone of the handle
+    // and keep the window for presenting.
+    let mut surface = window.skia_surface.clone();
+    let window_ptr: *mut EglWindow = &mut window;
+    let mut present = move |s: &mut skia_safe::Surface| {
+        // Safe in practice: `present` is only called from the arms below, on
+        // this thread, and nothing else touches the window while they run.
+        unsafe { (*window_ptr).present(s) };
+    };
+    compare_arms(&mut surface, &sorted, &font, &icon, floor, &mut present);
+}

--- a/components/otto-files/src/dbus.rs
+++ b/components/otto-files/src/dbus.rs
@@ -1,0 +1,407 @@
+//! `org.otto.FilePicker1` — the private interface `otto-portal` brokers
+//! `org.freedesktop.impl.portal.FileChooser` requests over.
+//!
+//! Both ends are Otto's, so the signature is typed rather than `a{sv}`: the
+//! same decision, for the same reason, as `org.otto.Dialog1`. See
+//! `specs/file-picker.md` for the contract, which is permanent from the
+//! first release.
+//!
+//! The bridge is otto-islands' dialog bridge in miniature: the zbus task
+//! parks a request plus a one-shot sender in shared state, wakes the UI loop,
+//! and awaits the reply. Nothing here touches Wayland, and nothing in the UI
+//! thread awaits.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use otto_kit::prelude::AppContext;
+use tokio::sync::oneshot;
+use zbus::interface;
+
+use crate::picker::{self, Filter, Outcome, Request, Session};
+
+pub const DBUS_NAME: &str = "org.otto.FilePicker1";
+pub const DBUS_PATH: &str = "/org/otto/FilePicker";
+
+/// The request tuple as it arrives on the wire. Field for field the table in
+/// `specs/file-picker.md`; unpacked into a [`Request`] by [`parse_request`].
+#[allow(clippy::type_complexity)]
+pub type WireRequest = (
+    u32,                                                  // mode
+    String,                                               // handle
+    String,                                               // app_id
+    String,                                               // parent_window
+    String,                                               // title
+    String,                                               // accept_label
+    bool,                                                 // multiple
+    bool,                                                 // directory
+    bool,                                                 // modal
+    String,                                               // current_name
+    String,                                               // current_folder
+    String,                                               // current_file
+    Vec<String>,                                          // files
+    Vec<(String, Vec<(u32, String)>)>,                    // filters
+    String,                                               // current_filter
+    Vec<(String, String, Vec<(String, String)>, String)>, // choices
+);
+
+/// What the UI thread has been asked to do, and has not done yet.
+#[derive(Default)]
+struct Pending {
+    /// Requests waiting for a window. v1 shows one at a time — see
+    /// `run_picker` — so a second request queues behind the first rather than
+    /// opening a second window.
+    requests: VecDeque<Session>,
+    /// Handles the portal has withdrawn. Checked against both the queue and
+    /// the window currently up.
+    withdrawn: Vec<String>,
+}
+
+/// The queue as both halves see it.
+///
+/// Two wakeups, because there are two waiters and they wait differently: the
+/// zbus side is async and parks on [`Notify`], the UI side is a `poll`-driven
+/// event loop and parks on otto-kit's wakeup pipe. A request arriving pokes
+/// both, and whichever is actually waiting picks it up.
+#[derive(Default)]
+pub struct Queue {
+    pending: Mutex<Pending>,
+    arrived: tokio::sync::Notify,
+}
+
+pub type SharedQueue = Arc<Queue>;
+
+impl Queue {
+    /// Park until there is something to serve, then take it.
+    pub async fn next_session_async(&self) -> Session {
+        loop {
+            // Register interest *before* looking, so a request arriving
+            // between the two is not missed.
+            let notified = self.arrived.notified();
+            if let Some(session) = self.next_session() {
+                return session;
+            }
+            notified.await;
+        }
+    }
+
+    fn push(&self, session: Session) {
+        self.pending.lock().unwrap().requests.push_back(session);
+        self.arrived.notify_one();
+        AppContext::request_wakeup();
+    }
+
+    fn withdraw(&self, handle: String) {
+        self.pending.lock().unwrap().withdrawn.push(handle);
+        self.arrived.notify_one();
+        AppContext::request_wakeup();
+    }
+    /// Take the next request that has not been withdrawn in the meantime.
+    pub fn next_session(&self) -> Option<Session> {
+        let mut pending = self.pending.lock().unwrap();
+        while let Some(mut session) = pending.requests.pop_front() {
+            if let Some(index) = pending
+                .withdrawn
+                .iter()
+                .position(|h| *h == session.request.handle)
+            {
+                pending.withdrawn.remove(index);
+                session.resolve(Outcome::ended());
+                continue;
+            }
+            return Some(session);
+        }
+        None
+    }
+
+    /// Whether `handle` has been withdrawn, consuming the record if so. The
+    /// window currently up asks this about its own request every update.
+    pub fn take_withdrawn(&self, handle: &str) -> bool {
+        let mut pending = self.pending.lock().unwrap();
+        match pending.withdrawn.iter().position(|h| h == handle) {
+            Some(index) => {
+                pending.withdrawn.remove(index);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+pub struct FilePickerService {
+    queue: SharedQueue,
+}
+
+impl FilePickerService {
+    pub fn new(queue: SharedQueue) -> Self {
+        Self { queue }
+    }
+}
+
+#[interface(name = "org.otto.FilePicker1")]
+impl FilePickerService {
+    /// Present a picker and block until the user answers or the request is
+    /// withdrawn. See `specs/file-picker.md` for the tuple's fields.
+    async fn present(
+        &self,
+        request: WireRequest,
+    ) -> (u32, Vec<String>, String, Vec<(String, String)>) {
+        let request = match parse_request(request) {
+            Ok(request) => request,
+            Err(reason) => {
+                tracing::warn!(reason, "rejecting malformed picker request");
+                let ended = Outcome::ended();
+                return (
+                    ended.response,
+                    ended.uris,
+                    ended.current_filter,
+                    ended.choices,
+                );
+            }
+        };
+
+        // Save mode is specified but not built. Saying so is the contract's
+        // `response = 2`: the application learns it got no file, rather than
+        // being shown an Open dialog that returns a file it cannot write.
+        if request.mode != picker::Mode::Open {
+            tracing::warn!(?request.mode, "save modes are not implemented yet");
+            let ended = Outcome::ended();
+            return (
+                ended.response,
+                ended.uris,
+                ended.current_filter,
+                ended.choices,
+            );
+        }
+
+        tracing::info!(
+            app_id = %request.app_id,
+            handle = %request.handle,
+            "picker request received"
+        );
+
+        let (tx, rx) = oneshot::channel();
+        self.queue.push(Session::new(request, tx));
+
+        // A dropped sender means the window went away without deciding, which
+        // the Session's own Drop has already turned into `response = 2`; the
+        // `Err` arm only catches the case where even that could not run.
+        let outcome = rx.await.unwrap_or_else(|_| Outcome::ended());
+        (
+            outcome.response,
+            outcome.uris,
+            outcome.current_filter,
+            outcome.choices,
+        )
+    }
+
+    /// Withdraw a pending request. Its `Present` resolves with `response = 2`.
+    async fn close(&self, handle: String) {
+        tracing::info!(%handle, "picker request withdrawn");
+        self.queue.withdraw(handle);
+    }
+}
+
+/// Claim the bus name and serve requests until the connection dies.
+///
+/// The name is claimed with replacement allowed, for the reason the portal
+/// backend records: the session bus outlives the graphical session, so a
+/// picker left over from an earlier login would otherwise hold the name
+/// forever and every later instance would die on startup.
+pub async fn serve(queue: SharedQueue) -> zbus::Result<()> {
+    use zbus::fdo::{DBusProxy, RequestNameFlags, RequestNameReply};
+
+    let connection = zbus::ConnectionBuilder::session()?.build().await?;
+    connection
+        .object_server()
+        .at(DBUS_PATH, FilePickerService::new(queue))
+        .await?;
+
+    let dbus = DBusProxy::new(&connection).await?;
+    let reply = dbus
+        .request_name(
+            DBUS_NAME.try_into()?,
+            RequestNameFlags::AllowReplacement
+                | RequestNameFlags::ReplaceExisting
+                | RequestNameFlags::DoNotQueue,
+        )
+        .await?;
+    if reply != RequestNameReply::PrimaryOwner {
+        return Err(zbus::Error::Failure(format!(
+            "{DBUS_NAME} is held by another picker that refuses replacement ({reply:?})"
+        )));
+    }
+
+    tracing::info!(name = DBUS_NAME, "file picker service running");
+    std::future::pending::<()>().await;
+    Ok(())
+}
+
+/// Unpack the wire tuple, validating what must be valid and dropping what may
+/// simply be absent.
+fn parse_request(wire: WireRequest) -> Result<Request, &'static str> {
+    let (
+        mode,
+        handle,
+        app_id,
+        parent_window,
+        title,
+        accept_label,
+        multiple,
+        directory,
+        modal,
+        current_name,
+        current_folder,
+        current_file,
+        files,
+        filters,
+        current_filter,
+        choices,
+    ) = wire;
+
+    let mode = picker::Mode::from_wire(mode).ok_or("unknown mode")?;
+    if handle.is_empty() {
+        return Err("empty request handle");
+    }
+
+    let filters: Vec<Filter> = filters.into_iter().map(Filter::from_wire).collect();
+    let current_filter = filters
+        .iter()
+        .position(|f| f.label == current_filter)
+        .unwrap_or(0);
+
+    Ok(Request {
+        mode,
+        handle,
+        app_id,
+        parent_window,
+        title,
+        accept_label,
+        multiple,
+        directory,
+        modal,
+        current_name,
+        current_folder: absolute_path(current_folder),
+        current_file: absolute_path(current_file),
+        files,
+        filters,
+        current_filter,
+        choices,
+    })
+}
+
+/// A path the request supplied, if it is usable.
+///
+/// A relative path is dropped rather than rejected — the spec's rule is that
+/// the picker then falls back as if the field were absent, which is friendlier
+/// than failing a whole request over a hint.
+fn absolute_path(value: String) -> Option<PathBuf> {
+    let path = PathBuf::from(value);
+    path.is_absolute().then_some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire() -> WireRequest {
+        (
+            0,
+            "req1".into(),
+            "org.example.App".into(),
+            String::new(),
+            String::new(),
+            String::new(),
+            false,
+            false,
+            true,
+            String::new(),
+            String::new(),
+            String::new(),
+            Vec::new(),
+            Vec::new(),
+            String::new(),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn a_relative_folder_hint_is_dropped_rather_than_failing_the_request() {
+        let mut w = wire();
+        w.10 = "not/absolute".into();
+        let request = parse_request(w).expect("relative hints are dropped, not fatal");
+        assert!(request.current_folder.is_none());
+    }
+
+    #[test]
+    fn an_absolute_folder_hint_is_kept() {
+        let mut w = wire();
+        w.10 = "/tmp".into();
+        assert_eq!(
+            parse_request(w).unwrap().current_folder,
+            Some(PathBuf::from("/tmp"))
+        );
+    }
+
+    #[test]
+    fn an_unknown_mode_is_refused() {
+        let mut w = wire();
+        w.0 = 9;
+        assert!(parse_request(w).is_err());
+    }
+
+    #[test]
+    fn a_request_with_no_handle_is_refused() {
+        let mut w = wire();
+        w.1 = String::new();
+        assert!(parse_request(w).is_err());
+    }
+
+    #[test]
+    fn current_filter_names_the_filter_by_label() {
+        let mut w = wire();
+        w.13 = vec![
+            ("Text".into(), vec![(0, "*.txt".into())]),
+            ("Images".into(), vec![(0, "*.png".into())]),
+        ];
+        w.14 = "Images".into();
+        assert_eq!(parse_request(w).unwrap().current_filter, 1);
+    }
+
+    #[test]
+    fn an_unknown_current_filter_falls_back_to_the_first() {
+        let mut w = wire();
+        w.13 = vec![("Text".into(), vec![(0, "*.txt".into())])];
+        w.14 = "Nothing By That Name".into();
+        assert_eq!(parse_request(w).unwrap().current_filter, 0);
+    }
+
+    #[test]
+    fn a_withdrawn_request_is_skipped_and_answered() {
+        let (tx, mut rx) = oneshot::channel();
+        let queue = Queue::default();
+        let request = parse_request(wire()).unwrap();
+        queue
+            .pending
+            .lock()
+            .unwrap()
+            .requests
+            .push_back(Session::new(request, tx));
+        queue.pending.lock().unwrap().withdrawn.push("req1".into());
+
+        assert!(
+            queue.next_session().is_none(),
+            "a withdrawn request must not open a window"
+        );
+        assert_eq!(rx.try_recv().map(|o| o.response), Ok(2));
+    }
+
+    #[test]
+    fn a_withdrawal_is_reported_once_and_then_forgotten() {
+        let queue = Queue::default();
+        queue.pending.lock().unwrap().withdrawn.push("req1".into());
+        assert!(queue.take_withdrawn("req1"));
+        assert!(!queue.take_withdrawn("req1"));
+    }
+}

--- a/components/otto-files/src/lib.rs
+++ b/components/otto-files/src/lib.rs
@@ -1,0 +1,27 @@
+//! Otto's file browser and file picker — see `specs/file-browser.md` and
+//! `specs/file-picker.md`.
+//!
+//! One crate, two shells over one view layer. The browser is a document
+//! window the user opens; the picker is a transient serving somebody else's
+//! application through the XDG desktop portal. Below the chrome they are the
+//! same code: the same directory model, the same async reads, the same
+//! list/grid/column presentations, the same Quick View.
+//!
+//! ```sh
+//! cargo run -p otto-files            # browse $HOME
+//! cargo run -p otto-files -- /etc    # browse somewhere else
+//! cargo run -p otto-files -- --picker  # serve org.otto.FilePicker1
+//! ```
+
+#[cfg(test)]
+mod bench;
+
+pub mod app;
+pub mod dbus;
+pub mod model;
+pub mod pane_surfaces;
+pub mod perf;
+pub mod picker;
+pub mod quickview;
+pub mod scene;
+pub mod view;

--- a/components/otto-files/src/main.rs
+++ b/components/otto-files/src/main.rs
@@ -1,0 +1,47 @@
+//! The `otto-files` binary. Everything of substance lives in the library —
+//! see `lib.rs` — so the picker's D-Bus service and the browser window are
+//! two entry points into one body of code rather than two programs.
+
+use std::path::PathBuf;
+
+/// The runtime is not decoration: otto-kit only starts the colour-scheme and
+/// icon-theme watchers when one is current, and without them
+/// `current_icon_theme()` stays empty. An empty theme name makes every icon
+/// lookup search `hicolor` alone, which ships no `folder` or mimetype icons —
+/// so the whole listing draws without icons. The theme comes from Otto's own
+/// settings, surfaced through the settings portal.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // First, before the tokio runtime starts a thread and before anything
+    // connects to Wayland. The sandboxed decode worker is *this binary*
+    // re-executed, so without this line a preview would start a second file
+    // browser instead of decoding a file. Returns immediately on a normal
+    // start; never returns at all when this process is a worker.
+    otto_quickview::run_worker_if_requested();
+
+    tokio::runtime::Runtime::new()?.block_on(run())
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    // `--picker` is how the bus activates us: no window until a request
+    // arrives, and the process outlives each one so a run of picks shares a
+    // warm icon and thumbnail cache.
+    if std::env::args().any(|a| a == "--picker") {
+        return otto_files::app::run_picker().await;
+    }
+
+    let start = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .or_else(otto_files::model::home_dir)
+        .unwrap_or_else(|| PathBuf::from("/"));
+
+    otto_files::app::run_browser(start)
+}

--- a/components/otto-files/src/model.rs
+++ b/components/otto-files/src/model.rs
@@ -1,0 +1,1570 @@
+//! The directory model: entries, places, sorting.
+//!
+//! Every filesystem call in here runs on a worker thread — see [`Directory`].
+//! The UI thread only ever reads a finished [`Snapshot`]. See
+//! `specs/file-browser.md` under *Async I/O*.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, Receiver};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use otto_kit::components::scroll::ScrollView;
+use otto_kit::filetype::{self, Kind};
+use skia_safe::Rect;
+
+/// One entry in a directory.
+///
+/// `size` and `modified` are `None` until the metadata pass fills them in.
+/// The initial listing uses only what `readdir` returns, because 10,000 files
+/// is 10,000 `stat` calls before anything can be drawn.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub name: String,
+    pub path: PathBuf,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub hidden: bool,
+    pub kind: Kind,
+    pub size: Option<u64>,
+    pub modified: Option<SystemTime>,
+}
+
+impl Entry {
+    /// The Kind column's text.
+    pub fn kind_label(&self) -> &'static str {
+        if self.is_dir {
+            "Folder"
+        } else {
+            self.kind.label()
+        }
+    }
+
+    /// Icon names to try, most specific first, so a sparse theme still resolves.
+    pub fn icon_chain(&self) -> Vec<String> {
+        if self.is_dir {
+            return vec!["folder".to_string(), "inode-directory".to_string()];
+        }
+        match filetype::mime_for_name(&self.name) {
+            Some(mime) => filetype::icon_names(mime),
+            None => vec![self.kind.generic_icon().to_string()],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortKey {
+    Name,
+    Size,
+    Kind,
+    Modified,
+}
+
+impl SortKey {
+    pub fn label(self) -> &'static str {
+        match self {
+            SortKey::Name => "Name",
+            SortKey::Size => "Size",
+            SortKey::Kind => "Kind",
+            SortKey::Modified => "Date Modified",
+        }
+    }
+}
+
+/// Compare two names the way a person reads them: digit runs compare as
+/// numbers, so `file2` precedes `file10`, and case is ignored.
+///
+/// No locale collation — a known limitation, taken deliberately rather than
+/// depending on a collation crate. See `specs/file-picker.md` under *Sorting*.
+pub fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    let mut ai = a.chars().peekable();
+    let mut bi = b.chars().peekable();
+
+    loop {
+        match (ai.peek().copied(), bi.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(ac), Some(bc)) => {
+                if ac.is_ascii_digit() && bc.is_ascii_digit() {
+                    // Take the whole digit run from each side and compare it as
+                    // a number, ignoring leading zeros.
+                    let an = take_digits(&mut ai);
+                    let bn = take_digits(&mut bi);
+                    let atrim = an.trim_start_matches('0');
+                    let btrim = bn.trim_start_matches('0');
+                    let ord = atrim
+                        .len()
+                        .cmp(&btrim.len())
+                        .then_with(|| atrim.cmp(btrim))
+                        // Equal values: more leading zeros sorts first, so the
+                        // ordering stays total rather than arbitrary.
+                        .then_with(|| an.len().cmp(&bn.len()));
+                    if ord != Ordering::Equal {
+                        return ord;
+                    }
+                } else {
+                    let al = ac.to_ascii_lowercase();
+                    let bl = bc.to_ascii_lowercase();
+                    if al != bl {
+                        return al.cmp(&bl);
+                    }
+                    ai.next();
+                    bi.next();
+                }
+            }
+        }
+    }
+}
+
+fn take_digits(it: &mut std::iter::Peekable<std::str::Chars>) -> String {
+    let mut s = String::new();
+    while let Some(c) = it.peek().copied() {
+        if c.is_ascii_digit() {
+            s.push(c);
+            it.next();
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Reading, off the UI thread
+// ---------------------------------------------------------------------------
+
+/// A finished read of one directory.
+#[derive(Debug, Clone, Default)]
+pub struct Snapshot {
+    pub path: PathBuf,
+    pub entries: Vec<Entry>,
+    /// Set when the directory could not be read at all — shown in place of the
+    /// listing, rather than as an empty directory.
+    pub error: Option<String>,
+}
+
+/// One directory in the path stack: its contents, what is selected in it, and
+/// where it is scrolled.
+///
+/// The stack is what Miller columns render side by side and what the list view
+/// renders the last element of. Navigation pushes and pops it in both views, so
+/// switching between them preserves where the user is.
+pub struct Column {
+    pub path: PathBuf,
+    pub snapshot: Snapshot,
+    pub loader: Directory,
+    /// The selection, held as entry **names** rather than indices.
+    ///
+    /// Indices into the filtered, sorted list are only meaningful until
+    /// something re-sorts, re-filters or reloads it — and all three happen
+    /// while a selection is live. Names survive every one of those, which is
+    /// what makes a multi-selection stable when a file appears in the
+    /// directory underneath it.
+    pub selection: std::collections::BTreeSet<String>,
+    /// Where the keyboard is, as an index into the current visible list.
+    pub cursor: Option<usize>,
+    /// Where a range selection extends from.
+    pub anchor: Option<usize>,
+    /// This pane's scrolling, momentum, overscroll and scrollbar — the shared
+    /// otto-kit scroll view, the same one the settings app drives. Its
+    /// viewport and content height are re-set every frame by the view, since
+    /// both change with the window size and the listing.
+    pub scroll: ScrollView,
+    /// Bumped whenever [`Self::snapshot`] is replaced, so a cached order can
+    /// tell whether it was computed from the listing that is there now.
+    pub epoch: u64,
+    /// The filtered, sorted order of `snapshot`, recomputed only when
+    /// something it depends on moves. See [`SortCache`].
+    pub sorted: std::cell::RefCell<SortCache>,
+}
+
+impl Column {
+    pub fn new(path: PathBuf) -> Self {
+        let mut loader = Directory::new();
+        loader.load(&path);
+        Self {
+            path,
+            snapshot: Snapshot::default(),
+            loader,
+            selection: std::collections::BTreeSet::new(),
+            cursor: None,
+            anchor: None,
+            scroll: ScrollView::new(Rect::new_empty()),
+            epoch: 0,
+            sorted: std::cell::RefCell::new(SortCache::default()),
+        }
+    }
+
+    pub fn loading(&self) -> bool {
+        self.loader.loading
+    }
+
+    /// Take a finished read, if one has arrived. Returns whether anything
+    /// changed, so the caller knows to repaint.
+    pub fn poll(&mut self) -> bool {
+        match self.loader.poll() {
+            Some(snapshot) => {
+                self.snapshot = snapshot;
+                // The only place the listing is ever replaced, so the only
+                // place the sorted order can go stale under it.
+                self.epoch = self.epoch.wrapping_add(1);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// The filtered, sorted order of a column's listing, remembered between
+/// frames.
+///
+/// Sorting is not a per-frame cost that anyone can afford: a directory of
+/// twenty-five thousand entries takes ~20 ms to filter and sort, and the
+/// browser asks for the order eight times a frame (once per column while
+/// building the frame, twice more for the subtitle, once per column again
+/// for the scroll metrics) *plus* once per column on every wheel event. Any
+/// of those alone would blow a 120 Hz budget on a big directory.
+///
+/// `key` is everything the order depends on: which listing it was computed
+/// from ([`Column::epoch`]), the three settings that decide the order, and —
+/// in the picker — which of the request's filters is in force.
+/// The entries themselves are not copied — `order` holds indices into
+/// [`Column::snapshot`], which is what `epoch` guards.
+#[derive(Default)]
+pub struct SortCache {
+    pub key: Option<(u64, SortKey, bool, bool, usize)>,
+    pub order: Vec<usize>,
+}
+
+/// Reads directories on worker threads and hands finished snapshots back.
+///
+/// The UI thread calls [`Directory::load`] and then [`Directory::poll`]; it
+/// never blocks, so a stalled network mount costs a spinner rather than a
+/// frame.
+pub struct Directory {
+    rx: Option<Receiver<Snapshot>>,
+    /// Bumped on every load. A snapshot arriving with a stale generation is
+    /// dropped — that is how navigating away cancels a slow read, without
+    /// needing to interrupt the worker.
+    generation: Arc<Mutex<u64>>,
+    current: u64,
+    pub loading: bool,
+}
+
+impl Default for Directory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Directory {
+    pub fn new() -> Self {
+        Self {
+            rx: None,
+            generation: Arc::new(Mutex::new(0)),
+            current: 0,
+            loading: false,
+        }
+    }
+
+    /// Start reading `path`. Any read already in flight is abandoned.
+    pub fn load(&mut self, path: &Path) {
+        let (tx, rx) = channel();
+        self.rx = Some(rx);
+        self.loading = true;
+
+        let generation = {
+            let mut g = self.generation.lock().unwrap();
+            *g += 1;
+            *g
+        };
+        self.current = generation;
+
+        let path = path.to_path_buf();
+        let gen_handle = Arc::clone(&self.generation);
+        std::thread::spawn(move || {
+            let snapshot = read_directory(&path);
+            // Only deliver if this is still the read the UI is waiting for.
+            if *gen_handle.lock().unwrap() == generation {
+                let _ = tx.send(snapshot);
+                // Wake the UI thread. Without this the snapshot waits for the
+                // next input: a window with nothing moving commits no frames,
+                // so there is no frame callback to notice it landed.
+                otto_kit::prelude::AppContext::request_wakeup();
+            }
+        });
+    }
+
+    /// A finished snapshot, if one has arrived. Never blocks.
+    pub fn poll(&mut self) -> Option<Snapshot> {
+        let rx = self.rx.as_ref()?;
+        match rx.try_recv() {
+            Ok(snapshot) => {
+                self.loading = false;
+                Some(snapshot)
+            }
+            Err(_) => None,
+        }
+    }
+}
+
+/// Read one directory. Runs on a worker thread, never on the UI thread.
+///
+/// This first version stats every entry as it reads, which is what the spec
+/// forbids on the fast path for very large directories. The streaming
+/// name-first pass is the next change; the snapshot shape is already what it
+/// will deliver.
+fn read_directory(path: &Path) -> Snapshot {
+    let read = match std::fs::read_dir(path) {
+        Ok(read) => read,
+        Err(err) => {
+            return Snapshot {
+                path: path.to_path_buf(),
+                entries: Vec::new(),
+                error: Some(describe_error(&err)),
+            }
+        }
+    };
+
+    let mut entries = Vec::new();
+    for entry in read.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let path = entry.path();
+
+        // `file_type` comes from readdir's d_type where the filesystem
+        // supplies it, so it is usually free.
+        let file_type = entry.file_type().ok();
+        let is_symlink = file_type.is_some_and(|t| t.is_symlink());
+        // A symlink's target decides whether it behaves as a directory.
+        let is_dir = match file_type {
+            Some(t) if t.is_dir() => true,
+            Some(t) if t.is_symlink() => path.is_dir(),
+            _ => false,
+        };
+
+        let meta = entry.metadata().ok();
+        let kind = if is_dir {
+            Kind::Folder
+        } else {
+            filetype::kind_for_name(&name)
+        };
+
+        entries.push(Entry {
+            hidden: name.starts_with('.') || name.ends_with('~'),
+            kind,
+            size: meta.as_ref().map(|m| m.len()),
+            modified: meta.as_ref().and_then(|m| m.modified().ok()),
+            name,
+            path,
+            is_dir,
+            is_symlink,
+        });
+    }
+
+    Snapshot {
+        path: path.to_path_buf(),
+        entries,
+        error: None,
+    }
+}
+
+/// A message worth showing a user, rather than a debug rendering.
+fn describe_error(err: &std::io::Error) -> String {
+    match err.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            "You do not have permission to see this folder's contents.".to_string()
+        }
+        std::io::ErrorKind::NotFound => "This folder no longer exists.".to_string(),
+        _ => format!("This folder could not be opened: {err}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Places
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Place {
+    pub label: String,
+    pub path: PathBuf,
+    pub icon: &'static str,
+}
+
+/// The sidebar's places: home, then the XDG user directories that actually
+/// exist. A directory that is not there is not listed — an empty row leading
+/// nowhere is worse than its absence.
+pub fn places() -> Vec<Place> {
+    let mut places = Vec::new();
+    let Some(home) = home_dir() else {
+        return places;
+    };
+
+    places.push(Place {
+        label: "Home".to_string(),
+        path: home.clone(),
+        icon: "user-home",
+    });
+
+    // `user-dirs.dirs` is `XDG_DESKTOP_DIR="$HOME/Desktop"` per line. Parsed
+    // here rather than by a crate: it is five lines of shell-ish assignment.
+    let configured = user_dirs(&home);
+
+    const WANTED: &[(&str, &str, &str)] = &[
+        ("XDG_DESKTOP_DIR", "Desktop", "user-desktop"),
+        ("XDG_DOCUMENTS_DIR", "Documents", "folder-documents"),
+        ("XDG_DOWNLOAD_DIR", "Downloads", "folder-download"),
+        ("XDG_MUSIC_DIR", "Music", "folder-music"),
+        ("XDG_PICTURES_DIR", "Pictures", "folder-pictures"),
+        ("XDG_VIDEOS_DIR", "Videos", "folder-videos"),
+    ];
+
+    for (key, fallback_name, icon) in WANTED {
+        let path = configured
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_else(|| home.join(fallback_name));
+        if path.is_dir() {
+            let label = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| (*fallback_name).to_string());
+            places.push(Place { label, path, icon });
+        }
+    }
+
+    places
+}
+
+fn user_dirs(home: &Path) -> Vec<(String, PathBuf)> {
+    let config = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".config"));
+
+    let Ok(text) = std::fs::read_to_string(config.join("user-dirs.dirs")) else {
+        return Vec::new();
+    };
+
+    text.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+            let (key, value) = line.split_once('=')?;
+            let value = value.trim().trim_matches('"');
+            let expanded = match value.strip_prefix("$HOME/") {
+                Some(rest) => home.join(rest),
+                None if value == "$HOME" => home.to_path_buf(),
+                None => PathBuf::from(value),
+            };
+            Some((key.trim().to_string(), expanded))
+        })
+        .collect()
+}
+
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .filter(|h| !h.is_empty())
+        .map(PathBuf::from)
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/// Human-readable size, the way a file manager writes it.
+pub fn format_size(bytes: u64) -> String {
+    const UNITS: &[&str] = &["bytes", "KB", "MB", "GB", "TB"];
+    if bytes < 1000 {
+        return format!("{bytes} bytes");
+    }
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1000.0 && unit < UNITS.len() - 1 {
+        value /= 1000.0;
+        unit += 1;
+    }
+    if value < 10.0 {
+        format!("{value:.1} {}", UNITS[unit])
+    } else {
+        format!("{value:.0} {}", UNITS[unit])
+    }
+}
+
+/// Date, as a listing shows it. Deliberately plain: no locale formatting, and
+/// no relative "yesterday" — both need more than the standard library gives.
+pub fn format_time(time: SystemTime) -> String {
+    let Ok(elapsed) = time.duration_since(SystemTime::UNIX_EPOCH) else {
+        return String::new();
+    };
+    let secs = elapsed.as_secs() as i64;
+    let days = secs.div_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let time_of_day = secs.rem_euclid(86_400);
+    let (hour, minute) = (time_of_day / 3600, (time_of_day % 3600) / 60);
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    format!(
+        "{day} {} {year} at {hour:02}:{minute:02}",
+        MONTHS[(month as usize - 1).min(11)]
+    )
+}
+
+/// Days since the Unix epoch to a civil date. Howard Hinnant's algorithm —
+/// exact, branch-light, and shorter than taking on a date crate.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn natural_order_reads_numbers_as_numbers() {
+        assert_eq!(natural_cmp("file2", "file10"), std::cmp::Ordering::Less);
+        assert_eq!(natural_cmp("file10", "file2"), std::cmp::Ordering::Greater);
+        assert_eq!(natural_cmp("a", "a"), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn natural_order_ignores_case() {
+        assert_eq!(natural_cmp("Apple", "apple"), std::cmp::Ordering::Equal);
+        assert_eq!(natural_cmp("apple", "Banana"), std::cmp::Ordering::Less);
+    }
+
+    #[test]
+    fn natural_order_is_a_total_order() {
+        // Leading zeros must not make two different names compare equal, or
+        // the sort becomes unstable in a way the user sees as flicker.
+        assert_ne!(natural_cmp("file007", "file7"), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn sizes_read_the_way_a_file_manager_writes_them() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(999), "999 bytes");
+        assert_eq!(format_size(1_500), "1.5 KB");
+        assert_eq!(format_size(15_000), "15 KB");
+        assert_eq!(format_size(2_000_000), "2.0 MB");
+    }
+
+    #[test]
+    fn epoch_formats_correctly() {
+        // A fixed point, so the date arithmetic is pinned rather than trusted.
+        assert_eq!(
+            format_time(SystemTime::UNIX_EPOCH),
+            "1 Jan 1970 at 00:00".to_string()
+        );
+        let d = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        assert_eq!(format_time(d), "14 Nov 2023 at 22:13");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Get Info
+// ---------------------------------------------------------------------------
+
+/// Everything the Get Info panel shows about one entry.
+///
+/// Read on a worker like everything else — `stat`, and the passwd/group lookups
+/// behind it, can block on a networked account database just as a slow mount
+/// can block a listing.
+#[derive(Debug, Clone)]
+pub struct FileInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub is_dir: bool,
+    pub mime: String,
+    pub kind: Kind,
+    pub size: u64,
+    pub modified: Option<SystemTime>,
+    pub accessed: Option<SystemTime>,
+    pub created: Option<SystemTime>,
+    /// Unix permission bits, the low 12 of `st_mode` (setuid/setgid/sticky
+    /// included, so toggling a bit cannot silently clear them).
+    pub mode: u32,
+    pub owner: String,
+    pub group: String,
+    pub link_target: Option<PathBuf>,
+    /// Set when the panel could not read the file at all.
+    pub error: Option<String>,
+}
+
+impl FileInfo {
+    /// `rwxr-xr-x`, the way `ls -l` writes it.
+    pub fn mode_string(&self) -> String {
+        let mut s = String::with_capacity(9);
+        for who in 0..3 {
+            // Owner bits are the top triad, so shift down by 6, 3, 0.
+            let shift = 6 - who * 3;
+            let bits = (self.mode >> shift) & 0o7;
+            s.push(if bits & 0b100 != 0 { 'r' } else { '-' });
+            s.push(if bits & 0b010 != 0 { 'w' } else { '-' });
+            s.push(if bits & 0b001 != 0 { 'x' } else { '-' });
+        }
+        s
+    }
+
+    /// The octal a user would type at `chmod`.
+    pub fn mode_octal(&self) -> String {
+        format!("{:03o}", self.mode & 0o777)
+    }
+
+    /// Is the bit for `who` (0 owner, 1 group, 2 other) and `what`
+    /// (0 read, 1 write, 2 execute) set?
+    pub fn permission(&self, who: usize, what: usize) -> bool {
+        self.mode & permission_bit(who, what) != 0
+    }
+}
+
+/// The single `st_mode` bit for one cell of the permissions grid.
+pub fn permission_bit(who: usize, what: usize) -> u32 {
+    let shift = 6 - who.min(2) * 3;
+    let bit = match what.min(2) {
+        0 => 0b100,
+        1 => 0b010,
+        _ => 0b001,
+    };
+    bit << shift
+}
+
+/// Read everything the info panel needs. Runs on a worker.
+pub fn read_info(path: &Path) -> FileInfo {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned());
+
+    // `symlink_metadata`, not `metadata`: the panel describes *this* entry, and
+    // the permissions it offers to change are this entry's own.
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(err) => {
+            return FileInfo {
+                name,
+                path: path.to_path_buf(),
+                is_dir: false,
+                mime: String::new(),
+                kind: Kind::Other,
+                size: 0,
+                modified: None,
+                accessed: None,
+                created: None,
+                mode: 0,
+                owner: String::new(),
+                group: String::new(),
+                link_target: None,
+                error: Some(describe_error(&err)),
+            }
+        }
+    };
+
+    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let is_dir = meta.is_dir();
+    let mime = if is_dir {
+        "inode/directory".to_string()
+    } else {
+        filetype::mime_for_name(&name)
+            .unwrap_or("application/octet-stream")
+            .to_string()
+    };
+
+    FileInfo {
+        kind: if is_dir {
+            Kind::Folder
+        } else {
+            filetype::kind_of(&mime)
+        },
+        size: meta.len(),
+        modified: meta.modified().ok(),
+        accessed: meta.accessed().ok(),
+        created: meta.created().ok(),
+        // Low 12 bits: the 9 rwx plus setuid/setgid/sticky.
+        mode: meta.permissions().mode() & 0o7777,
+        owner: user_name(meta.uid()).unwrap_or_else(|| meta.uid().to_string()),
+        group: group_name(meta.gid()).unwrap_or_else(|| meta.gid().to_string()),
+        link_target: std::fs::read_link(path).ok(),
+        name,
+        path: path.to_path_buf(),
+        is_dir,
+        mime,
+        error: None,
+    }
+}
+
+/// Apply a new permission mode. Runs on a worker; returns the reason on failure
+/// so the panel can say why rather than silently reverting.
+pub fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|err| {
+        match err.kind() {
+            std::io::ErrorKind::PermissionDenied => {
+                "Only the file's owner can change its permissions.".to_string()
+            }
+            _ => format!("Could not change permissions: {err}"),
+        }
+    })
+}
+
+/// Resolve a uid through the system account database.
+///
+/// `getpwuid_r` rather than parsing `/etc/passwd`, because the passwd file is
+/// not the whole story on a machine with networked or systemd-homed accounts —
+/// it would show a bare number for exactly the users who are not local.
+fn user_name(uid: u32) -> Option<String> {
+    // SAFETY: `getpwuid_r` writes into the buffers we hand it and reports the
+    // result through `result`, which is null when there is no such user. No
+    // pointer we pass outlives this call.
+    unsafe {
+        let mut pwd: libc::passwd = std::mem::zeroed();
+        let mut buf = vec![0 as libc::c_char; 2048];
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        if libc::getpwuid_r(uid, &mut pwd, buf.as_mut_ptr(), buf.len(), &mut result) != 0
+            || result.is_null()
+        {
+            return None;
+        }
+        cstr_to_string(pwd.pw_name)
+    }
+}
+
+fn group_name(gid: u32) -> Option<String> {
+    // SAFETY: as `user_name`.
+    unsafe {
+        let mut grp: libc::group = std::mem::zeroed();
+        let mut buf = vec![0 as libc::c_char; 2048];
+        let mut result: *mut libc::group = std::ptr::null_mut();
+        if libc::getgrgid_r(gid, &mut grp, buf.as_mut_ptr(), buf.len(), &mut result) != 0
+            || result.is_null()
+        {
+            return None;
+        }
+        cstr_to_string(grp.gr_name)
+    }
+}
+
+/// SAFETY: `ptr` must be a NUL-terminated C string owned by the caller's buffer.
+unsafe fn cstr_to_string(ptr: *const libc::c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    Some(std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod info_tests {
+    use super::*;
+
+    fn info_with_mode(mode: u32) -> FileInfo {
+        FileInfo {
+            name: "f".into(),
+            path: PathBuf::from("f"),
+            is_dir: false,
+            mime: String::new(),
+            kind: Kind::Other,
+            size: 0,
+            modified: None,
+            accessed: None,
+            created: None,
+            mode,
+            owner: String::new(),
+            group: String::new(),
+            link_target: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn mode_renders_the_way_ls_does() {
+        assert_eq!(info_with_mode(0o755).mode_string(), "rwxr-xr-x");
+        assert_eq!(info_with_mode(0o644).mode_string(), "rw-r--r--");
+        assert_eq!(info_with_mode(0o000).mode_string(), "---------");
+        assert_eq!(info_with_mode(0o777).mode_string(), "rwxrwxrwx");
+        assert_eq!(info_with_mode(0o644).mode_octal(), "644");
+    }
+
+    #[test]
+    fn permission_bits_address_the_right_cell() {
+        let info = info_with_mode(0o640);
+        // owner rw-, group r--, other ---
+        assert!(info.permission(0, 0) && info.permission(0, 1) && !info.permission(0, 2));
+        assert!(info.permission(1, 0) && !info.permission(1, 1));
+        assert!(!info.permission(2, 0));
+    }
+
+    #[test]
+    fn toggling_a_bit_leaves_the_others_alone() {
+        // The grid edits one bit at a time; setuid and the rest must survive.
+        let mode = 0o4755;
+        let toggled = mode ^ permission_bit(2, 1);
+        assert_eq!(toggled, 0o4757);
+        assert_eq!(toggled & 0o7000, 0o4000, "setuid preserved");
+    }
+
+    #[test]
+    fn the_current_user_resolves() {
+        // If this returns None the panel would show a bare uid for everyone.
+        let uid = unsafe { libc::getuid() };
+        assert!(user_name(uid).is_some());
+    }
+}
+
+#[cfg(test)]
+mod chmod_tests {
+    use super::*;
+
+    /// The toggle path end to end: read a real file's mode, flip one bit
+    /// through `set_mode`, and confirm the re-read agrees. This is what the
+    /// info sheet's checkboxes do on every click.
+    #[test]
+    fn toggling_group_write_applies_and_reads_back() {
+        let dir = std::env::temp_dir().join(format!("otto-files-chmod-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("target.txt");
+        std::fs::write(&path, b"x").unwrap();
+        set_mode(&path, 0o644).unwrap();
+
+        let before = read_info(&path);
+        assert_eq!(before.mode_octal(), "644");
+        assert!(!before.permission(1, 1), "group write starts clear");
+
+        let next = before.mode ^ permission_bit(1, 1);
+        set_mode(&path, next).unwrap();
+
+        let after = read_info(&path);
+        assert_eq!(after.mode_octal(), "664");
+        assert!(after.permission(1, 1), "group write is now set");
+        // Everything else must be untouched.
+        assert!(after.permission(0, 0) && after.permission(0, 1));
+        assert!(!after.permission(2, 1));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// setuid and friends live above the nine rwx bits and must survive a
+    /// toggle — the grid edits one bit, not the whole mode.
+    #[test]
+    fn special_bits_survive_a_toggle() {
+        let dir = std::env::temp_dir().join(format!("otto-files-suid-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("target.txt");
+        std::fs::write(&path, b"x").unwrap();
+        set_mode(&path, 0o2755).unwrap();
+
+        let before = read_info(&path);
+        assert_eq!(before.mode & 0o7000, 0o2000, "setgid is set to begin with");
+
+        set_mode(&path, before.mode ^ permission_bit(2, 1)).unwrap();
+        let after = read_info(&path);
+        assert_eq!(after.mode & 0o7000, 0o2000, "setgid survived");
+        assert_eq!(after.mode_octal(), "757");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard and file operations
+// ---------------------------------------------------------------------------
+
+/// What a cut or copy put on the clipboard.
+///
+/// **Internal to this application.** otto-kit has no `wl_data_device` support,
+/// so nothing here reaches the system clipboard and copying a file in the
+/// browser cannot be pasted into another application. Cross-application copy
+/// needs data-device support in the toolkit first — the same gap that blocks
+/// drag and drop. See `specs/file-browser.md`.
+#[derive(Debug, Clone, Default)]
+pub struct Clipboard {
+    pub paths: Vec<PathBuf>,
+    /// A cut is not applied until the paste: the source stays put until then,
+    /// so an abandoned cut loses nothing.
+    pub cut: bool,
+}
+
+impl Clipboard {
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+}
+
+/// How to resolve a destination that already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnConflict {
+    /// Give the new file a numbered name; never destroys anything.
+    KeepBoth,
+    Replace,
+    Skip,
+}
+
+/// The outcome of a paste.
+#[derive(Debug, Clone, Default)]
+pub struct OpResult {
+    pub moved: usize,
+    pub copied: usize,
+    pub skipped: usize,
+    /// Items moved to Trash — kept apart from `moved` since it reads as a
+    /// different sentence in [`Self::summary`].
+    pub trashed: usize,
+    /// One message per file that failed. A failure stops that file, not the
+    /// whole operation.
+    pub errors: Vec<String>,
+}
+
+impl OpResult {
+    pub fn summary(&self) -> String {
+        if !self.errors.is_empty() {
+            return self.errors[0].clone();
+        }
+        if self.trashed > 0 {
+            return format!(
+                "Moved {} item{} to Trash",
+                self.trashed,
+                plural(self.trashed)
+            );
+        }
+        match (self.moved, self.copied, self.skipped) {
+            (0, 0, 0) => String::new(),
+            (m, 0, _) if m > 0 => format!("Moved {m} item{}", plural(m)),
+            (0, c, _) if c > 0 => format!("Copied {c} item{}", plural(c)),
+            (m, c, _) => format!("Moved {m}, copied {c}"),
+        }
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Paste `clipboard` into `dest`. Runs on a worker thread.
+pub fn paste(clipboard: &Clipboard, dest: &Path, on_conflict: OnConflict) -> OpResult {
+    let mut result = OpResult::default();
+
+    for source in &clipboard.paths {
+        let Some(name) = source.file_name() else {
+            continue;
+        };
+
+        // Pasting a directory into itself or its own descendant would recurse
+        // forever. Checked before anything is written.
+        if source.is_dir() && dest.starts_with(source) {
+            result.errors.push(format!(
+                "Cannot paste “{}” into itself.",
+                name.to_string_lossy()
+            ));
+            continue;
+        }
+
+        let mut target = dest.join(name);
+        if target == *source {
+            // Copying into the same directory: always keep both, or the file
+            // would be asked to replace itself.
+            target = unique_name(dest, name);
+        } else if target.exists() {
+            match on_conflict {
+                OnConflict::Skip => {
+                    result.skipped += 1;
+                    continue;
+                }
+                OnConflict::KeepBoth => target = unique_name(dest, name),
+                OnConflict::Replace => {}
+            }
+        }
+
+        let outcome = if clipboard.cut {
+            move_entry(source, &target).map(|_| result.moved += 1)
+        } else {
+            copy_entry(source, &target).map(|_| result.copied += 1)
+        };
+        if let Err(err) = outcome {
+            result
+                .errors
+                .push(format!("“{}”: {err}", name.to_string_lossy()));
+        }
+    }
+
+    result
+}
+
+/// `name`, `name 2`, `name 3`… — the first that does not exist in `dir`.
+///
+/// The suffix goes before the extension, so `photo.png` becomes `photo 2.png`
+/// rather than `photo.png 2`.
+fn unique_name(dir: &Path, name: &std::ffi::OsStr) -> PathBuf {
+    let name = name.to_string_lossy();
+    let (stem, ext) = match name.rsplit_once('.') {
+        // A leading dot is the whole name of a hidden file, not an extension.
+        Some((stem, ext)) if !stem.is_empty() => (stem, format!(".{ext}")),
+        _ => (name.as_ref(), String::new()),
+    };
+
+    for n in 2..10_000 {
+        let candidate = dir.join(format!("{stem} {n}{ext}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    dir.join(format!("{stem} {}{ext}", std::process::id()))
+}
+
+/// Move one entry, falling back to copy-then-delete across filesystems.
+///
+/// The source is unlinked only after the destination is fully written — that
+/// ordering is the whole guarantee that a failed move cannot lose data.
+fn move_entry(source: &Path, target: &Path) -> Result<(), String> {
+    match std::fs::rename(source, target) {
+        Ok(()) => Ok(()),
+        // EXDEV: a rename cannot cross filesystems, so do it the long way.
+        Err(err) if err.raw_os_error() == Some(libc::EXDEV) => {
+            copy_entry(source, target)?;
+            remove_entry(source)
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+/// Copy a file or a directory tree.
+fn copy_entry(source: &Path, target: &Path) -> Result<(), String> {
+    let meta = std::fs::symlink_metadata(source).map_err(|e| e.to_string())?;
+
+    if meta.is_symlink() {
+        // Copy the link itself, not what it points at — following it could
+        // duplicate a whole tree the user did not ask for.
+        let link = std::fs::read_link(source).map_err(|e| e.to_string())?;
+        return std::os::unix::fs::symlink(link, target).map_err(|e| e.to_string());
+    }
+
+    if meta.is_dir() {
+        std::fs::create_dir_all(target).map_err(|e| e.to_string())?;
+        for entry in std::fs::read_dir(source)
+            .map_err(|e| e.to_string())?
+            .flatten()
+        {
+            copy_entry(&entry.path(), &target.join(entry.file_name()))?;
+        }
+        return Ok(());
+    }
+
+    // Write to a temporary name in the destination directory and rename into
+    // place, so an interrupted copy never leaves a truncated file wearing the
+    // real name.
+    let parent = target.parent().unwrap_or(Path::new("."));
+    let temp = parent.join(format!(
+        ".{}.otto-files-{}",
+        target
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+
+    let copy = std::fs::copy(source, &temp).map_err(|e| e.to_string());
+    if let Err(err) = copy {
+        std::fs::remove_file(&temp).ok();
+        return Err(err);
+    }
+    if let Err(err) = std::fs::rename(&temp, target) {
+        std::fs::remove_file(&temp).ok();
+        return Err(err.to_string());
+    }
+    Ok(())
+}
+
+fn remove_entry(path: &Path) -> Result<(), String> {
+    let meta = std::fs::symlink_metadata(path).map_err(|e| e.to_string())?;
+    if meta.is_dir() && !meta.is_symlink() {
+        std::fs::remove_dir_all(path).map_err(|e| e.to_string())
+    } else {
+        std::fs::remove_file(path).map_err(|e| e.to_string())
+    }
+}
+
+/// `dir.join(name)`, or the next free numbered variant if that is taken.
+///
+/// Unlike [`unique_name`] — which always numbers, because every caller of it
+/// already knows the plain name collides — this checks first, so a fresh
+/// "untitled folder" doesn't open as "untitled folder 2" for no reason.
+fn first_free_name(dir: &Path, name: &std::ffi::OsStr) -> PathBuf {
+    let plain = dir.join(name);
+    if plain.exists() {
+        unique_name(dir, name)
+    } else {
+        plain
+    }
+}
+
+/// Create a new, empty directory in `dest`, named "untitled folder" or a
+/// numbered variant if that name is already taken.
+pub fn create_folder(dest: &Path) -> Result<PathBuf, String> {
+    let target = first_free_name(dest, std::ffi::OsStr::new("untitled folder"));
+    std::fs::create_dir(&target).map_err(|e| e.to_string())?;
+    Ok(target)
+}
+
+// ---------------------------------------------------------------------------
+// Trash
+// ---------------------------------------------------------------------------
+
+/// Move `paths` to the freedesktop trash can, each with a `.trashinfo`
+/// sidecar recording where it came from — so a spec-compliant file manager
+/// (this one, eventually) can restore it. Runs on the calling thread; see
+/// [`paste`] for why that is acceptable here.
+pub fn move_to_trash(paths: &[PathBuf]) -> OpResult {
+    let mut result = OpResult::default();
+    let Some(trash) = trash_dir() else {
+        result
+            .errors
+            .push("No home directory to trash into.".to_string());
+        return result;
+    };
+    let files_dir = trash.join("files");
+    let info_dir = trash.join("info");
+    if let Err(err) =
+        std::fs::create_dir_all(&files_dir).and_then(|_| std::fs::create_dir_all(&info_dir))
+    {
+        result
+            .errors
+            .push(format!("Couldn\u{2019}t prepare Trash: {err}"));
+        return result;
+    }
+
+    for source in paths {
+        let Some(name) = source.file_name() else {
+            continue;
+        };
+        match trash_one(source, name, &files_dir, &info_dir) {
+            Ok(()) => result.trashed += 1,
+            Err(err) => result
+                .errors
+                .push(format!("\u{201c}{}\u{201d}: {err}", name.to_string_lossy())),
+        }
+    }
+    result
+}
+
+fn trash_one(
+    source: &Path,
+    name: &std::ffi::OsStr,
+    files_dir: &Path,
+    info_dir: &Path,
+) -> Result<(), String> {
+    let target = first_free_name(files_dir, name);
+    let trashed_name = target.file_name().unwrap().to_string_lossy().to_string();
+    let info_path = info_dir.join(format!("{trashed_name}.trashinfo"));
+
+    move_entry(source, &target)?;
+
+    let info = format!(
+        "[Trash Info]\nPath={}\nDeletionDate={}\n",
+        percent_encode_path(source),
+        deletion_date(),
+    );
+    std::fs::write(&info_path, info).map_err(|e| e.to_string())
+}
+
+/// `$XDG_DATA_HOME/Trash`, falling back to `~/.local/share/Trash` — the
+/// "home trashcan" the freedesktop Trash spec describes.
+fn trash_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("XDG_DATA_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(dir).join("Trash"));
+    }
+    home_dir().map(|h| h.join(".local/share/Trash"))
+}
+
+/// Percent-encode a path the way a `.trashinfo`'s `Path=` key requires:
+/// everything but the unreserved characters and the `/` separator.
+fn percent_encode_path(path: &Path) -> String {
+    let mut out = String::new();
+    for byte in path.to_string_lossy().bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// Local time as `YYYY-MM-DDTHH:MM:SS`, the format a `.trashinfo`'s
+/// `DeletionDate` key requires.
+fn deletion_date() -> String {
+    // Safe: `tm` is POD and `localtime_r` fills every field it reads back.
+    unsafe {
+        let mut when: libc::time_t = 0;
+        libc::time(&mut when);
+        let mut broken: libc::tm = std::mem::zeroed();
+        libc::localtime_r(&when, &mut broken);
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            broken.tm_year + 1900,
+            broken.tm_mon + 1,
+            broken.tm_mday,
+            broken.tm_hour,
+            broken.tm_min,
+            broken.tm_sec,
+        )
+    }
+}
+
+#[cfg(test)]
+mod paste_tests {
+    use super::*;
+
+    struct Tmp(PathBuf);
+    impl Tmp {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "otto-files-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            std::fs::remove_dir_all(&dir).ok();
+            std::fs::create_dir_all(&dir).unwrap();
+            Tmp(dir)
+        }
+        fn file(&self, name: &str, body: &str) -> PathBuf {
+            let p = self.0.join(name);
+            std::fs::write(&p, body).unwrap();
+            p
+        }
+        fn dir(&self, name: &str) -> PathBuf {
+            let p = self.0.join(name);
+            std::fs::create_dir_all(&p).unwrap();
+            p
+        }
+    }
+    impl Drop for Tmp {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    #[test]
+    fn copy_leaves_the_source_alone() {
+        let t = Tmp::new("copy");
+        let src = t.file("a.txt", "hello");
+        let dest = t.dir("dest");
+
+        let clip = Clipboard {
+            paths: vec![src.clone()],
+            cut: false,
+        };
+        let result = paste(&clip, &dest, OnConflict::KeepBoth);
+
+        assert_eq!(result.copied, 1);
+        assert!(result.errors.is_empty());
+        assert!(src.exists(), "copy must not remove the source");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.txt")).unwrap(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn cut_removes_the_source_only_after_the_destination_exists() {
+        let t = Tmp::new("cut");
+        let src = t.file("a.txt", "hello");
+        let dest = t.dir("dest");
+
+        let clip = Clipboard {
+            paths: vec![src.clone()],
+            cut: true,
+        };
+        let result = paste(&clip, &dest, OnConflict::KeepBoth);
+
+        assert_eq!(result.moved, 1);
+        assert!(!src.exists(), "cut removes the source");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.txt")).unwrap(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn keep_both_never_destroys_the_existing_file() {
+        let t = Tmp::new("keepboth");
+        let src = t.file("a.txt", "new");
+        let dest = t.dir("dest");
+        std::fs::write(dest.join("a.txt"), "existing").unwrap();
+
+        let clip = Clipboard {
+            paths: vec![src],
+            cut: false,
+        };
+        let result = paste(&clip, &dest, OnConflict::KeepBoth);
+
+        assert_eq!(result.copied, 1);
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.txt")).unwrap(),
+            "existing",
+            "the file that was there must survive"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a 2.txt")).unwrap(),
+            "new"
+        );
+    }
+
+    #[test]
+    fn the_numbered_suffix_goes_before_the_extension() {
+        let t = Tmp::new("suffix");
+        let dest = t.dir("dest");
+        std::fs::write(dest.join("photo.png"), "x").unwrap();
+        let src = t.file("photo.png", "y");
+
+        paste(
+            &Clipboard {
+                paths: vec![src],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+        assert!(dest.join("photo 2.png").exists(), "expected `photo 2.png`");
+    }
+
+    #[test]
+    fn a_dotfile_is_not_treated_as_all_extension() {
+        let t = Tmp::new("dotfile");
+        let dest = t.dir("dest");
+        std::fs::write(dest.join(".bashrc"), "x").unwrap();
+        let src = t.file(".bashrc", "y");
+
+        paste(
+            &Clipboard {
+                paths: vec![src],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+        assert!(
+            dest.join(".bashrc 2").exists(),
+            "a leading dot is the name, not an extension"
+        );
+    }
+
+    #[test]
+    fn skip_leaves_both_sides_untouched() {
+        let t = Tmp::new("skip");
+        let src = t.file("a.txt", "new");
+        let dest = t.dir("dest");
+        std::fs::write(dest.join("a.txt"), "existing").unwrap();
+
+        let result = paste(
+            &Clipboard {
+                paths: vec![src.clone()],
+                cut: true,
+            },
+            &dest,
+            OnConflict::Skip,
+        );
+
+        assert_eq!(result.skipped, 1);
+        assert_eq!(result.moved, 0);
+        assert!(src.exists(), "a skipped cut must not remove the source");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.txt")).unwrap(),
+            "existing"
+        );
+    }
+
+    #[test]
+    fn pasting_into_the_same_directory_duplicates_rather_than_self_replacing() {
+        let t = Tmp::new("same");
+        let src = t.file("a.txt", "body");
+
+        let result = paste(
+            &Clipboard {
+                paths: vec![src.clone()],
+                cut: false,
+            },
+            &t.0,
+            OnConflict::Replace,
+        );
+
+        assert!(result.errors.is_empty());
+        assert!(src.exists(), "the original must survive");
+        assert!(t.0.join("a 2.txt").exists());
+    }
+
+    #[test]
+    fn a_directory_cannot_be_pasted_into_itself() {
+        let t = Tmp::new("recurse");
+        let outer = t.dir("outer");
+        let inner = outer.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+
+        let result = paste(
+            &Clipboard {
+                paths: vec![outer.clone()],
+                cut: false,
+            },
+            &inner,
+            OnConflict::KeepBoth,
+        );
+
+        assert_eq!(result.copied, 0);
+        assert_eq!(result.errors.len(), 1, "refused with a reason");
+        assert!(result.errors[0].contains("itself"));
+    }
+
+    #[test]
+    fn directories_copy_with_their_contents() {
+        let t = Tmp::new("tree");
+        let tree = t.dir("tree");
+        std::fs::create_dir_all(tree.join("sub")).unwrap();
+        std::fs::write(tree.join("sub/deep.txt"), "deep").unwrap();
+        let dest = t.dir("dest");
+
+        let result = paste(
+            &Clipboard {
+                paths: vec![tree],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+
+        assert_eq!(result.copied, 1);
+        assert_eq!(
+            std::fs::read_to_string(dest.join("tree/sub/deep.txt")).unwrap(),
+            "deep"
+        );
+    }
+
+    #[test]
+    fn a_symlink_is_copied_as_a_link_not_as_its_target() {
+        let t = Tmp::new("symlink");
+        let target = t.file("target.txt", "body");
+        let link = t.0.join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let dest = t.dir("dest");
+
+        paste(
+            &Clipboard {
+                paths: vec![link],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+
+        let copied = dest.join("link.txt");
+        let meta = std::fs::symlink_metadata(&copied).unwrap();
+        assert!(
+            meta.is_symlink(),
+            "following the link would duplicate its target"
+        );
+    }
+
+    #[test]
+    fn one_failure_does_not_abandon_the_rest() {
+        let t = Tmp::new("partial");
+        let good = t.file("good.txt", "g");
+        let missing = t.0.join("does-not-exist.txt");
+        let dest = t.dir("dest");
+
+        let result = paste(
+            &Clipboard {
+                paths: vec![missing, good],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+
+        assert_eq!(result.copied, 1, "the good file still went across");
+        assert_eq!(result.errors.len(), 1, "and the bad one was reported");
+        assert!(dest.join("good.txt").exists());
+    }
+
+    #[test]
+    fn no_temporary_file_is_left_behind() {
+        let t = Tmp::new("temp");
+        let src = t.file("a.txt", "body");
+        let dest = t.dir("dest");
+
+        paste(
+            &Clipboard {
+                paths: vec![src],
+                cut: false,
+            },
+            &dest,
+            OnConflict::KeepBoth,
+        );
+
+        let leftovers: Vec<_> = std::fs::read_dir(&dest)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains("otto-files-"))
+            .collect();
+        assert!(leftovers.is_empty(), "stray temp files: {leftovers:?}");
+    }
+
+    #[test]
+    fn create_folder_names_the_first_one_plainly() {
+        let t = Tmp::new("newfolder");
+        let made = create_folder(&t.0).unwrap();
+        assert_eq!(made.file_name().unwrap(), "untitled folder");
+        assert!(made.is_dir());
+    }
+
+    #[test]
+    fn create_folder_numbers_past_a_collision() {
+        let t = Tmp::new("newfolder-collide");
+        t.dir("untitled folder");
+        let made = create_folder(&t.0).unwrap();
+        assert_eq!(made.file_name().unwrap(), "untitled folder 2");
+    }
+
+    #[test]
+    fn trash_moves_the_file_and_writes_a_sidecar() {
+        let t = Tmp::new("trash");
+        let home = t.dir("home");
+        std::env::set_var("XDG_DATA_HOME", home.join("data"));
+        let victim = t.file("gone.txt", "bye");
+
+        let result = move_to_trash(&[victim.clone()]);
+        std::env::remove_var("XDG_DATA_HOME");
+
+        assert_eq!(result.trashed, 1, "{:?}", result.errors);
+        assert!(!victim.exists());
+        let trashed = home.join("data/Trash/files/gone.txt");
+        assert!(trashed.exists());
+        let info = home.join("data/Trash/info/gone.txt.trashinfo");
+        let contents = std::fs::read_to_string(info).unwrap();
+        assert!(contents.starts_with("[Trash Info]\n"));
+        assert!(contents.contains("DeletionDate="));
+    }
+}

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -1,0 +1,855 @@
+//! Miller columns as their own Wayland subsurfaces.
+//!
+//! The browser normally paints every column into the window's single buffer,
+//! which means a scroll in one column repaints the whole window and — because
+//! otto-kit damages the entire buffer on commit — tells the compositor that
+//! everything changed. Measured on the `scroll_ab` example, that is 82 full
+//! window repaints across one fling.
+//!
+//! Here each column gets a subsurface the size of the column. The client still
+//! does all the work — it renders, translates and clips the rows itself, in
+//! that subsurface's own buffer — so the painting is unchanged. What changes is
+//! the *scope*: a scroll damages one column, not the window, and the toplevel
+//! is left alone entirely.
+//!
+//! This is deliberately the cheaper of the two subsurface designs. The other,
+//! [`otto_kit::components::scroll::ScrollSurfaces`], keeps a band taller than
+//! the viewport and scrolls it with `otto_surface_style_v1`, so a frame of
+//! scrolling costs no paint at all — but it needs band management, the style
+//! protocol and pointer routing per column. This one reuses the existing
+//! drawing untouched and still gets the damage confinement.
+//!
+//! **Input is not routed here.** Every column surface carries an empty input
+//! region, so pointer events fall straight through to the toplevel and the
+//! browser keeps hit-testing in window coordinates exactly as it always has.
+//! Without that, `Window::on_pointer_event` — which filters to the toplevel's
+//! own surface — would silently stop seeing anything over the columns.
+//!
+//! Off by default; set `OTTO_FILES_PANE_SUBS=1` to turn it on.
+
+use otto_kit::app_runner::AppContext;
+use otto_kit::components::scroll::ScrollRenderer;
+use otto_kit::surfaces::SubsurfaceSurface;
+use skia_safe::Rect;
+use wayland_client::backend::ObjectId;
+use wayland_client::protocol::wl_surface::WlSurface;
+
+use crate::quickview;
+use crate::scene;
+use crate::view::{self, Frame, ViewMode};
+
+/// Whether Quick View is centred on the display rather than on the window.
+///
+/// The panel is a subsurface, so its position is relative to the browser's
+/// window — and a client is never told where its own window sits, so it cannot
+/// place itself anywhere else on its own. `set_output_placement` asks the
+/// compositor, which knows both, to resolve the position against the output.
+///
+/// On by default: a preview is a thing you look at, and where the *window*
+/// happens to sit is no reason for it to open off to one side of the display.
+/// A window pushed to a screen edge otherwise puts its preview there too.
+///
+/// This is independent of [`enabled`] — Quick View gets a surface of its own
+/// whether or not the columns do, because it is the only part of this module
+/// that needs one to be positioned at all. `OTTO_FILES_QV_CENTER=0` opts out
+/// and goes back to centring on the window.
+pub fn quickview_centered() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        !matches!(
+            std::env::var("OTTO_FILES_QV_CENTER").as_deref(),
+            Ok("0") | Ok("false")
+        )
+    })
+}
+
+/// Whether Quick View is presented on a subsurface rather than painted into
+/// the window's own canvas.
+///
+/// Centring on the display requires one: a client is never told where its
+/// window is, so the panel has to be a surface the compositor can place.
+pub fn quickview_on_surface() -> bool {
+    enabled() || quickview_centered()
+}
+
+/// Whether the subsurface path is enabled for this process.
+pub fn enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("OTTO_FILES_PANE_SUBS").is_some())
+}
+
+/// One column's surface and what it currently holds.
+struct PaneSurface {
+    surface: SubsurfaceSurface,
+    /// Where it sits and how big it is, in window points.
+    rect: Rect,
+    /// The scroll offset the painted content was drawn at.
+    scroll: f32,
+    /// The scrollbar opacity it was drawn at. The bar fades in on a scroll and
+    /// out again when the glide stops, and that fade is the column's own to
+    /// draw now — so it has to be able to make the column repaint on its own,
+    /// with the offset unchanged.
+    bar: f32,
+    /// Identity of everything else that feeds the drawing.
+    key: u64,
+    hidden: bool,
+    /// The compositor owns this surface's position, so nothing here may set
+    /// it: a parent-relative position sent after the centring would simply
+    /// undo it.
+    output_centered: bool,
+}
+
+/// The per-column subsurfaces, pooled the way the scene pools its pane layers.
+pub struct PaneSurfaces {
+    panes: Vec<PaneSurface>,
+    /// The stack's horizontal bar, in a surface of its own over the columns.
+    pan: Option<PaneSurface>,
+    /// The Quick View panel, in a surface of its own over everything.
+    quickview: Option<PaneSurface>,
+    /// Which panel, and which direction, [`Self::quickview_resting`] was
+    /// worked out for: the session's generation and whether it is closing.
+    /// `Some(closing)` once the output has been asked about for the panel
+    /// currently up. Deliberately *not* keyed on the decode generation:
+    /// arrow-keying to the next file does not move the window or resize the
+    /// panel, so the compositor's answer cannot have changed, and re-asking
+    /// per file made the panel fall back to the window's centre for the frame
+    /// or two before the new answer landed — a visible jump on every file.
+    quickview_placement: Option<bool>,
+    /// A fresh answer has been asked for and has not arrived. The previous
+    /// resting rect stays in use until it does.
+    quickview_awaiting: bool,
+    /// Where the panel rests, frozen for the length of one opening or one
+    /// closing.
+    ///
+    /// Recomputed only at those two moments, and never in between. The
+    /// compositor's answer is relative to the *window*, so anything that moves
+    /// the window — tiling it, dragging it — changes what it means. Following
+    /// that continuously would drag the panel across the screen mid-animation
+    /// and, when the window moves far enough, off it.
+    quickview_resting: Option<Rect>,
+    /// Set when a paint was wanted but the surface still had a frame in
+    /// flight. The throttle is only safe while something else keeps calling
+    /// `sync`: a surface whose content has stopped changing is never asked
+    /// again, so a skipped paint at the end of an animation would be skipped
+    /// for good — the panel would simply never appear.
+    pending: bool,
+    /// Set when a surface has been created, which is the only thing that can
+    /// disturb the sibling order: a new subsurface arrives on top of every
+    /// one of its siblings, including the overlays that must stay above them.
+    stack_dirty: bool,
+    scale: f32,
+}
+
+/// How tall a slice of the viewport the horizontal bar can touch: the gutter
+/// it sits in, plus room for the widening it does on hover.
+const PAN_BAR_STRIP: f32 = 16.0;
+
+impl PaneSurfaces {
+    pub fn new(scale: f32) -> Self {
+        Self {
+            panes: Vec::new(),
+            pan: None,
+            quickview: None,
+            quickview_placement: None,
+            quickview_awaiting: false,
+            quickview_resting: None,
+            pending: false,
+            stack_dirty: false,
+            scale,
+        }
+    }
+
+    /// Bring the column surfaces in line with the frame: create, move, resize
+    /// and repaint them as needed.
+    ///
+    /// Returns whether anything was repainted, so a caller can tell a frame
+    /// that did real work from one that did nothing.
+    pub fn sync(
+        &mut self,
+        parent: &WlSurface,
+        f: &Frame,
+        quickview: Option<(&quickview::Session, u64)>,
+    ) -> bool {
+        self.pending = false;
+        // The column half is still opt-in. When it is off this module exists
+        // only to carry Quick View's surface, so the scene keeps drawing the
+        // columns and nothing here touches them.
+        if f.mode != ViewMode::Columns || !enabled() {
+            let mut changed = self.hide_all();
+            changed |= self.sync_quickview(parent, f, quickview);
+            self.restack(parent);
+            return changed;
+        }
+        let viewport = view::content_viewport(f.width, f.height, ViewMode::Columns);
+        let mut painted = false;
+
+        for depth in 0..f.panes.len() {
+            let full = view::miller_pane_rect(depth, f.height, f.pan, f.miller_w);
+            // A column panned entirely off the content area has nothing to
+            // show; leaving its surface mapped would put it under the sidebar.
+            let visible = full.right > viewport.left && full.left < viewport.right;
+
+            if depth >= self.panes.len() {
+                match Self::create(parent, full) {
+                    Some(pane) => {
+                        self.panes.push(pane);
+                        self.stack_dirty = true;
+                    }
+                    None => continue,
+                }
+            }
+
+            let scale = self.scale;
+            let pane = &mut self.panes[depth];
+            if !visible {
+                painted |= pane.hide();
+                continue;
+            }
+            painted |= pane.show();
+
+            // Crop the surface to the content area rather than letting it
+            // spill. The scene clipped columns with `content.set_clip_children`
+            // — a subsurface has no such parent, it is a child of the toplevel,
+            // so a column panned past the sidebar would simply draw over it.
+            // Shrinking the surface to the visible slice *is* the clip, and the
+            // content is then shifted by however much was cropped off the left.
+            let mut clipped = full;
+            if !clipped.intersect(viewport) {
+                painted |= pane.hide();
+                continue;
+            }
+            let dx = full.left - clipped.left;
+            pane.place(clipped, scale);
+
+            let key = column_key(f, depth);
+            let scroll = f.panes[depth].scroll;
+            let bar = f.panes[depth]
+                .bar
+                .map(|state| state.scrollbar_opacity())
+                .unwrap_or(0.0);
+            if pane.key == key && pane.scroll == scroll && pane.bar == bar {
+                continue;
+            }
+            // Frame-callback throttled, like the toplevel: painting again
+            // while the last buffer has not been presented only queues work
+            // the compositor has not asked for.
+            use wayland_client::Proxy;
+            if AppContext::frame_in_flight(&pane.surface.wl_surface().id()) {
+                self.pending = true;
+                continue;
+            }
+            pane.key = key;
+            pane.scroll = scroll;
+            pane.bar = bar;
+            // The rows are laid out against the column's full width, then
+            // slid by the cropped-off amount, so a half-visible column shows
+            // the correct half rather than a squeezed whole.
+            let width = full.width();
+            let origin = (clipped.left, clipped.top);
+            pane.surface.draw(|canvas| {
+                canvas.save();
+                canvas.translate((dx, 0.0));
+                scene::paint_column(canvas, f, depth, width);
+                canvas.restore();
+
+                // The column's own scrollbar. It used to be drawn over the
+                // stack from `view::draw_miller`, but the window is no longer
+                // repainted for a scroll — which is the point — so the bar
+                // would fade in and never move. It belongs to the column, so
+                // it rides in the column's surface, shifted out of window
+                // coordinates into this surface's own.
+                if let Some(state) = f.panes[depth].bar {
+                    canvas.save();
+                    canvas.translate((-origin.0, -origin.1));
+                    ScrollRenderer::draw(canvas, state, f.theme, |_, _| {});
+                    canvas.restore();
+                }
+            });
+            painted = true;
+        }
+
+        for pane in self.panes.iter_mut().skip(f.panes.len()) {
+            painted |= pane.hide();
+        }
+        painted |= self.sync_pan_bar(parent, f, viewport);
+        painted |= self.sync_quickview(parent, f, quickview);
+        self.restack(parent);
+        painted
+    }
+
+    /// Put the sibling surfaces back into a known order, bottom to top:
+    /// columns in depth order, then the stack's bar, then Quick View.
+    ///
+    /// Stacking each surface against the one below it states the whole order
+    /// rather than assuming one. Placing an overlay above "the last column"
+    /// does not: `wl_subsurface.place_above` is relative to one named sibling,
+    /// so it only lifts the overlay above *that* surface, and the last column
+    /// in this pool is not always the topmost sibling — a hidden one still
+    /// holds its place in the stack. That is how a third column ended up over
+    /// the panel.
+    ///
+    /// Only after a surface has been created, since nothing else reorders
+    /// siblings, and only relative to surfaces that exist — the requests are
+    /// double-buffered on the *parent*, so they land with the toplevel's next
+    /// commit rather than this one.
+    fn restack(&mut self, parent: &WlSurface) {
+        // Only when a surface was created, which is the only thing that
+        // reaches into the sibling order: a pooled column is hidden by going
+        // transparent, never destroyed, so it keeps its place in the stack
+        // and coming back does not disturb anyone.
+        if !std::mem::take(&mut self.stack_dirty) {
+            return;
+        }
+        let trace = std::env::var_os("OTTO_FILES_QV_TRACE").is_some();
+        let mut order: Vec<String> = Vec::new();
+        let mut below: Option<WlSurface> = None;
+        let overlays = [self.pan.as_ref(), self.quickview.as_ref()];
+        for (index, pane) in self.panes.iter().map(Some).chain(overlays).enumerate() {
+            let Some(pane) = pane else { continue };
+            let surface = pane.surface.wl_surface().clone();
+            if trace {
+                use wayland_client::Proxy;
+                order.push(format!("{index}:{}", surface.id().protocol_id()));
+            }
+            if let Some(below) = &below {
+                pane.surface.place_above(below);
+            }
+            below = Some(surface);
+        }
+        if trace {
+            eprintln!("qv restack: {}", order.join(" < "));
+        }
+        // `place_above` is part of the *parent's* pending state, so committing
+        // the children does nothing for it. Without this the new order waits
+        // for whatever else happens to commit the toplevel — and when a column
+        // appears while Quick View is up, nothing does, so the column that
+        // arrived on top stays on top.
+        parent.commit();
+    }
+
+    /// Where this panel rests, worked out once per opening and once per
+    /// closing and held steady in between.
+    fn resting_for(&mut self, session: &quickview::Session) -> Option<Rect> {
+        if !quickview_centered() {
+            return None;
+        }
+        let pane = self.quickview.as_ref()?;
+        let style = pane.surface.layer()?;
+
+        use wayland_client::Proxy;
+        // Once per open, and again when the exit starts — the two moments the
+        // answer can actually differ.
+        let placement = session.closing.is_some();
+        if self.quickview_placement != Some(placement) {
+            self.quickview_placement = Some(placement);
+            self.quickview_awaiting = true;
+            // Clear before asking, so a stale answer cannot be mistaken for
+            // the new one.
+            AppContext::clear_output_frame(&style.id());
+            style.request_output_frame();
+        }
+        // The *old* rect stays in force until the new answer lands. Nulling it
+        // here is what made the panel snap to the window's centre and back.
+        if self.quickview_awaiting {
+            if let Some(rect) = centered_resting(pane, self.scale) {
+                self.quickview_resting = Some(rect);
+                self.quickview_awaiting = false;
+            }
+        }
+        self.quickview_resting
+    }
+
+    /// The Quick View panel.
+    ///
+    /// Drawn into the window it would be buried: the column surfaces sit over
+    /// the toplevel, so a panel painted underneath them is a panel nobody can
+    /// see. It gets a surface of its own, stacked above every column and above
+    /// the horizontal bar — the topmost thing this window puts on screen.
+    ///
+    /// Its input region stays empty like the columns'. The panel already owns
+    /// the pointer through the host's own routing, which works in window
+    /// coordinates and does not care which surface the pixels came from.
+    fn sync_quickview(
+        &mut self,
+        parent: &WlSurface,
+        f: &Frame,
+        quickview: Option<(&quickview::Session, u64)>,
+    ) -> bool {
+        let Some((session, generation)) = quickview else {
+            // Nothing is up, so the next open asks afresh. The last known
+            // resting rect is kept: if the window has not moved it is still
+            // right, and starting from it beats starting from the window's
+            // centre and correcting.
+            self.quickview_placement = None;
+            self.quickview_awaiting = false;
+            return self
+                .quickview
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false);
+        };
+        // Centred on the display when the compositor has told us where the
+        // display is, and centred on the window until it has. Everything below
+        // stays in window coordinates either way, which is what lets the
+        // entrance keep growing out of the file's icon: the anchor and the
+        // resting place are in the same space.
+        let resting = self
+            .resting_for(session)
+            .unwrap_or_else(|| quickview::panel_rect(f.width, f.height + f.footer));
+        // Wherever the panel is *now* — part way in, at rest, or part way
+        // back to its file. Asking for the entrance alone left the exit out
+        // of the surface entirely: once open, `entrance_t` is pinned at 1, so
+        // through the whole close this rect never moved and the key below
+        // never changed, and the card sat frozen at full size until the
+        // session was retired out from under it.
+        let panel = session.panel(resting);
+        let mut rect = panel.with_outset((quickview::SURFACE_MARGIN, quickview::SURFACE_MARGIN));
+        // A panel centred on the display may legitimately reach past the
+        // window it belongs to, so it is only clipped to the window when it is
+        // the window it is centred on.
+        if !quickview_centered() && !rect.intersect(Rect::from_wh(f.width, f.height)) {
+            return self
+                .quickview
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false);
+        }
+
+        if self.quickview.is_none() {
+            self.quickview = Self::create(parent, rect);
+            self.stack_dirty = true;
+            if let Some(pane) = self.quickview.as_mut() {
+                pane.output_centered = quickview_centered();
+                Self::style_quickview(pane, self.scale);
+                // Undo the empty input region `create` sets. A panel centred
+                // on the display hangs outside the toplevel, and the pointer
+                // never reports those coordinates to this client — so the
+                // close button would be dead exactly when the panel is where
+                // it is supposed to be. `None` means "the whole surface".
+                pane.surface.wl_surface().set_input_region(None);
+                pane.surface.commit();
+            }
+        }
+        let scale = self.scale;
+        let Some(pane) = self.quickview.as_mut() else {
+            return false;
+        };
+        let mut painted = pane.show();
+        let resized = pane.place(rect, scale);
+        // Everything the panel's pixels depend on has to be in here or the
+        // repaint is skipped: the card's rect, which file it is showing, how
+        // far its content is scrolled — and now how far its picture is zoomed
+        // and dragged, which changes what is drawn without moving the card an
+        // inch.
+        let key = hash_rect(panel)
+            ^ generation.rotate_left(17)
+            ^ (session.first_row as u64) << 1
+            ^ hash_zoom(session.zoom).rotate_left(33);
+        if pane.key == key {
+            return painted;
+        }
+        use wayland_client::Proxy;
+        if AppContext::frame_in_flight(&pane.surface.wl_surface().id()) {
+            self.pending = true;
+            return painted;
+        }
+        pane.key = key;
+        let origin = (rect.left, rect.top);
+        let started = qv_trace::now();
+        pane.surface.draw(|canvas| {
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+            canvas.save();
+            canvas.translate((-origin.0, -origin.1));
+            view::draw_quickview(canvas, f, session, resting);
+            canvas.restore();
+        });
+        qv_trace::frame(session, rect, resized, started);
+        painted = true;
+        painted
+    }
+
+    /// The stack's horizontal bar.
+    ///
+    /// It spans the whole stack, so unlike the vertical bars it belongs to no
+    /// column and cannot ride in one. Drawn into the window it would be buried:
+    /// subsurfaces sit over the toplevel, so the columns would cover it. It
+    /// gets a surface of its own instead, a strip along the bottom of the
+    /// content area, stacked above every column.
+    fn sync_pan_bar(&mut self, parent: &WlSurface, f: &Frame, viewport: Rect) -> bool {
+        let Some(state) = f.pan_bar.filter(|s| s.scrollbar_opacity() > 0.0) else {
+            return self.pan.as_mut().map(PaneSurface::hide).unwrap_or(false);
+        };
+        let bar_viewport = state.viewport();
+        let mut strip = Rect::from_ltrb(
+            bar_viewport.left,
+            bar_viewport.bottom - PAN_BAR_STRIP,
+            bar_viewport.right,
+            bar_viewport.bottom,
+        );
+        if !strip.intersect(viewport) {
+            return self.pan.as_mut().map(PaneSurface::hide).unwrap_or(false);
+        }
+
+        if self.pan.is_none() {
+            self.pan = Self::create(parent, strip);
+            self.stack_dirty = true;
+        }
+        let scale = self.scale;
+        let Some(pane) = self.pan.as_mut() else {
+            return false;
+        };
+        let mut painted = pane.show();
+        pane.place(strip, scale);
+
+        // The thumb slides as the stack pans and widens on hover, and neither
+        // shows up in the opacity, so the geometry is what decides a repaint.
+        let thumb = ScrollRenderer::thumb_rect(state).unwrap_or(Rect::new_empty());
+        let key = hash_rect(thumb);
+        let bar = state.scrollbar_opacity();
+        if pane.key == key && pane.bar == bar {
+            return painted;
+        }
+        use wayland_client::Proxy;
+        if AppContext::frame_in_flight(&pane.surface.wl_surface().id()) {
+            self.pending = true;
+            return painted;
+        }
+        pane.key = key;
+        pane.bar = bar;
+        let origin = (strip.left, strip.top);
+        let theme = f.theme;
+        pane.surface.draw(|canvas| {
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+            canvas.save();
+            canvas.translate((-origin.0, -origin.1));
+            ScrollRenderer::draw(canvas, state, theme, |_, _| {});
+            canvas.restore();
+        });
+        painted = true;
+        painted
+    }
+
+    /// Whether a paint is still owed, because the throttle turned one away.
+    /// The caller has to keep the frame loop turning until this clears.
+    pub fn pending(&self) -> bool {
+        self.pending
+    }
+
+    fn hide_all(&mut self) -> bool {
+        let mut changed = false;
+        for pane in &mut self.panes {
+            changed |= pane.hide();
+        }
+        if let Some(pan) = self.pan.as_mut() {
+            changed |= pan.hide();
+        }
+        changed
+    }
+
+    /// Quick View's surface and where its card sits *within* that surface,
+    /// for the pointer callback.
+    ///
+    /// The panel is centred on the display, so it routinely reaches outside
+    /// the toplevel — and a pointer event over that part is never delivered
+    /// to the toplevel at all. So the panel takes its own input, and is
+    /// hit-tested in surface-local coordinates rather than the window's.
+    ///
+    /// The card's rect rather than the close button's, because the callback
+    /// needs both that button and the content box under it: everything else
+    /// the panel's own geometry is derived from the card, and deriving it
+    /// twice from two published rects is how the two drift apart.
+    pub fn quickview_target(&self) -> Option<(ObjectId, Rect)> {
+        use wayland_client::Proxy;
+        let pane = self.quickview.as_ref()?;
+        let panel = Rect::from_xywh(
+            quickview::SURFACE_MARGIN,
+            quickview::SURFACE_MARGIN,
+            pane.rect.width() - quickview::SURFACE_MARGIN * 2.0,
+            pane.rect.height() - quickview::SURFACE_MARGIN * 2.0,
+        );
+        Some((pane.surface.wl_surface().id(), panel))
+    }
+
+    /// Where Quick View's panel actually rests, once it has been worked out.
+    ///
+    /// `None` until the compositor has answered with the output's geometry,
+    /// and always `None` when the panel is centred on the window — the caller
+    /// can compute that one itself. Hit-testing must use this rather than
+    /// re-deriving a rect from the window size: a panel centred on the
+    /// *display* is nowhere near the window's own centre.
+    pub fn quickview_resting(&self) -> Option<Rect> {
+        self.quickview_resting
+    }
+
+    /// The panel's material, handed to the compositor once.
+    ///
+    /// The shadow and the blur both belong here rather than in the card's own
+    /// drawing. Painted client-side they would be re-recorded on every frame
+    /// of an animation that resizes the surface as it goes — a full-card
+    /// Gaussian per frame — and the blur could not see past this surface
+    /// anyway. The compositor already has the pixels behind the panel and
+    /// composites the shadow outside its bounds, so both are free here and
+    /// impossible there.
+    ///
+    /// `material_popup` is 0xD8 — the toolkit's popup material is translucent
+    /// by design, expecting exactly this blur behind it.
+    fn style_quickview(pane: &PaneSurface, scale: f32) {
+        let Some(style) = pane.surface.layer() else {
+            return;
+        };
+        // Physical pixels, like every other measurement this protocol takes.
+        let scale = scale as f64;
+        // Matches the radius the card paints itself with, so the blur and the
+        // shadow follow the corners instead of squaring them off.
+        style.set_corner_radius(12.0 * scale);
+        style.set_shadow(0.30, 28.0 * scale, 0.0, 10.0 * scale, 0.0, 0.0, 0.0);
+        style.set_blend_mode(otto_kit::protocols::otto_surface_style_v1::BlendMode::BackgroundBlur);
+
+        // Nothing here asks where the display is: that is worked out once per
+        // opening and once per closing, in `resting_for`, because the answer is
+        // relative to the window and the window moves.
+        //
+        // And it is asked for, rather than handed to the compositor to act on.
+        // `set_output_placement` moves the *layer*, and for a subsurface the
+        // layer carries the material — the blur, the shadow, the rounded
+        // corners — while the client's pixels are put where
+        // `wl_subsurface.set_position` says. Moving one without the other
+        // leaves the card's frame in the middle of the screen and its contents
+        // back over the window. Positioning both, as this client already does
+        // for its columns, moves them together — and keeps the entrance, since
+        // the icon it grows from is in the same coordinates as the answer.
+    }
+
+    fn create(parent: &WlSurface, rect: Rect) -> Option<PaneSurface> {
+        let surface = SubsurfaceSurface::new(
+            parent,
+            rect.left as i32,
+            rect.top as i32,
+            rect.width().max(1.0) as i32,
+            rect.height().max(1.0) as i32,
+        )
+        .ok()?;
+        // Presentation only: input belongs to the toplevel, which is where all
+        // of the browser's hit-testing already happens. Quick View is the
+        // exception and undoes this — see `accept_input`.
+        surface.wl_surface().set_input_region(Some(
+            &AppContext::compositor_state()
+                .wl_compositor()
+                .create_region(AppContext::queue_handle(), ()),
+        ));
+        surface.commit();
+        Some(PaneSurface {
+            surface,
+            rect: Rect::new_empty(),
+            scroll: f32::NAN,
+            bar: f32::NAN,
+            key: 0,
+            hidden: false,
+            output_centered: false,
+        })
+    }
+}
+
+impl PaneSurface {
+    /// Returns whether the surface had to be reallocated, which is the
+    /// expensive half of a move.
+    fn place(&mut self, rect: Rect, scale: f32) -> bool {
+        if self.rect == rect {
+            return false;
+        }
+        let resized = self.rect.width() != rect.width() || self.rect.height() != rect.height();
+        self.rect = rect;
+        if resized {
+            self.surface
+                .resize(rect.width().max(1.0) as i32, rect.height().max(1.0) as i32);
+            // A resize invalidates what was painted.
+            self.scroll = f32::NAN;
+        }
+        // A move does too, now that the bar is drawn in window coordinates
+        // shifted by this rect's origin.
+        self.bar = f32::NAN;
+        self.surface.set_position(rect.left as i32, rect.top as i32);
+        if let Some(style) = self.surface.layer() {
+            // Claiming the size stops the compositor re-deriving both size and
+            // position from the surface tree — see `ScrollSurfaces`, which
+            // depends on the same rule.
+            style.set_size(
+                (rect.width() * scale) as f64,
+                (rect.height() * scale) as f64,
+            );
+            style.set_position((rect.left * scale) as f64, (rect.top * scale) as f64);
+        }
+        self.surface.commit();
+        resized
+    }
+
+    fn hide(&mut self) -> bool {
+        if self.hidden {
+            return false;
+        }
+        self.hidden = true;
+        if let Some(style) = self.surface.layer() {
+            style.set_opacity(0.0);
+        }
+        self.surface.commit();
+        true
+    }
+
+    fn show(&mut self) -> bool {
+        if !self.hidden {
+            return false;
+        }
+        self.hidden = false;
+        if let Some(style) = self.surface.layer() {
+            style.set_opacity(1.0);
+        }
+        self.surface.commit();
+        true
+    }
+}
+
+/// Everything other than the scroll offset that decides what a column draws.
+fn column_key(f: &Frame, depth: usize) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let pane = &f.panes[depth];
+    let mut hasher = DefaultHasher::new();
+    pane.entries.len().hash(&mut hasher);
+    for entry in pane.entries.iter() {
+        entry.name.hash(&mut hasher);
+        entry.is_dir.hash(&mut hasher);
+    }
+    for index in 0..pane.entries.len() {
+        pane.is_selected(index).hash(&mut hasher);
+    }
+    pane.cursor.hash(&mut hasher);
+    pane.loading.hash(&mut hasher);
+    pane.error.hash(&mut hasher);
+    (depth == f.active).hash(&mut hasher);
+    f.renaming.map(|(d, i)| (d == depth, i)).hash(&mut hasher);
+    view::is_dark().hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A rect as a repaint key. Positions are the whole of what a bar draws, so
+/// its geometry is its identity.
+/// The zoom, as a repaint key contribution. Bit patterns rather than values,
+/// like [`hash_rect`]: a float has no `Hash`, and rounding one to compare it
+/// would let a slow pinch stall.
+fn hash_zoom(zoom: otto_kit::preview::Zoom) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    for value in [zoom.scale, zoom.offset.0, zoom.offset.1] {
+        value.to_bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn hash_rect(rect: Rect) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    for value in [rect.left, rect.top, rect.right, rect.bottom] {
+        value.to_bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Per-frame timing for the Quick View entrance and exit.
+///
+/// The two animations run the same geometry in opposite directions, so if one
+/// is smooth and the other is not, the difference is either in what a frame
+/// costs or in how far apart the frames land — and those are two different
+/// bugs. `OTTO_FILES_QV_TRACE=1` prints a line per painted frame.
+mod qv_trace {
+    use std::cell::Cell;
+    use std::time::Instant;
+
+    use skia_safe::Rect;
+
+    use crate::quickview::Session;
+
+    thread_local! {
+        static LAST: Cell<Option<Instant>> = const { Cell::new(None) };
+    }
+
+    fn enabled() -> bool {
+        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ON.get_or_init(|| std::env::var_os("OTTO_FILES_QV_TRACE").is_some())
+    }
+
+    pub fn now() -> Option<Instant> {
+        enabled().then(Instant::now)
+    }
+
+    pub fn frame(session: &Session, rect: Rect, resized: bool, started: Option<Instant>) {
+        let Some(started) = started else { return };
+        let gap = LAST.with(|last| {
+            let gap = last.get().map(|prev| started.duration_since(prev));
+            last.set(Some(started));
+            gap
+        });
+        let (direction, t) = match session.closing {
+            Some(_) => ("out", session.exit_t()),
+            None => ("in ", session.entrance_t()),
+        };
+        // The pause between one animation and the next is not a gap worth
+        // reading, so it is left blank rather than reported as a stall.
+        let gap_ms = match gap {
+            Some(gap) if gap.as_millis() < 2000 => format!("{:>6.1}", gap.as_secs_f32() * 1000.0),
+            _ => "     -".to_string(),
+        };
+        eprintln!(
+            "qv {direction} t={t:.2} @({:>6.0},{:>5.0}) {:>4.0}x{:<4.0} {} paint {:>5}us  gap {gap_ms}ms",
+            rect.left,
+            rect.top,
+            rect.width(),
+            rect.height(),
+            if resized { "resize" } else { "      " },
+            started.elapsed().as_micros(),
+        );
+    }
+}
+
+/// Where the panel rests when it is centred on the display, in window points.
+///
+/// `None` until the compositor has answered — the request goes out when the
+/// surface is created, and the reply lands a round trip later, so the first
+/// frame or two of an entrance are still centred on the window. Those frames
+/// are the smallest ones, at the file's icon, so the correction is invisible.
+fn centered_resting(pane: &PaneSurface, scale: f32) -> Option<Rect> {
+    use wayland_client::Proxy;
+
+    let style = pane.surface.layer()?;
+    let frame = AppContext::output_frame(&style.id())?;
+    if std::env::var_os("OTTO_FILES_QV_TRACE").is_some() {
+        eprintln!("qv output_frame(px) = {frame:?} scale={scale}");
+    }
+    let (x, y, width, height) = frame;
+    if width <= 0.0 || height <= 0.0 || scale <= 0.0 {
+        return None;
+    }
+    // The answer is in the same pixels the positions are set in; the rest of
+    // this module works in points.
+    let (x, y, width, height) = (x / scale, y / scale, width / scale, height / scale);
+
+    // The panel's share of the display, floored the same way it is floored
+    // against a window, and never quite touching the edges.
+    let panel_width = (width * quickview::PANEL_FRACTION)
+        .max(quickview::PANEL_MIN.0)
+        .min(width - 32.0);
+    let panel_height = (height * quickview::PANEL_FRACTION)
+        .max(quickview::PANEL_MIN.1)
+        .min(height - 32.0);
+
+    Some(Rect::from_xywh(
+        x + (width - panel_width) / 2.0,
+        y + (height - panel_height) / 2.0,
+        panel_width.max(1.0),
+        panel_height.max(1.0),
+    ))
+}

--- a/components/otto-files/src/perf.rs
+++ b/components/otto-files/src/perf.rs
@@ -1,0 +1,104 @@
+//! Where a frame's time went, when anyone asks.
+//!
+//! Off unless `OTTO_FILES_PERF` is set, and cheap enough when off that the
+//! call sites can stay in the hot path: one relaxed atomic load, no clock
+//! read. The point is to be able to answer "what is spinning the fans" on the
+//! installed binary, on the user's real directories, without another build and
+//! another fingerprint to install it.
+//!
+//! Set `OTTO_FILES_PERF=1` and every 120 frames a line lands on stderr with
+//! the mean and worst microseconds of each stage:
+//!
+//! ```text
+//! otto-files perf: 120 frames | scene.update 41µs/312µs | scene.render 890µs/2104µs | chrome 233µs/501µs
+//! ```
+//!
+//! `scene.update` is the keying and the engine tick; `scene.render` is the
+//! scene replay; `chrome` is everything [`crate::view::draw`] still paints
+//! immediately. A stage that dominates while scrolling is the one to chase.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// How many frames to fold into one line.
+const WINDOW: u64 = 120;
+
+#[derive(Clone, Copy)]
+pub enum Stage {
+    Prep = 0,
+    FrameBuild = 1,
+    Visible = 2,
+    SceneUpdate = 3,
+    SceneRender = 4,
+    Chrome = 5,
+    Total = 6,
+}
+
+const STAGES: usize = 7;
+const NAMES: [&str; STAGES] = [
+    "prep",
+    "frame",
+    "  visible",
+    "scene.update",
+    "scene.render",
+    "chrome",
+    "TOTAL",
+];
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static FRAMES: AtomicU64 = AtomicU64::new(0);
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO: AtomicU64 = AtomicU64::new(0);
+static TOTAL_US: [AtomicU64; STAGES] = [ZERO; STAGES];
+static WORST_US: [AtomicU64; STAGES] = [ZERO; STAGES];
+/// Set once the window's last stage has been folded in, so the report is
+/// emitted by exactly one stage and reads a complete set of totals.
+static REPORTING: AtomicBool = AtomicBool::new(false);
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| std::env::var_os("OTTO_FILES_PERF").is_some())
+}
+
+/// A clock read, or `None` when the probe is off — which is what keeps the
+/// call sites free in the normal case.
+pub fn now() -> Option<Instant> {
+    enabled().then(Instant::now)
+}
+
+/// Fold the time since `start` into `stage`, and report once a window is full.
+pub fn mark(stage: Stage, start: Option<Instant>) {
+    let Some(start) = start else { return };
+    let index = stage as usize;
+    let micros = start.elapsed().as_micros() as u64;
+
+    TOTAL_US[index].fetch_add(micros, Ordering::Relaxed);
+    WORST_US[index].fetch_max(micros, Ordering::Relaxed);
+
+    // The last stage of a frame closes it, so a window is a whole number of
+    // frames and the means below divide by something real.
+    if !matches!(stage, Stage::Total) {
+        return;
+    }
+    if FRAMES.fetch_add(1, Ordering::Relaxed) + 1 < WINDOW {
+        return;
+    }
+    if REPORTING.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let frames = FRAMES.swap(0, Ordering::Relaxed);
+    let report: Vec<String> = (0..STAGES)
+        .map(|i| {
+            let total = TOTAL_US[i].swap(0, Ordering::Relaxed);
+            let worst = WORST_US[i].swap(0, Ordering::Relaxed);
+            format!("{} {}µs/{}µs", NAMES[i], total / frames.max(1), worst)
+        })
+        .collect();
+    eprintln!(
+        "otto-files perf: {} frames | {}",
+        frames,
+        report.join(" | ")
+    );
+    REPORTING.store(false, Ordering::Relaxed);
+}

--- a/components/otto-files/src/picker.rs
+++ b/components/otto-files/src/picker.rs
@@ -1,0 +1,398 @@
+//! The file picker's own model: what a portal request asks for, and what
+//! answers it. See `specs/file-picker.md`.
+//!
+//! Everything here is pure — no Wayland, no D-Bus, no filesystem beyond
+//! probing candidate directories — so the parts most likely to harbour a
+//! silent data bug (glob matching, URI encoding) are unit-testable alone.
+
+use std::path::{Path, PathBuf};
+
+use otto_kit::filetype;
+
+/// What the request wants done. `Save` and `SaveFiles` are carried from the
+/// first version so the wire contract never has to change to gain them; the
+/// picker refuses them for now rather than pretending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Open,
+    Save,
+    SaveFiles,
+}
+
+impl Mode {
+    pub fn from_wire(mode: u32) -> Option<Self> {
+        match mode {
+            0 => Some(Self::Open),
+            1 => Some(Self::Save),
+            2 => Some(Self::SaveFiles),
+            _ => None,
+        }
+    }
+
+    /// The window title to use when the request supplies none.
+    pub fn default_title(self) -> &'static str {
+        match self {
+            Self::Open => "Open",
+            Self::Save => "Save As",
+            Self::SaveFiles => "Save Files",
+        }
+    }
+
+    /// The confirm button's text when the request supplies none.
+    pub fn default_accept_label(self) -> &'static str {
+        match self {
+            Self::Open => "Open",
+            Self::Save | Self::SaveFiles => "Save",
+        }
+    }
+}
+
+/// One rule of a filter. MIME rules are expanded into globs when the request
+/// is parsed, so only one matcher exists at match time — see the spec's
+/// *MIME filters collapse into glob filters*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Filter {
+    pub label: String,
+    /// Name patterns, already expanded. Empty means the filter matches
+    /// nothing, which is reported rather than silently matching everything.
+    pub globs: Vec<String>,
+    /// The request named a MIME type with no registered glob. Kept so the
+    /// empty state can say *why* nothing matches.
+    pub unresolved: bool,
+    /// `inode/directory` was named: the filter is about directories.
+    pub matches_directories: bool,
+}
+
+/// A filter as it arrives over the wire: `(label, [(kind, pattern)])` with
+/// `kind` `0` glob and `1` MIME.
+pub type WireFilter = (String, Vec<(u32, String)>);
+
+impl Filter {
+    /// Expand a wire filter, resolving every MIME rule to the globs the
+    /// shared MIME database registers for it and for its descendants.
+    pub fn from_wire((label, rules): WireFilter) -> Self {
+        let mut globs = Vec::new();
+        let mut unresolved = false;
+        let mut matches_directories = false;
+        for (kind, pattern) in rules {
+            match kind {
+                0 => globs.push(pattern),
+                1 => {
+                    if pattern == "inode/directory" {
+                        matches_directories = true;
+                        continue;
+                    }
+                    let expanded = filetype::globs_for(&pattern);
+                    if expanded.is_empty() {
+                        unresolved = true;
+                    }
+                    globs.extend(expanded);
+                }
+                // An unknown rule kind is not a reason to match everything.
+                _ => unresolved = true,
+            }
+        }
+        globs.sort();
+        globs.dedup();
+        Self {
+            label,
+            globs,
+            unresolved,
+            matches_directories,
+        }
+    }
+
+    /// A filter with no rules at all — "All Files", offered when the request
+    /// supplies none.
+    pub fn all_files() -> Self {
+        Self {
+            label: "All Files".to_string(),
+            globs: vec!["*".to_string()],
+            unresolved: false,
+            matches_directories: true,
+        }
+    }
+
+    /// Whether `name` passes. An entry passes if it matches any rule.
+    ///
+    /// Matching is case-sensitive except that an all-lowercase pattern also
+    /// matches an uppercase extension: `*.png` matches `PHOTO.PNG`, which is
+    /// what applications mean by it.
+    pub fn matches(&self, name: &str) -> bool {
+        self.globs.iter().any(|pattern| {
+            if pattern.chars().any(|c| c.is_ascii_uppercase()) {
+                filetype::glob::matches(pattern, name)
+            } else {
+                filetype::glob::matches_ignore_case(pattern, name)
+            }
+        })
+    }
+}
+
+/// A choice group the application wants answered alongside the file:
+/// `(id, label, [(option_id, option_label)], default_option_id)`.
+pub type WireChoice = (String, String, Vec<(String, String)>, String);
+
+/// A parsed `Present` request. Field for field the wire tuple, with the
+/// paths validated and the filters expanded.
+#[derive(Debug, Clone)]
+pub struct Request {
+    pub mode: Mode,
+    pub handle: String,
+    pub app_id: String,
+    pub parent_window: String,
+    pub title: String,
+    pub accept_label: String,
+    pub multiple: bool,
+    pub directory: bool,
+    pub modal: bool,
+    pub current_name: String,
+    pub current_folder: Option<PathBuf>,
+    pub current_file: Option<PathBuf>,
+    pub files: Vec<String>,
+    pub filters: Vec<Filter>,
+    /// Index into `filters` of the one to preselect.
+    pub current_filter: usize,
+    pub choices: Vec<WireChoice>,
+}
+
+impl Request {
+    /// The window title to show.
+    pub fn window_title(&self) -> String {
+        if self.title.is_empty() {
+            self.mode.default_title().to_string()
+        } else {
+            self.title.clone()
+        }
+    }
+
+    /// The confirm button's text.
+    pub fn accept_text(&self) -> String {
+        if self.accept_label.is_empty() {
+            self.mode.default_accept_label().to_string()
+        } else {
+            self.accept_label.clone()
+        }
+    }
+
+    /// Where to open, in the spec's order of preference: the directory of
+    /// `current_file`, then `current_folder`, then the directory this
+    /// `app_id` last accepted from, then home. A candidate that is not a
+    /// readable directory falls through to the next.
+    pub fn starting_directory(&self, remembered: Option<PathBuf>) -> PathBuf {
+        let candidates = [
+            self.current_file.as_deref().and_then(Path::parent),
+            self.current_folder.as_deref(),
+            remembered.as_deref(),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if std::fs::read_dir(candidate).is_ok() {
+                return candidate.to_path_buf();
+            }
+        }
+        crate::model::home_dir().unwrap_or_else(|| PathBuf::from("/"))
+    }
+}
+
+/// How a request ended.
+#[derive(Debug, Clone, Default)]
+pub struct Outcome {
+    /// `0` accepted, `1` cancelled by the user, `2` ended for another reason.
+    pub response: u32,
+    /// Percent-encoded absolute `file://` URIs. Empty unless `response` is 0.
+    pub uris: Vec<String>,
+    /// The label of the filter in effect at acceptance.
+    pub current_filter: String,
+    pub choices: Vec<(String, String)>,
+}
+
+impl Outcome {
+    /// The user cancelled.
+    pub fn cancelled() -> Self {
+        Self {
+            response: 1,
+            ..Default::default()
+        }
+    }
+
+    /// The request ended without the user answering — withdrawn, or the
+    /// picker could not serve it.
+    pub fn ended() -> Self {
+        Self {
+            response: 2,
+            ..Default::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A request in progress
+// ---------------------------------------------------------------------------
+
+/// A request the picker window is currently serving.
+///
+/// It owns the reply channel, and answers on drop if nothing else did — a
+/// file dialog that never returns hangs the requesting application's UI
+/// thread, so "the window went away without deciding" has to resolve to
+/// *something*, and `response = 2` is what the portal contract says that is.
+pub struct Session {
+    pub request: Request,
+    /// The request's filters, plus "All Files" when it supplied none.
+    pub filters: Vec<Filter>,
+    pub current_filter: usize,
+    /// The filter menu is showing.
+    pub filter_open: bool,
+    /// The accept button's text and the filter control's labels, resolved
+    /// once. The frame borrows them for the length of a paint, which owned
+    /// values built per frame could not survive.
+    pub accept_label: String,
+    pub filter_labels: Vec<String>,
+    responder: Option<tokio::sync::oneshot::Sender<Outcome>>,
+}
+
+impl Session {
+    pub fn new(request: Request, responder: tokio::sync::oneshot::Sender<Outcome>) -> Self {
+        let mut filters = request.filters.clone();
+        let current_filter = request.current_filter.min(filters.len().saturating_sub(1));
+        if filters.is_empty() {
+            filters.push(Filter::all_files());
+        }
+        Self {
+            accept_label: request.accept_text(),
+            filter_labels: filters.iter().map(|f| f.label.clone()).collect(),
+            request,
+            filters,
+            current_filter,
+            filter_open: false,
+            responder: Some(responder),
+        }
+    }
+
+    /// The filter currently in force.
+    pub fn filter(&self) -> &Filter {
+        &self.filters[self.current_filter.min(self.filters.len() - 1)]
+    }
+
+    /// Whether `name` should be shown, given the filter in force.
+    ///
+    /// **Filters never hide directories.** A filter is the application saying
+    /// what it can open, not what the user may navigate through; hiding a
+    /// folder because it does not match `*.png` would make the files that do
+    /// match unreachable.
+    pub fn shows(&self, name: &str, is_dir: bool) -> bool {
+        if is_dir || self.request.directory {
+            // Directory mode still lists files — greyed, so the user can see
+            // where they are — so nothing is filtered out on that path either.
+            return true;
+        }
+        self.filter().matches(name)
+    }
+
+    /// Whether an entry may be returned to the application.
+    pub fn selectable(&self, name: &str, is_dir: bool) -> bool {
+        if self.request.directory {
+            return is_dir;
+        }
+        !is_dir && self.filter().matches(name)
+    }
+
+    /// Answer the request. Only the first call is delivered, so a
+    /// double-click that both accepts and closes cannot try to send two
+    /// outcomes down a one-shot channel.
+    pub fn resolve(&mut self, outcome: Outcome) {
+        if let Some(tx) = self.responder.take() {
+            let _ = tx.send(outcome);
+        }
+    }
+
+    /// Accept `paths`, recording the filter that was in force.
+    ///
+    /// The URIs come from otto-quickview's encoder, which lives beside the
+    /// decoder every consumer of them uses — the round trip is the property
+    /// that matters, and it is only testable with both halves together.
+    pub fn accept(&mut self, paths: &[PathBuf]) {
+        let outcome = Outcome {
+            response: 0,
+            uris: paths
+                .iter()
+                .map(|p| otto_quickview::uri::path_to_uri(p))
+                .collect(),
+            current_filter: self.filter().label.clone(),
+            choices: Vec::new(),
+        };
+        self.resolve(outcome);
+    }
+
+    pub fn answered(&self) -> bool {
+        self.responder.is_none()
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.resolve(Outcome::ended());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_lowercase_glob_also_matches_an_uppercase_extension() {
+        let f = Filter::from_wire(("Images".into(), vec![(0, "*.png".into())]));
+        assert!(f.matches("photo.png"));
+        assert!(f.matches("PHOTO.PNG"));
+        assert!(!f.matches("photo.jpg"));
+    }
+
+    #[test]
+    fn a_glob_carrying_case_is_matched_with_case() {
+        let f = Filter::from_wire(("Makefiles".into(), vec![(0, "Makefile".into())]));
+        assert!(f.matches("Makefile"));
+        assert!(!f.matches("makefile"));
+    }
+
+    #[test]
+    fn an_entry_passes_if_any_rule_matches() {
+        let f = Filter::from_wire((
+            "Images".into(),
+            vec![(0, "*.png".into()), (0, "*.jpg".into())],
+        ));
+        assert!(f.matches("a.png"));
+        assert!(f.matches("a.jpg"));
+        assert!(!f.matches("a.gif"));
+    }
+
+    #[test]
+    fn a_mime_rule_expands_to_the_globs_registered_for_it() {
+        let f = Filter::from_wire(("PNG".into(), vec![(1, "image/png".into())]));
+        assert!(!f.unresolved, "image/png should be in the shared MIME db");
+        assert!(f.matches("photo.png"));
+        assert!(!f.matches("photo.txt"));
+    }
+
+    #[test]
+    fn a_mime_rule_with_no_registered_glob_matches_nothing_and_says_so() {
+        let f = Filter::from_wire((
+            "Nonsense".into(),
+            vec![(1, "application/x-otto-not-a-real-type".into())],
+        ));
+        assert!(f.unresolved);
+        assert!(!f.matches("anything.at.all"));
+    }
+
+    #[test]
+    fn inode_directory_is_a_directory_rule_not_a_name_pattern() {
+        let f = Filter::from_wire(("Folders".into(), vec![(1, "inode/directory".into())]));
+        assert!(f.matches_directories);
+        assert!(f.globs.is_empty());
+    }
+
+    #[test]
+    fn all_files_matches_everything_including_dotfiles() {
+        let f = Filter::all_files();
+        assert!(f.matches("photo.png"));
+        assert!(f.matches(".bashrc"));
+    }
+}

--- a/components/otto-files/src/quickview.rs
+++ b/components/otto-files/src/quickview.rs
@@ -1,0 +1,376 @@
+//! Quick View, embedded — the Space-bar preview.
+//!
+//! Quick View used to be a separate application reached over `org.otto.QuickView1`.
+//! It is now a library this window embeds, because the preview wants to be a
+//! subsurface of the file view and a subsurface's parent must be a `wl_surface`
+//! owned by the same client: "parented to the browser" and "separate process"
+//! are mutually exclusive. Being parented also dissolves the anchor problem —
+//! the row's rect is already in this surface's coordinates — and hands
+//! stacking, focus and dismissal to this window instead of leaving them to be
+//! managed by hand.
+//!
+//! What is still a separate process is the *decoder*. Untrusted bytes are
+//! parsed by a sandboxed worker that is this binary re-executed, which is why
+//! `main` must call [`otto_quickview::run_worker_if_requested`] before anything
+//! else. This module never interprets file bytes; it receives a validated
+//! [`Preview`] and draws it.
+
+use std::path::Path;
+use std::time::Instant;
+
+use otto_kit::preview::{Preview, Zoom};
+use otto_quickview::decode::Request;
+use otto_quickview::opening;
+use skia_safe::Rect;
+
+/// The title strip along the top of the panel: the file's name, and the
+/// close button. The preview's content starts below it, so neither ever
+/// draws over the other.
+pub const TITLEBAR_H: f32 = 30.0;
+
+/// The panel's share of the window, and the least it may shrink to. A preview
+/// that filled the window would stop reading as something laid over the file
+/// list; one that scaled without a floor would be useless in a small window.
+pub const PANEL_FRACTION: f32 = 0.72;
+pub const PANEL_MIN: (f32, f32) = (420.0, 320.0);
+
+/// An open preview.
+pub struct Session {
+    pub preview: Preview,
+    /// The file's own name, shown in the panel's title strip. The preview
+    /// itself does not carry one — a decoded image knows nothing about where
+    /// it came from — so the host puts it here when it opens the session.
+    pub name: String,
+    /// Scroll offset into a listing or a text preview. The host owns it, as it
+    /// owns every other piece of interaction state.
+    pub first_row: usize,
+    /// How far an image preview is zoomed in, and how far it has been dragged
+    /// about while it is. Lives here rather than in the toolkit for the same
+    /// reason `first_row` does: the drawing half is canvas-pure and holds no
+    /// interaction state. Reset by construction — a session is built afresh
+    /// for every file, so changing file or closing the panel puts the picture
+    /// back to fit without anything having to remember to.
+    pub zoom: Zoom,
+    /// The row this grew out of, in surface-local coordinates. Empty means
+    /// "open in place" — a row scrolled out of view, or a panned-away Miller
+    /// column.
+    pub anchor: Rect,
+    /// When the entrance started.
+    pub opened_at: Instant,
+    /// When the exit started, once it has. A closing session is no longer the
+    /// window's open preview — it is only still on screen, going home.
+    pub closing: Option<Instant>,
+}
+
+impl Session {
+    /// How far into the entrance the panel is, 0 → 1.
+    pub fn entrance_t(&self) -> f32 {
+        let elapsed = self.opened_at.elapsed().as_secs_f32();
+        (elapsed / opening::geometry_in().as_secs_f32()).clamp(0.0, 1.0)
+    }
+
+    /// How far into the exit the panel is, 0 → 1. Always 0 while open.
+    pub fn exit_t(&self) -> f32 {
+        let Some(started) = self.closing else {
+            return 0.0;
+        };
+        (started.elapsed().as_secs_f32() / opening::geometry_out().as_secs_f32()).clamp(0.0, 1.0)
+    }
+
+    /// Whether this session still has frames to run — arriving, or leaving.
+    pub fn animating(&self) -> bool {
+        match self.closing {
+            Some(_) => self.exit_t() < 1.0,
+            None => self.entrance_t() < 1.0,
+        }
+    }
+
+    /// Where the panel is now: partway in, at rest, or partway back to the
+    /// item it came from.
+    pub fn panel(&self, resting: Rect) -> Rect {
+        match self.closing {
+            Some(_) => exit_at(self.anchor, resting, self.exit_t()),
+            None => entrance_at(self.anchor, resting, self.entrance_t()),
+        }
+    }
+
+    /// Scroll a listing or a text preview by `rows`, stopping at both ends.
+    ///
+    /// Images and cards do not scroll: they are laid out to fit, so there is
+    /// nothing under the fold to reach. A zoomed image *does* have something
+    /// under the fold, but that is a pan rather than a scroll — see
+    /// [`Session::pan_by`], which the host reaches for first.
+    pub fn scroll_by(&mut self, rows: i32, panel: Rect) {
+        let total = match &self.preview {
+            Preview::Text { lines, .. } => lines.len(),
+            Preview::Rows { rows, .. } => rows.len(),
+            _ => return,
+        };
+        let visible =
+            otto_kit::preview::layout(panel, &self.preview, self.first_row, self.zoom).visible_rows;
+        let max = total.saturating_sub(visible);
+        let next = self.first_row as i64 + rows as i64;
+        self.first_row = next.clamp(0, max as i64) as usize;
+    }
+
+    /// Whether a two-finger gesture over `panel` should move the picture
+    /// rather than scroll the content.
+    ///
+    /// False for everything but an image, and false for an image at fit: one
+    /// that fills no more than its box has nothing to pan to, so the gesture
+    /// must go on meaning exactly what it meant before there was a zoom.
+    /// Asked against the panel's content rect because a zoom clamped for one
+    /// box is not clamped for another — resizing the window can leave a
+    /// stored zoom with no slack left.
+    pub fn pannable(&self, panel: Rect) -> bool {
+        !otto_kit::preview::clamp_zoom(panel, &self.preview, self.zoom).is_fit()
+    }
+
+    /// Drag a zoomed image by `dx`, `dy` in the panel's own pixels, stopping
+    /// where its edge reaches the edge of the content box.
+    ///
+    /// Returns whether anything moved, so a host that repaints on demand does
+    /// not repaint for a gesture that was already against the stop.
+    pub fn pan_by(&mut self, dx: f32, dy: f32, panel: Rect) -> bool {
+        let asked = Zoom {
+            scale: self.zoom.scale,
+            offset: (self.zoom.offset.0 + dx, self.zoom.offset.1 + dy),
+        };
+        let next = otto_kit::preview::clamp_zoom(panel, &self.preview, asked);
+        let moved = next != self.zoom;
+        self.zoom = next;
+        moved
+    }
+
+    /// Zoom an image to `scale` about `focus`, a point in the same
+    /// coordinates as `panel`.
+    ///
+    /// Returns whether anything moved. The clamping — the range, the snap
+    /// back to fit and the pan limits — all happens in the toolkit, so the
+    /// panel and the file picker cannot end up with different ideas of how
+    /// far a picture zooms.
+    pub fn zoom_to(&mut self, scale: f32, focus: (f32, f32), panel: Rect) -> bool {
+        let next = otto_kit::preview::zoom_about(panel, &self.preview, self.zoom, scale, focus);
+        let moved = next != self.zoom;
+        self.zoom = next;
+        moved
+    }
+}
+
+/// Where the panel rests, centred in a window of `width` × `height`.
+pub fn panel_rect(width: f32, height: f32) -> Rect {
+    let w = (width * PANEL_FRACTION).max(PANEL_MIN.0).min(width - 32.0);
+    let h = (height * PANEL_FRACTION)
+        .max(PANEL_MIN.1)
+        .min(height - 32.0);
+    Rect::from_xywh(
+        (width - w) / 2.0,
+        (height - h) / 2.0,
+        w.max(1.0),
+        h.max(1.0),
+    )
+}
+
+/// Room around the panel in its own surface. The card has no shadow to spill
+/// past its edge any more — only the antialiasing on its border — so this is
+/// a single point, and the surface is the card.
+pub const SURFACE_MARGIN: f32 = 1.0;
+
+/// The panel's rect partway through the entrance.
+///
+/// Runs the same curve `opening` describes, in this process rather than through
+/// a compositor transaction — the panel is drawn into this window's own
+/// surface, so there is no separate surface for the compositor to transform.
+pub fn entrance_at(anchor: Rect, resting: Rect, t: f32) -> Rect {
+    let rect = opening::sample(to_opening(anchor), to_opening(resting), t);
+    Rect::from_xywh(rect.x, rect.y, rect.width, rect.height)
+}
+
+/// The reverse: the panel on its way back to the item it grew out of.
+pub fn exit_at(anchor: Rect, resting: Rect, t: f32) -> Rect {
+    let rect = opening::sample_out(to_opening(anchor), to_opening(resting), t);
+    Rect::from_xywh(rect.x, rect.y, rect.width, rect.height)
+}
+
+fn to_opening(rect: Rect) -> opening::Rect {
+    if rect.is_empty() {
+        return opening::Rect::new(0.0, 0.0, 0.0, 0.0);
+    }
+    opening::Rect::new(rect.left, rect.top, rect.width(), rect.height())
+}
+
+/// Decode one file. **Blocks** until the sandboxed worker answers or its
+/// deadline expires, so it must never be called on the UI thread.
+///
+/// `panel` is the resting rect in logical pixels and `scale` the output's
+/// scale; the worker is asked for roughly twice that, so a scaled decode still
+/// has detail to show when the panel is looked at closely.
+pub fn decode(path: &Path, panel: Rect, scale: f32) -> Preview {
+    let request = Request {
+        width: ((panel.width() * scale * 2.0) as u32).clamp(64, 4096),
+        height: ((panel.height() * scale * 2.0) as u32).clamp(64, 4096),
+        name: path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        ..Request::default()
+    };
+    otto_quickview::decode_path(path, &request)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use otto_kit::preview::Pixels;
+
+    /// A session on a picture wide and tall enough that it is scaled *down*
+    /// to fit any panel these tests use, so the fit rect fills one axis of
+    /// the content box exactly and the zoom arithmetic has something to bite
+    /// on.
+    fn image_session(width: u32, height: u32) -> Session {
+        Session {
+            preview: Preview::Pixels {
+                pixels: Pixels {
+                    width,
+                    height,
+                    intrinsic_width: width,
+                    intrinsic_height: height,
+                    data: vec![0; (width * height * 4) as usize],
+                },
+                pages: 1,
+                page: 1,
+            },
+            name: "photo.png".into(),
+            first_row: 0,
+            zoom: Zoom::FIT,
+            anchor: Rect::new_empty(),
+            opened_at: Instant::now(),
+            closing: None,
+        }
+    }
+
+    fn text_session() -> Session {
+        Session {
+            preview: Preview::Text {
+                lines: (0..200).map(|n| format!("line {n}")).collect(),
+                truncated: false,
+                language: String::new(),
+            },
+            name: "notes.txt".into(),
+            first_row: 0,
+            zoom: Zoom::FIT,
+            anchor: Rect::new_empty(),
+            opened_at: Instant::now(),
+            closing: None,
+        }
+    }
+
+    /// The content box of a panel resting in a window of a comfortable size.
+    fn content() -> Rect {
+        crate::view::quickview_content_rect(panel_rect(1100.0, 700.0))
+    }
+
+    #[test]
+    fn a_pinch_zooms_between_fit_and_the_maximum() {
+        let content = content();
+        let mut session = image_session(2000, 1500);
+        let centre = (content.center_x(), content.center_y());
+
+        session.zoom_to(200.0, centre, content);
+        assert_eq!(session.zoom.scale, Zoom::MAX);
+
+        // Pinching back out lands on fit exactly, rather than a hair above it.
+        session.zoom_to(1.005, centre, content);
+        assert!(session.zoom.is_fit(), "{:?}", session.zoom);
+    }
+
+    /// A picture no larger than its box has nothing to pan to, so a
+    /// two-finger scroll over one must go on meaning what it always meant.
+    #[test]
+    fn a_fitted_image_does_not_pan() {
+        let content = content();
+        let mut session = image_session(2000, 1500);
+        assert!(!session.pannable(content));
+        assert!(!session.pan_by(-120.0, -90.0, content));
+        assert_eq!(session.zoom, Zoom::FIT);
+    }
+
+    /// Zoomed in, panning stops with the picture still covering the box —
+    /// it can never be dragged off the panel and left showing nothing.
+    #[test]
+    fn a_zoomed_image_pans_but_cannot_be_dragged_off_the_panel() {
+        let content = content();
+        let mut session = image_session(2000, 1500);
+        session.zoom_to(3.0, (content.center_x(), content.center_y()), content);
+        assert!(session.pannable(content));
+        assert!(session.pan_by(-40.0, -30.0, content));
+
+        // Far past any stop, in both directions, and the picture still
+        // reaches both edges of the box it is looked at through.
+        session.pan_by(-100_000.0, -100_000.0, content);
+        let drawn = otto_kit::preview::layout(content, &session.preview, 0, session.zoom).content;
+        let inner = otto_kit::preview::layout(content, &session.preview, 0, Zoom::FIT).inner;
+        assert!(drawn.right >= inner.right, "{drawn:?} {inner:?}");
+        assert!(drawn.bottom >= inner.bottom, "{drawn:?} {inner:?}");
+        assert!(drawn.left <= inner.left, "{drawn:?} {inner:?}");
+    }
+
+    /// Zoom is an image affordance. A text preview keeps scrolling, and a
+    /// pinch over one changes nothing.
+    #[test]
+    fn text_previews_scroll_and_do_not_zoom() {
+        let content = content();
+        let mut session = text_session();
+        session.zoom_to(4.0, (content.center_x(), content.center_y()), content);
+        assert!(session.zoom.is_fit());
+        assert!(!session.pannable(content));
+
+        session.scroll_by(5, content);
+        assert_eq!(session.first_row, 5);
+    }
+
+    #[test]
+    fn the_panel_is_centred_and_inside_the_window() {
+        let panel = panel_rect(1100.0, 700.0);
+        assert!(panel.left > 0.0 && panel.right < 1100.0, "{panel:?}");
+        assert!((panel.center_x() - 550.0).abs() < 0.5, "{panel:?}");
+        assert!((panel.center_y() - 350.0).abs() < 0.5, "{panel:?}");
+    }
+
+    #[test]
+    fn a_small_window_still_gets_a_panel_with_area() {
+        let panel = panel_rect(320.0, 240.0);
+        assert!(panel.width() > 0.0 && panel.height() > 0.0, "{panel:?}");
+    }
+
+    /// The entrance starts at the row and ends at the resting rect — the whole
+    /// point of carrying the anchor.
+    #[test]
+    fn the_panel_grows_out_of_the_row() {
+        let resting = panel_rect(1100.0, 700.0);
+        let row = Rect::from_xywh(240.0, 180.0, 260.0, 24.0);
+
+        let start = entrance_at(row, resting, 0.0);
+        assert!(start.width() < resting.width() / 2.0, "{start:?}");
+        // Near the row it came from, not the middle of the window.
+        assert!((start.center_x() - row.center_x()).abs() < 1.0, "{start:?}");
+
+        let end = entrance_at(row, resting, 1.0);
+        assert!((end.width() - resting.width()).abs() < 1.0, "{end:?}");
+    }
+
+    /// A row scrolled out of view has no anchor; the panel swells in place
+    /// rather than growing out of nowhere.
+    #[test]
+    fn no_anchor_opens_in_place() {
+        let resting = panel_rect(1100.0, 700.0);
+        let start = entrance_at(Rect::new_empty(), resting, 0.0);
+        assert!(
+            (start.center_x() - resting.center_x()).abs() < 1.0,
+            "{start:?}"
+        );
+        assert!(start.width() < resting.width(), "{start:?}");
+        assert!(start.width() > resting.width() * 0.9, "{start:?}");
+    }
+}

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -1,0 +1,726 @@
+//! otto-files' panels as a `lay-rs` scene.
+//!
+//! The browser used to be one canvas: every frame replayed the sidebar, the
+//! header, every visible row of every Miller column and the preview, because
+//! immediate mode has no way to say "this part did not change". Hovering a
+//! traffic light re-recorded the file listing; a one-pixel scroll re-recorded
+//! the sidebar. It also meant [`Entry::icon_chain`] — a MIME lookup and a
+//! `Vec<String>` — ran per row per frame.
+//!
+//! Here the panels are *layers* instead. Their backgrounds are a style the
+//! engine composites (`set_background_color`), not a rect this client paints,
+//! and their content is a picture the engine caches until something that
+//! actually feeds it changes. What "actually feeds it" means is [`PaneKey`]:
+//! rebuild the closure when the key moves, replay the cached picture when it
+//! does not.
+//!
+//! The window's own background is a style too, but one the *compositor* holds
+//! — see `FilesApp::on_app_ready`. It has to be, because a client cannot blur
+//! what is behind itself.
+//!
+//! What is still immediate-mode, drawn over this scene by [`crate::view::draw`]:
+//! the sidebar's places, the header's title and buttons, and the list and grid
+//! views. Those are bounded and cheap; the Miller stack was neither.
+
+use layers::prelude::*;
+use layers::types::{Color as LayerColor, Point as LayerPoint, Size as LayerSize};
+use otto_kit::icons;
+use otto_kit::prelude::*;
+use otto_kit::theme::Theme;
+use otto_kit::typography::styles;
+use skia_safe::{Canvas, Color, Image, Paint, Point, Rect};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::model::Entry;
+use crate::view::{self, Frame, PaneData, RunEnds, ViewMode};
+
+/// Colours that reach the engine as a style rather than a paint.
+fn paint_color(color: Color) -> PaintColor {
+    PaintColor::Solid {
+        color: LayerColor::new_rgba255(color.r(), color.g(), color.b(), color.a()),
+    }
+}
+
+/// The scene's structural panels, plus one layer per Miller column.
+pub struct Scene {
+    engine: std::sync::Arc<Engine>,
+    /// The surface's own root node, handed over by otto-kit. Everything here
+    /// hangs off it, so it is drawn into this window's canvas and no other.
+    root: Layer,
+    sidebar: Layer,
+    header: Layer,
+    /// The picker's action row. Hidden in the browser, which has none.
+    footer: Layer,
+    /// The paper the file area sits on. Clips, so a column panned past the
+    /// window edge is cut off by the engine rather than by a `clip_rect` this
+    /// client has to remember to balance.
+    content: Layer,
+    /// Pooled: a column that goes away is hidden, not destroyed, because the
+    /// next navigation almost always wants it straight back.
+    panes: Vec<PaneLayer>,
+    preview: Layer,
+    preview_key: Option<u64>,
+
+    /// What the panels were last laid out against, so a frame that changed
+    /// nothing geometric does not touch the engine at all.
+    layout: Option<LayoutKey>,
+    dark: Option<bool>,
+}
+
+/// One Miller column: the pane itself, and the strip of rows inside it that
+/// the scroll offset moves.
+struct PaneLayer {
+    pane: Layer,
+    /// Separated from `pane` so that scrolling is a *position* change. Within
+    /// one row's pitch that is all a scroll is, and the engine replays the
+    /// cached picture at the new offset without this client recording a thing.
+    rows: Layer,
+    key: Option<PaneKey>,
+}
+
+#[derive(PartialEq)]
+struct LayoutKey {
+    width: u32,
+    height: u32,
+    mode: ViewMode,
+    pan: i32,
+    miller_w: u32,
+    panes: usize,
+    preview: bool,
+    footer: u32,
+}
+
+/// Everything one column's rows are drawn from, reduced to something cheap to
+/// compare. The entries themselves are hashed rather than cloned: a listing
+/// that has not changed hashes the same, and hashing thirty visible rows costs
+/// far less than the re-record it avoids.
+#[derive(PartialEq)]
+struct PaneKey {
+    /// Which rows are on screen. Scrolling past a row boundary changes this
+    /// and costs one column a re-record; scrolling within a row does not.
+    range: (usize, usize),
+    entries: u64,
+    /// Selection, cursor, cut marks and an in-place rename, over the visible
+    /// rows only.
+    marks: u64,
+    active: bool,
+    status: Status,
+    size: (u32, u32),
+    dark: bool,
+}
+
+#[derive(PartialEq, Clone)]
+enum Status {
+    Rows,
+    Loading,
+    Empty,
+    Error(String),
+}
+
+impl Scene {
+    /// `root` is the window surface's layer node — see
+    /// `BaseWaylandSurface::new`, which builds one per surface and positions
+    /// it absolutely so each surface's scene draws at its own origin.
+    pub fn new(root: Layer) -> Self {
+        let engine = root.engine.clone();
+
+        let new_layer = |key: &str| {
+            let layer = engine.new_layer();
+            layer.set_key(key);
+            layer.set_layout_style(taffy::Style {
+                position: taffy::style::Position::Absolute,
+                ..Default::default()
+            });
+            layer
+        };
+
+        let sidebar = new_layer("files-sidebar");
+        let header = new_layer("files-header");
+        let footer = new_layer("files-footer");
+        let content = new_layer("files-content");
+        let preview = new_layer("files-preview");
+
+        // Header last: it overlaps nothing, but it is the panel drawn over the
+        // top of the content area's ground and the order records that.
+        let _ = root.add_sublayer(&sidebar);
+        let _ = root.add_sublayer(&content);
+        let _ = root.add_sublayer(&header);
+        let _ = root.add_sublayer(&footer);
+        let _ = content.add_sublayer(&preview);
+
+        // `clip_children`, not just `clip_content`: what has to be cut off at
+        // the content area's edge is the *columns*, which are children of it.
+        // A column panned half past the sidebar is then clipped by the engine
+        // rather than by a `clip_rect` this client has to balance by hand.
+        content.set_clip_content(true, None);
+        content.set_clip_children(true, None);
+        preview.set_picture_cached(true);
+
+        Self {
+            engine,
+            root,
+            sidebar,
+            header,
+            footer,
+            content,
+            panes: Vec::new(),
+            preview,
+            preview_key: None,
+            layout: None,
+            dark: None,
+        }
+    }
+
+    /// Draw the scene into the window's canvas.
+    ///
+    /// The same thing `BaseWaylandSurface::render_layer_node` does, done here
+    /// so the caller does not have to reach back through the surface for a
+    /// node this already holds.
+    pub fn render(&self, canvas: &Canvas) {
+        draw_scene(canvas, self.engine.scene(), self.root.id());
+    }
+
+    /// Bring the scene up to date with `f`, ahead of the frame being drawn.
+    ///
+    /// Every step here is gated on its own key, so the common frame — a hover
+    /// somewhere, a repaint after a frame callback — reaches the engine with
+    /// no changes at all and the whole window is replayed from cached
+    /// pictures.
+    pub fn update(&mut self, f: &Frame) {
+        self.sync_materials(f.theme);
+        self.sync_layout(f);
+        self.sync_panes(f);
+        // One tick, so the changes above are folded into the scene before the
+        // host renders it. Nothing here animates, so the delta is zero.
+        self.engine.update(0.0);
+    }
+
+    /// Panel materials. These are the backgrounds the panes "should not draw":
+    /// they are set once per colour-scheme change and composited by the
+    /// engine, not painted per frame.
+    fn sync_materials(&mut self, theme: &Theme) {
+        let dark = view::is_dark();
+        if self.dark == Some(dark) {
+            return;
+        }
+        self.dark = Some(dark);
+
+        self.sidebar
+            .set_background_color(paint_color(theme.material_sidebar), None);
+        self.header
+            .set_background_color(paint_color(view::header_material()), None);
+        // The action row is the same material as the header, and for the same
+        // reason: it is chrome laid over the window's blur, not a hole in it.
+        // Without a ground it reads as bare blur with buttons floating on it.
+        self.footer
+            .set_background_color(paint_color(view::header_material()), None);
+        self.content
+            .set_background_color(paint_color(view::content_ground()), None);
+        self.preview
+            .set_background_color(paint_color(view::content_ground()), None);
+    }
+
+    fn sync_layout(&mut self, f: &Frame) {
+        let key = LayoutKey {
+            width: f.width.to_bits(),
+            height: f.height.to_bits(),
+            mode: f.mode,
+            pan: f.pan.to_bits() as i32,
+            miller_w: f.miller_w.to_bits(),
+            panes: f.panes.len(),
+            preview: f.preview.is_some(),
+            footer: f.footer.to_bits(),
+        };
+        if self.layout.as_ref() == Some(&key) {
+            return;
+        }
+        self.layout = Some(key);
+
+        let sidebar_w = view::SIDEBAR_W;
+        let header_h = view::HEADER_H;
+
+        // The full *window* height, not the file area's: the sidebar is one
+        // column of material running from the titlebar to the bottom edge,
+        // and stopping it at the content's bottom leaves the picker's
+        // bottom-left corner unpainted beside the action row.
+        place(&self.sidebar, 0.0, 0.0, sidebar_w, f.height + f.footer);
+        place(
+            &self.header,
+            sidebar_w,
+            0.0,
+            (f.width - sidebar_w).max(0.0),
+            header_h,
+        );
+        place(
+            &self.content,
+            sidebar_w,
+            header_h,
+            (f.width - sidebar_w).max(0.0),
+            (f.height - header_h).max(0.0),
+        );
+        // `f.height` is the file area's bottom, so the row starts exactly
+        // where the content ends. Beside the sidebar rather than over it, the
+        // way the header is — the sidebar is one column of material running
+        // the full height of the window.
+        if f.footer > 0.0 {
+            self.footer.set_hidden(false);
+            place(
+                &self.footer,
+                sidebar_w,
+                f.height,
+                (f.width - sidebar_w).max(0.0),
+                f.footer,
+            );
+        } else {
+            self.footer.set_hidden(true);
+        }
+    }
+
+    /// Create, place and hide column layers to match the current stack.
+    ///
+    /// Only Miller view has columns; the list and grid draw into the content
+    /// area directly, so their panes are simply all hidden.
+    fn sync_panes(&mut self, f: &Frame) {
+        // With the columns in their own subsurfaces they are painted there and
+        // composited over this scene; drawing them here too would double them.
+        let miller = f.mode == ViewMode::Columns && !crate::pane_surfaces::enabled();
+        let wanted = if miller { f.panes.len() } else { 0 };
+
+        while self.panes.len() < wanted {
+            let pane = self.engine.new_layer();
+            pane.set_key("files-pane");
+            pane.set_layout_style(taffy::Style {
+                position: taffy::style::Position::Absolute,
+                ..Default::default()
+            });
+            // Likewise the rows strip, which is a child the scroll offset
+            // moves: without this a scrolled column would paint over the one
+            // below the header.
+            pane.set_clip_content(true, None);
+            pane.set_clip_children(true, None);
+
+            let rows = self.engine.new_layer();
+            rows.set_key("files-pane-rows");
+            rows.set_layout_style(taffy::Style {
+                position: taffy::style::Position::Absolute,
+                ..Default::default()
+            });
+            rows.set_picture_cached(true);
+            // The strip is the one layer here that is stable in content and
+            // moves constantly, which is exactly what an offscreen cache is
+            // for: a frame of scrolling becomes a blit of the recorded band
+            // instead of a replay of every row's display list.
+            //
+            // **Off by default, because lay-rs rasterises it at the wrong
+            // resolution.** `create_surface_for_node` sizes the offscreen
+            // from `surface_size_for_render_layer`, which is the layer's
+            // bounds in *points*, with no device scale applied — and the
+            // image is then drawn back onto a render canvas that already
+            // carries the HiDPI transform. On a 2x display every cached row
+            // is therefore a 2x upscale, and the column text is visibly
+            // soft next to the sidebar and the list view, which draw
+            // straight to the canvas. It is invisible at 1x, which is why it
+            // survived.
+            //
+            // `picture_cached` above is unaffected — a display list is
+            // replayed at the canvas's own resolution, not resampled — so
+            // what is lost here is blit-instead-of-replay, not the far
+            // larger win of not re-recording the rows at all.
+            //
+            // `OTTO_FILES_ROWCACHE=1` turns it back on, for testing a lay-rs
+            // that has been fixed.
+            rows.set_image_cached(std::env::var_os("OTTO_FILES_ROWCACHE").is_some());
+
+            let _ = pane.add_sublayer(&rows);
+            // Before the preview, which is the trailing member of the stack.
+            let _ = self.content.add_sublayer(&pane);
+            self.panes.push(PaneLayer {
+                pane,
+                rows,
+                key: None,
+            });
+        }
+
+        for (depth, slot) in self.panes.iter_mut().enumerate() {
+            if depth >= wanted {
+                slot.pane.set_hidden(true);
+                continue;
+            }
+            slot.pane.set_hidden(false);
+            slot.sync(depth, f);
+        }
+
+        self.sync_preview(f);
+    }
+
+    fn sync_preview(&mut self, f: &Frame) {
+        let Some(data) = f.preview.as_ref() else {
+            self.preview.set_hidden(true);
+            self.preview_key = None;
+            return;
+        };
+        if f.mode != ViewMode::Columns {
+            self.preview.set_hidden(true);
+            return;
+        }
+        self.preview.set_hidden(false);
+
+        // The preview's rect comes from the same stack geometry the columns
+        // use, translated into the content area's own coordinates.
+        let full = view::preview_pane_rect(f.panes.len(), f.height, f.pan, f.miller_w);
+        place_in_content(&self.preview, full, f.height);
+
+        let key = hash_of(&(
+            data.name,
+            data.first_row,
+            data.decoded.is_some(),
+            view::is_dark(),
+            full.width().to_bits(),
+            full.height().to_bits(),
+        ));
+        if self.preview_key == Some(key) {
+            return;
+        }
+        self.preview_key = Some(key);
+
+        let content = view::preview_content(data, f.theme.clone());
+        self.preview
+            .set_draw_content(move |canvas: &Canvas, w: f32, h: f32| {
+                content(canvas, w, h);
+                Rect::from_wh(w, h)
+            });
+    }
+}
+
+impl PaneLayer {
+    fn sync(&mut self, depth: usize, f: &Frame) {
+        let pane = &f.panes[depth];
+        let full = view::miller_pane_rect(depth, f.height, f.pan, f.miller_w);
+        place_in_content(&self.pane, full, f.height);
+
+        // The active column is a shade off the ground — as a style, so which
+        // column has the keyboard costs a colour change and not a repaint.
+        let active = depth == f.active;
+        self.pane.set_background_color(
+            paint_color(if active {
+                f.theme.fill_quaternary
+            } else {
+                Color::TRANSPARENT
+            }),
+            None,
+        );
+
+        let status = if let Some(error) = pane.error {
+            Status::Error(error.to_string())
+        } else if pane.loading {
+            Status::Loading
+        } else if pane.entries.is_empty() {
+            Status::Empty
+        } else {
+            Status::Rows
+        };
+
+        // Record a few rows past each edge of the viewport. The strip's own
+        // key is what triggers a re-record, and the key holds `range` — so
+        // without any margin the band is left, and re-recorded, on every row
+        // boundary the scroll crosses. A margin turns that into once every
+        // `OVERSCAN_ROWS`, at the cost of carrying that many extra rows in
+        // the cached image.
+        const OVERSCAN_ROWS: usize = 8;
+        let visible = view::miller_visible_range(f, depth);
+        let range = (
+            visible.0.saturating_sub(OVERSCAN_ROWS),
+            (visible.1 + OVERSCAN_ROWS).min(pane.entries.len()),
+        );
+        let inset = view::MILLER_ROW_INSET;
+
+        // The strip covers the *visible band*, not the whole listing.
+        //
+        // Sizing it to the listing is the obvious thing and it is wrong: a
+        // directory of five hundred entries makes a twelve-thousand-pixel
+        // layer, and moving that layer once per scroll frame damages its whole
+        // bounds however little of it the pane shows. The picture stays cheap
+        // — Skia replays only what was recorded — but the compositor is handed
+        // a full-screen damage rect every frame, which is what spins the fans.
+        //
+        // So the strip holds only the rows in `range` and is positioned so
+        // that row `range.0` lands where it belongs. Scrolling within a row's
+        // pitch moves the strip and nothing more; crossing a row boundary
+        // changes `range`, which moves the key below and re-records the band.
+        //
+        // A column with no rows to show — loading, empty, or failed — has no
+        // band at all, so the strip takes the pane's own box instead and its
+        // one line of text is centred in that.
+        let rows_shown = status == Status::Rows;
+        let (strip_h, strip_y) = if rows_shown {
+            (
+                range.1.saturating_sub(range.0) as f32 * view::ROW_H,
+                inset + range.0 as f32 * view::ROW_H - pane.scroll,
+            )
+        } else {
+            (full.height(), 0.0)
+        };
+        self.rows
+            .set_size(LayerSize::points(full.width(), strip_h), None);
+        self.rows.set_position(LayerPoint::new(0.0, strip_y), None);
+
+        let key = PaneKey {
+            range,
+            entries: hash_entries(&pane.entries, range),
+            marks: hash_marks(pane, range, f, depth),
+            active,
+            status: status.clone(),
+            size: (full.width().to_bits(), strip_h.to_bits()),
+            dark: view::is_dark(),
+        };
+        if self.key.as_ref() == Some(&key) {
+            return;
+        }
+        self.key = Some(key);
+
+        let theme = f.theme.clone();
+        match status {
+            Status::Rows => {
+                let rows = build_rows(pane, range, f, depth);
+                self.rows
+                    .set_draw_content(move |canvas: &Canvas, w: f32, h: f32| {
+                        for row in &rows {
+                            row.draw(canvas, &theme, w);
+                        }
+                        Rect::from_wh(w, h)
+                    });
+            }
+            Status::Loading | Status::Empty | Status::Error(_) => {
+                let (text, color) = match &status {
+                    Status::Error(error) => (error.clone(), theme.text_secondary),
+                    Status::Loading => ("Loading…".to_string(), theme.text_tertiary),
+                    _ => ("Empty".to_string(), theme.text_tertiary),
+                };
+                // The strip is the pane's own box in this state, so centring on
+                // it is centring on the column.
+                self.rows
+                    .set_draw_content(move |canvas: &Canvas, w: f32, h: f32| {
+                        Label::new(&text)
+                            .with_style(styles::BODY)
+                            .with_color(color)
+                            .centered_at(w / 2.0, h / 2.0)
+                            .render(canvas);
+                        Rect::from_wh(w, h)
+                    });
+            }
+        }
+    }
+}
+
+/// Paint one Miller column's rows into a canvas whose origin is the column's
+/// own top-left corner, with the scroll offset already applied.
+///
+/// The same drawing [`PaneLayer::sync`] records into the rows strip, but aimed
+/// at whatever canvas the caller has — used by [`crate::pane_surfaces`] to
+/// paint a column into its own subsurface instead of into the window.
+pub(crate) fn paint_column(canvas: &Canvas, f: &Frame, depth: usize, width: f32) {
+    let pane = &f.panes[depth];
+    canvas.clear(paint_to_color(view::content_ground()));
+    if pane.error.is_some() || pane.loading || pane.entries.is_empty() {
+        return;
+    }
+    let range = view::miller_visible_range(f, depth);
+    let rows = build_rows(pane, range, f, depth);
+    canvas.save();
+    canvas.translate((
+        0.0,
+        view::MILLER_ROW_INSET + range.0 as f32 * view::ROW_H - pane.scroll,
+    ));
+    for row in &rows {
+        row.draw(canvas, f.theme, width);
+    }
+    canvas.restore();
+}
+
+fn paint_to_color(color: Color) -> Color {
+    color
+}
+
+/// One row, with everything it draws already resolved — the icon decoded, the
+/// name measured and ellipsized, the colours chosen. This is the work that
+/// used to happen per row per frame.
+struct Row {
+    /// Top edge in the strip's own coordinates.
+    top: f32,
+    name: String,
+    icon: Option<Image>,
+    is_dir: bool,
+    selected: bool,
+    ends: RunEnds,
+    cursor: bool,
+    cut: bool,
+    /// Suppressed while the host's text field is over this row.
+    renaming: bool,
+    text_color: Color,
+    detail_color: Color,
+    selection_color: Color,
+}
+
+impl Row {
+    fn draw(&self, canvas: &Canvas, theme: &Theme, width: f32) {
+        let rect = Rect::from_ltrb(0.0, self.top, width, self.top + view::ROW_H);
+
+        if self.selected {
+            view::draw_selection_run(canvas, rect, self.selection_color, 6.0, self.ends);
+        } else if self.cursor {
+            view::draw_cursor_ring(canvas, theme, rect, 6.0);
+        }
+
+        if let Some(image) = &self.icon {
+            let mut paint = Paint::default();
+            if self.cut {
+                paint.set_alpha(110);
+            }
+            canvas.draw_image_rect(
+                image,
+                None,
+                Rect::from_xywh(
+                    14.0,
+                    rect.center_y() - view::ICON_SIZE / 2.0,
+                    view::ICON_SIZE,
+                    view::ICON_SIZE,
+                ),
+                &paint,
+            );
+        }
+
+        if !self.renaming {
+            Label::new(&self.name)
+                .with_style(styles::BODY_MEDIUM)
+                .with_color(self.text_color)
+                .centered_on(14.0 + view::ICON_SIZE + 8.0, rect.center_y())
+                .render(canvas);
+        }
+
+        if self.is_dir {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_color(self.detail_color);
+            paint.set_stroke_width(1.4);
+            paint.set_style(skia_safe::paint::Style::Stroke);
+            paint.set_stroke_cap(skia_safe::paint::Cap::Round);
+            let x = width - 18.0;
+            let cy = rect.center_y();
+            let mut builder = skia_safe::PathBuilder::new();
+            builder.move_to(Point::new(x, cy - 3.5));
+            builder.line_to(Point::new(x + 3.5, cy));
+            builder.line_to(Point::new(x, cy + 3.5));
+            canvas.draw_path(&builder.detach(), &paint);
+        }
+    }
+}
+
+fn build_rows(pane: &PaneData<'_>, range: (usize, usize), f: &Frame, depth: usize) -> Vec<Row> {
+    let width = f.miller_w;
+    let font = styles::BODY_MEDIUM.font();
+    let active = depth == f.active;
+
+    (range.0..range.1)
+        .map(|index| {
+            let entry = pane.entries[index];
+            let selected = pane.is_selected(index);
+            let cut = f.cut.contains(&entry.path);
+            let highlighted = selected && active;
+            let (text_color, detail_color) = view::row_colors(f.theme, highlighted);
+
+            let chain = entry.icon_chain();
+            let refs: Vec<&str> = chain.iter().map(String::as_str).collect();
+            let icon =
+                icons::cached_icon_chain_at(&refs, view::ICON_SIZE as i32, icons::FULL_COLOUR_SIZE);
+
+            let name_x = 14.0 + view::ICON_SIZE + 8.0;
+            let trailing = if entry.is_dir { 24.0 } else { 8.0 };
+            let name = view::ellipsize(&font, &entry.name, width - trailing - name_x);
+
+            Row {
+                // Relative to the band, which is what the strip layer holds:
+                // the strip's own position carries `range.0` and the scroll.
+                top: (index - range.0) as f32 * view::ROW_H,
+                name,
+                icon,
+                is_dir: entry.is_dir,
+                selected,
+                ends: RunEnds::of_pane(pane, index),
+                cursor: active && pane.cursor == Some(index) && !selected,
+                cut,
+                renaming: f.renaming == Some((depth, index)),
+                text_color: if cut {
+                    view::dim_color(text_color)
+                } else {
+                    text_color
+                },
+                detail_color,
+                selection_color: if active {
+                    f.theme.material_selection_focused
+                } else {
+                    f.theme.fill_quaternary
+                },
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Keys
+// ---------------------------------------------------------------------------
+
+fn hash_of<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Identity of the visible rows. Names and kinds are what is drawn, so they
+/// are what has to be watched; a listing reordered or refreshed under the same
+/// names draws the same picture.
+fn hash_entries(entries: &[&Entry], range: (usize, usize)) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for entry in &entries[range.0.min(entries.len())..range.1.min(entries.len())] {
+        entry.name.hash(&mut hasher);
+        entry.is_dir.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn hash_marks(pane: &PaneData<'_>, range: (usize, usize), f: &Frame, depth: usize) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    // One past the range at each end: a selection run's rounding depends on
+    // whether its neighbour is selected, so a row just off screen changes what
+    // the first visible one draws.
+    let lo = range.0.saturating_sub(1);
+    let hi = (range.1 + 1).min(pane.entries.len());
+    for index in lo..hi {
+        pane.is_selected(index).hash(&mut hasher);
+        f.cut.contains(&pane.entries[index].path).hash(&mut hasher);
+    }
+    pane.cursor.hash(&mut hasher);
+    f.renaming.map(|(d, i)| (d == depth, i)).hash(&mut hasher);
+    hasher.finish()
+}
+
+// ---------------------------------------------------------------------------
+// Placement
+// ---------------------------------------------------------------------------
+
+fn place(layer: &Layer, x: f32, y: f32, width: f32, height: f32) {
+    layer.set_position(LayerPoint::new(x, y), None);
+    layer.set_size(LayerSize::points(width, height), None);
+}
+
+/// Place a column, whose geometry [`crate::view`] computes in *window*
+/// coordinates, inside the content layer.
+fn place_in_content(layer: &Layer, full: Rect, window_h: f32) {
+    place(
+        layer,
+        full.left - view::SIDEBAR_W,
+        0.0,
+        full.width(),
+        (window_h - view::HEADER_H).max(0.0),
+    );
+}

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -1,0 +1,3265 @@
+//! Window layout: full-height sidebar, a large header over the content, and
+//! the file area — either a list or Miller columns.
+//!
+//! Geometry lives in the `*_rect` / `*_at` helpers so drawing and hit-testing
+//! read the same numbers — the otto-kit convention. Nothing here holds state.
+
+use otto_kit::components::icon::Icon;
+use otto_kit::components::scroll::{ScrollRenderer, ScrollState};
+use otto_kit::components::titlebar::{WindowControl, WindowControls, WindowControlsState};
+use otto_kit::icons;
+use otto_kit::prelude::*;
+use skia_safe::{ClipOp, Contains, Font, Paint, PathBuilder, Point, RRect};
+
+use crate::model::{self, Column, Entry, Place, SortKey};
+
+/// The size the window asks for on first map; after that the compositor is in
+/// charge and everything draws against the configured size.
+pub const WINDOW_W: f32 = 1100.0;
+pub const WINDOW_H: f32 = 700.0;
+pub const MIN_W: f32 = 640.0;
+pub const MIN_H: f32 = 400.0;
+pub const CORNER: f32 = 12.0;
+
+/// Full-height sidebar, like Finder's — the header sits beside it, not above.
+pub const SIDEBAR_W: f32 = 232.0;
+/// The preview pane's width — a Miller column of its own, sitting right
+/// after the last real one and panned into view exactly the way a freshly
+/// opened directory column is, rather than docked outside the stack.
+pub const PREVIEW_W: f32 = 280.0;
+/// The "big header": tall enough for a large title with a subtitle under it,
+/// which is what makes the window read as a document rather than a dialog.
+pub const HEADER_H: f32 = 92.0;
+
+/// The picker's action row along the bottom: filter control on the left,
+/// Cancel and the accept button on the right. Zero in the browser, which has
+/// no footer at all — see [`Frame::footer`].
+pub const FOOTER_H: f32 = 60.0;
+/// Column-name strip, list view only.
+pub const COLUMNS_H: f32 = 28.0;
+
+/// Rows are tight and abut with no gap, in every view: a listing is scanned
+/// rather than read, and the fewer pixels between one name and the next, the
+/// more of the directory the eye takes in at once.
+pub const ROW_H: f32 = 24.0;
+const CONTENT_PAD: f32 = 20.0;
+pub const ICON_SIZE: f32 = 18.0;
+const CONTROLS_INSET: f32 = 18.0;
+/// Optical centres of the header's two text lines, within `HEADER_H`.
+const TITLE_CY: f32 = 40.0;
+const SUBTITLE_CY: f32 = 66.0;
+/// The back/forward pair sits to the left of the title as one split button:
+/// a single rounded capsule the width of both halves, divided by a hairline.
+const NAV_BTN_W: f32 = 30.0;
+const NAV_BTN_H: f32 = 26.0;
+const NAV_GROUP_W: f32 = NAV_BTN_W * 2.0;
+const NAV_RADIUS: f32 = 7.0;
+const NAV_ICON_SIZE: f32 = 13.0;
+/// How far the title's own text starts right of the sidebar, once the nav
+/// pair and its trailing gap are accounted for.
+const TITLE_X: f32 = SIDEBAR_W + CONTENT_PAD + NAV_GROUP_W + 10.0;
+
+/// The picker toolbar's single row, optically centred in the header the way
+/// the browser's two text lines are.
+pub const TOOLBAR_CY: f32 = 52.0;
+/// The location control's width. Wide enough for a deep directory name and
+/// narrow enough to leave the switcher its corner.
+const LOCATION_W: f32 = 260.0;
+
+/// The picker's location control, centred on the toolbar row.
+pub fn location_rect(width: f32) -> Rect {
+    let left = ((width - SIDEBAR_W - LOCATION_W) / 2.0 + SIDEBAR_W)
+        .max(SIDEBAR_W + CONTENT_PAD + NAV_GROUP_W + 16.0);
+    Rect::from_ltrb(
+        left,
+        TOOLBAR_CY - 15.0,
+        left + LOCATION_W,
+        TOOLBAR_CY + 15.0,
+    )
+}
+/// One Miller pane's default width. Every pane shares one width — a column
+/// whose width changes as you descend is disorienting, and this is what makes
+/// the view scannable — but that shared width is user-resizable.
+pub const MILLER_W: f32 = 260.0;
+/// Miller panes cannot be dragged narrower than this.
+pub const MILLER_MIN_W: f32 = 140.0;
+pub const MILLER_MAX_W: f32 = 520.0;
+
+/// How close the pointer must be to a column boundary to grab it.
+const COLUMN_GRAB: f32 = 4.0;
+/// Column widths cannot be dragged below this — thinner and a header label
+/// no longer fits.
+pub const COLUMN_MIN_W: f32 = 48.0;
+
+/// The list view's Size/Kind/Modified column widths — Name is not stored: it
+/// is whatever is left between the sidebar and wherever Size starts, so it
+/// grows and shrinks with the window the way Finder's does.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ListColumnWidths {
+    pub size: f32,
+    pub kind: f32,
+    pub modified: f32,
+}
+
+impl Default for ListColumnWidths {
+    fn default() -> Self {
+        Self {
+            size: 90.0,
+            kind: 110.0,
+            modified: 150.0,
+        }
+    }
+}
+
+/// Which divider between two list-view columns the pointer is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnBoundary {
+    /// Between Name and Size — dragging it resizes Size (Name absorbs the
+    /// rest, being unstored).
+    Size,
+    /// Between Size and Kind — dragging it resizes Kind (Size keeps its own
+    /// width and slides with the boundary; Name absorbs the difference).
+    Kind,
+    /// Between Kind and Modified — dragging it resizes Modified the same way.
+    Modified,
+}
+/// Gap between a Miller pane's top edge and its first row, so the row does not
+/// touch the header hairline.
+pub const MILLER_ROW_INSET: f32 = 8.0;
+
+/// Icon grid metrics. Kept together and public because this geometry is the
+/// reusable part: a desktop surface lays out the same cells against its own
+/// rect, with no file-manager chrome around them.
+pub const CELL_W: f32 = 112.0;
+pub const CELL_H: f32 = 120.0;
+pub const GRID_ICON: f32 = 64.0;
+const GRID_PAD: f32 = 14.0;
+/// Space between the bottom of the icon and the optical centre of the
+/// caption's first line. Tuned so the icon's selection rectangle and the
+/// caption's pill meet edge to edge: they read as one highlight, without
+/// either overlapping the other.
+const GRID_LABEL_GAP: f32 = 14.0;
+/// Baseline-to-baseline distance between the caption's two lines.
+const GRID_LABEL_LINE: f32 = 16.0;
+/// Padding above and below the caption inside its selection pill. The pill is
+/// built out from the line centres, so the text sits optically centred in it.
+const GRID_LABEL_INSET: f32 = 10.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    List,
+    Columns,
+    Grid,
+}
+
+// ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+/// The file area: right of the sidebar, below the header (and the column strip
+/// in list view).
+pub fn content_viewport(width: f32, height: f32, mode: ViewMode) -> Rect {
+    let top = match mode {
+        ViewMode::List => HEADER_H + COLUMNS_H,
+        ViewMode::Columns | ViewMode::Grid => HEADER_H,
+    };
+    Rect::from_ltrb(SIDEBAR_W, top, width, height)
+}
+
+// --- Icon grid geometry -----------------------------------------------------
+//
+// These four functions know nothing about the browser: give them an area and a
+// cell index and they answer where it goes. That is what makes the grid
+// reusable for a desktop surface, which has the same cells and none of the
+// chrome. They are the shape `icon_grid` takes when it moves into otto-kit.
+
+/// How many cells fit across `area`. Never zero, so a very narrow window
+/// degrades to one column rather than dividing by it.
+pub fn grid_columns(area: Rect) -> usize {
+    (((area.width() - GRID_PAD) / CELL_W).floor() as usize).max(1)
+}
+
+/// The cell rect for `index`, in `area`, scrolled by `scroll`.
+pub fn grid_cell_rect(area: Rect, index: usize, scroll: f32) -> Rect {
+    let cols = grid_columns(area);
+    let (row, col) = (index / cols, index % cols);
+    Rect::from_xywh(
+        area.left + GRID_PAD + col as f32 * CELL_W,
+        area.top + GRID_PAD + row as f32 * CELL_H - scroll,
+        CELL_W,
+        CELL_H,
+    )
+}
+
+/// The cell index under `(x, y)`, if any.
+pub fn grid_cell_at(area: Rect, x: f32, y: f32, count: usize, scroll: f32) -> Option<usize> {
+    if !area.contains(Point::new(x, y)) {
+        return None;
+    }
+    let cols = grid_columns(area);
+    let local_x = x - area.left - GRID_PAD;
+    let local_y = y - area.top - GRID_PAD + scroll;
+    if local_x < 0.0 || local_y < 0.0 {
+        return None;
+    }
+    let col = (local_x / CELL_W) as usize;
+    let row = (local_y / CELL_H) as usize;
+    if col >= cols {
+        return None;
+    }
+    let index = row * cols + col;
+    (index < count).then_some(index)
+}
+
+/// The cells that intersect `band` — the visible strip of the grid, in the
+/// same window coordinates [`grid_cell_rect`] places cells in.
+///
+/// Widened to whole rows of cells, so the answer is one contiguous range a
+/// caller can walk without testing each cell again. As with [`RowStrip`], only
+/// the vertical extent is compared: every column of the grid is on screen
+/// whenever any of them is.
+pub fn grid_visible_range(
+    area: Rect,
+    count: usize,
+    scroll: f32,
+    band: Rect,
+) -> std::ops::Range<usize> {
+    if count == 0 || band.is_empty() {
+        return 0..0;
+    }
+    let cols = grid_columns(area);
+    let top = area.top + GRID_PAD - scroll;
+    let first_row = ((band.top - top) / CELL_H).floor().max(0.0) as usize;
+    let last_row = ((band.bottom - top) / CELL_H).floor().min(count as f32);
+    if last_row < 0.0 {
+        return 0..0;
+    }
+    let first = (first_row * cols).min(count);
+    let end = ((last_row as usize + 1) * cols).min(count);
+    first..end.max(first)
+}
+
+/// Total height `count` cells need in `area`.
+pub fn grid_content_height(area: Rect, count: usize) -> f32 {
+    let cols = grid_columns(area);
+    let rows = count.div_ceil(cols);
+    rows as f32 * CELL_H + GRID_PAD * 2.0
+}
+
+pub fn place_rect(index: usize) -> Rect {
+    const FIRST_Y: f32 = 78.0;
+    const STEP: f32 = 30.0;
+    Rect::from_xywh(10.0, FIRST_Y + index as f32 * STEP, SIDEBAR_W - 20.0, 26.0)
+}
+
+pub fn place_at(x: f32, y: f32, count: usize) -> Option<usize> {
+    (0..count).find(|i| place_rect(*i).contains(Point::new(x, y)))
+}
+
+/// The split button holding both arrows, before the title.
+pub fn nav_group_rect() -> Rect {
+    Rect::from_xywh(
+        SIDEBAR_W + CONTENT_PAD,
+        TITLE_CY - NAV_BTN_H / 2.0,
+        NAV_GROUP_W,
+        NAV_BTN_H,
+    )
+}
+
+/// The Back half of the split button.
+pub fn nav_back_rect() -> Rect {
+    let group = nav_group_rect();
+    Rect::from_xywh(group.left, group.top, NAV_BTN_W, group.height())
+}
+
+/// The Forward half of the split button.
+pub fn nav_forward_rect() -> Rect {
+    let group = nav_group_rect();
+    Rect::from_xywh(group.left + NAV_BTN_W, group.top, NAV_BTN_W, group.height())
+}
+
+/// Which nav arrow, if either, sits under `(x, y)`.
+pub fn nav_button_at(x: f32, y: f32) -> Option<NavButton> {
+    let p = Point::new(x, y);
+    if nav_back_rect().contains(p) {
+        Some(NavButton::Back)
+    } else if nav_forward_rect().contains(p) {
+        Some(NavButton::Forward)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavButton {
+    Back,
+    Forward,
+}
+
+/// The three view-switcher segments, in the header's top right.
+pub fn switcher_rect(width: f32) -> Rect {
+    Rect::from_xywh(width - CONTENT_PAD - 114.0, 24.0, 114.0, 26.0)
+}
+
+pub const SWITCHER_MODES: [ViewMode; 3] = [ViewMode::List, ViewMode::Grid, ViewMode::Columns];
+
+/// Which view the switcher segment at `(x, y)` selects, if any.
+pub fn switcher_at(x: f32, y: f32, width: f32) -> Option<ViewMode> {
+    let rect = switcher_rect(width);
+    if !rect.contains(Point::new(x, y)) {
+        return None;
+    }
+    let segment = ((x - rect.left) / (rect.width() / 3.0)) as usize;
+    SWITCHER_MODES.get(segment.min(2)).copied()
+}
+
+pub(crate) fn column_edges(width: f32, widths: ListColumnWidths) -> (f32, f32, f32) {
+    let content_w = width - SIDEBAR_W;
+    let modified_x = width - CONTENT_PAD - widths.modified;
+    let kind_x = modified_x - widths.kind;
+    let size_x = kind_x - widths.size;
+    let min_name = SIDEBAR_W + CONTENT_PAD + 120.0;
+    if size_x < min_name {
+        let spread = (content_w - 140.0).max(90.0) / 3.0;
+        let base = SIDEBAR_W + CONTENT_PAD + 120.0;
+        (base, base + spread, base + spread * 2.0)
+    } else {
+        (size_x, kind_x, modified_x)
+    }
+}
+
+/// The divider the pointer is over, in the column-name strip — `None` once
+/// the layout has fallen back to the narrow-window spread (those edges are
+/// not draggable, since they are not real column widths).
+pub fn column_boundary_at(
+    x: f32,
+    y: f32,
+    width: f32,
+    widths: ListColumnWidths,
+) -> Option<ColumnBoundary> {
+    if !(HEADER_H..=HEADER_H + COLUMNS_H).contains(&y) || x < SIDEBAR_W {
+        return None;
+    }
+    let (size_x, kind_x, modified_x) = column_edges(width, widths);
+    let modified_x_stored = width - CONTENT_PAD - widths.modified;
+    if (modified_x - modified_x_stored).abs() > 0.5 {
+        // The narrow-window fallback spread is active — those edges are not
+        // real column widths, so there is nothing to drag.
+        return None;
+    }
+    for (edge, boundary) in [
+        (size_x, ColumnBoundary::Size),
+        (kind_x, ColumnBoundary::Kind),
+        (modified_x, ColumnBoundary::Modified),
+    ] {
+        if (x - edge).abs() <= COLUMN_GRAB {
+            return Some(boundary);
+        }
+    }
+    None
+}
+
+/// The Name column's left edge, in list-view row coordinates — where the
+/// text starts, past the icon.
+pub(crate) fn name_text_x() -> f32 {
+    SIDEBAR_W + CONTENT_PAD + ICON_SIZE + 10.0
+}
+
+/// The `size` width that makes the Name column exactly wide enough for
+/// `longest_name` (measured in points), for a double-click on the Name/Size
+/// divider — Finder's "fit to content" gesture.
+pub fn fit_size_column(width: f32, widths: ListColumnWidths, longest_name: f32) -> f32 {
+    let kind_x = width - CONTENT_PAD - widths.modified - widths.kind;
+    let desired_size_x = name_text_x() + longest_name + 12.0;
+    let max_w = (kind_x - SIDEBAR_W - CONTENT_PAD).max(COLUMN_MIN_W);
+    (kind_x - desired_size_x).clamp(COLUMN_MIN_W, max_w)
+}
+
+/// Where an in-place rename's text field sits over row `index` of the list —
+/// the same span the name label would otherwise occupy.
+pub fn list_rename_rect(
+    width: f32,
+    list_columns: ListColumnWidths,
+    count: usize,
+    scroll: f32,
+    index: usize,
+) -> Rect {
+    let row = RowStrip::list(width, count, scroll).rect(index);
+    let (size_x, ..) = column_edges(width, list_columns);
+    let name_x = name_text_x();
+    Rect::from_ltrb(name_x - 4.0, row.top + 3.0, size_x - 8.0, row.bottom - 3.0)
+}
+
+/// Where an in-place rename's text field sits over row `index` of Miller
+/// pane `depth` — the same span the name label would otherwise occupy.
+pub fn miller_rename_rect(
+    height: f32,
+    pan: f32,
+    miller_w: f32,
+    depth: usize,
+    count: usize,
+    scroll: f32,
+    index: usize,
+    is_dir: bool,
+) -> Rect {
+    let pane = miller_pane_rect(depth, height, pan, miller_w);
+    let row = RowStrip::miller(pane, count, scroll).rect(index);
+    let name_x = row.left + 14.0 + ICON_SIZE + 8.0;
+    let trailing = if is_dir { 24.0 } else { 8.0 };
+    Rect::from_ltrb(
+        name_x - 4.0,
+        row.top + 3.0,
+        row.right - trailing,
+        row.bottom - 3.0,
+    )
+}
+
+/// Where an in-place rename's text field sits over grid cell `index` — over
+/// the caption, sized like the selection pill it replaces so the cell does not
+/// visibly change shape when the field appears.
+pub fn grid_rename_rect(width: f32, height: f32, scroll: f32, index: usize) -> Rect {
+    let area = content_viewport(width, height, ViewMode::Grid);
+    let cell = grid_cell_rect(area, index, scroll);
+    let center_y = cell.top + 8.0 + GRID_ICON + GRID_LABEL_GAP;
+    Rect::from_ltrb(
+        cell.left + 2.0,
+        center_y - GRID_LABEL_INSET - 2.0,
+        cell.right - 2.0,
+        center_y + GRID_LABEL_LINE + GRID_LABEL_INSET + 2.0,
+    )
+}
+
+/// A pane's rows, as a uniform-pitch strip in window coordinates with the
+/// pane's scroll already subtracted.
+///
+/// Every consumer of row geometry is derived from this one description — the
+/// render walk, the hit test, the keyboard's idea of where a row is, and the
+/// Quick View anchor — so what is painted and what is clickable cannot drift
+/// apart. Because the pitch is fixed the walk is closed-form rather than a
+/// fold over the entries, which is what lets a directory of ten thousand
+/// files cost a frame no more than one of ten.
+#[derive(Debug, Clone, Copy)]
+pub struct RowStrip {
+    /// Top of row 0, scroll already applied.
+    top: f32,
+    left: f32,
+    width: f32,
+    count: usize,
+}
+
+impl RowStrip {
+    /// The list view's single strip: full content width, flush under the
+    /// column-name band.
+    pub fn list(width: f32, count: usize, scroll: f32) -> Self {
+        Self {
+            top: HEADER_H + COLUMNS_H - scroll,
+            left: SIDEBAR_W,
+            width: width - SIDEBAR_W,
+            count,
+        }
+    }
+
+    /// One Miller pane's strip. Rows start a little way down the pane so the
+    /// first one does not touch the header hairline.
+    fn miller(pane: Rect, count: usize, scroll: f32) -> Self {
+        Self {
+            top: pane.top + MILLER_ROW_INSET - scroll,
+            left: pane.left,
+            width: pane.width(),
+            count,
+        }
+    }
+
+    pub fn rect(&self, index: usize) -> Rect {
+        Rect::from_xywh(
+            self.left,
+            self.top + index as f32 * ROW_H,
+            self.width,
+            ROW_H,
+        )
+    }
+
+    /// The row `y` falls on, if any. Rows above the strip and past its last
+    /// entry are both misses.
+    pub fn index_at(&self, y: f32) -> Option<usize> {
+        let local = y - self.top;
+        if local < 0.0 {
+            return None;
+        }
+        let index = (local / ROW_H) as usize;
+        (index < self.count).then_some(index)
+    }
+
+    /// The rows that intersect `band` — the visible band of the pane, in the
+    /// same window coordinates the rows are placed in.
+    ///
+    /// Only the vertical extent is compared: a row always spans its pane's
+    /// full width, so a horizontal test would reject nothing while risking
+    /// rejecting something (a chevron, a date column) that reaches past the
+    /// nominal edge. The comparison is inclusive at both ends so a row
+    /// resting exactly on an edge survives, along with the stripe or hairline
+    /// it contributes there.
+    ///
+    /// An empty band — a Miller pane panned off screen — yields no rows at
+    /// all, which is the whole point: that pane costs nothing.
+    pub fn visible(&self, band: Rect) -> std::ops::Range<usize> {
+        if self.count == 0 || band.is_empty() {
+            return 0..0;
+        }
+        let first = (((band.top - self.top) / ROW_H).floor().max(0.0) as usize).min(self.count);
+        // Clamped before the cast: a band far past the end of a short strip
+        // would otherwise turn into an index no `usize` can hold.
+        let last = ((band.bottom - self.top) / ROW_H)
+            .floor()
+            .min(self.count as f32);
+        if last < 0.0 {
+            return 0..0;
+        }
+        let end = (last as usize + 1).min(self.count);
+        first..end.max(first)
+    }
+}
+
+/// The entry index under `(x, y)` in list view.
+pub fn row_at(x: f32, y: f32, width: f32, height: f32, count: usize, scroll: f32) -> Option<usize> {
+    if !content_viewport(width, height, ViewMode::List).contains(Point::new(x, y)) {
+        return None;
+    }
+    RowStrip::list(width, count, scroll).index_at(y)
+}
+
+/// The untruncated pane rect, for laying rows out — drawing clips it, but a row
+/// must not shift because its pane is half off-screen.
+pub fn miller_pane_rect(depth: usize, height: f32, pan: f32, miller_w: f32) -> Rect {
+    let left = SIDEBAR_W + depth as f32 * miller_w - pan;
+    Rect::from_ltrb(left, HEADER_H, left + miller_w, height)
+}
+
+/// The preview pane's untruncated rect — a trailing member of the stack, one
+/// `miller_w`-wide slot past the last real column, but its own [`PREVIEW_W`]
+/// wide rather than sharing the columns' width.
+pub fn preview_pane_rect(columns_len: usize, height: f32, pan: f32, miller_w: f32) -> Rect {
+    let left = SIDEBAR_W + columns_len as f32 * miller_w - pan;
+    Rect::from_ltrb(left, HEADER_H, left + PREVIEW_W, height)
+}
+
+/// Which pane and row is under `(x, y)` in Miller view.
+pub fn miller_at(
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    columns: &[Column],
+    counts: &[usize],
+    pan: f32,
+    miller_w: f32,
+) -> Option<(usize, Option<usize>)> {
+    if !content_viewport(width, height, ViewMode::Columns).contains(Point::new(x, y)) {
+        return None;
+    }
+    for depth in 0..columns.len() {
+        let pane = miller_pane_rect(depth, height, pan, miller_w);
+        if x < pane.left || x >= pane.right {
+            continue;
+        }
+        let strip = RowStrip::miller(pane, counts[depth], columns[depth].scroll.offset());
+        return Some((depth, strip.index_at(y)));
+    }
+    None
+}
+
+/// How far the stack must be panned to bring the pane spanning
+/// `[left, left + pane_w)` fully into a `width`-wide viewport.
+fn pan_for(left: f32, pane_w: f32, width: f32, current: f32) -> f32 {
+    let visible = width - SIDEBAR_W;
+    let right = left + pane_w;
+    if right - current > visible {
+        (right - visible).max(0.0)
+    } else if left < current {
+        left
+    } else {
+        current
+    }
+}
+
+/// How far the Miller stack must be panned to keep pane `depth` in view.
+pub fn miller_pan_for(depth: usize, width: f32, current: f32, miller_w: f32) -> f32 {
+    pan_for(depth as f32 * miller_w, miller_w, width, current)
+}
+
+/// How far the stack must be panned to bring the preview pane — sitting
+/// right after the last of `columns_len` real columns — fully into view.
+/// The same gesture [`miller_pan_for`] performs for a freshly opened column.
+pub fn preview_pan_for(columns_len: usize, width: f32, current: f32, miller_w: f32) -> f32 {
+    pan_for(columns_len as f32 * miller_w, PREVIEW_W, width, current)
+}
+
+/// Total width the whole stack wants: every real column, plus the preview
+/// pane's own width when one is showing.
+pub fn miller_content_width(depth: usize, miller_w: f32, preview_w: f32) -> f32 {
+    depth as f32 * miller_w + preview_w
+}
+
+/// Is the pointer on the draggable edge between two Miller panes? All panes
+/// share one width, so any divider found resizes them all — dragging one
+/// divider is dragging the width. Returns the depth of the pane whose right
+/// edge was grabbed: since that edge sits `(depth + 1) * miller_w` from the
+/// sidebar, the caller needs it to turn pointer travel back into a width
+/// delta that tracks the mouse exactly, however deep the divider is.
+pub fn miller_boundary_at(
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    pan: f32,
+    pane_count: usize,
+    miller_w: f32,
+) -> Option<usize> {
+    if !(HEADER_H..=height).contains(&y) || x < SIDEBAR_W {
+        return None;
+    }
+    let viewport_right = width;
+    (0..pane_count).find(|&depth| {
+        let pane = miller_pane_rect(depth, height, pan, miller_w);
+        pane.right >= SIDEBAR_W
+            && pane.right <= viewport_right
+            && (x - pane.right).abs() <= COLUMN_GRAB
+    })
+}
+
+pub fn column_at(x: f32, y: f32, width: f32, widths: ListColumnWidths) -> Option<SortKey> {
+    if !(HEADER_H..=HEADER_H + COLUMNS_H).contains(&y) || x < SIDEBAR_W {
+        return None;
+    }
+    let (size_x, kind_x, modified_x) = column_edges(width, widths);
+    Some(if x >= modified_x {
+        SortKey::Modified
+    } else if x >= kind_x {
+        SortKey::Kind
+    } else if x >= size_x {
+        SortKey::Size
+    } else {
+        SortKey::Name
+    })
+}
+
+pub fn content_height(count: usize) -> f32 {
+    count as f32 * ROW_H
+}
+
+/// The scrolling viewport of one pane, whichever view is on.
+///
+/// In list and grid views there is one pane and it is the whole content area;
+/// in Miller view each column scrolls on its own, so each gets its own strip.
+/// This is what a pane's [`ScrollView`](otto_kit::components::scroll::ScrollView)
+/// is given as its viewport, so the scrollbar lands on the right edge of the
+/// pane the pointer is actually over.
+pub fn pane_viewport(
+    width: f32,
+    height: f32,
+    mode: ViewMode,
+    depth: usize,
+    pan: f32,
+    miller_w: f32,
+) -> Rect {
+    match mode {
+        ViewMode::List | ViewMode::Grid => content_viewport(width, height, mode),
+        ViewMode::Columns => {
+            let mut pane = miller_pane_rect(depth, height, pan, miller_w);
+            // Clipped to what is actually on screen: a pane panned half out of
+            // the window must not put its scrollbar under the sidebar.
+            if !pane.intersect(content_viewport(width, height, mode)) {
+                return Rect::new_empty();
+            }
+            pane
+        }
+    }
+}
+
+/// Which of a Miller column's rows are on screen — the half-open range the
+/// scene records a picture for.
+///
+/// The same band [`draw_miller`] used to walk, lifted out so the scene can key
+/// its cached picture on it: cross a row boundary and the column re-records,
+/// scroll within one and it does not.
+pub fn miller_visible_range(f: &Frame, depth: usize) -> (usize, usize) {
+    let pane = &f.panes[depth];
+    let full = miller_pane_rect(depth, f.height, f.pan, f.miller_w);
+    let strip = RowStrip::miller(full, pane.entries.len(), pane.scroll);
+    let band = pane.band(pane_viewport(
+        f.width,
+        f.height,
+        ViewMode::Columns,
+        depth,
+        f.pan,
+        f.miller_w,
+    ));
+    let range = strip.visible(band);
+    (range.start, range.end)
+}
+
+// ---------------------------------------------------------------------------
+// The picker's action row
+// ---------------------------------------------------------------------------
+//
+// Geometry first, drawing second, and the hit test reads the same rects the
+// paint does — the shape every other control in this file takes.
+
+const FOOTER_PAD: f32 = 20.0;
+const FOOTER_BTN_H: f32 = 30.0;
+const FOOTER_BTN_MIN_W: f32 = 92.0;
+const FOOTER_BTN_RADIUS: f32 = 8.0;
+const FOOTER_FILTER_W: f32 = 220.0;
+/// One row of the open filter menu.
+const FOOTER_MENU_ROW_H: f32 = 26.0;
+
+/// The action row's own strip, below the file area.
+pub fn footer_rect(width: f32, window_height: f32) -> Rect {
+    Rect::from_ltrb(0.0, window_height - FOOTER_H, width, window_height)
+}
+
+/// The accept button, hard against the right edge.
+pub fn footer_accept_rect(width: f32, window_height: f32) -> Rect {
+    let cy = window_height - FOOTER_H / 2.0;
+    Rect::from_ltrb(
+        width - FOOTER_PAD - FOOTER_BTN_MIN_W,
+        cy - FOOTER_BTN_H / 2.0,
+        width - FOOTER_PAD,
+        cy + FOOTER_BTN_H / 2.0,
+    )
+}
+
+/// Cancel, to the accept button's left.
+pub fn footer_cancel_rect(width: f32, window_height: f32) -> Rect {
+    let accept = footer_accept_rect(width, window_height);
+    Rect::from_ltrb(
+        accept.left - 10.0 - FOOTER_BTN_MIN_W,
+        accept.top,
+        accept.left - 10.0,
+        accept.bottom,
+    )
+}
+
+/// The filter control, on the left where the sidebar ends.
+pub fn footer_filter_rect(window_height: f32) -> Rect {
+    let cy = window_height - FOOTER_H / 2.0;
+    Rect::from_ltrb(
+        SIDEBAR_W + FOOTER_PAD,
+        cy - FOOTER_BTN_H / 2.0,
+        SIDEBAR_W + FOOTER_PAD + FOOTER_FILTER_W,
+        cy + FOOTER_BTN_H / 2.0,
+    )
+}
+
+/// One row of the filter menu, which opens *upwards* out of the control —
+/// there is nothing below the action row to open into.
+pub fn footer_filter_option_rect(window_height: f32, index: usize, count: usize) -> Rect {
+    let control = footer_filter_rect(window_height);
+    let height = count as f32 * FOOTER_MENU_ROW_H + 8.0;
+    let top = control.top - 6.0 - height + 4.0 + index as f32 * FOOTER_MENU_ROW_H;
+    Rect::from_ltrb(control.left, top, control.right, top + FOOTER_MENU_ROW_H)
+}
+
+/// What the action row has under `(x, y)`, if anything.
+///
+/// `window_height` is the whole window, not the file area. Takes the two
+/// facts it needs rather than a [`FooterData`], so a caller can hit-test
+/// without holding a borrow of the state it is about to mutate.
+pub fn footer_at(
+    x: f32,
+    y: f32,
+    width: f32,
+    window_height: f32,
+    filter_count: usize,
+    filter_open: bool,
+) -> Option<FooterButton> {
+    let point = Point::new(x, y);
+
+    // The open menu floats above the row and takes the pointer first,
+    // exactly as a context menu would.
+    if filter_open {
+        for index in 0..filter_count {
+            if footer_filter_option_rect(window_height, index, filter_count).contains(point) {
+                return Some(FooterButton::FilterOption(index));
+            }
+        }
+    }
+    if footer_accept_rect(width, window_height).contains(point) {
+        return Some(FooterButton::Accept);
+    }
+    if footer_cancel_rect(width, window_height).contains(point) {
+        return Some(FooterButton::Cancel);
+    }
+    if filter_count > 0 && footer_filter_rect(window_height).contains(point) {
+        return Some(FooterButton::Filter);
+    }
+    None
+}
+
+fn draw_footer(canvas: &Canvas, f: &Frame) {
+    let Some(footer) = &f.action_row else {
+        return;
+    };
+    let theme = f.theme;
+    let window_h = f.height + f.footer;
+
+    // A hairline, not a filled strip: the row sits on the same material the
+    // rest of the window does, and only needs separating from the listing.
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(theme.fill_tertiary);
+    paint.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(0.0, window_h - FOOTER_H),
+        Point::new(f.width, window_h - FOOTER_H),
+        &paint,
+    );
+
+    if !footer.filters.is_empty() {
+        draw_filter_control(canvas, f, footer, window_h);
+    }
+
+    draw_footer_button(
+        canvas,
+        footer_cancel_rect(f.width, window_h),
+        "Cancel",
+        theme.fill_secondary,
+        theme.text_primary,
+        footer.pressed == Some(FooterButton::Cancel),
+        true,
+    );
+    draw_footer_button(
+        canvas,
+        footer_accept_rect(f.width, window_h),
+        footer.accept_label,
+        accent(theme),
+        Color::WHITE,
+        footer.pressed == Some(FooterButton::Accept),
+        footer.accept_enabled,
+    );
+}
+
+/// The user's accent colour, or the theme's own selection tone when the
+/// desktop has not set one.
+fn accent(theme: &Theme) -> Color {
+    otto_kit::accent::current_accent().unwrap_or(theme.material_selection_focused)
+}
+
+fn draw_footer_button(
+    canvas: &Canvas,
+    rect: Rect,
+    label: &str,
+    background: Color,
+    text: Color,
+    pressed: bool,
+    enabled: bool,
+) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    // Disabled and pressed are both expressed as alpha, so a themed accent
+    // stays itself rather than being replaced by a grey that ignores the
+    // user's colour. The fill's *own* alpha is scaled, never replaced: the
+    // theme's secondary fill is 8% black, and forcing it opaque would draw a
+    // black slab where a barely-there button belongs.
+    let scale = match (enabled, pressed) {
+        (false, _) => 0.35,
+        (true, true) => 0.70,
+        (true, false) => 1.0,
+    };
+    paint.set_color(Color::from_argb(
+        (background.a() as f32 * scale) as u8,
+        background.r(),
+        background.g(),
+        background.b(),
+    ));
+    canvas.draw_rrect(
+        RRect::new_rect_xy(rect, FOOTER_BTN_RADIUS, FOOTER_BTN_RADIUS),
+        &paint,
+    );
+
+    Label::new(label)
+        .with_style(styles::BODY_EMPHASIZED)
+        .with_color(if enabled {
+            text
+        } else {
+            Color::from_argb(0x80, text.r(), text.g(), text.b())
+        })
+        .centered_at(rect.center_x(), rect.center_y())
+        .render(canvas);
+}
+
+fn draw_filter_control(canvas: &Canvas, f: &Frame, footer: &FooterData<'_>, window_h: f32) {
+    let theme = f.theme;
+    let rect = footer_filter_rect(window_h);
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(theme.fill_secondary);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(rect, FOOTER_BTN_RADIUS, FOOTER_BTN_RADIUS),
+        &paint,
+    );
+
+    let label = footer
+        .filters
+        .get(footer.current_filter)
+        .map(String::as_str)
+        .unwrap_or("All Files");
+    Label::new(label)
+        .with_style(styles::BODY)
+        .with_color(theme.text_primary)
+        .centered_on(rect.left + 12.0, rect.center_y())
+        .render(canvas);
+
+    // The disclosure chevron, pointing the way the menu opens.
+    let mut chevron = Paint::default();
+    chevron.set_anti_alias(true);
+    chevron.set_color(theme.text_secondary);
+    chevron.set_style(skia_safe::paint::Style::Stroke);
+    chevron.set_stroke_width(1.6);
+    chevron.set_stroke_cap(skia_safe::paint::Cap::Round);
+    let cx = rect.right - 14.0;
+    let cy = rect.center_y();
+    let mut path = skia_safe::PathBuilder::new();
+    path.move_to((cx - 4.0, cy + 2.0));
+    path.line_to((cx, cy - 2.5));
+    path.line_to((cx + 4.0, cy + 2.0));
+    canvas.draw_path(&path.detach(), &chevron);
+
+    if !footer.filter_open {
+        return;
+    }
+
+    let count = footer.filters.len();
+    let first = footer_filter_option_rect(window_h, 0, count);
+    let last = footer_filter_option_rect(window_h, count - 1, count);
+    let panel = Rect::from_ltrb(rect.left, first.top - 4.0, rect.right, last.bottom + 4.0);
+
+    let mut menu = Paint::default();
+    menu.set_anti_alias(true);
+    menu.set_color(theme.material_popup);
+    canvas.draw_rrect(RRect::new_rect_xy(panel, 8.0, 8.0), &menu);
+
+    for (index, name) in footer.filters.iter().enumerate() {
+        let row = footer_filter_option_rect(window_h, index, count);
+        let hovered = footer.hovered == Some(FooterButton::FilterOption(index));
+        if hovered {
+            let mut hl = Paint::default();
+            hl.set_anti_alias(true);
+            hl.set_color(accent(theme));
+            canvas.draw_rrect(
+                RRect::new_rect_xy(row.with_inset((4.0, 0.0)), 5.0, 5.0),
+                &hl,
+            );
+        }
+        Label::new(name.as_str())
+            .with_style(styles::BODY)
+            .with_color(if hovered {
+                Color::WHITE
+            } else {
+                theme.text_primary
+            })
+            .centered_on(row.left + 24.0, row.center_y())
+            .render(canvas);
+
+        if index == footer.current_filter {
+            let mut tick = Paint::default();
+            tick.set_anti_alias(true);
+            tick.set_color(if hovered {
+                Color::WHITE
+            } else {
+                theme.text_primary
+            });
+            tick.set_style(skia_safe::paint::Style::Stroke);
+            tick.set_stroke_width(1.8);
+            tick.set_stroke_cap(skia_safe::paint::Cap::Round);
+            let mx = row.left + 13.0;
+            let my = row.center_y();
+            let mut p = skia_safe::PathBuilder::new();
+            p.move_to((mx - 4.0, my));
+            p.line_to((mx - 1.0, my + 3.5));
+            p.line_to((mx + 4.5, my - 4.0));
+            canvas.draw_path(&p.detach(), &tick);
+        }
+    }
+}
+
+/// Whether the current colour scheme is the dark one — what the materials
+/// below switch on, and what the scene keys its styles on.
+pub fn is_dark() -> bool {
+    matches!(current_color_scheme(), ColorScheme::Dark)
+}
+
+/// How tall one pane's content is, for the same three views.
+pub fn pane_content_height(width: f32, height: f32, mode: ViewMode, count: usize) -> f32 {
+    match mode {
+        ViewMode::Grid => grid_content_height(content_viewport(width, height, mode), count),
+        // Miller rows start a little way down the pane; the list starts flush.
+        ViewMode::Columns => content_height(count) + MILLER_ROW_INSET,
+        ViewMode::List => content_height(count),
+    }
+}
+
+/// Where item `index` sits in its pane's content coordinates — its top and its
+/// height, before the pane's scroll offset is taken off. This is the half of
+/// the geometry a "scroll the cursor into view" needs; the other half is the
+/// pane's viewport height, from [`pane_viewport`].
+pub fn item_span(width: f32, height: f32, mode: ViewMode, index: usize) -> (f32, f32) {
+    match mode {
+        ViewMode::List => (index as f32 * ROW_H, ROW_H),
+        // Miller rows start a little way down the pane.
+        ViewMode::Columns => (MILLER_ROW_INSET + index as f32 * ROW_H, ROW_H),
+        ViewMode::Grid => {
+            let cols = grid_columns(content_viewport(width, height, mode));
+            (GRID_PAD + (index / cols) as f32 * CELL_H, CELL_H)
+        }
+    }
+}
+
+pub fn is_drag_area(x: f32, y: f32, width: f32) -> bool {
+    if y > HEADER_H || x > width {
+        return false;
+    }
+    if switcher_rect(width).contains(Point::new(x, y)) {
+        return false;
+    }
+    if nav_group_rect().contains(Point::new(x, y)) {
+        return false;
+    }
+    !Rect::from_xywh(CONTROLS_INSET - 4.0, CONTROLS_INSET - 4.0, 70.0, 20.0)
+        .contains(Point::new(x, y))
+}
+
+pub fn control_at(x: f32, y: f32) -> Option<WindowControl> {
+    const STEP: f32 = 20.0;
+    const R: f32 = 6.0;
+    for (i, control) in [
+        WindowControl::Close,
+        WindowControl::Minimize,
+        WindowControl::Zoom,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let cx = CONTROLS_INSET + R + i as f32 * STEP;
+        let cy = CONTROLS_INSET + R;
+        if (x - cx).powi(2) + (y - cy).powi(2) <= (R + 3.0).powi(2) {
+            return Some(control);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Drawing
+// ---------------------------------------------------------------------------
+
+/// One pane's worth of already-filtered, already-sorted entries.
+pub struct PaneData<'a> {
+    pub entries: Vec<&'a Entry>,
+    /// One flag per entry, parallel to `entries`. A multi-selection has no
+    /// single index, so this is a mask rather than a position.
+    pub selected: Vec<bool>,
+    /// Where the keyboard is. Drawn as a ring when it is not itself selected,
+    /// so extending a selection with Ctrl+Arrow stays legible.
+    pub cursor: Option<usize>,
+    pub scroll: f32,
+    /// The pane's scroll view state, for drawing its bar. `None` where there
+    /// is no live view to read — the anchor tests, which care only about row
+    /// geometry.
+    pub bar: Option<&'a ScrollState>,
+    pub loading: bool,
+    pub error: Option<&'a str>,
+}
+
+impl PaneData<'_> {
+    /// Draw this pane's scrollbar over whatever has been painted.
+    ///
+    /// The content is drawn by the pane itself, in window coordinates with
+    /// `scroll` already applied, so the renderer is handed an empty closure:
+    /// what is wanted here is the bar, the fade and the hover width, not the
+    /// clipping.
+    fn draw_scrollbar(&self, canvas: &Canvas, theme: &Theme) {
+        if let Some(state) = self.bar {
+            ScrollRenderer::draw(canvas, state, theme, |_, _| {});
+        }
+    }
+
+    /// The band of this pane that can be seen, in the window coordinates its
+    /// rows are laid out in — what the render walk is allowed to restrict
+    /// itself to.
+    ///
+    /// This is the scroll view's own content rect, read back off the state so
+    /// the two cannot disagree about where the pane is. `ScrollRenderer`
+    /// reports the band in content-local coordinates, `(0, offset)` to
+    /// `(width, offset + height)`; the rows here are placed in window
+    /// coordinates with that same offset already subtracted, so the two are
+    /// one band written from two origins, and mapping either way is just the
+    /// viewport's own rect. That holds during a rubber-band overscroll too:
+    /// the offset both sides read carries the overscroll, so the band and the
+    /// rows move together and the pulled-past rows stay drawn.
+    ///
+    /// `fallback` is the viewport the pane would have been given, for callers
+    /// with no live scroll view to ask — the anchor tests, which care only
+    /// about row geometry.
+    fn band(&self, fallback: Rect) -> Rect {
+        match self.bar {
+            Some(state) => {
+                let viewport = state.viewport();
+                let content = ScrollRenderer::visible_content_rect(state);
+                content.with_offset((viewport.left, viewport.top - state.offset()))
+            }
+            None => fallback,
+        }
+    }
+}
+
+impl PaneData<'_> {
+    pub fn is_selected(&self, index: usize) -> bool {
+        self.selected.get(index).copied().unwrap_or(false)
+    }
+}
+
+/// Everything the view needs for one frame. Rebuilt each frame; owns nothing.
+pub struct Frame<'a> {
+    pub width: f32,
+    pub height: f32,
+    pub theme: &'a Theme,
+    pub title: &'a str,
+    pub subtitle: String,
+    pub places: &'a [Place],
+    pub selected_place: Option<usize>,
+    pub mode: ViewMode,
+    /// One per column in the path stack. In list view only the last is drawn.
+    pub panes: Vec<PaneData<'a>>,
+    /// Which pane has the keyboard, and whose selection is "the" selection.
+    pub active: usize,
+    /// How far the Miller stack is panned left, in points.
+    pub pan: f32,
+    /// The Miller pan's scroll view state, for drawing the horizontal bar
+    /// along the bottom of the stack. `None` outside Miller view, and in
+    /// tests with no live view to read.
+    pub pan_bar: Option<&'a ScrollState>,
+    /// The Miller view's draggable pane width, shared by every pane.
+    pub miller_w: f32,
+    pub sort: SortKey,
+    pub ascending: bool,
+    /// The list view's draggable Size/Kind/Modified column widths.
+    pub list_columns: ListColumnWidths,
+    /// Depth and row index of an in-place rename in progress. That row's
+    /// name label is skipped so the host's text field shows through instead.
+    pub renaming: Option<(usize, usize)>,
+    /// Paths marked by a cut, drawn dimmed until the paste happens.
+    pub cut: Vec<std::path::PathBuf>,
+    /// Hover and press state of the traffic lights.
+    pub controls: WindowControlsState,
+    /// Whether the back/forward arrows have anywhere to go.
+    pub can_go_back: bool,
+    pub can_go_forward: bool,
+    /// The nav half being held down, drawn filled until it is released.
+    pub nav_pressed: Option<NavButton>,
+    /// The preview pane — a trailing member of the Miller stack, panned into
+    /// and out of view the same as any real column — when one is showing.
+    /// `None` outside Miller view or with no single file selected; drawn at
+    /// [`PREVIEW_W`] by [`draw_miller`], the same way [`miller_w`] sizes
+    /// every other pane rather than being carried on `Frame` itself.
+    ///
+    /// [`miller_w`]: Frame::miller_w
+    pub preview: Option<PreviewData<'a>>,
+    /// The picker's action row, when this is a picker window. `None` in the
+    /// browser.
+    ///
+    /// Note that [`Frame::height`] is the *file area's* bottom, not the
+    /// window's: the footer is subtracted from it before the frame is built,
+    /// so every piece of geometry below already stops short of the action
+    /// row without knowing the row exists. Chrome that genuinely spans the
+    /// whole window adds [`Frame::footer`] back on.
+    pub action_row: Option<FooterData<'a>>,
+    /// How much of the window height the footer takes. `0.0` in the browser.
+    pub footer: f32,
+    /// Pointer is over Quick View's close button, so it lights up — the same
+    /// hover behaviour the sheet's close dot has.
+    pub quickview_close_hovered: bool,
+}
+
+/// The picker's action row.
+pub struct FooterData<'a> {
+    pub accept_label: &'a str,
+    pub accept_enabled: bool,
+    /// The filter control's labels. Empty hides the control entirely.
+    pub filters: &'a [String],
+    pub current_filter: usize,
+    /// The filter menu is open, so the control draws as pressed and its
+    /// options are listed above it.
+    pub filter_open: bool,
+    pub hovered: Option<FooterButton>,
+    pub pressed: Option<FooterButton>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FooterButton {
+    Accept,
+    Cancel,
+    Filter,
+    /// One option of the open filter menu.
+    FilterOption(usize),
+}
+
+/// What the preview pane shows for the current selection.
+pub struct PreviewData<'a> {
+    pub name: &'a str,
+    pub icon_chain: Vec<String>,
+    /// The decode, once it lands. `None` while it is still in flight, which
+    /// is the big icon's cue to stand in for it.
+    pub decoded: Option<&'a otto_kit::preview::Preview>,
+    pub first_row: usize,
+    /// What the column says about the file underneath its name — kind, size,
+    /// when it was last written. Already formatted, because the listing has
+    /// the same facts in the same words and they are formatted once.
+    pub info: Vec<String>,
+}
+
+pub fn draw(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+
+    // No clear: the surface's buffer is cleared by otto-kit before this runs,
+    // and [`crate::scene`] has already composited the panels into it.
+    //
+    // The panels' grounds are not painted here. The sidebar's frosted
+    // material, the header's fainter version of it and the content area's
+    // sheet of opaque paper are all *styles* on layers the engine composites
+    // under this canvas — see [`crate::scene`]. What is left below is the
+    // chrome drawn on top of them.
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    draw_sidebar(canvas, f);
+    draw_header(canvas, f);
+
+    match f.mode {
+        ViewMode::List => {
+            draw_column_strip(canvas, f);
+            draw_list(canvas, f);
+        }
+        ViewMode::Columns => draw_miller(canvas, f),
+        ViewMode::Grid => draw_grid(canvas, f),
+    }
+
+    paint.set_color(theme.fill_tertiary);
+    paint.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(SIDEBAR_W, 0.0),
+        Point::new(SIDEBAR_W, f.height + f.footer),
+        &paint,
+    );
+
+    if f.action_row.is_some() {
+        draw_footer(canvas, f);
+    }
+}
+
+/// The preview pane's content, as a closure the scene records into its own
+/// layer's cached picture.
+///
+/// The panel is the layer's own box, so this draws from `(0, 0)` rather than
+/// in window coordinates: the column's position on screen is the layer's, and
+/// panning the Miller stack moves it without touching what was recorded.
+///
+/// Nothing here paints the pane's ground. That is `content_ground` — and *not*
+/// `otto_kit::preview::background`, which is the translucent material Quick
+/// View floats over a dimmed window with. This pane is not a card laid over
+/// the browser; it reads as one more column on the same opaque paper the
+/// listing sits on. The scene carries it as the layer's background style.
+///
+/// The decode is cloned in, because the picture outlives the frame that
+/// recorded it. That only happens when the selection changes or a decode
+/// lands, which is exactly when the picture had to be rebuilt anyway.
+pub fn preview_content(
+    data: &PreviewData<'_>,
+    theme: Theme,
+) -> impl Fn(&Canvas, f32, f32) + Send + Sync + 'static {
+    let name = data.name.to_string();
+    let icon_chain = data.icon_chain.clone();
+    let decoded = data.decoded.cloned();
+    let first_row = data.first_row;
+    let info = data.info.clone();
+
+    move |canvas: &Canvas, width: f32, height: f32| {
+        let panel = Rect::from_wh(width, height);
+        // The caption is laid out from the bottom up — the facts, then the
+        // name above them — and whatever is left over is the preview's. That
+        // way the name and the facts sit on the same line whatever the file
+        // is, instead of riding up and down with the size of the thing above
+        // them, and the preview gets every point that is not spoken for.
+        let caption = preview_caption_rect(panel, info.len());
+        draw_preview_caption(canvas, &theme, panel, &name, &info);
+
+        let stage = Rect::from_ltrb(
+            panel.left,
+            panel.top,
+            panel.right,
+            (caption.top - PREVIEW_GAP).max(panel.top),
+        );
+        match &decoded {
+            // A decoder that gave up (an unreadable archive, a format with no
+            // previewer) is not a blank panel, and neither is one still
+            // running: the file's own icon is still true, and drawn large it
+            // is a preview of a kind rather than a placeholder apologising
+            // for itself.
+            Some(otto_kit::preview::Preview::Unavailable { .. }) | None => {
+                draw_preview_icon(canvas, stage, &icon_chain);
+            }
+            Some(preview) => {
+                otto_kit::preview::draw(
+                    canvas,
+                    stage,
+                    preview,
+                    &theme,
+                    first_row,
+                    // The docked column is a glance, not a viewer: zooming
+                    // belongs to Quick View, which is the panel the user
+                    // opened deliberately.
+                    otto_kit::preview::Zoom::FIT,
+                    &|name, size| {
+                        icons::cached_icon_chain_at(&[name], size, icons::FULL_COLOUR_SIZE)
+                    },
+                );
+            }
+        }
+    }
+}
+
+/// Room between the preview and the name below it.
+const PREVIEW_GAP: f32 = 14.0;
+/// How far the caption's side margins hold its text off the column's edges.
+const PREVIEW_PAD: f32 = 16.0;
+/// The gap under the last line of facts, along the foot of the column. Wider
+/// than the side margins: the column ends there, and text that stops as close
+/// to the bottom edge as it does to the sides reads as having run out of
+/// room rather than as having been placed.
+const PREVIEW_FOOT: f32 = 32.0;
+const PREVIEW_NAME_H: f32 = 22.0;
+const PREVIEW_INFO_H: f32 = 18.0;
+
+/// The band at the foot of the preview column: the name, and the facts under
+/// it. Sized for however many facts there are, and pinned to the bottom.
+fn preview_caption_rect(panel: Rect, lines: usize) -> Rect {
+    let height = PREVIEW_NAME_H + lines as f32 * PREVIEW_INFO_H + PREVIEW_FOOT;
+    Rect::from_ltrb(
+        panel.left,
+        (panel.bottom - height).max(panel.top),
+        panel.right,
+        panel.bottom,
+    )
+}
+
+/// The file's name, and the facts about it, along the bottom of the column.
+fn draw_preview_caption(canvas: &Canvas, theme: &Theme, panel: Rect, name: &str, info: &[String]) {
+    let caption = preview_caption_rect(panel, info.len());
+    let room = panel.width() - PREVIEW_PAD * 2.0;
+
+    let name_font = styles::BODY_EMPHASIZED.font();
+    Label::new(ellipsize(&name_font, name, room.max(40.0)))
+        .with_style(styles::BODY_EMPHASIZED)
+        .with_color(theme.text_primary)
+        .centered_at(panel.center_x(), caption.top + PREVIEW_NAME_H / 2.0)
+        .render(canvas);
+
+    let info_font = styles::CALLOUT.font();
+    let mut y = caption.top + PREVIEW_NAME_H + PREVIEW_INFO_H / 2.0;
+    for line in info {
+        Label::new(ellipsize(&info_font, line, room.max(40.0)))
+            .with_style(styles::CALLOUT)
+            .with_color(theme.text_tertiary)
+            .centered_at(panel.center_x(), y)
+            .render(canvas);
+        y += PREVIEW_INFO_H;
+    }
+}
+
+/// The file's icon, as large as the space above the caption allows.
+///
+/// It stands in for a preview that has not landed or cannot be made. Sized to
+/// the stage rather than fixed at the listing's 16 points: this is the one
+/// place the browser has room to show what a file *is* at a glance, and a
+/// small icon marooned in a wide column reads as something missing.
+fn draw_preview_icon(canvas: &Canvas, stage: Rect, icon_chain: &[String]) {
+    const MAX: f32 = 128.0;
+    let side = stage.width().min(stage.height()).min(MAX);
+    if side < 16.0 {
+        return;
+    }
+    let refs: Vec<&str> = icon_chain.iter().map(String::as_str).collect();
+    let Some(image) = icons::cached_icon_chain_at(&refs, side as i32, icons::FULL_COLOUR_SIZE)
+    else {
+        return;
+    };
+    let dst = Rect::from_xywh(
+        stage.center_x() - side / 2.0,
+        stage.center_y() - side / 2.0,
+        side,
+        side,
+    );
+    canvas.draw_image_rect(&image, None, dst, &Paint::default());
+}
+
+fn draw_sidebar(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+
+    // The picker has no traffic lights. It is a dialog, not a document
+    // window: it is dismissed with Cancel, and a close control beside it
+    // would be a second, worse way to say the same thing — one that skips
+    // the request's answer.
+    if f.action_row.is_none() {
+        f.controls
+            .apply(WindowControls::new().at(CONTROLS_INSET, CONTROLS_INSET))
+            .render(canvas);
+    }
+
+    Label::new("Places")
+        .with_style(styles::SUBHEADLINE_EMPHASIZED)
+        .with_color(theme.text_tertiary)
+        .centered_on(20.0, 54.0)
+        .render(canvas);
+
+    for (i, place) in f.places.iter().enumerate() {
+        let rect = place_rect(i);
+        let selected = f.selected_place == Some(i);
+
+        if selected {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_color(theme.material_selection_focused);
+            canvas.draw_rrect(RRect::new_rect_xy(rect, 6.0, 6.0), &paint);
+        }
+
+        if let Some(image) = icons::cached_icon_chain(&[place.icon, "folder"], 16) {
+            let dst = Rect::from_xywh(rect.left + 8.0, rect.center_y() - 8.0, 16.0, 16.0);
+            // The theme's small-size art is a monochrome outline glyph baked
+            // at whatever colour the theme authored it in — usually a dark
+            // grey that all but vanishes on a dark sidebar. SrcIn recolours
+            // it to the theme's own text tone while keeping its alpha, the
+            // way a template/symbolic icon is meant to be drawn.
+            let mut paint = Paint::default();
+            paint.set_color_filter(skia_safe::color_filters::blend(
+                theme.text_secondary,
+                skia_safe::BlendMode::SrcIn,
+            ));
+            canvas.draw_image_rect(&image, None, dst, &paint);
+        }
+
+        Label::new(&place.label)
+            .with_style(styles::BODY_EMPHASIZED)
+            .with_color(if selected {
+                Color::WHITE
+            } else {
+                theme.text_primary
+            })
+            .centered_on(rect.left + 32.0, rect.center_y())
+            .render(canvas);
+    }
+}
+
+fn draw_header(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    // The header's own ground — the content's, thinned just enough for the
+    // frost to show through so the translucency runs across the whole top of
+    // the window instead of stopping at the sidebar's edge — is the header
+    // layer's background style. The hairline below is drawn here, because it
+    // is what separates it from the opaque file area.
+    draw_nav_buttons(canvas, f);
+
+    if f.action_row.is_some() {
+        // The picker's header is a toolbar, not a title bar: one row, no
+        // window title, no item count. What the user needs here is where
+        // they are and how to get elsewhere — the same things the macOS open
+        // panel puts on its single toolbar row.
+        draw_location_button(canvas, f);
+    } else {
+        Label::new(f.title)
+            .with_style(styles::TITLE_1_EMPHASIZED)
+            .with_color(theme.text_primary)
+            .centered_on(TITLE_X, TITLE_CY)
+            .render(canvas);
+
+        Label::new(&f.subtitle)
+            .with_style(styles::CALLOUT)
+            .with_color(theme.text_secondary)
+            .centered_on(SIDEBAR_W + CONTENT_PAD, SUBTITLE_CY)
+            .render(canvas);
+    }
+
+    draw_switcher(canvas, f);
+
+    paint.set_color(theme.fill_tertiary);
+    paint.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(SIDEBAR_W, HEADER_H),
+        Point::new(f.width, HEADER_H),
+        &paint,
+    );
+}
+
+/// The picker's location control: a folder icon and the current directory's
+/// name in a soft capsule, centred on the toolbar row between the navigation
+/// arrows and the view switcher.
+///
+/// It does not open a menu yet — it says where you are. The popup of ancestor
+/// directories the reference layout has is the next thing it grows.
+fn draw_location_button(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let cy = TOOLBAR_CY;
+    let rect = location_rect(f.width);
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(theme.fill_tertiary);
+    canvas.draw_rrect(RRect::new_rect_xy(rect, NAV_RADIUS, NAV_RADIUS), &paint);
+
+    let mut text_x = rect.left + 10.0;
+    if let Some(image) = icons::cached_icon_chain(&["folder"], 16) {
+        let dst = Rect::from_xywh(text_x, cy - 8.0, 16.0, 16.0);
+        canvas.draw_image_rect(&image, None, dst, &Paint::default());
+        text_x += 22.0;
+    }
+
+    Label::new(f.title)
+        .with_style(styles::BODY_EMPHASIZED)
+        .with_color(theme.text_primary)
+        .centered_on(text_x, cy)
+        .render(canvas);
+}
+
+/// The Back/Forward split button: one capsule, a hairline down the middle,
+/// each half dimmed when there is nowhere for it to go. Drawn like the view
+/// switcher on the other end of the header, so the two read as one family.
+fn draw_nav_buttons(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let group = nav_group_rect();
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(theme.fill_tertiary);
+    canvas.draw_rrect(RRect::new_rect_xy(group, NAV_RADIUS, NAV_RADIUS), &paint);
+
+    // The held half darkens for as long as it is down. A disabled half is
+    // never armed, so nothing here has to check whether it can go anywhere.
+    if let Some(pressed) = f.nav_pressed {
+        let (rect, back) = match pressed {
+            NavButton::Back => (nav_back_rect(), true),
+            NavButton::Forward => (nav_forward_rect(), false),
+        };
+        paint.set_color(theme.fill_secondary);
+        canvas.draw_rrect(nav_half_rrect(rect, back), &paint);
+    }
+
+    // The divider stops short of the capsule's ends so it reads as a seam
+    // between two halves rather than a cut through the shape.
+    paint.set_color(theme.fill_secondary);
+    paint.set_stroke_width(1.0);
+    let split = group.left + NAV_BTN_W;
+    canvas.draw_line(
+        Point::new(split, group.top + 5.0),
+        Point::new(split, group.bottom - 5.0),
+        &paint,
+    );
+
+    draw_nav_button(
+        canvas,
+        theme,
+        nav_back_rect(),
+        "chevron-left",
+        f.can_go_back,
+        f.nav_pressed == Some(NavButton::Back),
+    );
+    draw_nav_button(
+        canvas,
+        theme,
+        nav_forward_rect(),
+        "chevron-right",
+        f.can_go_forward,
+        f.nav_pressed == Some(NavButton::Forward),
+    );
+}
+
+/// One half of the capsule as its own shape: rounded on the capsule's outside
+/// edge, square against the seam, so a pressed half fills its corner of the
+/// capsule instead of floating inside it as a pill.
+fn nav_half_rrect(rect: Rect, back: bool) -> RRect {
+    let round = Point::new(NAV_RADIUS, NAV_RADIUS);
+    let square = Point::new(0.0, 0.0);
+    // Radii run from the top left, clockwise.
+    let radii = if back {
+        [round, square, square, round]
+    } else {
+        [square, round, round, square]
+    };
+    RRect::new_rect_radii(rect, &radii)
+}
+
+fn draw_nav_button(
+    canvas: &Canvas,
+    theme: &Theme,
+    rect: Rect,
+    icon_name: &str,
+    enabled: bool,
+    pressed: bool,
+) {
+    let color = match (enabled, pressed) {
+        // Held: the arrow comes forward with the fill under it, so the press
+        // reads at a glance rather than as a faint change of ground.
+        (true, true) => theme.text_primary,
+        (true, false) => theme.text_secondary,
+        (false, _) => theme.text_tertiary,
+    };
+    Icon::new(icon_name)
+        .with_size(NAV_ICON_SIZE)
+        .with_color(color)
+        .at(
+            rect.center_x() - NAV_ICON_SIZE / 2.0,
+            rect.center_y() - NAV_ICON_SIZE / 2.0,
+        )
+        .render(canvas);
+}
+
+/// A three-segment control: list, icon grid, Miller columns. Glyphs are drawn
+/// rather than themed so it stays legible with no icon-theme entry.
+fn draw_switcher(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let rect = switcher_rect(f.width);
+    let seg = rect.width() / 3.0;
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    paint.set_color(theme.fill_tertiary);
+    canvas.draw_rrect(RRect::new_rect_xy(rect, 7.0, 7.0), &paint);
+
+    let index = SWITCHER_MODES
+        .iter()
+        .position(|m| *m == f.mode)
+        .unwrap_or(0);
+    let active = Rect::from_xywh(
+        rect.left + index as f32 * seg + 2.0,
+        rect.top + 2.0,
+        seg - 4.0,
+        rect.height() - 4.0,
+    );
+    paint.set_color(theme.material_popup);
+    canvas.draw_rrect(RRect::new_rect_xy(active, 5.0, 5.0), &paint);
+
+    let cy = rect.center_y();
+    for (i, mode) in SWITCHER_MODES.iter().enumerate() {
+        let cx = rect.left + seg * i as f32 + seg / 2.0;
+        paint.set_color(if *mode == f.mode {
+            theme.text_primary
+        } else {
+            theme.text_secondary
+        });
+        match mode {
+            // Three stacked lines.
+            ViewMode::List => {
+                for r in 0..3 {
+                    let y = cy - 4.0 + r as f32 * 4.0;
+                    canvas.draw_rrect(
+                        RRect::new_rect_xy(Rect::from_xywh(cx - 7.0, y - 1.0, 14.0, 2.0), 1.0, 1.0),
+                        &paint,
+                    );
+                }
+            }
+            // A 2x2 block of squares.
+            ViewMode::Grid => {
+                for r in 0..2 {
+                    for c in 0..2 {
+                        canvas.draw_rrect(
+                            RRect::new_rect_xy(
+                                Rect::from_xywh(
+                                    cx - 6.0 + c as f32 * 7.0,
+                                    cy - 6.0 + r as f32 * 7.0,
+                                    5.0,
+                                    5.0,
+                                ),
+                                1.2,
+                                1.2,
+                            ),
+                            &paint,
+                        );
+                    }
+                }
+            }
+            // Three vertical bars.
+            ViewMode::Columns => {
+                for c in 0..3 {
+                    let x = cx - 7.5 + c as f32 * 5.5;
+                    canvas.draw_rrect(
+                        RRect::new_rect_xy(Rect::from_xywh(x, cy - 5.0, 4.0, 10.0), 1.0, 1.0),
+                        &paint,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The icon grid. The cell drawing is deliberately free of browser state — it
+/// takes an entry, a rect and whether it is selected — so a desktop surface can
+/// call it with its own rects.
+fn draw_grid(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let area = content_viewport(f.width, f.height, ViewMode::Grid);
+    let Some(pane) = f.panes.last() else { return };
+
+    canvas.save();
+    canvas.clip_rect(area, ClipOp::Intersect, true);
+
+    if let Some(error) = pane.error {
+        draw_centered(canvas, area, error, theme.text_secondary);
+    } else if pane.loading {
+        draw_centered(canvas, area, "Loading…", theme.text_tertiary);
+    } else if pane.entries.is_empty() {
+        draw_centered(canvas, area, "This folder is empty.", theme.text_tertiary);
+    } else {
+        // Only the rows of cells the viewport is asking for are drawn.
+        let band = pane.band(area);
+        for index in grid_visible_range(area, pane.entries.len(), pane.scroll, band) {
+            let cell = grid_cell_rect(area, index, pane.scroll);
+            draw_grid_cell(
+                canvas,
+                theme,
+                pane.entries[index],
+                cell,
+                pane.is_selected(index),
+                f.renaming == Some((f.panes.len() - 1, index)),
+            );
+        }
+    }
+
+    canvas.restore();
+    pane.draw_scrollbar(canvas, theme);
+}
+
+/// One grid cell: icon over a centred, wrapped-to-two-lines name.
+///
+/// `renaming` suppresses the caption — and the pill behind it — while the
+/// host's text field sits over it, the way a list row does.
+pub fn draw_grid_cell(
+    canvas: &Canvas,
+    theme: &Theme,
+    entry: &Entry,
+    cell: Rect,
+    selected: bool,
+    renaming: bool,
+) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    let icon_top = cell.top + 8.0;
+    // The optical centre of the caption's first line, not its top: that is what
+    // `Label::centered_at` wants, and the pill is measured off the same point.
+    let label_center_y = icon_top + GRID_ICON + GRID_LABEL_GAP;
+
+    if selected {
+        // The highlight hugs the label, not the whole cell — that is what keeps
+        // a grid of selected items from becoming a wall of colour.
+        paint.set_color(theme.material_selection_focused);
+        paint.set_alpha(60);
+        canvas.draw_rrect(
+            RRect::new_rect_xy(
+                Rect::from_xywh(
+                    cell.left + 6.0,
+                    icon_top - 4.0,
+                    cell.width() - 12.0,
+                    GRID_ICON + 8.0,
+                ),
+                8.0,
+                8.0,
+            ),
+            &paint,
+        );
+    }
+
+    let chain = entry.icon_chain();
+    let refs: Vec<&str> = chain.iter().map(String::as_str).collect();
+    if let Some(image) =
+        icons::cached_icon_chain_at(&refs, GRID_ICON as i32, icons::FULL_COLOUR_SIZE)
+    {
+        let dst = Rect::from_xywh(
+            cell.center_x() - GRID_ICON / 2.0,
+            icon_top,
+            GRID_ICON,
+            GRID_ICON,
+        );
+        canvas.draw_image_rect(&image, None, dst, &Paint::default());
+    }
+
+    // Two lines at most, the second elided — a long name must not push the
+    // grid out of alignment.
+    let (first, second) = split_label(&entry.name, 13);
+    let text_color = if selected {
+        Color::WHITE
+    } else {
+        theme.text_primary
+    };
+
+    if selected && !renaming {
+        let font = styles::CALLOUT_EMPHASIZED.font();
+        let text_w = font
+            .measure_str(&first, None)
+            .0
+            .max(font.measure_str(&second, None).0);
+        let width = (text_w + 12.0).min(cell.width() - 4.0);
+        let lines = if second.is_empty() {
+            0.0
+        } else {
+            GRID_LABEL_LINE
+        };
+        let height = lines + GRID_LABEL_INSET * 2.0;
+        paint.set_color(theme.material_selection_focused);
+        paint.set_alpha(255);
+        canvas.draw_rrect(
+            RRect::new_rect_xy(
+                Rect::from_xywh(
+                    cell.center_x() - width / 2.0,
+                    label_center_y - GRID_LABEL_INSET,
+                    width,
+                    height,
+                ),
+                5.0,
+                5.0,
+            ),
+            &paint,
+        );
+    }
+
+    for (line, offset) in [(first.as_str(), 0.0), (second.as_str(), GRID_LABEL_LINE)] {
+        if renaming || line.is_empty() {
+            continue;
+        }
+        Label::new(line)
+            .with_style(styles::CALLOUT_EMPHASIZED)
+            .with_color(text_color)
+            .centered_at(cell.center_x(), label_center_y + offset)
+            .render(canvas);
+    }
+}
+
+/// Split a name across at most two lines of `per_line` characters, eliding the
+/// tail. Character-count based rather than measured — good enough for a fixed
+/// cell, and it keeps this callable without a font.
+fn split_label(name: &str, per_line: usize) -> (String, String) {
+    let chars: Vec<char> = name.chars().collect();
+    if chars.len() <= per_line {
+        return (name.to_string(), String::new());
+    }
+    let first: String = chars[..per_line].iter().collect();
+    let rest = &chars[per_line..];
+    if rest.len() <= per_line {
+        return (first, rest.iter().collect());
+    }
+    let second: String = rest[..per_line.saturating_sub(1)].iter().collect();
+    (first, format!("{second}…"))
+}
+
+/// Truncate `text` with a trailing ellipsis so it measures no wider than
+/// `max_width` under `font` — a long file name must stop before it runs into
+/// the next column rather than drawing straight through it.
+pub fn ellipsize(font: &Font, text: &str, max_width: f32) -> String {
+    if font.measure_str(text, None).0 <= max_width {
+        return text.to_string();
+    }
+    let ellipsis = "…";
+    let budget = (max_width - font.measure_str(ellipsis, None).0).max(0.0);
+
+    let chars: Vec<char> = text.chars().collect();
+    let mut lo = 0usize;
+    let mut hi = chars.len();
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        let candidate: String = chars[..mid].iter().collect();
+        if font.measure_str(&candidate, None).0 <= budget {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    format!("{}{ellipsis}", chars[..lo].iter().collect::<String>())
+}
+
+/// The width the Name column needs to show every given name in full — what a
+/// double-click on the Name/Size divider fits it to, the way Finder does.
+pub fn widest_name(names: impl Iterator<Item = impl AsRef<str>>) -> f32 {
+    let font = styles::BODY_MEDIUM.font();
+    names.fold(0.0f32, |max, name| {
+        max.max(font.measure_str(name.as_ref(), None).0)
+    })
+}
+
+/// The shared Miller pane width that fits `longest_name` without truncating
+/// — a double-click on a pane's right edge, the way the Name/Size divider
+/// fits in list view. `has_dirs` reserves room for the disclosure chevron,
+/// since it sits at the end of every directory row in the pane.
+pub fn fit_miller_width(longest_name: f32, has_dirs: bool) -> f32 {
+    let trailing = if has_dirs { 24.0 } else { 8.0 };
+    let content = 14.0 + ICON_SIZE + 8.0 + longest_name + trailing + 12.0;
+    content.clamp(MILLER_MIN_W, MILLER_MAX_W)
+}
+
+fn draw_column_strip(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let (size_x, kind_x, modified_x) = column_edges(f.width, f.list_columns);
+    // Optical centre of the column strip, not a baseline.
+    let cy = HEADER_H + COLUMNS_H / 2.0;
+
+    for (key, x) in [
+        (SortKey::Name, SIDEBAR_W + CONTENT_PAD),
+        (SortKey::Size, size_x),
+        (SortKey::Kind, kind_x),
+        (SortKey::Modified, modified_x),
+    ] {
+        let active = f.sort == key;
+        Label::new(key.label())
+            .with_style(styles::SUBHEADLINE)
+            .with_color(if active {
+                theme.text_primary
+            } else {
+                theme.text_tertiary
+            })
+            .centered_on(x, cy)
+            .render(canvas);
+
+        if active {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_color(theme.text_secondary);
+            let label_w = styles::SUBHEADLINE.font().measure_str(key.label(), None).0;
+            let cx = x + label_w + 8.0;
+            let dir = if f.ascending { -1.0 } else { 1.0 };
+            let mut builder = PathBuilder::new();
+            builder.move_to(Point::new(cx - 3.5, cy - 2.0 * dir));
+            builder.line_to(Point::new(cx + 3.5, cy - 2.0 * dir));
+            builder.line_to(Point::new(cx, cy + 2.5 * dir));
+            builder.close();
+            canvas.draw_path(&builder.detach(), &paint);
+        }
+    }
+
+    let mut paint = Paint::default();
+    paint.set_color(theme.fill_tertiary);
+    paint.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(SIDEBAR_W, HEADER_H + COLUMNS_H),
+        Point::new(f.width, HEADER_H + COLUMNS_H),
+        &paint,
+    );
+}
+
+fn draw_list(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let viewport = content_viewport(f.width, f.height, ViewMode::List);
+    let depth = f.panes.len().saturating_sub(1);
+    let Some(pane) = f.panes.last() else { return };
+
+    canvas.save();
+    canvas.clip_rect(viewport, ClipOp::Intersect, true);
+
+    if let Some(error) = pane.error {
+        draw_centered(canvas, viewport, error, theme.text_secondary);
+        canvas.restore();
+        return;
+    }
+    if pane.loading {
+        draw_centered(canvas, viewport, "Loading…", theme.text_tertiary);
+        canvas.restore();
+        return;
+    }
+    if pane.entries.is_empty() {
+        draw_centered(
+            canvas,
+            viewport,
+            "This folder is empty.",
+            theme.text_tertiary,
+        );
+        canvas.restore();
+        return;
+    }
+
+    let (size_x, kind_x, modified_x) = column_edges(f.width, f.list_columns);
+
+    // Only rows the viewport is asking for are laid out or drawn — the cost of
+    // a frame must not grow with the size of the directory, and measuring and
+    // shaping the text of a row nobody can see is most of what that would buy.
+    let strip = RowStrip::list(f.width, pane.entries.len(), pane.scroll);
+    let band = pane.band(viewport);
+
+    for index in strip.visible(band) {
+        let entry = pane.entries[index];
+        let rect = strip.rect(index);
+        let selected = pane.is_selected(index);
+
+        draw_row_background(
+            canvas,
+            theme,
+            rect,
+            selected,
+            RunEnds::of_pane(pane, index),
+            index,
+        );
+        if pane.cursor == Some(index) && !selected {
+            draw_cursor_ring(canvas, theme, rect, 8.0);
+        }
+
+        let (text_color, detail_color) = row_colors(theme, selected);
+        let cut = f.cut.contains(&entry.path);
+        let centre = rect.center_y();
+
+        draw_entry_icon(canvas, entry, rect.left + CONTENT_PAD, rect.center_y(), cut);
+
+        if f.renaming != Some((depth, index)) {
+            let name_x = rect.left + CONTENT_PAD + ICON_SIZE + 10.0;
+            let name_font = styles::BODY_MEDIUM.font();
+            let name = ellipsize(&name_font, &entry.name, size_x - 12.0 - name_x);
+            Label::new(name)
+                .with_style(styles::BODY_MEDIUM)
+                .with_color(if cut {
+                    dim_color(text_color)
+                } else {
+                    text_color
+                })
+                .centered_on(name_x, centre)
+                .render(canvas);
+        }
+
+        let size_text = if entry.is_dir {
+            "--".to_string()
+        } else {
+            entry.size.map(model::format_size).unwrap_or_default()
+        };
+        for (text, x) in [
+            (size_text, size_x),
+            (entry.kind_label().to_string(), kind_x),
+            (
+                entry.modified.map(model::format_time).unwrap_or_default(),
+                modified_x,
+            ),
+        ] {
+            Label::new(&text)
+                .with_style(styles::SUBHEADLINE)
+                .with_color(detail_color)
+                .centered_on(x, centre)
+                .render(canvas);
+        }
+    }
+
+    canvas.restore();
+    pane.draw_scrollbar(canvas, theme);
+}
+
+/// Miller columns: the chrome over the stack.
+///
+/// The columns themselves — their ground, and every row in them — are layers
+/// the engine composites under this canvas; see [`crate::scene`]. What is left
+/// here is what sits *over* them and is cheap enough not to be worth a layer
+/// of its own: each column's scrollbar, the hairline down its trailing edge,
+/// and the stack's own horizontal bar.
+fn draw_miller(canvas: &Canvas, f: &Frame) {
+    let theme = f.theme;
+    let viewport = content_viewport(f.width, f.height, ViewMode::Columns);
+
+    canvas.save();
+    canvas.clip_rect(viewport, ClipOp::Intersect, true);
+
+    let mut divider = Paint::default();
+    divider.set_color(theme.fill_tertiary);
+    divider.set_stroke_width(1.0);
+
+    let trailing_edges = (0..f.panes.len())
+        .map(|depth| miller_pane_rect(depth, f.height, f.pan, f.miller_w))
+        .chain(
+            f.preview
+                .is_some()
+                .then(|| preview_pane_rect(f.panes.len(), f.height, f.pan, f.miller_w)),
+        );
+
+    for (depth, full) in trailing_edges.enumerate() {
+        if full.right < viewport.left || full.left > viewport.right {
+            continue;
+        }
+        // The bar belongs to the column, but it is drawn from here so it lies
+        // over the column's content rather than being recorded into it — a
+        // scroll then moves the bar without the column re-recording anything.
+        // Unless the columns are in their own surfaces, in which case each
+        // draws its own bar into its own buffer: those surfaces sit over this
+        // canvas, so a bar drawn here would be hidden under them anyway, and
+        // would be stale besides.
+        if !crate::pane_surfaces::enabled() {
+            if let Some(pane) = f.panes.get(depth) {
+                pane.draw_scrollbar(canvas, theme);
+            }
+        }
+        canvas.draw_line(
+            Point::new(full.right, viewport.top),
+            Point::new(full.right, viewport.bottom),
+            &divider,
+        );
+    }
+
+    // The stack's own bar, along the bottom of every pane: the panes scroll
+    // vertically on their own bars, the stack scrolls sideways on this one.
+    // Drawn last so it lies over the pane dividers rather than under them.
+    // Unless it has a surface of its own over the columns — drawn here it
+    // would be covered by them. See [`crate::pane_surfaces`].
+    if !crate::pane_surfaces::enabled() {
+        if let Some(state) = f.pan_bar {
+            ScrollRenderer::draw(canvas, state, theme, |_, _| {});
+        }
+    }
+
+    canvas.restore();
+}
+
+/// Where a selected row sits within its run of selected rows. Rows abut, so a
+/// run has to be drawn as one shape: only its first row is rounded on top and
+/// only its last is rounded on the bottom, and the rows between are square at
+/// both ends. Rounding every row instead would draw a stack of separate pills
+/// with pinched waists where they meet.
+#[derive(Debug, Clone, Copy)]
+pub struct RunEnds {
+    pub first: bool,
+    pub last: bool,
+}
+
+impl RunEnds {
+    /// Read off the neighbours of `index`. A row at either end of the listing
+    /// is an end of its run by definition.
+    pub fn of_pane(pane: &PaneData<'_>, index: usize) -> Self {
+        Self {
+            first: index == 0 || !pane.is_selected(index - 1),
+            last: !pane.is_selected(index + 1),
+        }
+    }
+}
+
+/// One row's share of a selection run, inset horizontally by `inset`.
+pub fn draw_selection_run(canvas: &Canvas, rect: Rect, color: Color, inset: f32, ends: RunEnds) {
+    const R: f32 = 6.0;
+    let top = if ends.first { R } else { 0.0 };
+    let bottom = if ends.last { R } else { 0.0 };
+    let radii = [
+        Point::new(top, top),
+        Point::new(top, top),
+        Point::new(bottom, bottom),
+        Point::new(bottom, bottom),
+    ];
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(color);
+    canvas.draw_rrect(
+        RRect::new_rect_radii(
+            Rect::from_ltrb(rect.left + inset, rect.top, rect.right - inset, rect.bottom),
+            &radii,
+        ),
+        &paint,
+    );
+}
+
+fn draw_row_background(
+    canvas: &Canvas,
+    theme: &Theme,
+    rect: Rect,
+    selected: bool,
+    ends: RunEnds,
+    index: usize,
+) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    if selected {
+        // Full row height: the highlight of one row meets the next with no
+        // gap, so a run of selected rows reads as one block.
+        draw_selection_run(canvas, rect, theme.material_selection_focused, 8.0, ends);
+    } else if index % 2 == 1 {
+        // A faint stripe is what makes a wide row scannable across to the date.
+        // The theme colour is already the right weight — raising its alpha here
+        // would make a banded grey list rather than a hint.
+        paint.set_color(theme.fill_quaternary);
+        canvas.draw_rect(rect, &paint);
+    }
+}
+
+/// The opaque ground everything right of the sidebar sits on: white in light
+/// mode, near-black in dark.
+///
+/// Not taken from the theme's materials, which are all translucent by design
+/// for the compositor's blur path. This surface deliberately is not.
+pub fn content_ground() -> Color {
+    if matches!(current_color_scheme(), ColorScheme::Dark) {
+        Color::from_argb(0xFF, 0x1C, 0x1C, 0x1E)
+    } else {
+        Color::WHITE
+    }
+}
+
+/// Styling for an in-place rename's text field.
+///
+/// [`TextInputStyle::with_theme`]'s default background is a near-transparent
+/// fill meant for fields that float over a material — barely visible against
+/// a row that already sits on [`content_ground`]. A rename field wants to
+/// read as solid paper, the way Finder's does, with the focus ring alone
+/// marking it editable.
+pub fn rename_field_style(theme: Theme) -> TextInputStyle {
+    let mut style = TextInputStyle::with_theme(theme);
+    style.background = content_ground();
+    style
+}
+
+/// The header band: [`content_ground`] with a little alpha taken out of it.
+/// Much more opaque than the sidebar — the title sits here and the file list
+/// starts a hairline below, so the backdrop may only be hinted at.
+pub fn header_material() -> Color {
+    if matches!(current_color_scheme(), ColorScheme::Dark) {
+        Color::from_argb(0xE6, 0x1C, 0x1C, 0x1E)
+    } else {
+        Color::from_argb(0xE6, 0xFF, 0xFF, 0xFF)
+    }
+}
+
+pub fn row_colors(theme: &Theme, selected: bool) -> (Color, Color) {
+    if selected {
+        (Color::WHITE, Color::from_argb(200, 255, 255, 255))
+    } else {
+        (theme.text_primary, theme.text_secondary)
+    }
+}
+
+fn draw_entry_icon(canvas: &Canvas, entry: &Entry, left: f32, center_y: f32, cut: bool) {
+    let chain = entry.icon_chain();
+    let refs: Vec<&str> = chain.iter().map(String::as_str).collect();
+    if let Some(image) =
+        icons::cached_icon_chain_at(&refs, ICON_SIZE as i32, icons::FULL_COLOUR_SIZE)
+    {
+        let dst = Rect::from_xywh(left, center_y - ICON_SIZE / 2.0, ICON_SIZE, ICON_SIZE);
+        let mut paint = Paint::default();
+        if cut {
+            // A cut entry is still there — it does not move until the paste —
+            // so it is dimmed rather than hidden.
+            paint.set_alpha(110);
+        }
+        canvas.draw_image_rect(&image, None, dst, &paint);
+    }
+}
+
+/// The keyboard cursor when it is not itself part of the selection.
+pub fn draw_cursor_ring(canvas: &Canvas, theme: &Theme, rect: Rect, inset: f32) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_style(skia_safe::paint::Style::Stroke);
+    paint.set_stroke_width(1.5);
+    paint.set_color(theme.material_selection_focused);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(
+            Rect::from_ltrb(
+                rect.left + inset,
+                rect.top + 1.0,
+                rect.right - inset,
+                rect.bottom - 1.0,
+            ),
+            6.0,
+            6.0,
+        ),
+        &paint,
+    );
+}
+
+/// Half-strength, for entries marked by a pending cut.
+pub fn dim_color(color: Color) -> Color {
+    Color::from_argb(color.a() / 2, color.r(), color.g(), color.b())
+}
+
+fn draw_centered(canvas: &Canvas, area: Rect, text: &str, color: Color) {
+    Label::new(text)
+        .with_style(styles::BODY)
+        .with_color(color)
+        .centered_at(area.center_x(), area.center_y())
+        .render(canvas);
+}
+
+// ---------------------------------------------------------------------------
+// Get Info modal
+// ---------------------------------------------------------------------------
+
+/// The Get Info panel's size, in logical points. It is a window in its own
+/// right, so this is the size that window is created at — and it does not
+/// resize: the layout inside it is fixed.
+pub const INFO_W: f32 = 380.0;
+/// Tall enough for every detail row a symlink can produce *above* the
+/// permissions rule, which is fixed to the bottom of the panel. The rows are
+/// body text now and step 23 points, so a window sized for the old caption
+/// text ran the last of them into the section header.
+pub const INFO_H: f32 = 520.0;
+
+/// The strip the panel is dragged by: its top edge, beside the close dot.
+///
+/// It carries no title and draws nothing of its own — the icon and the name
+/// below it already say what the panel is about — so this is a hit target,
+/// not a titlebar. Everything below it is content, and dragging from there
+/// would fight the permission checkboxes.
+pub fn info_titlebar_rect(sheet: Rect) -> Rect {
+    Rect::from_ltrb(sheet.left, sheet.top, sheet.right, sheet.top + 40.0)
+}
+
+/// The close button, top-left of the sheet, matching the window's own controls.
+pub fn info_close_rect(sheet: Rect) -> Rect {
+    Rect::from_xywh(sheet.left + 14.0, sheet.top + 14.0, 12.0, 12.0)
+}
+
+/// Where the permissions grid starts inside the sheet: the baseline of the
+/// section, with the column headers above it and the rows below.
+fn perm_origin(sheet: Rect) -> (f32, f32) {
+    (sheet.left + 24.0, sheet.bottom - 118.0)
+}
+
+const PERM_COL_W: f32 = 62.0;
+const PERM_ROW_H: f32 = 26.0;
+const PERM_BOX: f32 = 15.0;
+/// Left edge of the first checkbox column, from the grid origin.
+const PERM_COL_X: f32 = 96.0;
+/// Drop from the origin to the first checkbox row. The column headers live in
+/// the gap; without it they are drawn underneath the first row of boxes.
+const PERM_ROWS_TOP: f32 = 14.0;
+
+/// The checkbox rect for `who` (0 owner, 1 group, 2 other) and `what`
+/// (0 read, 1 write, 2 execute).
+pub fn perm_box_rect(sheet: Rect, who: usize, what: usize) -> Rect {
+    let (ox, oy) = perm_origin(sheet);
+    Rect::from_xywh(
+        ox + PERM_COL_X + what as f32 * PERM_COL_W,
+        oy + PERM_ROWS_TOP + who as f32 * PERM_ROW_H - PERM_BOX / 2.0 + 1.0,
+        PERM_BOX,
+        PERM_BOX,
+    )
+}
+
+/// The permission cell under `(x, y)`, if any. Returns `(who, what)`.
+pub fn perm_box_at(sheet: Rect, x: f32, y: f32) -> Option<(usize, usize)> {
+    for who in 0..3 {
+        for what in 0..3 {
+            // A slightly generous target: a 15pt box is small for a pointer.
+            if perm_box_rect(sheet, who, what)
+                .with_outset((4.0, 4.0))
+                .contains(Point::new(x, y))
+            {
+                return Some((who, what));
+            }
+        }
+    }
+    None
+}
+
+/// Draw the Quick View panel over a dimmed window.
+///
+/// The panel is drawn into this window's own surface rather than into a
+/// separate previewer's, which is what lets it grow out of the row the user
+/// pressed Space on: [`quickview_anchor`] is already in these coordinates.
+/// The content itself comes from [`otto_kit::preview`], canvas-pure and shared
+/// with every other file view.
+///
+/// `resting` is where the panel comes to rest. It is passed in rather than
+/// computed here because it is not always the window's middle: a panel centred
+/// on the display rests somewhere only the caller knows, and the drawing and
+/// the surface it is drawn into must agree about it or the card is painted at
+/// one size inside a surface of another.
+/// Quick View's close button: a round dot in the panel's top-*right*.
+///
+/// Right, not left, because it is not a titlebar control. The card has no
+/// titlebar and no other controls to sit in a group with, and the browser's
+/// own traffic lights are already down the window's left edge — a second dot
+/// in the same corner would read as one of them.
+pub fn quickview_close_rect(panel: Rect) -> Rect {
+    const D: f32 = 17.0;
+    const INSET: f32 = 10.0;
+    let strip = quickview_titlebar_rect(panel);
+    Rect::from_xywh(panel.right - INSET - D, strip.center_y() - D / 2.0, D, D)
+}
+
+/// The panel's title strip: the file's name and the close button.
+///
+/// Chrome, not content. The preview is drawn below it, so a close button in
+/// the corner is never sitting on top of the thing being previewed — which
+/// is both hard to see against a busy image and easy to mis-click.
+pub fn quickview_titlebar_rect(panel: Rect) -> Rect {
+    Rect::from_ltrb(
+        panel.left,
+        panel.top,
+        panel.right,
+        panel.top + crate::quickview::TITLEBAR_H,
+    )
+}
+
+/// What is left of the panel for the preview itself.
+///
+/// Inset on every side, not just below the title strip: the card reads as a
+/// mount around the content rather than a window whose content is jammed
+/// against the glass, and an image that reaches the edge no longer collides
+/// with the panel's own rounded corners.
+///
+/// Narrow, because it is not the only inset the content gets: the preview
+/// pads itself as well ([`otto_kit::preview::PADDING`], and less than that
+/// for a picture). This one only has to clear the corners and the border.
+pub fn quickview_content_rect(panel: Rect) -> Rect {
+    const INSET: f32 = 4.0;
+    Rect::from_ltrb(
+        panel.left + INSET,
+        panel.top + crate::quickview::TITLEBAR_H + INSET,
+        panel.right - INSET,
+        panel.bottom - INSET,
+    )
+}
+
+/// Paint the close button. Split out so the panel's own draw stays readable.
+fn draw_quickview_close(canvas: &Canvas, theme: &Theme, panel: Rect, hovered: bool) {
+    let close = quickview_close_rect(panel);
+    let centre = Point::new(close.center_x(), close.center_y());
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    // A tint of the theme's own fill rather than the traffic lights' red:
+    // this dismisses a preview, it does not close a window, and borrowing
+    // the window-close colour would overstate it.
+    paint.set_color(if hovered {
+        theme.fill_primary
+    } else {
+        theme.fill_secondary
+    });
+    canvas.draw_circle(centre, close.width() / 2.0, &paint);
+
+    // The glyph is always drawn, unlike the traffic lights' reveal-on-hover:
+    // a bare dot in a corner with no group around it does not say "close".
+    let mut glyph = Paint::default();
+    glyph.set_anti_alias(true);
+    glyph.set_style(skia_safe::paint::Style::Stroke);
+    glyph.set_stroke_width(1.5);
+    glyph.set_stroke_cap(skia_safe::PaintCap::Round);
+    glyph.set_color(theme.text_secondary);
+    let r = close.width() * 0.24;
+    canvas.draw_line(
+        (centre.x - r, centre.y - r),
+        (centre.x + r, centre.y + r),
+        &glyph,
+    );
+    canvas.draw_line(
+        (centre.x + r, centre.y - r),
+        (centre.x - r, centre.y + r),
+        &glyph,
+    );
+}
+
+pub fn draw_quickview(
+    canvas: &Canvas,
+    f: &Frame,
+    session: &crate::quickview::Session,
+    resting: Rect,
+) {
+    let panel = session.panel(resting);
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    // No dim behind it, and no fade on it. The panel is a window laid over the
+    // browser, not a modal sheet the browser is answering: it carries its own
+    // shadow, and darkening everything else to make it read as focused would
+    // say the opposite of what it is. It arrives opaque, so what the eye
+    // follows is one card moving rather than a shape resolving out of nothing.
+
+    // No shadow. A Gaussian across the whole card, recorded again on every
+    // frame of a zoom that resizes the surface as it goes, is the most
+    // expensive thing this panel was doing — and it bought a soft edge nobody
+    // asked for. A hairline is enough to part the card from what is behind it.
+    paint.set_color(otto_kit::preview::background(f.theme));
+    canvas.draw_rrect(RRect::new_rect_xy(panel, 12.0, 12.0), &paint);
+
+    let mut edge = Paint::default();
+    edge.set_anti_alias(true);
+    edge.set_style(skia_safe::paint::Style::Stroke);
+    edge.set_stroke_width(1.0);
+    edge.set_color(f.theme.fill_tertiary);
+    canvas.draw_rrect(RRect::new_rect_xy(panel, 12.0, 12.0), &edge);
+
+    // Clipped to the panel: mid-entrance the content is drawn at its resting
+    // metrics inside a smaller card, exactly as the compositor-run version
+    // scales one buffer rather than re-laying-out the content.
+    // The title strip first, so the content's clip can exclude it.
+    let strip = quickview_titlebar_rect(panel);
+    let mut strip_paint = Paint::default();
+    strip_paint.set_anti_alias(true);
+    strip_paint.set_color(f.theme.fill_quaternary);
+    canvas.save();
+    // Clipped to the panel so the strip's own corners follow the card's.
+    canvas.clip_rrect(RRect::new_rect_xy(panel, 12.0, 12.0), None, true);
+    canvas.draw_rect(strip, &strip_paint);
+    canvas.restore();
+
+    let mut rule = Paint::default();
+    rule.set_anti_alias(true);
+    rule.set_color(f.theme.fill_tertiary);
+    rule.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(strip.left, strip.bottom),
+        Point::new(strip.right, strip.bottom),
+        &rule,
+    );
+
+    // The name, centred in the strip and clamped so a long one cannot run
+    // under the close button.
+    if !session.name.is_empty() {
+        // The same size the browser's own header gives a title. The strip is
+        // a titlebar and the name is what it is for, so it is read at the
+        // distance a window title is read at rather than a caption's.
+        let font = styles::BODY_EMPHASIZED.font();
+        let room = strip.width() - 80.0;
+        Label::new(ellipsize(&font, &session.name, room.max(40.0)))
+            .with_style(styles::BODY_EMPHASIZED)
+            .with_color(f.theme.text_secondary)
+            .centered_at(strip.center_x(), strip.center_y())
+            .render(canvas);
+    }
+
+    draw_quickview_close(canvas, f.theme, panel, f.quickview_close_hovered);
+
+    let content = quickview_content_rect(panel);
+    canvas.save();
+    canvas.clip_rrect(RRect::new_rect_xy(panel, 12.0, 12.0), None, true);
+    canvas.clip_rect(content, None, true);
+    otto_kit::preview::draw(
+        canvas,
+        content,
+        &session.preview,
+        f.theme,
+        session.first_row,
+        session.zoom,
+        &|name: &str, size: i32| {
+            icons::cached_icon_chain_at(&[name], size, icons::FULL_COLOUR_SIZE)
+        },
+    );
+    canvas.restore();
+}
+
+/// Draw the Get Info panel.
+///
+/// A panel, not a modal sheet: it is drawn into a surface of its own, the
+/// window behind it is not dimmed, and it goes on taking input while the
+/// browser underneath does too. The user drags it by its top strip and
+/// dismisses it with its close dot, which is the whole of what makes it feel
+/// like a window rather than a sheet.
+///
+/// `sheet` is where it currently sits, in window coordinates — the caller
+/// owns that, because the user moves it.
+///
+/// `shadow` paints one under the card. Only for the fallback path that draws
+/// into the window's own canvas: on its own surface the compositor casts the
+/// shadow outside the card's bounds, which no client-side one can do.
+pub fn draw_info(
+    canvas: &Canvas,
+    theme: &Theme,
+    sheet: Rect,
+    info: &model::FileInfo,
+    error: Option<&str>,
+    close_hovered: bool,
+    shadow: bool,
+) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    if shadow {
+        paint.set_color(theme.shadow);
+        canvas.draw_rrect(
+            RRect::new_rect_xy(sheet.with_offset((0.0, 6.0)), 14.0, 14.0),
+            &paint,
+        );
+    }
+    paint.set_color(content_ground());
+    canvas.draw_rrect(RRect::new_rect_xy(sheet, 14.0, 14.0), &paint);
+
+    // Close control, in the same red as the window's own — and, on hover,
+    // the same revealed × glyph as the window's own traffic lights.
+    let close = info_close_rect(sheet);
+    paint.set_color(Color::from_argb(0xFF, 0xFF, 0x5F, 0x57));
+    canvas.draw_circle(
+        Point::new(close.center_x(), close.center_y()),
+        close.width() / 2.0,
+        &paint,
+    );
+    if close_hovered {
+        let mut glyph = Paint::default();
+        glyph.set_anti_alias(true);
+        glyph.set_style(skia_safe::paint::Style::Stroke);
+        glyph.set_stroke_width((close.width() * 0.09).max(1.0));
+        glyph.set_stroke_cap(skia_safe::PaintCap::Round);
+        glyph.set_color(Color::from_argb(0xB0, 0x00, 0x00, 0x00));
+        let r = close.width() * 0.22;
+        let (cx, cy) = (close.center_x(), close.center_y());
+        canvas.draw_line((cx - r, cy - r), (cx + r, cy + r), &glyph);
+        canvas.draw_line((cx + r, cy - r), (cx - r, cy + r), &glyph);
+    }
+
+    // Icon and name.
+    let chain = if info.is_dir {
+        vec!["folder".to_string(), "inode-directory".to_string()]
+    } else {
+        otto_kit::filetype::icon_names(&info.mime)
+    };
+    let refs: Vec<&str> = chain.iter().map(String::as_str).collect();
+    if let Some(image) = icons::cached_icon_chain(&refs, 64) {
+        let dst = Rect::from_xywh(sheet.center_x() - 32.0, sheet.top + 34.0, 64.0, 64.0);
+        canvas.draw_image_rect(&image, None, dst, &Paint::default());
+    }
+
+    Label::new(elide(&info.name, 30))
+        .with_style(styles::TITLE_2_EMPHASIZED)
+        .with_color(theme.text_primary)
+        .centered_at(sheet.center_x(), sheet.top + 118.0)
+        .render(canvas);
+
+    let subtitle = if info.is_dir {
+        "Folder".to_string()
+    } else {
+        format!("{} — {}", info.kind.label(), model::format_size(info.size))
+    };
+    Label::new(&subtitle)
+        .with_style(styles::CALLOUT)
+        .with_color(theme.text_secondary)
+        .centered_at(sheet.center_x(), sheet.top + 144.0)
+        .render(canvas);
+
+    // Detail rows. Body text, not a caption: these are the panel's content —
+    // the path, the dates, who owns the file — and they were being set two
+    // steps smaller than the same facts are shown at in the browser itself.
+    let mut y = sheet.top + 180.0;
+    let label_x = sheet.left + 24.0;
+    let value_x = sheet.left + 118.0;
+    let value_w = sheet.right - 24.0 - value_x;
+    let value_font = styles::BODY.font();
+
+    let row = |label: &str, value: String, canvas: &Canvas, y: &mut f32| {
+        if value.is_empty() {
+            return;
+        }
+        Label::new(label)
+            .with_style(styles::BODY)
+            .with_color(theme.text_tertiary)
+            .centered_on(label_x, *y)
+            .render(canvas);
+        // Measured against the font rather than counted in characters: a
+        // per-character width estimate is a guess that has to be revisited
+        // every time the size changes, and the column is narrow enough that
+        // being wrong by a few characters runs the value under the edge.
+        Label::new(ellipsize(&value_font, &value, value_w))
+            .with_style(styles::BODY)
+            .with_color(theme.text_primary)
+            .centered_on(value_x, *y)
+            .render(canvas);
+        *y += 23.0;
+    };
+
+    let where_path = info
+        .path
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    row("Where", where_path, canvas, &mut y);
+    row("Kind", info.mime.clone(), canvas, &mut y);
+    row(
+        "Modified",
+        info.modified.map(model::format_time).unwrap_or_default(),
+        canvas,
+        &mut y,
+    );
+    row(
+        "Created",
+        info.created.map(model::format_time).unwrap_or_default(),
+        canvas,
+        &mut y,
+    );
+    row(
+        "Accessed",
+        info.accessed.map(model::format_time).unwrap_or_default(),
+        canvas,
+        &mut y,
+    );
+    row(
+        "Owner",
+        format!("{} : {}", info.owner, info.group),
+        canvas,
+        &mut y,
+    );
+    if let Some(target) = &info.link_target {
+        row(
+            "Links to",
+            target.to_string_lossy().into_owned(),
+            canvas,
+            &mut y,
+        );
+    }
+
+    // A file that could not be read at all says so instead of showing a
+    // permissions grid for a mode it never managed to load.
+    if let Some(reason) = &info.error {
+        Label::new(&elide(reason, 40))
+            .with_style(styles::CALLOUT)
+            .with_color(Color::from_argb(0xFF, 0xD7, 0x3A, 0x2E))
+            .centered_on(sheet.left + 24.0, y + 8.0)
+            .render(canvas);
+        return;
+    }
+
+    draw_permissions(canvas, theme, sheet, info, error);
+}
+
+fn draw_permissions(
+    canvas: &Canvas,
+    theme: &Theme,
+    sheet: Rect,
+    info: &model::FileInfo,
+    error: Option<&str>,
+) {
+    let (ox, oy) = perm_origin(sheet);
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    paint.set_color(theme.fill_tertiary);
+    paint.set_stroke_width(1.0);
+    canvas.draw_line(
+        Point::new(sheet.left + 20.0, oy - 40.0),
+        Point::new(sheet.right - 20.0, oy - 40.0),
+        &paint,
+    );
+
+    Label::new("Permissions")
+        .with_style(styles::BODY_EMPHASIZED)
+        .with_color(theme.text_secondary)
+        .centered_on(ox, oy - 18.0)
+        .render(canvas);
+
+    // The octal, because anyone changing permissions deliberately thinks in it.
+    let octal = format!("{}  {}", info.mode_string(), info.mode_octal());
+    let octal_w = styles::CALLOUT.font().measure_str(&octal, None).0;
+    Label::new(&octal)
+        .with_style(styles::CALLOUT)
+        .with_color(theme.text_tertiary)
+        .centered_on(sheet.right - 24.0 - octal_w, oy - 18.0)
+        .render(canvas);
+
+    // Headers sit in the gap above the first row, centred over their column.
+    for (what, header) in ["Read", "Write", "Exec"].into_iter().enumerate() {
+        let column_centre = ox + PERM_COL_X + what as f32 * PERM_COL_W + PERM_BOX / 2.0;
+        Label::new(header)
+            .with_style(styles::CALLOUT)
+            .with_color(theme.text_tertiary)
+            .centered_at(column_centre, oy - 3.0)
+            .render(canvas);
+    }
+
+    for (who, label) in ["Owner", "Group", "Everyone"].into_iter().enumerate() {
+        let y = oy + PERM_ROWS_TOP + who as f32 * PERM_ROW_H;
+        Label::new(label)
+            .with_style(styles::BODY)
+            .with_color(theme.text_primary)
+            .centered_on(ox, y)
+            .render(canvas);
+
+        for what in 0..3 {
+            let box_rect = perm_box_rect(sheet, who, what);
+            let on = info.permission(who, what);
+
+            paint.set_style(skia_safe::paint::Style::Fill);
+            paint.set_color(if on {
+                theme.material_selection_focused
+            } else {
+                theme.fill_tertiary
+            });
+            canvas.draw_rrect(RRect::new_rect_xy(box_rect, 4.0, 4.0), &paint);
+
+            if on {
+                // A tick, drawn rather than themed.
+                paint.set_color(Color::WHITE);
+                paint.set_style(skia_safe::paint::Style::Stroke);
+                paint.set_stroke_width(1.8);
+                paint.set_stroke_cap(skia_safe::paint::Cap::Round);
+                let mut builder = PathBuilder::new();
+                builder.move_to(Point::new(box_rect.left + 3.5, box_rect.center_y()));
+                builder.line_to(Point::new(box_rect.center_x() - 0.5, box_rect.bottom - 4.0));
+                builder.line_to(Point::new(box_rect.right - 3.5, box_rect.top + 4.5));
+                canvas.draw_path(&builder.detach(), &paint);
+                paint.set_style(skia_safe::paint::Style::Fill);
+            }
+        }
+    }
+
+    // A refused chmod says why, in place, rather than silently reverting.
+    if let Some(error) = error {
+        Label::new(elide(error, 42))
+            .with_style(styles::CALLOUT)
+            .with_color(Color::from_argb(0xFF, 0xD7, 0x3A, 0x2E))
+            .centered_on(ox, oy + PERM_ROWS_TOP + 3.0 * PERM_ROW_H + 12.0)
+            .render(canvas);
+    }
+}
+
+/// Truncate to `max` characters with an ellipsis. Character-count based, which
+/// is good enough for a fixed-width sheet and needs no font.
+fn elide(text: &str, max: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= max {
+        return text.to_string();
+    }
+    let head: String = chars[..max.saturating_sub(1)].iter().collect();
+    format!("{head}…")
+}
+
+// ---------------------------------------------------------------------------
+// Quick View anchor
+// ---------------------------------------------------------------------------
+
+/// The rect quick view should grow its card out of: the cursor's row, in this
+/// surface's own coordinates, with scrolling already applied.
+///
+/// Returns an **empty rect** when there is nothing to grow from — no cursor, or
+/// a cursor scrolled out of view. That is a documented answer meaning "open in
+/// place", not a missing value, and it is the case worth getting right: a stale
+/// rect for an off-screen selection makes the preview appear to erupt from a
+/// file that is not on screen.
+///
+/// Surface-local, never screen coordinates. A Wayland client cannot discover
+/// where its own surface sits on an output, and Otto exposes nothing that would
+/// tell it — `set_position` in `otto-surface-style` and `sc-layer` is a request,
+/// and no protocol carries a position back. Resolving this to the screen is the
+/// compositor's job. See `specs/file-browser.md`.
+pub fn quickview_anchor(
+    width: f32,
+    height: f32,
+    mode: ViewMode,
+    pane: &PaneData,
+    depth: usize,
+    pan: f32,
+    miller_w: f32,
+) -> Rect {
+    let Some(index) = pane.cursor else {
+        return Rect::new_empty();
+    };
+    if index >= pane.entries.len() {
+        return Rect::new_empty();
+    }
+
+    let viewport = content_viewport(width, height, mode);
+    let count = pane.entries.len();
+    let rect = match mode {
+        ViewMode::List => RowStrip::list(width, count, pane.scroll).rect(index),
+        ViewMode::Grid => grid_cell_rect(viewport, index, pane.scroll),
+        ViewMode::Columns => RowStrip::miller(
+            miller_pane_rect(depth, height, pan, miller_w),
+            count,
+            pane.scroll,
+        )
+        .rect(index),
+    };
+
+    // Grow from the icon, not the whole row. The row is a full-width band and
+    // the panel is a card, so a zoom out of the row reads as a stripe
+    // unfurling; the icon is already the thing on screen that stands for the
+    // file, and it is the shape the panel is closest to.
+    let rect = entry_icon_rect(rect, mode);
+
+    // Clipped away entirely, or scrolled out of the viewport: nothing to grow
+    // from. A partially visible row still counts — the user can see it.
+    // `Rect::intersect` reports overlap and mutates in place, so test a copy.
+    let mut probe = rect;
+    if probe.intersect(viewport) {
+        rect
+    } else {
+        Rect::new_empty()
+    }
+}
+
+/// Where the icon sits inside a row or a grid cell — the same geometry the
+/// drawing uses, read back so the Quick View entrance can start there.
+pub(crate) fn entry_icon_rect(rect: Rect, mode: ViewMode) -> Rect {
+    match mode {
+        ViewMode::Grid => Rect::from_xywh(
+            rect.center_x() - GRID_ICON / 2.0,
+            rect.top + 8.0,
+            GRID_ICON,
+            GRID_ICON,
+        ),
+        // The list insets its icon by the content padding; a Miller column,
+        // which has no such padding, by its own fixed inset.
+        ViewMode::List => Rect::from_xywh(
+            rect.left + CONTENT_PAD,
+            rect.center_y() - ICON_SIZE / 2.0,
+            ICON_SIZE,
+            ICON_SIZE,
+        ),
+        ViewMode::Columns => Rect::from_xywh(
+            rect.left + 14.0,
+            rect.center_y() - ICON_SIZE / 2.0,
+            ICON_SIZE,
+            ICON_SIZE,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod geometry_tests {
+    use super::*;
+
+    /// The panel opens centred, and moving it moves the whole card — the
+    /// close dot and the permission grid travel with it, because every piece
+    /// of its geometry is derived from the rect rather than the window.
+    #[test]
+    fn the_info_panel_travels_with_its_rect() {
+        let home = Rect::from_wh(INFO_W, INFO_H);
+        let moved = Rect::from_xywh(40.0, 12.0, INFO_W, INFO_H);
+        let dx = moved.left - home.left;
+        let dy = moved.top - home.top;
+        assert!(
+            (info_close_rect(moved).left - info_close_rect(home).left - dx).abs() < 0.01,
+            "the close dot stayed behind"
+        );
+        let (a, b) = (perm_box_rect(home, 1, 2), perm_box_rect(moved, 1, 2));
+        assert!((b.left - a.left - dx).abs() < 0.01, "{a:?} {b:?}");
+        assert!((b.top - a.top - dy).abs() < 0.01, "{a:?} {b:?}");
+    }
+
+    /// The strip the panel is dragged by must not sit over anything that is
+    /// clicked for another reason, or a drag would toggle a permission.
+    #[test]
+    fn the_drag_strip_holds_nothing_clickable() {
+        let sheet = Rect::from_wh(INFO_W, INFO_H);
+        let strip = info_titlebar_rect(sheet);
+        for who in 0..3 {
+            for what in 0..3 {
+                let mut box_rect = perm_box_rect(sheet, who, what);
+                assert!(
+                    !box_rect.intersect(strip),
+                    "permission box {who},{what} is under the drag strip"
+                );
+            }
+        }
+        // The close dot is the exception: it is *in* the strip, and is
+        // hit-tested before the drag.
+        assert!(strip.contains(skia_safe::Point::new(
+            info_close_rect(sheet).center_x(),
+            info_close_rect(sheet).center_y()
+        )));
+    }
+
+    use crate::model::Entry;
+    use otto_kit::filetype::Kind;
+
+    fn entries(n: usize) -> Vec<Entry> {
+        (0..n)
+            .map(|i| Entry {
+                name: format!("f{i}"),
+                path: std::path::PathBuf::from(format!("f{i}")),
+                is_dir: false,
+                is_symlink: false,
+                hidden: false,
+                kind: Kind::Text,
+                size: Some(0),
+                modified: None,
+            })
+            .collect()
+    }
+
+    fn pane<'a>(owned: &'a [Entry], cursor: Option<usize>, scroll: f32) -> PaneData<'a> {
+        PaneData {
+            entries: owned.iter().collect(),
+            selected: vec![false; owned.len()],
+            cursor,
+            scroll,
+            bar: None,
+            loading: false,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn no_cursor_means_no_anchor() {
+        let owned = entries(10);
+        let anchor = quickview_anchor(
+            1100.0,
+            700.0,
+            ViewMode::List,
+            &pane(&owned, None, 0.0),
+            0,
+            0.0,
+            MILLER_W,
+        );
+        assert!(anchor.is_empty(), "expected an empty rect, got {anchor:?}");
+    }
+
+    #[test]
+    fn a_visible_row_anchors_to_itself() {
+        let owned = entries(10);
+        let anchor = quickview_anchor(
+            1100.0,
+            700.0,
+            ViewMode::List,
+            &pane(&owned, Some(0), 0.0),
+            0,
+            0.0,
+            MILLER_W,
+        );
+        assert!(!anchor.is_empty());
+        // Inside the window, and below the header — a real place on screen.
+        assert!(anchor.top >= HEADER_H, "{anchor:?}");
+        assert!(anchor.left >= SIDEBAR_W, "{anchor:?}");
+        // The icon, not the row: a square the size the icon is drawn at,
+        // rather than a band running the width of the file area.
+        assert!((anchor.width() - ICON_SIZE).abs() < 0.5, "{anchor:?}");
+        assert!((anchor.height() - ICON_SIZE).abs() < 0.5, "{anchor:?}");
+    }
+
+    /// Every mode anchors to something icon-shaped, and inside the row it
+    /// belongs to — the entrance must not start from a rect the file is not
+    /// actually drawn in.
+    #[test]
+    fn every_mode_anchors_to_a_square_inside_its_row() {
+        let owned = entries(10);
+        for mode in [ViewMode::List, ViewMode::Grid, ViewMode::Columns] {
+            let anchor = quickview_anchor(
+                1100.0,
+                700.0,
+                mode,
+                &pane(&owned, Some(0), 0.0),
+                0,
+                0.0,
+                MILLER_W,
+            );
+            assert!(!anchor.is_empty(), "{mode:?}: {anchor:?}");
+            assert!(
+                (anchor.width() - anchor.height()).abs() < 0.5,
+                "{mode:?}: {anchor:?}"
+            );
+            let viewport = content_viewport(1100.0, 700.0, mode);
+            let mut probe = anchor;
+            assert!(probe.intersect(viewport), "{mode:?}: {anchor:?}");
+        }
+    }
+
+    #[test]
+    fn a_row_scrolled_out_of_view_anchors_nowhere() {
+        // The case that would look wrong once the zoom lands: the selection is
+        // real, but it is not on screen, so there is nothing to grow from.
+        let owned = entries(500);
+        let anchor = quickview_anchor(
+            1100.0,
+            700.0,
+            ViewMode::List,
+            &pane(&owned, Some(0), 5_000.0),
+            0,
+            0.0,
+            MILLER_W,
+        );
+        assert!(anchor.is_empty(), "expected an empty rect, got {anchor:?}");
+    }
+
+    #[test]
+    fn a_cursor_past_the_end_anchors_nowhere() {
+        let owned = entries(3);
+        let anchor = quickview_anchor(
+            1100.0,
+            700.0,
+            ViewMode::List,
+            &pane(&owned, Some(9), 0.0),
+            0,
+            0.0,
+            MILLER_W,
+        );
+        assert!(anchor.is_empty());
+    }
+
+    #[test]
+    fn every_view_mode_produces_an_anchor() {
+        let owned = entries(10);
+        for mode in [ViewMode::List, ViewMode::Grid, ViewMode::Columns] {
+            let anchor = quickview_anchor(
+                1100.0,
+                700.0,
+                mode,
+                &pane(&owned, Some(1), 0.0),
+                0,
+                0.0,
+                MILLER_W,
+            );
+            assert!(!anchor.is_empty(), "{mode:?} produced no anchor");
+        }
+    }
+
+    /// The band a pane of `count` rows would be asked for when the window is
+    /// `height` tall and scrolled to `offset`, through the same scroll state a
+    /// live pane carries.
+    fn scrolled(count: usize, height: f32, offset: f32) -> ScrollState {
+        let viewport = content_viewport(1100.0, height, ViewMode::List);
+        let mut state = ScrollState::new(viewport);
+        state.set_content_length(pane_content_height(1100.0, height, ViewMode::List, count));
+        state.set_offset(offset);
+        state
+    }
+
+    #[test]
+    fn a_strip_offers_only_the_rows_the_band_covers() {
+        let strip = RowStrip::list(1100.0, 4_000, 0.0);
+        let band = content_viewport(1100.0, 700.0, ViewMode::List);
+        let visible = strip.visible(band);
+
+        // A 580pt band of 30pt rows: twenty or so, never four thousand.
+        assert!(visible.len() < 30, "{visible:?}");
+        assert_eq!(visible.start, 0);
+        // Every row offered really does touch the band, and the ones just
+        // outside it really are left out.
+        for index in visible.clone() {
+            let rect = strip.rect(index);
+            assert!(
+                rect.bottom >= band.top && rect.top <= band.bottom,
+                "{index}"
+            );
+        }
+        assert!(strip.rect(visible.end).top > band.bottom);
+    }
+
+    #[test]
+    fn scrolling_moves_the_offered_rows_without_widening_them() {
+        let band = content_viewport(1100.0, 700.0, ViewMode::List);
+        // A thousand rows down, expressed in rows rather than points so the
+        // test says what it means when the pitch changes.
+        let scroll = 1_000.0 * ROW_H;
+        let top = RowStrip::list(1100.0, 4_000, 0.0).visible(band);
+        let deep = RowStrip::list(1100.0, 4_000, scroll).visible(band);
+
+        assert_eq!(top.len(), deep.len());
+        assert_eq!(deep.start, 1_000);
+    }
+
+    #[test]
+    fn a_rubber_banded_pane_still_offers_the_rows_pulled_into_view() {
+        // Overscrolled past the top: the rows are pushed down the window, and
+        // the first of them must still be drawn or the pull looks like a wipe.
+        let band = content_viewport(1100.0, 700.0, ViewMode::List);
+        let pulled = RowStrip::list(1100.0, 4_000, -80.0).visible(band);
+        assert_eq!(pulled.start, 0);
+        assert!(pulled.len() > 1);
+    }
+
+    #[test]
+    fn an_off_screen_miller_pane_offers_nothing() {
+        let strip = RowStrip::miller(Rect::from_xywh(-500.0, HEADER_H, MILLER_W, 600.0), 500, 0.0);
+        assert!(strip.visible(Rect::new_empty()).is_empty());
+    }
+
+    #[test]
+    fn the_grid_offers_whole_rows_of_cells_and_no_more() {
+        let area = content_viewport(1100.0, 700.0, ViewMode::Grid);
+        let band = area;
+        let visible = grid_visible_range(area, 4_000, 0.0, band);
+        assert!(!visible.is_empty());
+        assert!(visible.len() < 100, "{visible:?}");
+        for index in visible.clone() {
+            let cell = grid_cell_rect(area, index, 0.0);
+            assert!(
+                cell.bottom >= band.top && cell.top <= band.bottom,
+                "{index}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_band_a_pane_is_asked_for_matches_its_scroll_view() {
+        // The band is the scroll view's own content rect, mapped back into the
+        // window coordinates the rows live in — so it lands exactly on the
+        // viewport the scroll view was given, scrolled or not.
+        let owned = entries(4_000);
+        for offset in [0.0, 900.0] {
+            let state = scrolled(owned.len(), 700.0, offset);
+            let mut pane = pane(&owned, None, state.offset());
+            pane.bar = Some(&state);
+            assert_eq!(pane.band(Rect::new_empty()), state.viewport());
+        }
+    }
+
+    /// Draw ops `draw_list` emits for one window height, scrolled to `offset`.
+    fn list_ops(owned: &[Entry], height: f32, offset: f32) -> usize {
+        let state = scrolled(owned.len(), height, offset);
+        let mut data = pane(owned, None, state.offset());
+        data.bar = Some(&state);
+
+        let theme = Theme::light();
+        let frame = Frame {
+            action_row: None,
+            footer: 0.0,
+            quickview_close_hovered: false,
+            width: 1100.0,
+            height,
+            theme: &theme,
+            title: "Home",
+            subtitle: String::new(),
+            places: &[],
+            selected_place: None,
+            mode: ViewMode::List,
+            panes: vec![data],
+            active: 0,
+            pan: 0.0,
+            pan_bar: None,
+            miller_w: MILLER_W,
+            sort: SortKey::Name,
+            ascending: true,
+            list_columns: ListColumnWidths::default(),
+            renaming: None,
+            cut: Vec::new(),
+            controls: WindowControlsState::new(),
+            can_go_back: false,
+            can_go_forward: false,
+            nav_pressed: None,
+            preview: None,
+        };
+
+        let mut recorder = skia_safe::PictureRecorder::new();
+        let canvas = recorder.begin_recording(Rect::from_wh(1100.0, height), false);
+        draw_list(canvas, &frame);
+        recorder
+            .finish_recording_as_picture(None)
+            .expect("recorded picture")
+            .approximate_op_count()
+    }
+
+    #[test]
+    fn a_scrolled_tall_listing_draws_far_less_than_the_whole_of_it() {
+        let owned = entries(3_000);
+        // A window tall enough to hold every row is the "draw it all" case:
+        // the band covers the whole content, so nothing is skipped.
+        let whole = HEADER_H + COLUMNS_H + content_height(owned.len());
+
+        let all = list_ops(&owned, whole, 0.0);
+        let windowed = list_ops(&owned, 700.0, 15_000.0);
+
+        assert!(
+            windowed * 20 < all,
+            "a 700pt window into 3000 rows cost {windowed} ops against {all} for all of them"
+        );
+    }
+
+    #[test]
+    fn a_miller_column_panned_off_screen_anchors_nowhere() {
+        let owned = entries(10);
+        let anchor = quickview_anchor(
+            1100.0,
+            700.0,
+            ViewMode::Columns,
+            &pane(&owned, Some(0), 0.0),
+            0,
+            5_000.0,
+            MILLER_W,
+        );
+        assert!(anchor.is_empty(), "expected an empty rect, got {anchor:?}");
+    }
+}

--- a/components/otto-launcher/Cargo.toml
+++ b/components/otto-launcher/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "otto-launcher"
+version = "0.1.0"
+edition = "2021"
+description = "A keyboard-driven launcher for Otto — type to filter apps and windows, Enter to run"
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+taffy = "0.5"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+wayland-client = "0.31"
+smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
+freedesktop-desktop-entry = "0.7.5"
+shell-words = "1.1"
+
+[dependencies.laye-rs]
+git = "https://github.com/nongio/layers"
+tag = "v1.13.0"
+features = ["export-taffy"]
+
+[dependencies.skia-safe]
+version = "=0.93"
+features = ["gl", "textlayout", "svg", "skottie"]

--- a/components/otto-launcher/examples/preview.rs
+++ b/components/otto-launcher/examples/preview.rs
@@ -1,0 +1,82 @@
+//! Render the launcher's card to PNGs, without taking over a screen.
+//!
+//! The launcher is a fullscreen overlay that grabs the keyboard, which is a
+//! hostile thing to start while working on how it looks — and impossible to
+//! type into from a script without the keystrokes landing somewhere else if it
+//! is not up yet. This draws the same scene into an offscreen raster surface,
+//! for a given query:
+//!
+//! ```sh
+//! cargo run -p otto-launcher --example preview -- /tmp/launcher "term"
+//! ```
+//!
+//! The frosted material is the compositor's, so it cannot appear here; the
+//! preview paints a flat stand-in behind the scene in its place.
+
+use std::path::PathBuf;
+
+use layers::prelude::Engine;
+use otto_kit::components::text_input::TextInput;
+use otto_launcher::{field_style, rank, Apps, Item, Palette, Source, CARD_W, MAX_CARD_H};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let out_dir = args
+        .next()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp/otto-launcher-preview"));
+    std::fs::create_dir_all(&out_dir).expect("cannot create the output directory");
+    let queries: Vec<String> = args.collect();
+    let queries = if queries.is_empty() {
+        vec![String::new(), "term".into(), "zzzz".into()]
+    } else {
+        queries
+    };
+
+    let dark = true;
+    let engine = Engine::create(CARD_W, MAX_CARD_H);
+    let mut palette = Palette::new(engine.clone(), None, dark);
+    palette.set_size(1440.0, 930.0);
+
+    let mut apps = Apps::load(0);
+    let items: Vec<Item> = apps.items();
+    let labels = [apps.label()];
+
+    for query in &queries {
+        let mut input = TextInput::editing(query.clone(), field_style(dark));
+        input.state.placeholder = "Search apps and windows…".to_string();
+        input.set_size(CARD_W, otto_launcher::FIELD_H);
+
+        let matches = rank(&items, query);
+        let shown: Vec<&Item> = matches.iter().map(|m| &items[m.index]).collect();
+        let empty = (!query.trim().is_empty()).then_some("No results");
+        palette.update(&input, &shown, &labels, 0, 0, empty);
+        for _ in 0..60 {
+            engine.update(0.016);
+        }
+
+        let mut surface =
+            skia_safe::surfaces::raster_n32_premul((CARD_W as i32, MAX_CARD_H as i32))
+                .expect("cannot create the raster surface");
+        // Stand in for the compositor's frosted material.
+        surface.canvas().clear(if dark {
+            skia_safe::Color::from_argb(255, 34, 34, 38)
+        } else {
+            skia_safe::Color::from_argb(255, 240, 240, 244)
+        });
+        layers::prelude::draw_scene(surface.canvas(), engine.scene(), palette.card_layer().id());
+
+        let name = if query.is_empty() {
+            "empty".to_string()
+        } else {
+            query.replace(' ', "_")
+        };
+        let path = out_dir.join(format!("{name}.png"));
+        let image = surface.image_snapshot();
+        let data = image
+            .encode(None, skia_safe::EncodedImageFormat::PNG, 100)
+            .expect("cannot encode the preview");
+        std::fs::write(&path, data.as_bytes()).expect("cannot write the preview");
+        println!("{} ({} matches)", path.display(), matches.len());
+    }
+}

--- a/components/otto-launcher/src/apps.rs
+++ b/components/otto-launcher/src/apps.rs
@@ -1,0 +1,390 @@
+//! Installed applications, from their `.desktop` files.
+//!
+//! The launcher opens onto the last few applications started from it rather
+//! than onto all of them, so the list also remembers what was launched. That
+//! history is the only state the launcher keeps between runs.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+use freedesktop_desktop_entry::{default_paths, DesktopEntry, Iter};
+
+use crate::source::{Item, Origin, Source};
+
+/// How many recently launched applications the resting list shows.
+const RECENT_SHOWN: usize = 3;
+
+/// How many are remembered. More than are shown, so a launch that scrolls off
+/// the visible three is still there when the ones above it are uninstalled.
+const RECENT_KEPT: usize = 20;
+
+struct Entry {
+    /// The desktop file's stem, which is what the history records.
+    id: String,
+    name: String,
+    comment: Option<String>,
+    icon: Option<String>,
+    exec: String,
+    terminal: bool,
+    /// `Path=` — the directory the entry asks to be started in.
+    working_dir: Option<String>,
+    keywords: Vec<String>,
+}
+
+pub struct Apps {
+    index: usize,
+    entries: Vec<Entry>,
+}
+
+impl Apps {
+    /// Scan the XDG data directories. Entries that are hidden, that say they
+    /// do not belong in a menu, or that have nothing to run are left out —
+    /// they are all things that would only ever be picked by mistake.
+    pub fn load(index: usize) -> Self {
+        let locales = locales();
+        let locale_refs: Vec<&str> = locales.iter().map(String::as_str).collect();
+
+        let mut entries: Vec<Entry> = Vec::new();
+        let mut seen: Vec<String> = Vec::new();
+
+        for path in Iter::new(default_paths()) {
+            // Earlier XDG directories win: a user's ~/.local/share override
+            // must not appear twice alongside the system copy it replaces.
+            let id = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if id.is_empty() || seen.contains(&id) {
+                continue;
+            }
+
+            let Ok(entry) = DesktopEntry::from_path(path, Some(&locale_refs)) else {
+                continue;
+            };
+            if entry.no_display() || entry.type_() != Some("Application") {
+                continue;
+            }
+            if entry.desktop_entry("Hidden").is_some_and(|v| v == "true") {
+                continue;
+            }
+            let Some(exec) = entry.exec() else { continue };
+            let Some(name) = entry.name(&locale_refs) else {
+                continue;
+            };
+
+            seen.push(id.clone());
+            entries.push(Entry {
+                id,
+                name: name.to_string(),
+                comment: entry.comment(&locale_refs).map(|c| c.to_string()),
+                icon: entry.icon().map(|i| i.to_string()),
+                exec: exec.to_string(),
+                terminal: entry.terminal(),
+                working_dir: entry.path().map(|p| p.to_string()),
+                keywords: entry
+                    .keywords(&locale_refs)
+                    .map(|words| words.iter().map(|w| w.to_string()).collect())
+                    .unwrap_or_default(),
+            });
+        }
+
+        entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        Self { index, entries }
+    }
+}
+
+impl Source for Apps {
+    fn label(&self) -> &'static str {
+        "App"
+    }
+
+    fn items(&mut self) -> Vec<Item> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| Item {
+                title: entry.name.clone(),
+                subtitle: entry.comment.clone(),
+                icon: entry.icon.clone(),
+                search_terms: entry
+                    .keywords
+                    .iter()
+                    .cloned()
+                    .chain(binary_name(&entry.exec))
+                    .collect(),
+                origin: Origin {
+                    source: self.index,
+                    index,
+                },
+            })
+            .collect()
+    }
+
+    /// The last few applications started from the launcher, most recent first.
+    ///
+    /// Empty until something has been launched — a launcher that has never been
+    /// used has nothing to say about what you want, and says nothing.
+    fn resting(&mut self) -> Vec<Item> {
+        let items = self.items();
+        history()
+            .iter()
+            .filter_map(|id| {
+                let index = self.entries.iter().position(|entry| &entry.id == id)?;
+                items.get(index).cloned()
+            })
+            .take(RECENT_SHOWN)
+            .collect()
+    }
+
+    fn activate(&mut self, index: usize) -> Result<(), String> {
+        let entry = self.entries.get(index).ok_or("no such app")?;
+        spawn(entry)?;
+        // Only once it has actually started: an application that could not be
+        // launched should not be what the launcher offers next time.
+        remember(&entry.id);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Launch history
+// ---------------------------------------------------------------------------
+
+/// Where the history lives — state rather than config: it is written by the
+/// program, and losing it costs nothing.
+fn history_path() -> Option<PathBuf> {
+    let dir = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/state"))
+        })?;
+    Some(dir.join("otto").join("launcher-history"))
+}
+
+/// Desktop file ids, most recently launched first.
+fn history() -> Vec<String> {
+    let Some(path) = history_path() else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .take(RECENT_KEPT)
+        .collect()
+}
+
+/// `id` moved to the front, keeping the rest in order and dropping the oldest
+/// past [`RECENT_KEPT`].
+fn promote(id: &str, existing: Vec<String>) -> Vec<String> {
+    std::iter::once(id.to_string())
+        .chain(existing.into_iter().filter(|other| other != id))
+        .take(RECENT_KEPT)
+        .collect()
+}
+
+/// Move `id` to the front of the history.
+///
+/// Written whole and moved into place, so a launcher killed mid-write leaves
+/// the previous history rather than half of a new one.
+fn remember(id: &str) {
+    let Some(path) = history_path() else {
+        return;
+    };
+    let ids = promote(id, history());
+
+    let Some(dir) = path.parent() else { return };
+    if let Err(err) = std::fs::create_dir_all(dir) {
+        tracing::warn!(%err, "could not create the state directory");
+        return;
+    }
+    let temporary = path.with_extension("tmp");
+    let written = std::fs::File::create(&temporary).and_then(|mut file| {
+        file.write_all(ids.join("\n").as_bytes())?;
+        file.write_all(b"\n")
+    });
+    match written {
+        Ok(()) => {
+            if let Err(err) = std::fs::rename(&temporary, &path) {
+                tracing::warn!(%err, "could not save the launch history");
+            }
+        }
+        Err(err) => tracing::warn!(%err, "could not write the launch history"),
+    }
+}
+
+/// Start the app, detached.
+///
+/// The launcher exits immediately afterwards, so the child is put in its own
+/// process group: a session that reaps the launcher must not take the app with
+/// it, and a terminal app must not end up sharing our controlling terminal.
+fn spawn(entry: &Entry) -> Result<(), String> {
+    let line = strip_field_codes(&entry.exec);
+    let mut parts = shell_words::split(&line).map_err(|err| err.to_string())?;
+    if parts.is_empty() {
+        return Err("nothing to run".to_string());
+    }
+
+    if entry.terminal {
+        let mut wrapped = terminal_command();
+        wrapped.append(&mut parts);
+        parts = wrapped;
+    }
+
+    let mut command = Command::new(&parts[0]);
+    command.args(&parts[1..]);
+    if let Some(dir) = &entry.working_dir {
+        command.current_dir(dir);
+    }
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    command
+        .spawn()
+        .map(|_| ())
+        .map_err(|err| format!("could not start {}: {err}", parts[0]))
+}
+
+/// `Terminal=true` entries are a command, not a command line: something has to
+/// supply the terminal to run them in.
+fn terminal_command() -> Vec<String> {
+    let terminal = std::env::var("TERMINAL").unwrap_or_default();
+    let terminal = if terminal.is_empty() {
+        ["ghostty", "alacritty", "foot", "kitty", "xterm"]
+            .into_iter()
+            .find(|candidate| which(candidate))
+            .unwrap_or("xterm")
+            .to_string()
+    } else {
+        terminal
+    };
+    vec![terminal, "-e".to_string()]
+}
+
+fn which(program: &str) -> bool {
+    std::env::var("PATH")
+        .is_ok_and(|path| std::env::split_paths(&path).any(|dir| dir.join(program).is_file()))
+}
+
+/// Drop the `%f`/`%U`/… placeholders. The launcher opens applications with no
+/// arguments, so every field code expands to nothing — except `%%`, which is a
+/// literal percent sign.
+fn strip_field_codes(exec: &str) -> String {
+    let mut out = String::with_capacity(exec.len());
+    let mut chars = exec.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('%') => out.push('%'),
+            Some(_) => {}
+            None => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn binary_name(exec: &str) -> Option<String> {
+    let line = strip_field_codes(exec);
+    let first = line.split_whitespace().next()?;
+    let name = first.rsplit('/').next()?;
+    // `env FOO=bar app` and friends would otherwise contribute a search term
+    // that matches half the menu.
+    if matches!(name, "env" | "sh" | "bash" | "flatpak") {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+fn locales() -> Vec<String> {
+    let mut locales = Vec::new();
+    for var in ["LC_MESSAGES", "LC_ALL", "LANG"] {
+        let Ok(value) = std::env::var(var) else {
+            continue;
+        };
+        if value.is_empty() || value == "C" || value == "POSIX" {
+            continue;
+        }
+        let base = value.split('.').next().unwrap_or(&value).to_string();
+        let language = base.split('_').next().unwrap_or(&base).to_string();
+        for candidate in [base, language] {
+            if !locales.contains(&candidate) {
+                locales.push(candidate);
+            }
+        }
+    }
+    if locales.is_empty() {
+        locales.push("en".to_string());
+    }
+    locales
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launching_moves_an_app_to_the_front_without_duplicating_it() {
+        let existing = vec!["b".to_string(), "a".to_string()];
+        assert_eq!(promote("a", existing.clone()), ["a", "b"]);
+        assert_eq!(promote("c", existing), ["c", "b", "a"]);
+    }
+
+    #[test]
+    fn the_history_forgets_the_oldest_past_its_limit() {
+        let existing: Vec<String> = (0..RECENT_KEPT).map(|n| n.to_string()).collect();
+        let promoted = promote("new", existing);
+        assert_eq!(promoted.len(), RECENT_KEPT);
+        assert_eq!(promoted[0], "new");
+        assert!(!promoted.contains(&(RECENT_KEPT - 1).to_string()));
+    }
+
+    /// Reading and writing the file, end to end, in a directory of its own.
+    /// One test rather than several: they would be sharing an environment
+    /// variable.
+    #[test]
+    fn the_history_survives_a_round_trip_through_the_state_file() {
+        let dir = std::env::temp_dir().join(format!("otto-launcher-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::set_var("XDG_STATE_HOME", &dir);
+
+        assert!(history().is_empty(), "nothing has been launched yet");
+        remember("code");
+        remember("ghostty");
+        remember("code");
+        assert_eq!(history(), ["code", "ghostty"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("XDG_STATE_HOME");
+    }
+
+    #[test]
+    fn field_codes_are_dropped_and_double_percent_survives() {
+        assert_eq!(strip_field_codes("gimp %U"), "gimp");
+        assert_eq!(strip_field_codes("app -f %f --x %i"), "app -f --x");
+        assert_eq!(strip_field_codes("printf 100%%"), "printf 100%");
+    }
+
+    #[test]
+    fn the_binary_name_becomes_a_search_term() {
+        assert_eq!(
+            binary_name("/usr/bin/gimp-2.10 %U").as_deref(),
+            Some("gimp-2.10")
+        );
+    }
+
+    #[test]
+    fn wrappers_do_not_become_search_terms() {
+        assert_eq!(binary_name("env GDK_BACKEND=x11 inkscape"), None);
+        assert_eq!(binary_name("flatpak run org.gimp.GIMP"), None);
+    }
+}

--- a/components/otto-launcher/src/calc.rs
+++ b/components/otto-launcher/src/calc.rs
@@ -1,0 +1,357 @@
+//! Arithmetic typed into the query field.
+//!
+//! `24.5*3`, `3+100`, `1000,00/45.3` — when what has been typed is an
+//! expression rather than a search, the answer is offered as the first row.
+//! It is not ranked against the query the way the other sources are: the
+//! answer to `24.5*3` is `73.5`, which shares nothing with what was typed and
+//! would be filtered straight out.
+//!
+//! Only whole expressions count. A query has to parse from end to end and
+//! contain at least one operator, so `3` on its own is a search for something
+//! called "3" and `code` is not an unfinished sum.
+//!
+//! **Decimal separators.** A comma is a decimal point: `1000,00` is a thousand.
+//! When a number carries both separators the last one is the decimal point and
+//! the other is grouping, so `1.000,50` and `1,000.50` both read as a thousand
+//! and a half.
+
+use std::process::Command;
+
+use crate::source::{Item, Origin, Source};
+
+pub struct Calculator {
+    index: usize,
+    /// The last answer worked out, so activating the row knows what to copy.
+    last: Option<String>,
+}
+
+impl Calculator {
+    pub fn new(index: usize) -> Self {
+        Self { index, last: None }
+    }
+}
+
+impl Source for Calculator {
+    fn label(&self) -> &'static str {
+        "Calc"
+    }
+
+    /// Nothing to browse: an answer exists only for a question.
+    fn items(&mut self) -> Vec<Item> {
+        Vec::new()
+    }
+
+    fn answer(&mut self, query: &str) -> Option<Item> {
+        let answer = evaluate(query)?;
+        self.last = Some(answer.clone());
+        Some(Item {
+            title: answer,
+            subtitle: Some(format!("{} — copy to the clipboard", query.trim())),
+            icon: icon_name(),
+            search_terms: Vec::new(),
+            origin: Origin {
+                source: self.index,
+                index: 0,
+            },
+        })
+    }
+
+    fn activate(&mut self, _index: usize) -> Result<(), String> {
+        let answer = self.last.as_ref().ok_or("nothing to copy")?;
+        // `wl-copy` forks and stays alive to serve the selection, which this
+        // process cannot: it is about to exit, and a Wayland clipboard offer
+        // dies with the client that made it.
+        Command::new("wl-copy")
+            .arg(answer)
+            .spawn()
+            .map(|_| ())
+            .map_err(|err| format!("could not copy the answer: {err}"))
+    }
+}
+
+/// The first calculator icon the theme actually has.
+///
+/// The generic freedesktop name is not in every theme — this one is not in
+/// ours — so the installed calculator's own icon is the fallback, and a blank
+/// square is the last resort.
+fn icon_name() -> Option<String> {
+    static NAME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    NAME.get_or_init(|| {
+        [
+            "accessories-calculator",
+            "org.gnome.Calculator",
+            "gnome-calculator",
+            "galculator",
+        ]
+        .into_iter()
+        .find(|name| otto_kit::icons::find_icon(name, 56, 2).is_some())
+        .map(str::to_string)
+    })
+    .clone()
+}
+
+/// Work out `input`, or `None` if it is not an expression.
+pub fn evaluate(input: &str) -> Option<String> {
+    let tokens = tokenize(input)?;
+    if !tokens.iter().any(|token| matches!(token, Token::Op(_))) {
+        // A bare number is a search, not a sum.
+        return None;
+    }
+
+    let mut parser = Parser {
+        tokens: &tokens,
+        at: 0,
+    };
+    let value = parser.expression()?;
+    if parser.at != tokens.len() {
+        return None;
+    }
+    if !value.is_finite() {
+        return None;
+    }
+
+    // Answer in the notation the question was asked in.
+    let comma = input.contains(',') && !input.contains('.');
+    Some(format(value, comma))
+}
+
+fn format(value: f64, comma: bool) -> String {
+    let mut text = if value == value.trunc() && value.abs() < 1e15 {
+        format!("{}", value as i64)
+    } else {
+        // Ten decimal places is past the noise of binary floating point —
+        // 0.1 + 0.2 rounds back to 0.3 — and the zeros go afterwards.
+        let mut rounded = format!("{value:.10}");
+        while rounded.ends_with('0') {
+            rounded.pop();
+        }
+        if rounded.ends_with('.') {
+            rounded.pop();
+        }
+        rounded
+    };
+    if comma {
+        text = text.replace('.', ",");
+    }
+    text
+}
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Number(f64),
+    Op(char),
+    Open,
+    Close,
+}
+
+fn tokenize(input: &str) -> Option<Vec<Token>> {
+    let chars: Vec<char> = input.trim().chars().collect();
+    if chars.is_empty() {
+        return None;
+    }
+
+    let mut tokens = Vec::new();
+    let mut at = 0;
+    while at < chars.len() {
+        let c = chars[at];
+        if c.is_whitespace() {
+            at += 1;
+            continue;
+        }
+        if c.is_ascii_digit() || c == '.' || c == ',' {
+            let start = at;
+            while at < chars.len()
+                && (chars[at].is_ascii_digit() || chars[at] == '.' || chars[at] == ',')
+            {
+                at += 1;
+            }
+            let text: String = chars[start..at].iter().collect();
+            tokens.push(Token::Number(parse_number(&text)?));
+            continue;
+        }
+        at += 1;
+        match c {
+            '(' => tokens.push(Token::Open),
+            ')' => tokens.push(Token::Close),
+            '+' | '-' | '*' | '/' | '%' | '^' => tokens.push(Token::Op(c)),
+            // The characters a keyboard layout or a paste can produce for the
+            // same two operations.
+            '×' | 'x' | '·' => tokens.push(Token::Op('*')),
+            '÷' | ':' => tokens.push(Token::Op('/')),
+            '−' => tokens.push(Token::Op('-')),
+            // Anything else means this was never an expression.
+            _ => return None,
+        }
+    }
+    Some(tokens)
+}
+
+/// Read one number, working out what its separators mean.
+fn parse_number(text: &str) -> Option<f64> {
+    let dot = text.rfind('.');
+    let comma = text.rfind(',');
+
+    let normalized = match (dot, comma) {
+        // Both: whichever comes last is the decimal point, the other groups.
+        (Some(d), Some(c)) if d > c => text.replace(',', ""),
+        (Some(_), Some(_)) => text.replace('.', "").replace(',', "."),
+        // A comma alone is a decimal point — `1000,00` is a thousand.
+        (None, Some(_)) => text.replace(',', "."),
+        _ => text.to_string(),
+    };
+    // One separator at most survives, or this was never a number.
+    if normalized.matches('.').count() > 1 {
+        return None;
+    }
+    normalized.parse().ok()
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    at: usize,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.at)
+    }
+
+    fn eat_op(&mut self, wanted: &[char]) -> Option<char> {
+        match self.peek() {
+            Some(Token::Op(op)) if wanted.contains(op) => {
+                let op = *op;
+                self.at += 1;
+                Some(op)
+            }
+            _ => None,
+        }
+    }
+
+    fn expression(&mut self) -> Option<f64> {
+        let mut value = self.term()?;
+        while let Some(op) = self.eat_op(&['+', '-']) {
+            let rhs = self.term()?;
+            value = if op == '+' { value + rhs } else { value - rhs };
+        }
+        Some(value)
+    }
+
+    fn term(&mut self) -> Option<f64> {
+        let mut value = self.power()?;
+        while let Some(op) = self.eat_op(&['*', '/', '%']) {
+            let rhs = self.power()?;
+            value = match op {
+                '*' => value * rhs,
+                '/' => value / rhs,
+                _ => value % rhs,
+            };
+        }
+        Some(value)
+    }
+
+    /// Right-associative, so `2^3^2` is 512 rather than 64.
+    fn power(&mut self) -> Option<f64> {
+        let base = self.unary()?;
+        if self.eat_op(&['^']).is_some() {
+            let exponent = self.power()?;
+            return Some(base.powf(exponent));
+        }
+        Some(base)
+    }
+
+    fn unary(&mut self) -> Option<f64> {
+        if let Some(op) = self.eat_op(&['-', '+']) {
+            let value = self.unary()?;
+            return Some(if op == '-' { -value } else { value });
+        }
+        self.primary()
+    }
+
+    fn primary(&mut self) -> Option<f64> {
+        match self.peek()? {
+            Token::Number(value) => {
+                let value = *value;
+                self.at += 1;
+                Some(value)
+            }
+            Token::Open => {
+                self.at += 1;
+                let value = self.expression()?;
+                match self.peek() {
+                    Some(Token::Close) => {
+                        self.at += 1;
+                        Some(value)
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works_out_the_examples() {
+        assert_eq!(evaluate("24.5*3").as_deref(), Some("73.5"));
+        assert_eq!(evaluate("3+100").as_deref(), Some("103"));
+        assert_eq!(evaluate("1000,00/45.3").as_deref(), Some("22.0750551876"));
+    }
+
+    #[test]
+    fn a_comma_is_a_decimal_point() {
+        assert_eq!(evaluate("1000,00/2").as_deref(), Some("500"));
+        assert_eq!(evaluate("1,5+1,5").as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn an_answer_is_written_the_way_the_question_was() {
+        assert_eq!(evaluate("1,5*3").as_deref(), Some("4,5"));
+        assert_eq!(evaluate("1.5*3").as_deref(), Some("4.5"));
+    }
+
+    #[test]
+    fn both_separators_means_the_last_one_is_the_decimal_point() {
+        assert_eq!(parse_number("1.000,50"), Some(1000.5));
+        assert_eq!(parse_number("1,000.50"), Some(1000.5));
+    }
+
+    #[test]
+    fn precedence_and_parentheses_hold() {
+        assert_eq!(evaluate("2+3*4").as_deref(), Some("14"));
+        assert_eq!(evaluate("(2+3)*4").as_deref(), Some("20"));
+        assert_eq!(evaluate("2^3^2").as_deref(), Some("512"));
+        assert_eq!(evaluate("-3+10").as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn floating_point_noise_is_rounded_away() {
+        assert_eq!(evaluate("0.1+0.2").as_deref(), Some("0.3"));
+    }
+
+    #[test]
+    fn a_search_is_not_an_expression() {
+        assert_eq!(evaluate("code"), None);
+        assert_eq!(evaluate("3"), None, "a bare number is a search");
+        assert_eq!(evaluate(""), None);
+        assert_eq!(evaluate("2+"), None, "an unfinished sum has no answer");
+        assert_eq!(evaluate("gimp 2"), None);
+        assert_eq!(evaluate("(2+3"), None);
+    }
+
+    #[test]
+    fn dividing_by_zero_has_no_answer_to_show() {
+        assert_eq!(evaluate("1/0"), None);
+    }
+}

--- a/components/otto-launcher/src/lib.rs
+++ b/components/otto-launcher/src/lib.rs
@@ -1,0 +1,13 @@
+//! The launcher's parts, as a library so the preview example — and tests —
+//! can build the same scene the binary does without a compositor.
+
+pub mod apps;
+pub mod calc;
+pub mod source;
+pub mod view;
+pub mod windows;
+
+pub use apps::Apps;
+pub use calc::Calculator;
+pub use source::{rank, Item, Match, Origin, Source};
+pub use view::{field_style, Palette, CARD_W, FIELD_H, MAX_CARD_H, MAX_ROWS, RADIUS};

--- a/components/otto-launcher/src/main.rs
+++ b/components/otto-launcher/src/main.rs
@@ -1,0 +1,918 @@
+//! otto-launcher — type to find something, Enter to have it.
+//!
+//! A fullscreen overlay that takes the keyboard, filters a list of [`Item`]s
+//! from one or more [`Source`]s, and activates the one that is selected. Apps
+//! and open windows are the two sources it ships with; a source is a trait, so
+//! files, clipboard history or a calculator are additions rather than rewrites.
+//!
+//! Run it and it stays up until something is picked, Escape is pressed, or the
+//! click lands outside the card. It is meant to be bound to a key and started
+//! fresh each time — there is no daemon, and nothing to keep warm: the desktop
+//! entry scan is the only work at startup, and it is milliseconds.
+
+use std::os::fd::RawFd;
+use std::time::{Duration, Instant};
+
+use otto_kit::components::text_input::{
+    KeyMods, TextInput, TextInputKey, TextInputResponse, CARET_BLINK_PERIOD,
+};
+use otto_kit::protocols::otto_surface_style_v1::{BlendMode, ClipMode, ContentsGravity};
+use otto_kit::protocols::otto_timing_function_v1::Preset;
+use otto_kit::surfaces::{LayerShellSurface, SubsurfaceSurface};
+use otto_kit::{App, AppContext, AppRunner};
+use smithay_client_toolkit::seat::keyboard::{KeyEvent, Keysym};
+use smithay_client_toolkit::seat::pointer::{PointerEvent, PointerEventKind};
+use wayland_client::protocol::{wl_keyboard, wl_surface};
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::{
+    Anchor, KeyboardInteractivity,
+};
+
+use otto_launcher::apps::Apps;
+use otto_launcher::calc::Calculator;
+use otto_launcher::source::{rank, Item, Origin, Source};
+use otto_launcher::view::{field_style, Palette, CARD_W, FIELD_H, MAX_CARD_H, MAX_ROWS, RADIUS};
+use otto_launcher::windows;
+
+/// How long the scene is kept painting after a change, so the selection's
+/// slide and the card's resize are seen through to the end.
+const SETTLE: Duration = Duration::from_millis(220);
+
+/// A frame the compositor never answered must not freeze the launcher.
+const FRAME_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// How the card arrives and leaves.
+///
+/// It scales and fades rather than sliding: the launcher appears where it is
+/// going to stay. The two are deliberately out of step. The fade is quick — the
+/// card should be *there* almost at once, because it is about to be typed into
+/// — while the scale takes its time and springs past full size before settling,
+/// which is what gives the arrival some life. Leaving is quicker than arriving,
+/// and does not bounce: on the way out there is nothing to settle into.
+const FADE_IN: Duration = Duration::from_millis(90);
+const SCALE_IN: Duration = Duration::from_millis(340);
+const FADE_OUT: Duration = Duration::from_millis(90);
+const SCALE_OUT: Duration = Duration::from_millis(110);
+
+/// How much the scale overshoots on the way in. Enough to notice, not enough
+/// to wobble.
+const BOUNCE: f64 = 0.35;
+
+/// When the launcher may stop — the longest thing the exit is waiting on.
+const CLOSE: Duration = Duration::from_millis(120);
+
+/// How small the card is before it arrives, and again once it has gone. Near
+/// enough to full size that it reads as a swell rather than a zoom.
+const OPEN_SCALE: f64 = 0.96;
+const CLOSE_SCALE: f64 = 0.96;
+
+struct Launcher {
+    /// The fullscreen surface. It carries the scrim, takes the keyboard, and
+    /// catches the click that lands outside the card.
+    surface: Option<LayerShellSurface>,
+    /// The card. A surface of its own so the compositor can frost what is
+    /// behind *it* rather than behind the whole screen.
+    card: Option<SubsurfaceSurface>,
+    palette: Option<Palette>,
+    /// Last size handed to the card's style, so an unchanged frame does not
+    /// re-send it.
+    card_size: (f32, f32),
+
+    sources: Vec<Box<dyn Source>>,
+    labels: Vec<&'static str>,
+    /// Everything the sources have, which is what a query is ranked against.
+    items: Vec<Item>,
+    /// What is shown before anything is typed — the last few applications
+    /// launched, and every window in the switcher.
+    resting: Vec<Item>,
+    /// The rows as displayed: answers derived from the query, then either the
+    /// resting list or the ranked matches.
+    rows: Vec<Item>,
+
+    input: TextInput,
+    /// Index into `matches` of the highlighted row.
+    selected: usize,
+    /// First row on screen — the list scrolls past [`MAX_ROWS`].
+    offset: usize,
+
+    shift: bool,
+    sized: bool,
+    /// Set once the launcher has been interacted with, after which losing the
+    /// keyboard means "gone" rather than "not arrived yet".
+    engaged: bool,
+
+    /// Set once the card has something on it and the entrance has been
+    /// started, so it is started exactly once.
+    opened: bool,
+    /// When the closing animation will have finished, and the launcher can
+    /// stop. Input is ignored from the moment this is set.
+    closing_at: Option<Instant>,
+
+    dirty: bool,
+    painted_at: Option<Instant>,
+    settle_until: Option<Instant>,
+    last_tick: Instant,
+}
+
+/// Which sources a run offers. Everything, by default; the single-kind scopes
+/// exist so a binding can mean "switch window" specifically, the way rofi's
+/// `-show window` does.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Everything,
+    Apps,
+    Windows,
+}
+
+impl Scope {
+    /// What the field says when it is empty. It names the mode, because the
+    /// two bindings mean different things and the field is the only place that
+    /// says which one is up.
+    fn placeholder(self) -> &'static str {
+        match self {
+            Scope::Everything => "Search for apps and windows…",
+            Scope::Apps => "Search for apps…",
+            Scope::Windows => "Search for windows…",
+        }
+    }
+}
+
+/// When the process started, for the startup timings. A launcher is judged on
+/// how long it takes to appear, so the stages that make up that time are
+/// measurable without a profiler.
+static STARTED: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+
+fn since_start() -> u128 {
+    STARTED.get_or_init(Instant::now).elapsed().as_millis()
+}
+
+impl Launcher {
+    /// `query` is what the field starts with — the command line's optional
+    /// argument, for a binding that opens the launcher already narrowed.
+    fn new(query: &str, scope: Scope) -> Self {
+        let mut sources: Vec<Box<dyn Source>> = Vec::new();
+        let mut labels: Vec<&'static str> = Vec::new();
+
+        if scope != Scope::Windows {
+            let apps = Apps::load(sources.len());
+            tracing::debug!(ms = since_start(), "desktop entries scanned");
+            labels.push(apps.label());
+            sources.push(Box::new(apps));
+
+            let calculator = Calculator::new(sources.len());
+            labels.push(calculator.label());
+            sources.push(Box::new(calculator));
+        }
+
+        if scope != Scope::Apps {
+            let started = Instant::now();
+            let connected = windows::Windows::connect(sources.len(), scope == Scope::Windows);
+            tracing::debug!(ms = started.elapsed().as_millis(), "toplevels listed");
+            match connected {
+                Some(windows) => {
+                    labels.push(windows.label());
+                    sources.push(Box::new(windows));
+                }
+                None => tracing::info!("no foreign-toplevel protocol; windows will not be listed"),
+            }
+        }
+
+        let mut input = TextInput::editing(query, field_style(dark()));
+        input.state.placeholder = scope.placeholder().to_string();
+        // Without a box to be laid out in, the field scrolls the text it is
+        // given out of its own (zero-width) clip and draws nothing.
+        input.set_size(CARD_W, FIELD_H);
+
+        Self {
+            surface: None,
+            card: None,
+            palette: None,
+            card_size: (0.0, 0.0),
+            sources,
+            labels,
+            items: Vec::new(),
+            resting: Vec::new(),
+            rows: Vec::new(),
+            input,
+            selected: 0,
+            offset: 0,
+            shift: false,
+            sized: false,
+            engaged: false,
+            opened: false,
+            closing_at: None,
+            dirty: true,
+            painted_at: None,
+            settle_until: None,
+            last_tick: Instant::now(),
+        }
+    }
+
+    /// Ask every source for its items again, keeping the selection on the same
+    /// item where that is still possible.
+    fn reload(&mut self) {
+        let previous = self.selected_origin();
+        self.items = self
+            .sources
+            .iter_mut()
+            .flat_map(|source| source.items())
+            .collect();
+        self.resting = self
+            .sources
+            .iter_mut()
+            .flat_map(|source| source.resting())
+            .collect();
+        self.refilter();
+
+        if let Some(origin) = previous {
+            if let Some(position) =
+                (0..self.row_count()).find(|row| self.row(*row).is_some_and(|i| i.origin == origin))
+            {
+                self.selected = position;
+                self.scroll_to_selection();
+            }
+        }
+    }
+
+    fn refilter(&mut self) {
+        let query = self.input.value().to_string();
+
+        let mut rows: Vec<Item> = self
+            .sources
+            .iter_mut()
+            .filter_map(|source| source.answer(&query))
+            .collect();
+
+        if query.trim().is_empty() {
+            // Nothing typed: the sources' own idea of what is worth showing,
+            // not everything they have.
+            rows.extend(self.resting.iter().cloned());
+        } else {
+            rows.extend(
+                rank(&self.items, &query)
+                    .into_iter()
+                    .filter_map(|matched| self.items.get(matched.index).cloned()),
+            );
+        }
+
+        self.rows = rows;
+        self.selected = 0;
+        self.offset = 0;
+        self.dirty = true;
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn row(&self, index: usize) -> Option<&Item> {
+        self.rows.get(index)
+    }
+
+    fn selected_origin(&self) -> Option<Origin> {
+        Some(self.row(self.selected)?.origin)
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.row_count() == 0 {
+            return;
+        }
+        let count = self.row_count() as isize;
+        // Wrapping, because a list that stops at the end makes someone check
+        // where the end was.
+        self.selected = (self.selected as isize + delta).rem_euclid(count) as usize;
+        self.scroll_to_selection();
+        self.dirty = true;
+    }
+
+    fn scroll_to_selection(&mut self) {
+        if self.selected < self.offset {
+            self.offset = self.selected;
+        } else if self.selected >= self.offset + MAX_ROWS {
+            self.offset = self.selected + 1 - MAX_ROWS;
+        }
+    }
+
+    /// Carry out the selection and leave. A source that refuses says why and
+    /// the launcher stays up, because the alternative is vanishing without
+    /// having done anything.
+    fn activate(&mut self) {
+        let Some(origin) = self.selected_origin() else {
+            return;
+        };
+        let Some(source) = self.sources.get_mut(origin.source) else {
+            return;
+        };
+        match source.activate(origin.index) {
+            Ok(()) => self.close(),
+            Err(err) => {
+                tracing::error!(%err, "could not activate the selection");
+                self.dirty = true;
+            }
+        }
+    }
+
+    // === Painting ===
+
+    fn push(&mut self) {
+        if !self.sized {
+            return;
+        }
+        // Destructured so the rows and the palette borrow different fields:
+        // the references handed to the palette point into `rows`, and they have
+        // to outlive the call that draws them.
+        let Self {
+            rows,
+            palette,
+            input,
+            labels,
+            offset,
+            selected,
+            ..
+        } = self;
+        let Some(palette) = palette.as_mut() else {
+            return;
+        };
+        let shown: Vec<&Item> = rows.iter().collect();
+        // "No results" answers a question. Nothing has been asked yet when the
+        // query is empty, and the launcher has nothing to report.
+        let empty_message = (!input.value().trim().is_empty()).then_some("No results");
+        palette.update(input, &shown, labels, *offset, *selected, empty_message);
+
+        let size = palette.card_size();
+        self.settle_until = Some(Instant::now() + SETTLE);
+        if size != self.card_size {
+            self.card_size = size;
+            self.resize_card(size);
+        }
+    }
+
+    /// Tell the compositor how much of the card's buffer is card. The frost,
+    /// the rounding and the shadow follow this rectangle, so a list that grew
+    /// or shrank has to say so or the material keeps the old shape.
+    fn resize_card(&self, (width, height): (f32, f32)) {
+        let (Some(card), Some(palette)) = (self.card.as_ref(), self.palette.as_ref()) else {
+            return;
+        };
+        let Some(style) = card.base_surface().surface_style() else {
+            return;
+        };
+        // Surface-style geometry is in physical pixels.
+        let scale = AppContext::fractional_scale();
+        let (x, y) = palette.card_origin();
+        // The anchor is the top centre, and position is measured from it.
+        style.set_position((x + width / 2.0) as f64 * scale, y as f64 * scale);
+        style.set_size(width as f64 * scale, height as f64 * scale);
+        // And the subsurface itself follows, in logical points. The style moves
+        // where the card is *drawn*; this is where the compositor looks for it
+        // when the pointer is over it, and pointer positions arrive relative to
+        // it. Left behind at the parent's origin, the card would be hovered
+        // three rows away from the cursor.
+        card.set_position(x as i32, y as i32);
+    }
+
+    /// Let the card in, once there is something drawn on it.
+    ///
+    /// Not before: the entrance animates a surface, and a surface with no
+    /// buffer yet would fade in as an empty rectangle and then fill.
+    fn open(&mut self) {
+        if self.opened {
+            return;
+        }
+        let Some(style) = self
+            .card
+            .as_ref()
+            .and_then(|card| card.base_surface().surface_style())
+        else {
+            return;
+        };
+        self.opened = true;
+        animate(FADE_IN, Curve::Preset(Preset::EaseOutQuad), || {
+            style.set_opacity(1.0);
+        });
+        animate(SCALE_IN, Curve::Spring(BOUNCE), || {
+            style.set_scale(1.0, 1.0);
+        });
+    }
+
+    /// Start closing, and stop the launcher once the card has gone.
+    ///
+    /// Whatever was chosen has already happened by this point — the
+    /// application is starting, the window is being focused — so the animation
+    /// costs nothing but the launcher's own last hundred milliseconds.
+    fn close(&mut self) {
+        if self.closing_at.is_some() {
+            return;
+        }
+        self.closing_at = Some(Instant::now() + CLOSE);
+
+        let Some(style) = self
+            .card
+            .as_ref()
+            .and_then(|card| card.base_surface().surface_style())
+        else {
+            AppContext::request_exit();
+            return;
+        };
+        animate(FADE_OUT, Curve::Preset(Preset::EaseInQuad), || {
+            style.set_opacity(0.0);
+        });
+        animate(SCALE_OUT, Curve::Preset(Preset::EaseInQuad), || {
+            style.set_scale(CLOSE_SCALE, CLOSE_SCALE);
+        });
+        // The transaction is a request like any other, and the launcher is
+        // about to stop doing anything else.
+        AppContext::flush();
+    }
+
+    fn frame_in_flight(&self) -> bool {
+        self.painted_at
+            .is_some_and(|at| at.elapsed() < FRAME_TIMEOUT)
+            && self
+                .surface
+                .as_ref()
+                .is_some_and(|surface| surface.base_surface().frame_in_flight())
+    }
+
+    fn paint(&mut self) {
+        let (Some(surface), true) = (self.surface.as_ref(), self.sized) else {
+            return;
+        };
+        self.painted_at = Some(Instant::now());
+        tracing::trace!(selected = self.selected, rows = self.rows.len(), "painting");
+        // otto-kit hands over a canvas with the buffer scale already applied,
+        // so both scenes are drawn in logical points.
+        // The parent surface draws nothing: it is there to take the keyboard
+        // and to catch the click that lands beside the card.
+        surface.draw(|canvas| {
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+        });
+
+        if let Some(card) = self.card.as_ref() {
+            let base = card.base_surface();
+            card.draw(|canvas| {
+                // Transparent, not the card's colour: what shows through is
+                // the frosted material the compositor put underneath.
+                canvas.clear(skia_safe::Color::TRANSPARENT);
+                base.render_layer_node(canvas);
+            });
+        }
+    }
+}
+
+/// Run `changes` inside an animated transaction of `duration`.
+///
+/// Every animated property the closure sets joins that one transaction, so
+/// properties that should move together do. Properties that should *not* move
+/// together — the card's fade and its scale — go in transactions of their own.
+fn animate(duration: Duration, curve: Curve, changes: impl FnOnce()) {
+    let Some(manager) = AppContext::surface_style_manager() else {
+        changes();
+        return;
+    };
+    let qh = AppContext::queue_handle();
+
+    let timing = manager.create_timing_function(qh, ());
+    match curve {
+        Curve::Preset(preset) => timing.set_preset(preset),
+        // The spring is tuned to settle inside the transaction's duration, so
+        // the bounce is a shape rather than a length.
+        Curve::Spring(bounce) => timing.set_spring(bounce, 0.0),
+    }
+    let transaction = manager.begin_transaction(qh, ());
+    transaction.set_duration(duration.as_secs_f64());
+    transaction.set_timing_function(&timing);
+
+    changes();
+
+    transaction.commit();
+}
+
+enum Curve {
+    Preset(Preset),
+    /// Overshoots and settles back. The argument is how far.
+    Spring(f64),
+}
+
+/// How solid the card runs, whatever the theme's popup material says.
+///
+/// There is a ceiling worth staying under: past roughly this the frost stops
+/// reading as frost and the card may as well be opaque, which throws away the
+/// blur the compositor is doing anyway.
+const CARD_MIN_ALPHA: u8 = 0xD8;
+
+fn at_least_opaque(colour: skia_safe::Color, min_alpha: u8) -> skia_safe::Color {
+    skia_safe::Color::from_argb(
+        colour.a().max(min_alpha),
+        colour.r(),
+        colour.g(),
+        colour.b(),
+    )
+}
+
+/// Ask the compositor for the card's material: the frost, and the shape it is
+/// cut to.
+///
+/// None of this can be drawn client-side. A blur needs the pixels behind the
+/// surface, and the only process that has them is the compositor — so the card
+/// declares what it wants to look like and paints its text on top of the
+/// result. `material_medium` is the same token the bar's menus use, so the
+/// launcher reads as the same kind of surface as the rest of the desktop.
+fn apply_card_material(card: &SubsurfaceSurface) {
+    let Some(style) = card.base_surface().surface_style() else {
+        tracing::warn!("no otto-surface-style; the card will not be frosted");
+        return;
+    };
+    // `material_popup` is the token the bar's menus use — the launcher is the
+    // same kind of thing, floating over whatever happens to be behind it. It is
+    // taken up to at least `CARD_MIN_ALPHA` on top of that: the card is large
+    // and full of small text, and a busy desktop showing through it costs more
+    // legibility than the frost gives back.
+    let colour = skia_safe::Color4f::from(at_least_opaque(
+        AppContext::current_theme().material_popup,
+        CARD_MIN_ALPHA,
+    ));
+    style.set_background_color(
+        colour.r as f64,
+        colour.g as f64,
+        colour.b as f64,
+        colour.a as f64,
+    );
+    style.set_blend_mode(BlendMode::BackgroundBlur);
+    style.set_corner_radius(RADIUS as f64 * AppContext::fractional_scale());
+    style.set_masks_to_bounds(ClipMode::Enabled);
+    style.set_shadow(0.32, 32.0, 0.0, 12.0, 0.0, 0.0, 0.0);
+    // The buffer is the card at its tallest; a shorter card shows the top of
+    // it, so the field stays where it is as rows come and go.
+    style.set_contents_gravity(ContentsGravity::TopLeft);
+
+    // Transforms are taken about the top centre. Centre horizontally so the
+    // card swells outwards evenly; top vertically so the field stays put both
+    // while the card arrives and later when the list grows under it.
+    style.set_anchor_point(0.5, 0.0);
+
+    // Where the card starts: just short of full size, and invisible. The
+    // entrance animates out of this once there is something on it to see.
+    style.set_scale(OPEN_SCALE, OPEN_SCALE);
+    style.set_opacity(0.0);
+}
+
+/// Whether to draw dark. The colour scheme comes from the desktop portal, the
+/// same source otto-kit's other components read.
+fn dark() -> bool {
+    matches!(
+        otto_kit::color_scheme::current_color_scheme(),
+        otto_kit::theme::ColorScheme::Dark
+    )
+}
+
+impl App for Launcher {
+    fn on_app_ready(&mut self, _ctx: &AppContext) -> Result<(), Box<dyn std::error::Error>> {
+        tracing::debug!(ms = since_start(), "wayland connected");
+        // The engine has to exist before the surface does: a surface builds its
+        // own root layer node, and that node is what the scene hangs off.
+        AppContext::enable_layer_engine(1920.0, 1080.0);
+        tracing::debug!(ms = since_start(), "layer engine ready");
+
+        // Anchored to all four edges with a zero size, so the compositor gives
+        // us the whole output — the scrim needs it, and so does "click outside
+        // the card to dismiss".
+        let surface = LayerShellSurface::with_anchor(
+            Layer::Overlay,
+            "otto-launcher",
+            0,
+            0,
+            Some(Anchor::Top | Anchor::Bottom | Anchor::Left | Anchor::Right),
+            Some(0),
+        )?;
+        // Exclusive: the launcher is modal while it is up, and every keystroke
+        // belongs to it — including the ones the focused window would want.
+        surface.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
+        tracing::debug!(ms = since_start(), "layer surface created");
+
+        // The card is a child surface, sized once to the tallest it can be.
+        // Shrinking it is the compositor clipping the same buffer, which costs
+        // nothing and keeps the text from being re-laid out as rows come and
+        // go.
+        let card = SubsurfaceSurface::new(
+            surface.base_surface().wl_surface(),
+            0,
+            0,
+            CARD_W as i32,
+            MAX_CARD_H as i32,
+        )?;
+        apply_card_material(&card);
+
+        tracing::debug!(ms = since_start(), "card surface created");
+        let Some(engine) = AppContext::layers_renderer(|renderer| renderer.engine().clone()) else {
+            return Err("the layers engine is unavailable".into());
+        };
+        let palette = Palette::new(engine, card.base_surface().layer_node(), dark());
+
+        self.palette = Some(palette);
+        self.card = Some(card);
+        self.surface = Some(surface);
+        tracing::debug!(ms = since_start(), "surfaces created");
+        self.reload();
+        tracing::debug!(ms = since_start(), "sources loaded");
+        Ok(())
+    }
+
+    fn on_configure_layer(&mut self, _ctx: &AppContext, width: i32, height: i32, _serial: u32) {
+        tracing::debug!(width, height, ms = since_start(), "configured");
+        if let Some(palette) = self.palette.as_mut() {
+            palette.set_size(width as f32, height as f32);
+        }
+        self.sized = true;
+        self.dirty = true;
+    }
+
+    fn on_key_event(
+        &mut self,
+        _ctx: &AppContext,
+        event: &KeyEvent,
+        state: wl_keyboard::KeyState,
+        _serial: u32,
+    ) {
+        // Shift is tracked from the key itself: the runner reports keys, not
+        // modifier state, and selection with Shift+arrows needs to know.
+        match event.keysym {
+            Keysym::Shift_L | Keysym::Shift_R => {
+                self.shift = state == wl_keyboard::KeyState::Pressed;
+                return;
+            }
+            _ => {}
+        }
+        if state != wl_keyboard::KeyState::Pressed || self.closing_at.is_some() {
+            return;
+        }
+        self.engaged = true;
+
+        // Ctrl combinations arrive as control characters rather than as a
+        // modifier flag, which is enough to recognise them by.
+        let control = event
+            .utf8
+            .as_deref()
+            .and_then(|text| text.chars().next())
+            .filter(|c| (*c as u32) < 0x20 && *c != '\r' && *c != '\n' && *c != '\t')
+            .map(|c| char::from(c as u8 + 0x60));
+
+        match (event.keysym, control) {
+            (Keysym::Escape, _) => {
+                self.close();
+                return;
+            }
+            (Keysym::Return | Keysym::KP_Enter, _) => {
+                self.activate();
+                return;
+            }
+            (Keysym::Down, _) | (_, Some('n')) => {
+                self.move_selection(1);
+                return;
+            }
+            (Keysym::Up, _) | (_, Some('p')) => {
+                self.move_selection(-1);
+                return;
+            }
+            (Keysym::Tab, _) => {
+                self.move_selection(if self.shift { -1 } else { 1 });
+                return;
+            }
+            (Keysym::ISO_Left_Tab, _) => {
+                self.move_selection(-1);
+                return;
+            }
+            (Keysym::Page_Down, _) => {
+                self.move_selection(MAX_ROWS as isize);
+                return;
+            }
+            (Keysym::Page_Up, _) => {
+                self.move_selection(-(MAX_ROWS as isize));
+                return;
+            }
+            // Clear the query without reaching for backspace — the fastest way
+            // to start a different search.
+            (_, Some('u')) => {
+                self.input.set_value("");
+                self.refilter();
+                return;
+            }
+            (_, Some('a')) => {
+                self.input
+                    .on_key(TextInputKey::SelectAll, KeyMods::default());
+                self.dirty = true;
+                return;
+            }
+            (_, Some('w')) => {
+                self.input.on_key(
+                    TextInputKey::Backspace,
+                    KeyMods {
+                        shift: false,
+                        ctrl: true,
+                    },
+                );
+                self.refilter();
+                return;
+            }
+            _ => {}
+        }
+
+        let mods = KeyMods {
+            shift: self.shift,
+            ctrl: false,
+        };
+        let key = match event.keysym {
+            Keysym::Left => TextInputKey::Left,
+            Keysym::Right => TextInputKey::Right,
+            Keysym::Home => TextInputKey::Home,
+            Keysym::End => TextInputKey::End,
+            Keysym::BackSpace => TextInputKey::Backspace,
+            Keysym::Delete => TextInputKey::Delete,
+            _ => {
+                let text: String = event
+                    .utf8
+                    .as_deref()
+                    .unwrap_or_default()
+                    .chars()
+                    .filter(|c| !c.is_control())
+                    .collect();
+                if text.is_empty() {
+                    return;
+                }
+                TextInputKey::Text(text)
+            }
+        };
+
+        match self.input.on_key(key, mods) {
+            TextInputResponse::Changed => self.refilter(),
+            TextInputResponse::Moved => self.dirty = true,
+            TextInputResponse::Commit => self.activate(),
+            TextInputResponse::Cancel => self.close(),
+            _ => {}
+        }
+    }
+
+    fn on_keyboard_leave(&mut self, _ctx: &AppContext, _surface: &wl_surface::WlSurface) {
+        // Something else has taken the keyboard. A modal that has lost its
+        // input is only in the way — but not before it has ever had it, which
+        // is what `engaged` guards against at startup.
+        if self.engaged {
+            self.close();
+        }
+    }
+
+    fn on_pointer_event(&mut self, _ctx: &AppContext, events: &[PointerEvent]) {
+        if self.closing_at.is_some() {
+            return;
+        }
+        let Some(palette) = self.palette.as_ref() else {
+            return;
+        };
+        let card_surface = self.card.as_ref().map(|card| card.wl_surface().clone());
+        for event in events {
+            // Positions are relative to the surface the pointer is over, and
+            // the card is a surface of its own: an event on it is already in
+            // card coordinates, an event on the parent is not on the card at
+            // all.
+            let on_card = card_surface
+                .as_ref()
+                .is_some_and(|surface| *surface == event.surface);
+            let (x, y) = (event.position.0 as f32, event.position.1 as f32);
+            match event.kind {
+                PointerEventKind::Motion { .. } if on_card => {
+                    if let Some(row) = palette.row_at(x, y) {
+                        let target = self.offset + row;
+                        if target < self.row_count() && target != self.selected {
+                            self.selected = target;
+                            self.dirty = true;
+                        }
+                    }
+                }
+                PointerEventKind::Press { .. } => {
+                    self.engaged = true;
+                    // The card's buffer stays at its full height even when the
+                    // list is short, so the surface catches presses under a
+                    // card that is not there. Those are beside it, like a press
+                    // on the parent — and beside the card is the other way of
+                    // saying Escape.
+                    let beside = !on_card || y > palette.card_size().1;
+                    if beside {
+                        self.close();
+                        return;
+                    }
+                }
+                PointerEventKind::Release { .. } if on_card => {
+                    if let Some(row) = palette.row_at(x, y) {
+                        let target = self.offset + row;
+                        if target < self.row_count() {
+                            self.selected = target;
+                            self.activate();
+                            return;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn on_update(&mut self, _ctx: &AppContext) {
+        // The card has gone; nothing is left to do but stop.
+        if let Some(at) = self.closing_at {
+            if Instant::now() >= at {
+                AppContext::request_exit();
+            }
+            return;
+        }
+
+        let mut changed = false;
+        for source in self.sources.iter_mut() {
+            source.pump();
+            changed |= source.changed();
+        }
+        if changed {
+            self.reload();
+        }
+
+        // The caret blinks on its own clock; the field asks to be redrawn when
+        // the phase flips.
+        let now = Instant::now();
+        let was_visible = self.input.caret_visible();
+        self.input
+            .tick(now.duration_since(self.last_tick).as_secs_f32());
+        self.last_tick = now;
+        if self.input.caret_visible() != was_visible {
+            self.dirty = true;
+        }
+
+        if self.dirty {
+            self.dirty = false;
+            self.push();
+            self.paint();
+            // The first frame is on the card, so it has something to arrive
+            // with.
+            self.open();
+            tracing::debug!(ms = since_start(), "first frame");
+            return;
+        }
+
+        if self.frame_in_flight() {
+            return;
+        }
+        // Keep painting while a transition is still running.
+        if self.settle_until.is_some_and(|until| now < until) {
+            self.paint();
+        } else {
+            self.settle_until = None;
+        }
+    }
+
+    fn idle_timeout(&self) -> Option<Duration> {
+        if self.closing_at.is_some() {
+            return Some(Duration::from_millis(8));
+        }
+        Some(if self.settle_until.is_some() {
+            Duration::from_millis(8)
+        } else {
+            // Half a blink period: the slowest the loop may sleep and still
+            // turn the caret on and off on time.
+            Duration::from_secs_f32(CARET_BLINK_PERIOD / 2.0)
+        })
+    }
+
+    fn poll_fds(&self) -> Vec<RawFd> {
+        self.sources.iter().filter_map(|s| s.poll_fd()).collect()
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    STARTED.get_or_init(Instant::now);
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    // `--apps` / `--windows` narrow what is offered; anything else on the
+    // command line is the initial query, so a binding can open the launcher
+    // already filtered.
+    // Apps unless asked otherwise: the two bindings are "launch something" and
+    // "switch to a window", and a mode that quietly does both is neither.
+    let mut scope = Scope::Apps;
+    let mut words: Vec<String> = Vec::new();
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--apps" | "-a" => scope = Scope::Apps,
+            "--windows" | "-w" => scope = Scope::Windows,
+            "--all" => scope = Scope::Everything,
+            "--help" | "-h" => {
+                println!("usage: otto-launcher [--apps|--windows|--all] [query]");
+                return Ok(());
+            }
+            _ => words.push(arg),
+        }
+    }
+    AppRunner::new(Launcher::new(&words.join(" "), scope)).run()?;
+    Ok(())
+}

--- a/components/otto-launcher/src/source.rs
+++ b/components/otto-launcher/src/source.rs
@@ -1,0 +1,271 @@
+//! What the launcher can offer, and how a choice is carried out.
+//!
+//! A source is a list of [`Item`]s plus the meaning of activating one. The
+//! launcher itself only knows how to filter and draw them, so adding files —
+//! or clipboard history, or a calculator — is a matter of another [`Source`],
+//! not another launcher.
+//!
+//! Sources are asked for their items once, when the launcher opens. Nothing
+//! here does I/O while someone is typing: a keystroke must never wait on a
+//! disk scan.
+
+/// One row: something that can be picked.
+#[derive(Clone, Debug)]
+pub struct Item {
+    /// The line someone reads and types against.
+    pub title: String,
+    /// The dimmer second line — a comment, a window's app, a path.
+    pub subtitle: Option<String>,
+    /// Icon theme name, resolved by the view.
+    pub icon: Option<String>,
+    /// Extra text that matches but is never shown: keywords, the binary name,
+    /// the app id behind a window.
+    pub search_terms: Vec<String>,
+    /// Which source this came from, and its index there. The launcher hands
+    /// this back to activate the item.
+    pub origin: Origin,
+}
+
+/// Where an item came from, so the right source is asked to act on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Origin {
+    pub source: usize,
+    pub index: usize,
+}
+
+/// A provider of items.
+pub trait Source {
+    /// Short name, shown as the row's badge — "App", "Window".
+    fn label(&self) -> &'static str;
+
+    /// The items as they stand now. Called when the launcher opens and
+    /// whenever the source says it has changed.
+    fn items(&mut self) -> Vec<Item>;
+
+    /// Do whatever picking `index` means. Returning `Ok(())` closes the
+    /// launcher.
+    fn activate(&mut self, index: usize) -> Result<(), String>;
+
+    /// What to show before anything has been typed.
+    ///
+    /// Opening the launcher onto every application installed is a wall of
+    /// names nobody reads. A source that has a shorter answer to "what did you
+    /// want?" gives it here; the default is everything it has, which is right
+    /// for a list that is already short.
+    fn resting(&mut self) -> Vec<Item> {
+        self.items()
+    }
+
+    /// An item derived from the query itself, shown first and never ranked.
+    ///
+    /// Ranking compares a query against the items it might have meant, which
+    /// is the wrong shape for a source whose item *is* the query worked out:
+    /// the answer to `24.5*3` is `73.5`, and nothing about `73.5` matches what
+    /// was typed. An answer is pinned above the matches instead.
+    fn answer(&mut self, _query: &str) -> Option<Item> {
+        None
+    }
+
+    /// Whether the item list has changed since it was last read — a window
+    /// opening or closing while the launcher is up.
+    fn changed(&mut self) -> bool {
+        false
+    }
+
+    /// A file descriptor the launcher should wake on, for a source that has
+    /// somewhere else to listen. Handed to
+    /// [`App::poll_fds`](otto_kit::App::poll_fds).
+    fn poll_fd(&self) -> Option<std::os::fd::RawFd> {
+        None
+    }
+
+    /// Read whatever is waiting on [`Source::poll_fd`]. Called every loop
+    /// iteration, so it must not block.
+    fn pump(&mut self) {}
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/// A matched item, with the score that ordered it.
+#[derive(Clone, Copy, Debug)]
+pub struct Match {
+    pub index: usize,
+    pub score: i32,
+}
+
+/// Rank `items` against `query`, best first.
+///
+/// An empty query keeps everything in the order the sources gave it, which is
+/// the order someone browsing with the arrow keys expects.
+pub fn rank(items: &[Item], query: &str) -> Vec<Match> {
+    if query.trim().is_empty() {
+        return items
+            .iter()
+            .enumerate()
+            .map(|(index, _)| Match { index, score: 0 })
+            .collect();
+    }
+
+    let query = query.trim();
+    let mut matches: Vec<Match> = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            // The title is what someone is aiming at; everything else is a way
+            // of still finding the item when they aimed at something adjacent,
+            // so it scores lower and can never outrank a title hit.
+            let title = score(&item.title, query);
+            let secondary = item
+                .subtitle
+                .iter()
+                .map(String::as_str)
+                .chain(item.search_terms.iter().map(String::as_str))
+                .filter_map(|text| score(text, query))
+                .max()
+                .map(|score| score / 2 - 20);
+
+            let best = match (title, secondary) {
+                (Some(a), Some(b)) => a.max(b),
+                (Some(a), None) => a,
+                (None, Some(b)) => b,
+                (None, None) => return None,
+            };
+            Some(Match { index, score: best })
+        })
+        .collect();
+
+    // Ties keep source order — a stable sort, so an unscored browse and a
+    // fully tied query look the same.
+    matches.sort_by(|a, b| b.score.cmp(&a.score));
+    matches
+}
+
+/// Score `query` as a subsequence of `text`, or `None` if it is not one.
+///
+/// The shape of the score is what makes a launcher feel right: a match at the
+/// start of a word beats one in the middle, a run of adjacent characters beats
+/// the same characters scattered, and a short name beats a long one that
+/// happens to contain the same letters.
+fn score(text: &str, query: &str) -> Option<i32> {
+    let hay: Vec<char> = text.to_lowercase().chars().collect();
+    let needle: Vec<char> = query.to_lowercase().chars().collect();
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > hay.len() {
+        return None;
+    }
+
+    let mut score = 0i32;
+    let mut cursor = 0usize;
+    let mut previous: Option<usize> = None;
+
+    for &wanted in &needle {
+        // Spaces in the query separate words rather than having to be matched:
+        // "fire dev" should find "Firefox Developer Edition".
+        if wanted == ' ' {
+            previous = None;
+            continue;
+        }
+        let found = hay[cursor..].iter().position(|&c| c == wanted)? + cursor;
+
+        score += 8;
+        let boundary = found == 0
+            || matches!(
+                hay[found - 1],
+                ' ' | '-' | '_' | '.' | '/' | ':' | '(' | '['
+            );
+        if boundary {
+            score += 14;
+        }
+        if found == 0 {
+            score += 20;
+        }
+        match previous {
+            Some(last) if found == last + 1 => score += 12,
+            Some(last) => score -= (found - last - 1).min(10) as i32,
+            None => {}
+        }
+
+        previous = Some(found);
+        cursor = found + 1;
+    }
+
+    // Prefer the shorter of two names that both match: "Files" over
+    // "Files (Nautilus) Preferences".
+    score -= (hay.len() / 6) as i32;
+    Some(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(title: &str) -> Item {
+        Item {
+            title: title.to_string(),
+            subtitle: None,
+            icon: None,
+            search_terms: Vec::new(),
+            origin: Origin {
+                source: 0,
+                index: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn a_query_that_is_not_a_subsequence_does_not_match() {
+        assert!(score("Firefox", "chrome").is_none());
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        assert!(score("Firefox", "FIRE").is_some());
+    }
+
+    #[test]
+    fn a_prefix_beats_a_match_in_the_middle() {
+        let prefix = score("Terminal", "term").unwrap();
+        let middle = score("XTerminal", "term").unwrap();
+        assert!(prefix > middle, "{prefix} should beat {middle}");
+    }
+
+    #[test]
+    fn adjacent_characters_beat_scattered_ones() {
+        let adjacent = score("gimp", "gim").unwrap();
+        let scattered = score("go into map", "gim").unwrap();
+        assert!(adjacent > scattered, "{adjacent} should beat {scattered}");
+    }
+
+    #[test]
+    fn a_space_in_the_query_crosses_words() {
+        assert!(score("Firefox Developer Edition", "fire dev").is_some());
+    }
+
+    #[test]
+    fn the_shorter_of_two_matching_names_wins() {
+        let items = [item("Files"), item("Files Preferences Dialog")];
+        let ranked = rank(&items, "files");
+        assert_eq!(ranked[0].index, 0);
+    }
+
+    #[test]
+    fn an_empty_query_keeps_every_item_in_order() {
+        let items = [item("b"), item("a")];
+        let ranked = rank(&items, "  ");
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].index, 0);
+    }
+
+    #[test]
+    fn a_title_hit_outranks_a_keyword_hit() {
+        let mut keyworded = item("Zed");
+        keyworded.search_terms = vec!["terminal".to_string()];
+        let items = [item("Terminal"), keyworded];
+        let ranked = rank(&items, "terminal");
+        assert_eq!(ranked[0].index, 0);
+    }
+}

--- a/components/otto-launcher/src/view.rs
+++ b/components/otto-launcher/src/view.rs
@@ -1,0 +1,570 @@
+//! The launcher as a `lay-rs` scene.
+//!
+//! Built the way otto-kit's other panels are: a tree of layers positioned once
+//! and then *changed*, rather than a canvas redrawn from scratch. That is what
+//! buys what an immediate-mode launcher could not have: the selection slides
+//! between rows instead of jumping, on a transition the engine runs without
+//! the app driving frames by hand.
+//!
+//! There is deliberately no dimming behind the card. A scrim painted by this
+//! client would sit between the desktop and the card, and the compositor's
+//! blur samples exactly that — the frost would be a blur of flat grey, and the
+//! desktop behind it would vanish rather than soften. The parent surface stays
+//! transparent, and the card is separated by its own material and shadow.
+//!
+//! The card's *material* is not drawn here at all. A client cannot blur the
+//! desktop behind itself — only the compositor can see what is back there — so
+//! the card is its own subsurface and its frost, corner radius, border and
+//! shadow are asked for through `otto-surface-style`, exactly as otto-bar's
+//! menus and the islands do. What this file draws onto that material is the
+//! query, the divider, and the rows.
+//!
+//! Rows are allocated once, up to [`MAX_ROWS`], and reused: filtering swaps
+//! each row's draw content, never the shape of the tree. Layout is in logical
+//! points and absolute — a row appearing must not move the field being typed
+//! into.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use layers::prelude::*;
+use layers::types::{Color as LayerColor, Point as LayerPoint, Size as LayerSize};
+use otto_kit::components::text_input::{TextInput, TextInputStyle};
+use otto_kit::icons::named_icon_sized;
+use otto_kit::theme::Theme;
+use otto_kit::typography::{get_font_with_fallback, styles};
+use skia_safe::{Canvas, Color, Color4f, Font, FontStyle, Image, Paint, Rect, SamplingOptions};
+
+use crate::source::Item;
+
+/// Width of the card. Wide enough for a window title and its application, and
+/// narrow enough to stay a dialog rather than become a page.
+pub const CARD_W: f32 = 620.0;
+/// Height of the query field.
+pub const FIELD_H: f32 = 58.0;
+/// Height of one result row.
+pub const ROW_H: f32 = 46.0;
+/// How many rows are on screen at once. Past this the list scrolls, because a
+/// list taller than this stops being scannable and the card starts to be the
+/// screen.
+pub const MAX_ROWS: usize = 8;
+/// Padding above and below the list.
+const LIST_PAD: f32 = 8.0;
+/// Corner radius of the card, applied by the compositor to the subsurface.
+pub const RADIUS: f32 = 10.0;
+const ICON: f32 = 28.0;
+const ROW_INSET: f32 = 8.0;
+/// The card at its tallest, which is how big its buffer is allocated: a
+/// shorter card is the same buffer with the compositor clipping it, so the
+/// height can change without reallocating anything.
+pub const MAX_CARD_H: f32 = FIELD_H + 1.0 + LIST_PAD * 2.0 + MAX_ROWS as f32 * ROW_H;
+
+/// Where the top of the card sits, as a fraction of the output's height.
+/// Above centre: the eye starts there, and the list grows downwards into
+/// space that was already empty.
+const TOP_FRACTION: f32 = 0.16;
+
+/// A row as the scene needs it — what to draw, with the icon already resolved.
+struct Row {
+    layer: Layer,
+}
+
+pub struct Palette {
+    engine: Arc<Engine>,
+    /// Root of the card subsurface's scene. Its own background is left to the
+    /// compositor — see the module docs.
+    card: Layer,
+    field: Layer,
+    divider: Layer,
+    list: Layer,
+    highlight: Layer,
+    rows: Vec<Row>,
+
+    size: (f32, f32),
+    /// Number of rows currently shown, which sets the card's height.
+    visible: usize,
+    /// Icons live as long as the launcher does. It is open for seconds, and
+    /// decoding the same icon on every keystroke is the one thing that would
+    /// make typing feel slow.
+    icons: HashMap<String, Option<Image>>,
+    dark: bool,
+}
+
+impl Palette {
+    /// `card_parent` is the layer node of the card subsurface. The fullscreen
+    /// parent surface has no scene of its own — see the module docs.
+    pub fn new(engine: Arc<Engine>, card_parent: Option<&Layer>, dark: bool) -> Self {
+        let new_layer = |key: &str| {
+            let layer = engine.new_layer();
+            layer.set_key(key);
+            layer.set_layout_style(taffy::Style {
+                position: taffy::style::Position::Absolute,
+                ..Default::default()
+            });
+            layer
+        };
+
+        let card = new_layer("launcher-card");
+        match card_parent {
+            Some(parent) => {
+                let _ = parent.add_sublayer(&card);
+            }
+            None => {
+                let _ = engine.add_layer(&card);
+            }
+        }
+
+        let field = new_layer("launcher-field");
+        let divider = new_layer("launcher-divider");
+        let list = new_layer("launcher-list");
+        let highlight = new_layer("launcher-highlight");
+
+        let _ = card.add_sublayer(&field);
+        let _ = card.add_sublayer(&divider);
+        let _ = card.add_sublayer(&list);
+        // Before the rows, so it is behind their text.
+        let _ = list.add_sublayer(&highlight);
+
+        let rows = (0..MAX_ROWS)
+            .map(|_| {
+                let layer = new_layer("launcher-row");
+                let _ = list.add_sublayer(&layer);
+                Row { layer }
+            })
+            .collect();
+
+        let mut palette = Self {
+            engine,
+            card,
+            field,
+            divider,
+            list,
+            highlight,
+            rows,
+            size: (0.0, 0.0),
+            visible: 0,
+            icons: HashMap::new(),
+            dark,
+        };
+        palette.style();
+        palette
+    }
+
+    /// The card's scene root, for a host that needs to draw it directly — the
+    /// preview example renders this subtree into a raster surface.
+    pub fn card_layer(&self) -> &Layer {
+        &self.card
+    }
+
+    /// Colours and radii, set once — `update` only touches what changes.
+    fn style(&mut self) {
+        // The card itself paints nothing: the compositor draws the frosted
+        // material under this scene, and anything painted here would sit on
+        // top of it as a second, unblurred pane.
+        self.card
+            .set_size(LayerSize::points(CARD_W, MAX_CARD_H), None);
+
+        self.divider.set_background_color(
+            PaintColor::Solid {
+                color: lay_color(if self.dark {
+                    Color::from_argb(36, 255, 255, 255)
+                } else {
+                    Color::from_argb(24, 0, 0, 0)
+                }),
+            },
+            None,
+        );
+
+        self.highlight.set_background_color(
+            PaintColor::Solid {
+                color: lay_color(if self.dark {
+                    Color::from_argb(46, 255, 255, 255)
+                } else {
+                    Color::from_argb(20, 0, 0, 0)
+                }),
+            },
+            None,
+        );
+        self.highlight
+            .set_border_corner_radius(BorderRadius::new_single(9.0), None);
+        self.highlight.set_opacity(0.0, None);
+    }
+
+    /// The surface's size changed. Everything that does not depend on the
+    /// result list is placed here.
+    pub fn set_size(&mut self, width: f32, height: f32) {
+        if (width, height) == self.size {
+            return;
+        }
+        self.size = (width, height);
+
+        self.engine.scene_set_size(width, height);
+
+        // The card's scene starts at the origin of its own surface; where that
+        // surface sits is [`Palette::card_origin`], which the app applies to
+        // the subsurface.
+        self.field
+            .set_size(LayerSize::points(CARD_W, FIELD_H), None);
+        self.divider
+            .set_position(LayerPoint { x: 0.0, y: FIELD_H }, None);
+        self.divider.set_size(LayerSize::points(CARD_W, 1.0), None);
+        self.list.set_position(
+            LayerPoint {
+                x: 0.0,
+                y: FIELD_H + 1.0 + LIST_PAD,
+            },
+            None,
+        );
+
+        for (index, row) in self.rows.iter().enumerate() {
+            row.layer.set_position(
+                LayerPoint {
+                    x: 0.0,
+                    y: index as f32 * ROW_H,
+                },
+                None,
+            );
+            row.layer.set_size(LayerSize::points(CARD_W, ROW_H), None);
+        }
+        self.highlight.set_size(
+            LayerSize::points(CARD_W - ROW_INSET * 2.0, ROW_H - 4.0),
+            None,
+        );
+
+        self.apply_card_height(self.visible, None);
+    }
+
+    /// Where the card subsurface belongs, in the parent surface's coordinates.
+    pub fn card_origin(&self) -> (f32, f32) {
+        let (width, height) = self.size;
+        (
+            ((width - CARD_W) / 2.0).round(),
+            (height * TOP_FRACTION).round(),
+        )
+    }
+
+    /// How much of the card is currently in use. The buffer stays
+    /// [`MAX_CARD_H`] tall; this is what the compositor should show of it.
+    pub fn card_size(&self) -> (f32, f32) {
+        (CARD_W, self.card_height(self.visible))
+    }
+
+    /// Which visible row a point in the *card's own* coordinates is over.
+    ///
+    /// Pointer events on the card arrive relative to its subsurface, so this
+    /// takes them as they come rather than in screen coordinates.
+    pub fn row_at(&self, x: f32, y: f32) -> Option<usize> {
+        let (width, height) = self.card_size();
+        if x < 0.0 || x > width || y < 0.0 || y > height {
+            return None;
+        }
+        let local_y = y - (FIELD_H + 1.0 + LIST_PAD);
+        if local_y < 0.0 {
+            return None;
+        }
+        let row = (local_y / ROW_H) as usize;
+        (row < self.visible).then_some(row)
+    }
+
+    /// Push the current query and results into the scene.
+    ///
+    /// `items` are the matches, already ranked; `offset` is the first of them
+    /// that is on screen and `selected` the one that is highlighted, both as
+    /// indices into `items`.
+    /// `empty_message` is what to say when there is nothing to show — `None`
+    /// when there is nothing to say, and the card is the field alone.
+    pub fn update(
+        &mut self,
+        input: &TextInput,
+        items: &[&Item],
+        labels: &[&'static str],
+        offset: usize,
+        selected: usize,
+        empty_message: Option<&str>,
+    ) {
+        let field = input.clone();
+        self.field
+            .set_draw_content(move |canvas: &Canvas, width: f32, height: f32| {
+                field.render_at(canvas, width, height);
+                Rect::from_wh(width, height)
+            });
+
+        let title_font = self.font(15.0, FontStyle::normal());
+        let subtitle_font = self.font(11.5, FontStyle::normal());
+        let badge_font = self.font(10.5, FontStyle::normal());
+        let title_color = if self.dark {
+            Color::from_argb(240, 255, 255, 255)
+        } else {
+            Color::from_argb(240, 12, 12, 14)
+        };
+        let subtitle_color = if self.dark {
+            Color::from_argb(150, 255, 255, 255)
+        } else {
+            Color::from_argb(140, 0, 0, 0)
+        };
+
+        let shown = items.len().saturating_sub(offset).min(MAX_ROWS);
+
+        // Nothing matched: the first row carries the message, so the card
+        // keeps a shape instead of collapsing to a bare field.
+        if items.is_empty() {
+            // A query that matched nothing says so, in the first row, so the
+            // card keeps a shape instead of collapsing under the answer. An
+            // empty query has nothing to report — a launcher just opened has
+            // not failed to find anything — and the card is the field alone.
+            let rows = match empty_message {
+                Some(message) => {
+                    self.rows[0].layer.set_opacity(1.0, None);
+                    self.rows[0].layer.set_draw_content(draw_message(
+                        message.to_string(),
+                        title_font.clone(),
+                        subtitle_color,
+                    ));
+                    1
+                }
+                None => 0,
+            };
+            for row in self.rows.iter().skip(rows) {
+                row.layer.set_opacity(0.0, None);
+                row.layer.set_draw_content(draw_nothing());
+            }
+            self.highlight.set_opacity(0.0, None);
+            self.visible = rows;
+            self.apply_card_height(rows, Some(Transition::ease_out_quad(0.12)));
+            return;
+        }
+
+        for (row_index, row) in self.rows.iter().enumerate() {
+            let Some(item) = items.get(offset + row_index) else {
+                row.layer.set_opacity(0.0, None);
+                row.layer.set_draw_content(draw_nothing());
+                continue;
+            };
+
+            let icon = item
+                .icon
+                .as_deref()
+                .and_then(|name| resolve_icon(&mut self.icons, name));
+
+            row.layer.set_opacity(1.0, None);
+            row.layer.set_draw_content(draw_row(
+                icon,
+                item.title.clone(),
+                item.subtitle.clone(),
+                labels.get(item.origin.source).copied().unwrap_or(""),
+                title_font.clone(),
+                subtitle_font.clone(),
+                badge_font.clone(),
+                title_color,
+                subtitle_color,
+            ));
+        }
+
+        // The selection slides. `selected` is an index into the whole match
+        // list; on screen it is however far it is past the scroll offset.
+        let on_screen = selected.saturating_sub(offset);
+        self.highlight.set_opacity(1.0, None);
+        self.highlight.set_position(
+            LayerPoint {
+                x: ROW_INSET,
+                y: on_screen as f32 * ROW_H + 2.0,
+            },
+            Some(Transition::ease_out_quad(0.11)),
+        );
+
+        self.visible = shown;
+        self.apply_card_height(shown, Some(Transition::ease_out_quad(0.12)));
+    }
+
+    fn card_height(&self, rows: usize) -> f32 {
+        if rows == 0 {
+            // No list, so no divider and no padding around it either: the card
+            // is the field.
+            return FIELD_H;
+        }
+        FIELD_H + 1.0 + LIST_PAD * 2.0 + rows as f32 * ROW_H
+    }
+
+    fn apply_card_height(&self, rows: usize, transition: Option<Transition>) {
+        self.divider
+            .set_opacity(if rows == 0 { 0.0 } else { 1.0 }, None);
+        let height = self.card_height(rows);
+        self.card
+            .set_size(LayerSize::points(CARD_W, height), transition);
+        self.list
+            .set_size(LayerSize::points(CARD_W, rows as f32 * ROW_H), None);
+    }
+
+    fn font(&self, size: f32, style: FontStyle) -> Font {
+        get_font_with_fallback(styles::BODY.family, style, size)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content draw functions
+//
+// Each returns a closure the engine calls with the layer's own size. They run
+// on the renderer thread, so everything they need — fonts, decoded icons — is
+// resolved here and moved in.
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn draw_row(
+    icon: Option<Image>,
+    title: String,
+    subtitle: Option<String>,
+    badge: &'static str,
+    title_font: Font,
+    subtitle_font: Font,
+    badge_font: Font,
+    title_color: Color,
+    subtitle_color: Color,
+) -> impl Fn(&Canvas, f32, f32) -> Rect + Send + Sync {
+    move |canvas, width, height| {
+        let mut paint = Paint::new(Color4f::from(title_color), None);
+        paint.set_anti_alias(true);
+
+        if let Some(image) = &icon {
+            let top = (height - ICON) / 2.0;
+            canvas.draw_image_rect_with_sampling_options(
+                image,
+                None,
+                Rect::from_xywh(ROW_INSET + 8.0, top, ICON, ICON),
+                SamplingOptions::default(),
+                &paint,
+            );
+        }
+
+        // The badge is measured first: the title is clipped to what is left,
+        // so a long window title cannot run underneath it.
+        let mut badge_paint = Paint::new(Color4f::from(subtitle_color), None);
+        badge_paint.set_anti_alias(true);
+        let badge_width = if badge.is_empty() {
+            0.0
+        } else {
+            badge_font.measure_str(badge, Some(&badge_paint)).0
+        };
+        if !badge.is_empty() {
+            canvas.draw_str(
+                badge,
+                (width - ROW_INSET - 8.0 - badge_width, height / 2.0 + 4.0),
+                &badge_font,
+                &badge_paint,
+            );
+        }
+
+        let text_x = ROW_INSET + 8.0 + ICON + 12.0;
+        let text_width = (width - ROW_INSET - 20.0 - badge_width - text_x).max(0.0);
+        canvas.save();
+        canvas.clip_rect(
+            Rect::from_xywh(text_x, 0.0, text_width, height),
+            None,
+            Some(true),
+        );
+
+        match &subtitle {
+            Some(subtitle) if !subtitle.is_empty() => {
+                canvas.draw_str(&title, (text_x, height / 2.0 - 1.0), &title_font, &paint);
+                let mut sub = Paint::new(Color4f::from(subtitle_color), None);
+                sub.set_anti_alias(true);
+                canvas.draw_str(
+                    subtitle,
+                    (text_x, height / 2.0 + 14.0),
+                    &subtitle_font,
+                    &sub,
+                );
+            }
+            _ => {
+                canvas.draw_str(&title, (text_x, height / 2.0 + 5.0), &title_font, &paint);
+            }
+        }
+        canvas.restore();
+
+        Rect::from_wh(width, height)
+    }
+}
+
+fn draw_message(
+    message: String,
+    font: Font,
+    color: Color,
+) -> impl Fn(&Canvas, f32, f32) -> Rect + Send + Sync {
+    move |canvas, width, height| {
+        let mut paint = Paint::new(Color4f::from(color), None);
+        paint.set_anti_alias(true);
+        let text_width = font.measure_str(&message, Some(&paint)).0;
+        canvas.draw_str(
+            &message,
+            ((width - text_width) / 2.0, height / 2.0 + 5.0),
+            &font,
+            &paint,
+        );
+        Rect::from_wh(width, height)
+    }
+}
+
+/// Decode an icon once and keep it. Misses are remembered too — an app whose
+/// icon the theme does not have must not be looked up again on every keystroke.
+fn resolve_icon(cache: &mut HashMap<String, Option<Image>>, name: &str) -> Option<Image> {
+    cache
+        .entry(name.to_string())
+        .or_insert_with(|| named_icon_sized(name, (ICON * 2.0) as i32))
+        .clone()
+}
+
+/// Draws nothing. Given to rows that have no item, whose opacity is zero
+/// anyway — the engine wants a content function, not the absence of one.
+fn draw_nothing() -> impl Fn(&Canvas, f32, f32) -> Rect + Send + Sync {
+    move |_canvas, width, height| Rect::from_wh(width, height)
+}
+
+/// The query field's look: no box of its own, because it already sits in one.
+pub fn field_style(dark: bool) -> TextInputStyle {
+    let mut style = TextInputStyle::with_theme(if dark { Theme::dark() } else { Theme::light() });
+    style.text_style = styles::TITLE_3;
+    style.text_style.size = 19.0;
+    style.horizontal_padding = 20.0;
+    style.corner_radius = 0.0;
+    style.focus_ring_width = 0.0;
+    style.background = Color::TRANSPARENT;
+    style.text_color = if dark {
+        Color::from_argb(245, 255, 255, 255)
+    } else {
+        Color::from_argb(245, 10, 10, 12)
+    };
+    style.placeholder_color = if dark {
+        Color::from_argb(110, 255, 255, 255)
+    } else {
+        Color::from_argb(100, 0, 0, 0)
+    };
+    style
+}
+
+fn lay_color(color: Color) -> LayerColor {
+    LayerColor::new_rgba255(color.r(), color.g(), color.b(), color.a())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use otto_kit::components::text_input::{KeyMods, TextInputKey};
+
+    /// A field that was never given a box scrolls whatever is typed into it out
+    /// of its own clip: `ensure_caret_visible` keeps the caret inside a width
+    /// of zero by scrolling the full width of the text. The launcher looked
+    /// like it was ignoring the keyboard — the query filtered the list, and the
+    /// field stayed empty.
+    #[test]
+    fn the_query_field_keeps_typed_text_inside_its_box() {
+        let mut input = TextInput::editing("", field_style(true));
+        input.set_size(CARD_W, FIELD_H);
+        for c in "terminal".chars() {
+            input.on_key(TextInputKey::Char(c), KeyMods::default());
+        }
+        assert_eq!(input.value(), "terminal");
+        assert_eq!(
+            input.state.scroll_px, 0.0,
+            "a query this short fits, so nothing should be scrolled out of view"
+        );
+    }
+}

--- a/components/otto-launcher/src/windows.rs
+++ b/components/otto-launcher/src/windows.rs
@@ -1,0 +1,312 @@
+//! Open windows, over `zwlr-foreign-toplevel-management-v1`.
+//!
+//! This source keeps its own Wayland connection. otto-kit's runner owns the
+//! app's event queue and the set of protocols it dispatches, and a client
+//! cannot add a `Dispatch` impl to a type it does not own — so rather than
+//! widen otto-kit for one source, the toplevel list gets a second connection
+//! whose file descriptor the launcher hands to
+//! [`App::poll_fds`](otto_kit::App::poll_fds). The runner then wakes for a
+//! window opening or closing exactly as it does for its own events.
+
+use std::collections::HashMap;
+use std::os::fd::{AsFd, AsRawFd, RawFd};
+
+use wayland_client::protocol::{wl_registry, wl_seat::WlSeat};
+use wayland_client::{delegate_noop, Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::{
+    zwlr_foreign_toplevel_handle_v1::{self, State as ToplevelState, ZwlrForeignToplevelHandleV1},
+    zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+};
+
+use crate::source::{Item, Origin, Source};
+
+/// One window as the compositor describes it.
+///
+/// Titles arrive in pieces — a `title`, an `app_id`, a `state` — and only
+/// become a window when `done` says the description is complete.
+#[derive(Clone, Default)]
+struct Toplevel {
+    handle: Option<ZwlrForeignToplevelHandleV1>,
+    title: String,
+    app_id: String,
+    minimized: bool,
+    activated: bool,
+    /// When this window was last focused, as a counter. Orders the list so the
+    /// window someone was just in is the one under the cursor keys.
+    touched: u64,
+}
+
+#[derive(Default)]
+struct Registry {
+    seat: Option<WlSeat>,
+    toplevels: HashMap<u32, Toplevel>,
+    /// Insertion order, so windows that have never been focused keep a stable
+    /// place instead of shuffling on every event.
+    order: Vec<u32>,
+    clock: u64,
+    changed: bool,
+}
+
+pub struct Windows {
+    index: usize,
+    /// Whether this run is a window switcher. It changes what an empty query
+    /// shows: browsing is the point of the switcher, and beside the point of
+    /// the launcher.
+    switcher: bool,
+    connection: Connection,
+    queue: EventQueue<Registry>,
+    registry: Registry,
+    /// The list as it was last handed out, so `activate` can map a row back to
+    /// a handle even after the compositor has changed the set of windows.
+    listed: Vec<u32>,
+}
+
+impl Windows {
+    /// Connect and wait for the compositor to describe every window it already
+    /// has. Returns `None` when the compositor does not offer the protocol.
+    pub fn connect(index: usize, switcher: bool) -> Option<Self> {
+        let connection = Connection::connect_to_env().ok()?;
+        let mut queue = connection.new_event_queue();
+        let handle = queue.handle();
+        connection.display().get_registry(&handle, ());
+
+        let mut registry = Registry::default();
+        // Two roundtrips: the first binds the globals, the second collects the
+        // toplevels the manager announces as soon as it is bound.
+        queue.roundtrip(&mut registry).ok()?;
+        queue.roundtrip(&mut registry).ok()?;
+
+        if registry.toplevels.is_empty() && registry.seat.is_none() {
+            return None;
+        }
+        registry.changed = false;
+
+        Some(Self {
+            index,
+            switcher,
+            connection,
+            queue,
+            registry,
+            listed: Vec::new(),
+        })
+    }
+}
+
+impl Source for Windows {
+    fn label(&self) -> &'static str {
+        "Window"
+    }
+
+    fn items(&mut self) -> Vec<Item> {
+        let mut ids: Vec<u32> = self
+            .registry
+            .order
+            .iter()
+            .copied()
+            .filter(|id| {
+                self.registry
+                    .toplevels
+                    .get(id)
+                    .is_some_and(|toplevel| !toplevel.title.is_empty())
+            })
+            .collect();
+
+        // Most recently focused first, and among windows that have never been
+        // focused, the order they appeared in.
+        ids.sort_by_key(|id| {
+            std::cmp::Reverse(self.registry.toplevels.get(id).map_or(0, |t| t.touched))
+        });
+
+        self.listed = ids.clone();
+        ids.iter()
+            .enumerate()
+            .filter_map(|(index, id)| {
+                let toplevel = self.registry.toplevels.get(id)?;
+                let app = otto_kit::desktop_entry::display_name_for_app(&toplevel.app_id);
+                Some(Item {
+                    title: toplevel.title.clone(),
+                    subtitle: Some(if toplevel.minimized {
+                        format!("{app} — minimised")
+                    } else {
+                        app
+                    }),
+                    icon: Some(toplevel.app_id.clone()),
+                    search_terms: vec![toplevel.app_id.clone()],
+                    origin: Origin {
+                        source: self.index,
+                        index,
+                    },
+                })
+            })
+            .collect()
+    }
+
+    /// Every window, but only in the switcher. In the launcher an empty query
+    /// is the resting state, and the resting state is the last few things
+    /// launched — not a list of what happens to be open.
+    fn resting(&mut self) -> Vec<Item> {
+        if self.switcher {
+            self.items()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn activate(&mut self, index: usize) -> Result<(), String> {
+        let id = self.listed.get(index).ok_or("no such window")?;
+        let toplevel = self
+            .registry
+            .toplevels
+            .get(id)
+            .ok_or("that window has closed")?;
+        let handle = toplevel.handle.as_ref().ok_or("that window has closed")?;
+        let seat = self.registry.seat.as_ref().ok_or("no seat")?;
+
+        // A minimised window has to be brought back before it can be focused;
+        // activating one that is still minimised would only mark it.
+        if toplevel.minimized {
+            handle.unset_minimized();
+        }
+        handle.activate(seat);
+        self.connection.flush().map_err(|err| err.to_string())?;
+        Ok(())
+    }
+
+    fn changed(&mut self) -> bool {
+        std::mem::take(&mut self.registry.changed)
+    }
+
+    fn poll_fd(&self) -> Option<RawFd> {
+        Some(self.connection.as_fd().as_raw_fd())
+    }
+
+    /// Read whatever the compositor has sent. Never blocks: the runner calls
+    /// this on every loop iteration, not only when this socket is readable.
+    fn pump(&mut self) {
+        let _ = self.queue.dispatch_pending(&mut self.registry);
+        let _ = self.connection.flush();
+        if let Some(guard) = self.connection.prepare_read() {
+            // `WouldBlock` is the normal answer — this is a poll, not a wait.
+            let _ = guard.read();
+            let _ = self.queue.dispatch_pending(&mut self.registry);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wayland plumbing
+// ---------------------------------------------------------------------------
+
+impl Dispatch<wl_registry::WlRegistry, ()> for Registry {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        else {
+            return;
+        };
+        match interface.as_str() {
+            "zwlr_foreign_toplevel_manager_v1" => {
+                registry.bind::<ZwlrForeignToplevelManagerV1, _, _>(name, version.min(3), qh, ());
+            }
+            "wl_seat" if state.seat.is_none() => {
+                state.seat = Some(registry.bind::<WlSeat, _, _>(name, version.min(7), qh, ()));
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for Registry {
+    fn event(
+        state: &mut Self,
+        _manager: &ZwlrForeignToplevelManagerV1,
+        event: zwlr_foreign_toplevel_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let zwlr_foreign_toplevel_manager_v1::Event::Toplevel { toplevel } = event {
+            let id = toplevel.id().protocol_id();
+            state.order.push(id);
+            state.toplevels.insert(
+                id,
+                Toplevel {
+                    handle: Some(toplevel),
+                    ..Default::default()
+                },
+            );
+        }
+    }
+
+    wayland_client::event_created_child!(Registry, ZwlrForeignToplevelManagerV1, [
+        zwlr_foreign_toplevel_manager_v1::EVT_TOPLEVEL_OPCODE => (ZwlrForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for Registry {
+    fn event(
+        state: &mut Self,
+        handle: &ZwlrForeignToplevelHandleV1,
+        event: zwlr_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let id = handle.id().protocol_id();
+        match event {
+            zwlr_foreign_toplevel_handle_v1::Event::Title { title } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    toplevel.title = title;
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    toplevel.app_id = app_id;
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::State { state: flags } => {
+                // The state arrives as a raw array of enum values, in the
+                // wire's native byte order.
+                let states: Vec<ToplevelState> = flags
+                    .chunks_exact(4)
+                    .map(|bytes| u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+                    .filter_map(|value| ToplevelState::try_from(value).ok())
+                    .collect();
+                let activated = states.contains(&ToplevelState::Activated);
+                let minimized = states.contains(&ToplevelState::Minimized);
+
+                state.clock += 1;
+                let clock = state.clock;
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    if activated && !toplevel.activated {
+                        toplevel.touched = clock;
+                    }
+                    toplevel.activated = activated;
+                    toplevel.minimized = minimized;
+                }
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::Closed => {
+                handle.destroy();
+                state.toplevels.remove(&id);
+                state.order.retain(|other| *other != id);
+                state.changed = true;
+            }
+            zwlr_foreign_toplevel_handle_v1::Event::Done => {
+                state.changed = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+delegate_noop!(Registry: ignore WlSeat);

--- a/components/otto-quickview/Cargo.toml
+++ b/components/otto-quickview/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "otto-quickview"
+version = "0.1.0"
+edition = "2021"
+description = "Press space on a file and see it — Otto's quick-view previewer"
+
+# A library the file views embed, plus a binary that is both the sandboxed
+# decode worker and a standalone previewer for a path named on the command line.
+[lib]
+name = "otto_quickview"
+path = "src/lib.rs"
+
+[[bin]]
+name = "otto-quickview"
+path = "src/main.rs"
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+wayland-client = "0.31"
+smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
+libc = "0.2"
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
+
+[dependencies.laye-rs]
+git = "https://github.com/nongio/layers"
+tag = "v1.13.0"
+features = ["export-taffy"]
+
+[dependencies.skia-safe]
+version = "=0.93"
+features = ["gl", "textlayout", "svg", "skottie"]

--- a/components/otto-quickview/src/decode/image.rs
+++ b/components/otto-quickview/src/decode/image.rs
@@ -1,0 +1,259 @@
+//! Images — the primary content type, and the one held to the highest standard.
+//!
+//! Two rules carry this file. **Never materialise a full-resolution decode of a
+//! very large image**: Skia's `Codec` can decode at a sample size, and that is
+//! the difference between previewing a 200 MP photograph and refusing to.
+//! **Never upscale a fit-sized decode when the user zooms in**: past roughly
+//! 1:1 the worker is asked again at a finer scale, so looking closely shows
+//! detail rather than blur.
+
+use std::fs::File;
+
+use skia_safe::{Codec, Data, ISize, ImageInfo};
+
+use crate::payload;
+use crate::payload::{Pixels, PreviewPayload};
+
+use super::{read_capped, Request};
+
+/// The most pixels a single decode may produce. A 100 MP decode at RGBA is
+/// 400 MB, which is already past what a preview should ever hold; the sample
+/// size is chosen to stay under this, and a codec that cannot scale is refused
+/// rather than allowed to blow the address-space limit.
+const MAX_DECODE_PIXELS: u64 = 64 * 1024 * 1024;
+
+pub fn raster(file: &mut File, request: &Request) -> PreviewPayload {
+    let bytes = match read_capped(file, request.budget.max_read) {
+        Ok(bytes) => bytes,
+        Err(err) => return payload::unavailable(format!("cannot read the image: {err}")),
+    };
+    let data = Data::new_copy(&bytes);
+    let Some(mut codec) = Codec::from_data(data) else {
+        return payload::unavailable("not an image this build can decode");
+    };
+
+    let intrinsic = codec.dimensions();
+    if intrinsic.width <= 0 || intrinsic.height <= 0 {
+        return payload::unavailable("the image reports no size");
+    }
+
+    let target = target_size(intrinsic, request);
+    // The codec picks the nearest sample size it can actually deliver, which is
+    // rarely exactly what was asked for.
+    let scale = (target.width as f32 / intrinsic.width as f32).clamp(0.0, 1.0);
+    let scaled = if scale >= 1.0 {
+        intrinsic
+    } else {
+        codec.get_scaled_dimensions(scale)
+    };
+
+    if pixel_count(scaled) > MAX_DECODE_PIXELS {
+        return too_large(intrinsic, request);
+    }
+
+    let info = codec
+        .info()
+        .with_dimensions(scaled)
+        .with_color_type(skia_safe::ColorType::RGBA8888)
+        .with_alpha_type(skia_safe::AlphaType::Premul);
+
+    let image = match codec.get_image(info, None) {
+        Ok(image) => image,
+        Err(err) => return payload::unavailable(format!("the image did not decode: {err:?}")),
+    };
+
+    match to_pixels(&image, intrinsic) {
+        Some(pixels) => PreviewPayload::Pixels {
+            pixels,
+            pages: 1,
+            page: 1,
+        },
+        None => payload::unavailable("the decoded image could not be read back"),
+    }
+}
+
+/// SVG, rendered at the size it will be shown rather than at some nominal one,
+/// so it stays sharp at every zoom level. Skia's own SVG module does this —
+/// Quick View deliberately does not become a new consumer of `resvg`.
+pub fn svg(file: &mut File, request: &Request) -> PreviewPayload {
+    let bytes = match read_capped(file, request.budget.max_read.min(64 * 1024 * 1024)) {
+        Ok(bytes) => bytes,
+        Err(err) => return payload::unavailable(format!("cannot read the drawing: {err}")),
+    };
+
+    // Skia's own `LocalResourceProvider` would happily open whatever an
+    // `xlink:href` points at. That is precisely the hole the sandbox exists to
+    // close, so the drawing gets a provider that refuses everything external
+    // and offers fonts only. The network namespace already forbids the remote
+    // case; this forbids the local one at the same time.
+    let Ok(mut dom) = skia_safe::svg::Dom::from_bytes(&bytes, SealedResources) else {
+        return payload::unavailable("the drawing could not be parsed");
+    };
+
+    let width = request.width.clamp(1, 8192) as i32;
+    let height = request.height.clamp(1, 8192) as i32;
+    let Some(mut surface) = skia_safe::surfaces::raster_n32_premul((width, height)) else {
+        return payload::unavailable("no surface to draw the drawing on");
+    };
+    dom.set_container_size(skia_safe::Size::new(width as f32, height as f32));
+    dom.render(surface.canvas());
+
+    let image = surface.image_snapshot();
+    match to_pixels(&image, ISize::new(width, height)) {
+        Some(pixels) => PreviewPayload::Pixels {
+            pixels,
+            pages: 1,
+            page: 1,
+        },
+        None => payload::unavailable("the drawing could not be read back"),
+    }
+}
+
+/// A resource provider that provides no resources.
+///
+/// An SVG may reference images and fonts by URL. Honouring those would let a
+/// file the user merely *looked at* pull in another file — the sandbox blocks
+/// the syscall, but refusing here means the drawing renders promptly with the
+/// reference missing rather than after the kernel says no.
+///
+/// Fonts are the exception: text in an SVG should still be laid out, and the
+/// system font manager reads only what is already on the font path.
+#[derive(Debug)]
+struct SealedResources;
+
+impl skia_safe::resources::ResourceProvider for SealedResources {
+    fn load(&self, _resource_path: &str, _resource_name: &str) -> Option<skia_safe::Data> {
+        None
+    }
+
+    fn load_typeface(&self, _name: &str, _url: &str) -> Option<skia_safe::Typeface> {
+        None
+    }
+
+    fn font_mgr(&self) -> skia_safe::FontMgr {
+        skia_safe::FontMgr::default()
+    }
+}
+
+/// What size to decode at.
+///
+/// The size the host asked for — which is already twice the panel, so the
+/// image survives being scaled down for display and has something in hand
+/// when the user starts zooming — but never more than the source actually
+/// has, since upsampling in the worker would only move the blur earlier in
+/// the pipeline.
+///
+/// The doubling belongs to the host and happens once. Doubling again here
+/// meant every preview was decoded at four times the panel, and the payload
+/// is uncompressed pixels: the cost lands twice, in the decode and in the
+/// bytes that then go down the pipe.
+fn target_size(intrinsic: ISize, request: &Request) -> ISize {
+    let zoom = request.zoom.max(1.0);
+    let wanted_w = (request.width as f32 * zoom).ceil() as i32;
+    let wanted_h = (request.height as f32 * zoom).ceil() as i32;
+    ISize::new(
+        wanted_w.clamp(1, intrinsic.width),
+        wanted_h.clamp(1, intrinsic.height),
+    )
+}
+
+fn pixel_count(size: ISize) -> u64 {
+    (size.width.max(0) as u64) * (size.height.max(0) as u64)
+}
+
+/// An image too large to decode is described rather than shown. Refusing with
+/// its real dimensions is more use than a blank rectangle.
+fn too_large(intrinsic: ISize, request: &Request) -> PreviewPayload {
+    PreviewPayload::Card {
+        title: request.name.clone(),
+        subtitle: "Too large to preview".into(),
+        facts: vec![
+            crate::payload::Fact {
+                key: "Dimensions".into(),
+                value: format!("{} × {}", intrinsic.width, intrinsic.height),
+            },
+            crate::payload::Fact {
+                key: "Pixels".into(),
+                value: format!("{} megapixels", pixel_count(intrinsic) / 1_000_000),
+            },
+        ],
+        hero: None,
+    }
+}
+
+/// Copy a decoded image out into a plain premultiplied RGBA buffer, which is
+/// all the wire format and the drawing side know about.
+pub(crate) fn to_pixels(image: &skia_safe::Image, intrinsic: ISize) -> Option<Pixels> {
+    let width = image.width().max(0) as u32;
+    let height = image.height().max(0) as u32;
+    let info = ImageInfo::new(
+        (width as i32, height as i32),
+        skia_safe::ColorType::RGBA8888,
+        skia_safe::AlphaType::Premul,
+        None,
+    );
+    let row_bytes = width as usize * 4;
+    let mut data = vec![0u8; row_bytes * height as usize];
+    image
+        .read_pixels(
+            &info,
+            &mut data,
+            row_bytes,
+            (0, 0),
+            skia_safe::image::CachingHint::Disallow,
+        )
+        .then_some(Pixels {
+            width,
+            height,
+            intrinsic_width: intrinsic.width.max(0) as u32,
+            intrinsic_height: intrinsic.height.max(0) as u32,
+            data,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_never_exceeds_the_source() {
+        let intrinsic = ISize::new(100, 80);
+        let request = Request {
+            width: 1600,
+            height: 1200,
+            ..Request::default()
+        };
+        let target = target_size(intrinsic, &request);
+        assert_eq!(target.width, 100);
+        assert_eq!(target.height, 80);
+    }
+
+    #[test]
+    fn zooming_asks_for_more_detail() {
+        let intrinsic = ISize::new(10_000, 8_000);
+        let fit = target_size(
+            intrinsic,
+            &Request {
+                width: 800,
+                height: 600,
+                zoom: 1.0,
+                ..Request::default()
+            },
+        );
+        let zoomed = target_size(
+            intrinsic,
+            &Request {
+                width: 800,
+                height: 600,
+                zoom: 4.0,
+                ..Request::default()
+            },
+        );
+        assert!(
+            zoomed.width > fit.width,
+            "zooming in must request a finer decode, got {} then {}",
+            fit.width,
+            zoomed.width
+        );
+    }
+}

--- a/components/otto-quickview/src/decode/listing.rs
+++ b/components/otto-quickview/src/decode/listing.rs
@@ -1,0 +1,384 @@
+//! Listings: directories, and archives.
+//!
+//! **Listing an archive needs no decompression.** A zip's central directory
+//! carries every entry's name, size and date in plain form at the end of the
+//! file, and a tar is 512-byte headers. That is why archives are a v1 type
+//! despite Otto having no inflate implementation — this is a parse, not an
+//! extraction. A *compressed* tar cannot be listed without inflating and is
+//! deliberately shown as a plain file card instead.
+
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+use std::os::fd::AsRawFd;
+
+use otto_kit::filetype;
+
+use crate::payload;
+use crate::payload::{PreviewPayload, Row};
+
+use super::{human_size, read_capped, Request};
+
+/// A listing is a look at what is inside, not a file manager. Enough rows to
+/// answer "what is this", few enough that the parent never lays out a
+/// hundred-thousand-row table.
+const MAX_ROWS: usize = 2_000;
+
+// ---------------------------------------------------------------------------
+// Directories
+// ---------------------------------------------------------------------------
+
+/// The worker holds a descriptor, not a path — deliberately, so no name can be
+/// substituted underneath it. `fdopendir` is how a directory is read from one.
+pub fn directory(file: &mut File, _request: &Request) -> PreviewPayload {
+    let mut rows = Vec::new();
+    let mut total = 0u64;
+    let mut truncated = false;
+
+    // SAFETY: `fdopendir` takes ownership of the descriptor it is given, so it
+    // gets a duplicate — the caller's `File` still owns the original and will
+    // close it. Every pointer below is checked before use, and `readdir` is
+    // called on one directory stream from one thread.
+    unsafe {
+        let duplicate = libc::dup(file.as_raw_fd());
+        if duplicate < 0 {
+            return payload::unavailable("cannot read the folder");
+        }
+        let dir = libc::fdopendir(duplicate);
+        if dir.is_null() {
+            libc::close(duplicate);
+            return payload::unavailable("cannot read the folder");
+        }
+
+        loop {
+            let entry = libc::readdir(dir);
+            if entry.is_null() {
+                break;
+            }
+            let name = std::ffi::CStr::from_ptr((*entry).d_name.as_ptr())
+                .to_string_lossy()
+                .into_owned();
+            if name == "." || name == ".." {
+                continue;
+            }
+            // Hidden entries are counted but not listed: a preview of a source
+            // checkout should not be mostly dotfiles.
+            if name.starts_with('.') {
+                total += 1;
+                continue;
+            }
+            total += 1;
+            if rows.len() >= MAX_ROWS {
+                truncated = true;
+                continue;
+            }
+            let is_dir = (*entry).d_type == libc::DT_DIR;
+            let icon = if is_dir {
+                "folder".to_string()
+            } else {
+                filetype::kind_for_name(&name).generic_icon().to_string()
+            };
+            rows.push(Row {
+                name,
+                size: 0,
+                mtime: 0,
+                icon,
+                is_dir,
+            });
+        }
+        libc::closedir(dir);
+    }
+
+    // Folders first, then by name, case-insensitively — the order a person
+    // expects rather than the order the filesystem happens to return.
+    rows.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    PreviewPayload::Rows {
+        rows,
+        truncated,
+        summary: match total {
+            0 => "Empty folder".to_string(),
+            1 => "1 item".to_string(),
+            count => format!("{count} items"),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Zip
+// ---------------------------------------------------------------------------
+
+/// How far back from the end of the file the end-of-central-directory record
+/// may start: 22 bytes of record plus a comment field of up to 64 KB.
+const EOCD_SEARCH: u64 = 22 + 0xFFFF;
+const EOCD_SIGNATURE: u32 = 0x0605_4B50;
+const CENTRAL_SIGNATURE: u32 = 0x0201_4B50;
+
+pub fn zip(file: &mut File, metadata: &Metadata, request: &Request) -> PreviewPayload {
+    match zip_rows(file, metadata) {
+        Some((rows, truncated, total)) => PreviewPayload::Rows {
+            rows,
+            truncated,
+            summary: format!(
+                "{} — {}",
+                match total {
+                    1 => "1 item".to_string(),
+                    count => format!("{count} items"),
+                },
+                human_size(metadata.len())
+            ),
+        },
+        // A zip we cannot walk is still a file we can describe.
+        None => super::media::generic(metadata, request, "application/zip"),
+    }
+}
+
+/// Walk the central directory. Returns `None` if the file is not a zip we can
+/// read — never a panic, and never a partial listing presented as complete.
+fn zip_rows(file: &mut File, metadata: &Metadata) -> Option<(Vec<Row>, bool, usize)> {
+    let length = metadata.len();
+    let tail_len = EOCD_SEARCH.min(length);
+    file.seek(SeekFrom::End(-(tail_len as i64))).ok()?;
+    let mut tail = vec![0u8; tail_len as usize];
+    file.read_exact(&mut tail).ok()?;
+
+    // The record is at the end, so scan backwards: a zip containing a zip would
+    // otherwise match the inner one's signature first.
+    let eocd = (0..=tail.len().checked_sub(22)?)
+        .rev()
+        .find(|at| read_u32(&tail, *at) == Some(EOCD_SIGNATURE))?;
+
+    let entry_count = read_u16(&tail, eocd + 10)? as usize;
+    let directory_offset = read_u32(&tail, eocd + 16)? as u64;
+    let directory_size = read_u32(&tail, eocd + 12)? as usize;
+    if directory_offset >= length {
+        return None;
+    }
+
+    file.seek(SeekFrom::Start(directory_offset)).ok()?;
+    // The central directory is names and numbers; it is not a decompression.
+    let mut directory = vec![0u8; directory_size.min(32 * 1024 * 1024)];
+    let read = file.read(&mut directory).ok()?;
+    directory.truncate(read);
+
+    let mut rows = Vec::new();
+    let mut truncated = false;
+    let mut at = 0usize;
+    let mut seen = 0usize;
+
+    while seen < entry_count && at + 46 <= directory.len() {
+        if read_u32(&directory, at) != Some(CENTRAL_SIGNATURE) {
+            break;
+        }
+        let uncompressed = read_u32(&directory, at + 24)? as u64;
+        let name_len = read_u16(&directory, at + 28)? as usize;
+        let extra_len = read_u16(&directory, at + 30)? as usize;
+        let comment_len = read_u16(&directory, at + 32)? as usize;
+        let dos_time = read_u16(&directory, at + 12)?;
+        let dos_date = read_u16(&directory, at + 14)?;
+
+        let name_at = at + 46;
+        let name_bytes = directory.get(name_at..name_at + name_len)?;
+        let name = String::from_utf8_lossy(name_bytes).into_owned();
+        let is_dir = name.ends_with('/');
+
+        seen += 1;
+        if rows.len() >= MAX_ROWS {
+            truncated = true;
+        } else {
+            let display = name.trim_end_matches('/').to_string();
+            let leaf = display.rsplit('/').next().unwrap_or(&display).to_string();
+            let icon = if is_dir {
+                "folder".to_string()
+            } else {
+                filetype::kind_for_name(&leaf).generic_icon().to_string()
+            };
+            rows.push(Row {
+                name: display,
+                size: uncompressed,
+                mtime: dos_timestamp(dos_date, dos_time),
+                icon,
+                is_dir,
+            });
+        }
+        at = name_at + name_len + extra_len + comment_len;
+    }
+
+    (!rows.is_empty() || entry_count == 0).then_some((rows, truncated, entry_count))
+}
+
+fn read_u16(bytes: &[u8], at: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(bytes.get(at..at + 2)?.try_into().ok()?))
+}
+
+fn read_u32(bytes: &[u8], at: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(bytes.get(at..at + 4)?.try_into().ok()?))
+}
+
+/// MS-DOS date/time as seconds since the epoch. Approximate by design — it
+/// carries no timezone, and a listing shows a date, not a timestamp.
+fn dos_timestamp(date: u16, time: u16) -> i64 {
+    let year = 1980 + ((date >> 9) & 0x7F) as i64;
+    let month = ((date >> 5) & 0x0F) as i64;
+    let day = (date & 0x1F) as i64;
+    let hour = ((time >> 11) & 0x1F) as i64;
+    let minute = ((time >> 5) & 0x3F) as i64;
+    let second = ((time & 0x1F) as i64) * 2;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return 0;
+    }
+    days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second
+}
+
+/// Days since 1970-01-01 for a proleptic Gregorian date. Howard Hinnant's
+/// `days_from_civil`, which is exact and needs no calendar library.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+// ---------------------------------------------------------------------------
+// Tar
+// ---------------------------------------------------------------------------
+
+/// Uncompressed tar only. A `.tar.gz` reaches here as its compressed type and
+/// gets a file card — listing it would need an inflate implementation, which is
+/// a dependency v1 declined.
+pub fn tar(file: &mut File, metadata: &Metadata, request: &Request) -> PreviewPayload {
+    // Headers are every 512 bytes and entries are padded to that, so walking
+    // the whole archive means reading it. Cap it: the point is a look inside.
+    let bytes = match read_capped(file, 64 * 1024 * 1024) {
+        Ok(bytes) => bytes,
+        Err(_) => return super::media::generic(metadata, request, "application/x-tar"),
+    };
+
+    let mut rows = Vec::new();
+    let mut truncated = bytes.len() as u64 == 64 * 1024 * 1024;
+    let mut at = 0usize;
+    let mut total = 0usize;
+
+    while at + 512 <= bytes.len() {
+        let header = &bytes[at..at + 512];
+        // Two zero blocks end the archive; one all-zero header is enough to
+        // stop walking.
+        if header.iter().all(|byte| *byte == 0) {
+            break;
+        }
+        let Some(name) = tar_string(&header[0..100]) else {
+            break;
+        };
+        if name.is_empty() {
+            break;
+        }
+        let size = tar_octal(&header[124..136]).unwrap_or(0);
+        let mtime = tar_octal(&header[136..148]).unwrap_or(0) as i64;
+        let type_flag = header[156];
+        // Directories are '5'; '0' and NUL are regular files. Everything else
+        // (links, devices, and the long-name extensions) is listed as-is.
+        let is_dir = type_flag == b'5' || name.ends_with('/');
+
+        total += 1;
+        if rows.len() >= MAX_ROWS {
+            truncated = true;
+        } else {
+            let display = name.trim_end_matches('/').to_string();
+            let leaf = display.rsplit('/').next().unwrap_or(&display).to_string();
+            let icon = if is_dir {
+                "folder".to_string()
+            } else {
+                filetype::kind_for_name(&leaf).generic_icon().to_string()
+            };
+            rows.push(Row {
+                name: display,
+                size,
+                mtime,
+                icon,
+                is_dir,
+            });
+        }
+
+        // Content is padded up to the next 512-byte boundary.
+        let advance = 512 + (size as usize).div_ceil(512) * 512;
+        at = match at.checked_add(advance) {
+            Some(next) if next > at => next,
+            _ => break,
+        };
+    }
+
+    if rows.is_empty() {
+        return super::media::generic(metadata, request, "application/x-tar");
+    }
+
+    PreviewPayload::Rows {
+        rows,
+        truncated,
+        summary: format!(
+            "{} — {}",
+            match total {
+                1 => "1 item".to_string(),
+                count => format!("{count} items"),
+            },
+            human_size(metadata.len())
+        ),
+    }
+}
+
+/// A NUL-terminated field from a tar header.
+fn tar_string(field: &[u8]) -> Option<String> {
+    let end = field
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(field.len());
+    Some(String::from_utf8_lossy(&field[..end]).trim().to_string())
+}
+
+/// Tar stores numbers as NUL/space-terminated octal text.
+fn tar_octal(field: &[u8]) -> Option<u64> {
+    let text = tar_string(field)?;
+    let digits = text.trim();
+    if digits.is_empty() {
+        return Some(0);
+    }
+    u64::from_str_radix(digits, 8).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dos_epoch_is_the_dos_epoch() {
+        // 1980-01-01 00:00:00, the earliest a zip can express.
+        assert_eq!(dos_timestamp(0b0000000_0001_00001, 0), 315_532_800);
+    }
+
+    #[test]
+    fn an_impossible_dos_date_is_no_date_rather_than_a_wrong_one() {
+        assert_eq!(dos_timestamp(0, 0), 0);
+    }
+
+    #[test]
+    fn civil_days_match_known_dates() {
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(2000, 3, 1), 11017);
+    }
+
+    #[test]
+    fn tar_octal_reads_padded_fields() {
+        assert_eq!(tar_octal(b"00000001750\0"), Some(1000));
+        assert_eq!(tar_octal(b"           \0"), Some(0));
+        assert_eq!(tar_octal(b"not octal!!\0"), None);
+    }
+
+    #[test]
+    fn tar_strings_stop_at_the_terminator() {
+        assert_eq!(tar_string(b"a.txt\0\0\0\0\0").as_deref(), Some("a.txt"));
+    }
+}

--- a/components/otto-quickview/src/decode/media.rs
+++ b/components/otto-quickview/src/decode/media.rs
@@ -1,0 +1,408 @@
+//! Audio, video, and everything else — described rather than rendered.
+//!
+//! v1 deliberately gets most of the value here without a decoder: tags and
+//! embedded cover art need no PCM decode, and container headers give dimensions
+//! and duration without reading a 2 GB file. Playback and poster frames are
+//! later stages; see `specs/quickview.md`.
+//!
+//! The hard rule in this file is that **nothing reads the whole file**. A
+//! metadata previewer that streams two gigabytes to find a duration has missed
+//! the point of being a previewer.
+
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+
+use otto_kit::filetype;
+use skia_safe::{Codec, Data};
+
+use crate::payload::{Fact, Pixels, PreviewPayload};
+
+use super::{human_size, Request};
+
+/// How much of a media file the metadata readers may look at. ID3 and MP4
+/// headers live at one end or the other; nothing here needs the middle.
+const HEADER_BYTES: u64 = 1024 * 1024;
+
+/// The last resort: a file we can name and size but not interpret.
+pub fn generic(metadata: &Metadata, request: &Request, mime: &str) -> PreviewPayload {
+    PreviewPayload::Card {
+        title: request.name.clone(),
+        subtitle: filetype::kind_of(mime).label().to_string(),
+        facts: vec![
+            Fact {
+                key: "Kind".into(),
+                value: describe(mime),
+            },
+            Fact {
+                key: "Size".into(),
+                value: human_size(metadata.len()),
+            },
+        ],
+        hero: None,
+    }
+}
+
+pub fn audio(
+    file: &mut File,
+    metadata: &Metadata,
+    request: &Request,
+    mime: &str,
+) -> PreviewPayload {
+    let head = read_head(file);
+    let tags = id3(&head);
+
+    let mut facts = Vec::new();
+    for (key, value) in [
+        ("Artist", tags.artist.as_deref()),
+        ("Album", tags.album.as_deref()),
+        ("Year", tags.year.as_deref()),
+    ] {
+        if let Some(value) = value.filter(|value| !value.is_empty()) {
+            facts.push(Fact {
+                key: key.into(),
+                value: value.to_string(),
+            });
+        }
+    }
+    facts.push(Fact {
+        key: "Kind".into(),
+        value: describe(mime),
+    });
+    facts.push(Fact {
+        key: "Size".into(),
+        value: human_size(metadata.len()),
+    });
+
+    PreviewPayload::Card {
+        title: tags.title.unwrap_or_else(|| request.name.clone()),
+        subtitle: tags
+            .artist
+            .clone()
+            .unwrap_or_else(|| filetype::kind_of(mime).label().to_string()),
+        facts,
+        // Cover art is an embedded JPEG or PNG, which Skia decodes like any
+        // other image — no audio decoder involved.
+        hero: tags.cover.as_deref().and_then(decode_cover),
+    }
+}
+
+pub fn video(
+    file: &mut File,
+    metadata: &Metadata,
+    request: &Request,
+    mime: &str,
+) -> PreviewPayload {
+    let head = read_head(file);
+    let mut facts = Vec::new();
+
+    if let Some((width, height)) = mp4_dimensions(&head) {
+        facts.push(Fact {
+            key: "Dimensions".into(),
+            value: format!("{width} × {height}"),
+        });
+    }
+    if let Some(seconds) = mp4_duration(&head) {
+        facts.push(Fact {
+            key: "Duration".into(),
+            value: clock(seconds),
+        });
+    }
+    facts.push(Fact {
+        key: "Kind".into(),
+        value: describe(mime),
+    });
+    facts.push(Fact {
+        key: "Size".into(),
+        value: human_size(metadata.len()),
+    });
+
+    PreviewPayload::Card {
+        title: request.name.clone(),
+        subtitle: filetype::kind_of(mime).label().to_string(),
+        facts,
+        hero: None,
+    }
+}
+
+/// Read the front of the file, and rewind so nothing downstream is surprised.
+fn read_head(file: &mut File) -> Vec<u8> {
+    let mut head = Vec::new();
+    let _ = file.seek(SeekFrom::Start(0));
+    let _ = file.take(HEADER_BYTES).read_to_end(&mut head);
+    let _ = file.seek(SeekFrom::Start(0));
+    head
+}
+
+fn describe(mime: &str) -> String {
+    // `image/jpeg` reads better as "JPEG" than as its full type.
+    mime.rsplit('/')
+        .next()
+        .map(|subtype| subtype.trim_start_matches("x-").to_ascii_uppercase())
+        .unwrap_or_else(|| mime.to_string())
+}
+
+fn clock(seconds: u64) -> String {
+    let (hours, minutes, seconds) = (seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ID3v2
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct Tags {
+    title: Option<String>,
+    artist: Option<String>,
+    album: Option<String>,
+    year: Option<String>,
+    cover: Option<Vec<u8>>,
+}
+
+/// A deliberately small ID3v2.3/2.4 reader: the four text frames worth showing
+/// and the attached picture. Unsynchronisation, compression and encryption are
+/// not handled — a frame we do not understand is skipped, not guessed at.
+fn id3(bytes: &[u8]) -> Tags {
+    let mut tags = Tags::default();
+    if bytes.len() < 10 || &bytes[0..3] != b"ID3" {
+        return tags;
+    }
+    // A syncsafe integer: seven bits per byte, so the size can never contain a
+    // byte that looks like a frame sync.
+    let size = syncsafe(&bytes[6..10]) as usize;
+    let end = (10 + size).min(bytes.len());
+    let mut at = 10usize;
+
+    while at + 10 <= end {
+        let id = &bytes[at..at + 4];
+        if id == b"\0\0\0\0" {
+            break;
+        }
+        // 2.4 uses syncsafe frame sizes, 2.3 plain ones. Reading it as plain
+        // and sanity-checking is enough for the frames we want.
+        let frame_size =
+            u32::from_be_bytes([bytes[at + 4], bytes[at + 5], bytes[at + 6], bytes[at + 7]])
+                as usize;
+        let body_at = at + 10;
+        if frame_size == 0 || body_at + frame_size > end {
+            break;
+        }
+        let body = &bytes[body_at..body_at + frame_size];
+
+        match id {
+            b"TIT2" => tags.title = text_frame(body),
+            b"TPE1" => tags.artist = text_frame(body),
+            b"TALB" => tags.album = text_frame(body),
+            b"TYER" | b"TDRC" => tags.year = text_frame(body),
+            b"APIC" => tags.cover = picture_frame(body),
+            _ => {}
+        }
+        at = body_at + frame_size;
+    }
+    tags
+}
+
+fn syncsafe(bytes: &[u8]) -> u32 {
+    bytes
+        .iter()
+        .take(4)
+        .fold(0u32, |total, byte| (total << 7) | (*byte as u32 & 0x7F))
+}
+
+/// A text frame: one encoding byte, then the string.
+fn text_frame(body: &[u8]) -> Option<String> {
+    let (encoding, rest) = body.split_first()?;
+    let text = match encoding {
+        // ISO-8859-1 and UTF-8 both decode bytewise for our purposes; the
+        // lossy path is correct for the former and exact for the latter.
+        0 => rest.iter().map(|byte| *byte as char).collect(),
+        3 => String::from_utf8_lossy(rest).into_owned(),
+        // UTF-16, with or without a BOM.
+        1 | 2 => utf16(rest)?,
+        _ => return None,
+    };
+    let text = text.trim_end_matches('\0').trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn utf16(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 2 {
+        return None;
+    }
+    let (little_endian, body) = match (bytes[0], bytes[1]) {
+        (0xFF, 0xFE) => (true, &bytes[2..]),
+        (0xFE, 0xFF) => (false, &bytes[2..]),
+        _ => (true, bytes),
+    };
+    let units: Vec<u16> = body
+        .chunks_exact(2)
+        .map(|pair| {
+            if little_endian {
+                u16::from_le_bytes([pair[0], pair[1]])
+            } else {
+                u16::from_be_bytes([pair[0], pair[1]])
+            }
+        })
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+/// An attached picture: encoding byte, MIME string, picture type, description,
+/// then the image itself.
+fn picture_frame(body: &[u8]) -> Option<Vec<u8>> {
+    let (encoding, rest) = body.split_first()?;
+    let mime_end = rest.iter().position(|byte| *byte == 0)?;
+    let after_mime = rest.get(mime_end + 1..)?;
+    let after_type = after_mime.get(1..)?;
+    // The description's terminator is one NUL for the byte encodings and two
+    // for the UTF-16 ones.
+    let description_end = if matches!(encoding, 1 | 2) {
+        after_type
+            .chunks_exact(2)
+            .position(|pair| pair == [0, 0])
+            .map(|index| index * 2 + 2)?
+    } else {
+        after_type.iter().position(|byte| *byte == 0)? + 1
+    };
+    let image = after_type.get(description_end..)?;
+    (!image.is_empty()).then(|| image.to_vec())
+}
+
+/// Cover art, decoded small: it is shown at card size and nothing is gained by
+/// holding a full-resolution copy.
+fn decode_cover(bytes: &[u8]) -> Option<Pixels> {
+    let mut codec = Codec::from_data(Data::new_copy(bytes))?;
+    let intrinsic = codec.dimensions();
+    if intrinsic.width <= 0 || intrinsic.height <= 0 {
+        return None;
+    }
+    let scale = (512.0 / intrinsic.width as f32).min(1.0);
+    let scaled = if scale >= 1.0 {
+        intrinsic
+    } else {
+        codec.get_scaled_dimensions(scale)
+    };
+    let info = codec
+        .info()
+        .with_dimensions(scaled)
+        .with_color_type(skia_safe::ColorType::RGBA8888)
+        .with_alpha_type(skia_safe::AlphaType::Premul);
+    let image = codec.get_image(info, None).ok()?;
+    super::image::to_pixels(&image, intrinsic)
+}
+
+// ---------------------------------------------------------------------------
+// MP4 / QuickTime
+// ---------------------------------------------------------------------------
+
+/// Walk the top-level atoms for `moov`, then find the movie header inside it.
+///
+/// Atom walking is a length and a four-character code; it needs no library, and
+/// it never reads past the header region we already have.
+fn find_atom(bytes: &[u8], want: &[u8; 4]) -> Option<(usize, usize)> {
+    let mut at = 0usize;
+    while at + 8 <= bytes.len() {
+        let size = u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?) as usize;
+        let kind = bytes.get(at + 4..at + 8)?;
+        let body = at + 8;
+        if kind == want {
+            let end = if size == 0 { bytes.len() } else { at + size };
+            return Some((body, end.min(bytes.len())));
+        }
+        // A size of 0 means "to end of file"; 1 means a 64-bit size follows.
+        // Neither is worth chasing in a header scan.
+        if size < 8 {
+            return None;
+        }
+        at += size;
+    }
+    None
+}
+
+/// Duration in seconds, from the movie header's timescale and duration.
+fn mp4_duration(bytes: &[u8]) -> Option<u64> {
+    let (moov, end) = find_atom(bytes, b"moov")?;
+    let (mvhd, _) = find_atom(bytes.get(moov..end)?, b"mvhd")?;
+    let header = bytes.get(moov + mvhd..)?;
+    let version = *header.first()?;
+    // Version 1 uses 64-bit creation/modification times, moving the fields on.
+    let (timescale_at, duration_at) = if version == 1 { (20, 24) } else { (12, 16) };
+    let timescale = u32::from_be_bytes(
+        header
+            .get(timescale_at..timescale_at + 4)?
+            .try_into()
+            .ok()?,
+    );
+    if timescale == 0 {
+        return None;
+    }
+    let duration = if version == 1 {
+        u64::from_be_bytes(header.get(duration_at..duration_at + 8)?.try_into().ok()?)
+    } else {
+        u32::from_be_bytes(header.get(duration_at..duration_at + 4)?.try_into().ok()?) as u64
+    };
+    Some(duration / timescale as u64)
+}
+
+/// Dimensions from the track header's width/height, which are 16.16 fixed
+/// point at the end of the atom.
+fn mp4_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    let (moov, moov_end) = find_atom(bytes, b"moov")?;
+    let region = bytes.get(moov..moov_end)?;
+    let (trak, trak_end) = find_atom(region, b"trak")?;
+    let (tkhd, _) = find_atom(region.get(trak..trak_end)?, b"tkhd")?;
+    let header = region.get(trak + tkhd..)?;
+    let version = *header.first()?;
+    let size_at = if version == 1 { 96 } else { 84 };
+    let width = u32::from_be_bytes(header.get(size_at..size_at + 4)?.try_into().ok()?) >> 16;
+    let height = u32::from_be_bytes(header.get(size_at + 4..size_at + 8)?.try_into().ok()?) >> 16;
+    (width > 0 && height > 0).then_some((width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clock_reads_as_a_duration() {
+        assert_eq!(clock(0), "0:00");
+        assert_eq!(clock(61), "1:01");
+        assert_eq!(clock(3_661), "1:01:01");
+    }
+
+    #[test]
+    fn describe_shortens_a_mime_type() {
+        assert_eq!(describe("image/jpeg"), "JPEG");
+        assert_eq!(describe("application/x-tar"), "TAR");
+    }
+
+    #[test]
+    fn syncsafe_ignores_the_high_bit() {
+        assert_eq!(syncsafe(&[0, 0, 2, 1]), 257);
+    }
+
+    #[test]
+    fn a_text_frame_decodes_in_each_encoding() {
+        assert_eq!(text_frame(&[0, b'h', b'i']).as_deref(), Some("hi"));
+        assert_eq!(text_frame(&[3, b'h', b'i']).as_deref(), Some("hi"));
+        let utf16_le = [1u8, 0xFF, 0xFE, b'h', 0, b'i', 0];
+        assert_eq!(text_frame(&utf16_le).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn tags_are_empty_rather_than_wrong_for_a_file_with_no_id3() {
+        let tags = id3(b"not an mp3 at all");
+        assert!(tags.title.is_none() && tags.cover.is_none());
+    }
+
+    #[test]
+    fn atom_walking_stops_rather_than_looping_on_a_bad_size() {
+        // A zero-length atom must not spin forever.
+        let bytes = [0, 0, 0, 0, b'm', b'o', b'o', b'v'];
+        assert!(find_atom(&bytes, b"trak").is_none());
+    }
+}

--- a/components/otto-quickview/src/decode/mod.rs
+++ b/components/otto-quickview/src/decode/mod.rs
@@ -1,0 +1,246 @@
+//! The decode worker: the only place in Otto that interprets an untrusted file.
+//!
+//! Runs as a separate short-lived process (`otto-quickview --decode-worker`),
+//! sandboxed by [`crate::sandbox`], holding one read-only descriptor and
+//! writing one [`PreviewPayload`] to stdout. It has no Wayland connection, no
+//! bus connection, and no path it could open.
+//!
+//! Dispatch is on the **sniffed** type, never on the file's name. A file called
+//! `.png` that is not one must not reach the PNG decoder; the sandbox would
+//! contain the consequences either way, but the correct preview is the one
+//! matching the bytes.
+
+mod image;
+mod listing;
+mod media;
+mod pdf;
+mod text;
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::fd::FromRawFd;
+
+use otto_kit::filetype;
+
+use crate::payload;
+use crate::payload::PreviewPayload;
+use crate::sandbox::{self, Budget, FILE_FD};
+
+/// What the parent asked for. Everything the decoders need to know, and
+/// nothing about where the file lives.
+#[derive(Debug, Clone)]
+pub struct Request {
+    /// Target size in physical pixels — roughly twice the window, so a scaled
+    /// decode still has detail to show.
+    pub width: u32,
+    pub height: u32,
+    /// 1-based page for paginated content.
+    pub page: u32,
+    /// Zoom factor being displayed. Past 1.0 the image decoders stop
+    /// downsampling, which is what keeps a photograph sharp when you look
+    /// closely.
+    pub zoom: f32,
+    /// The type the parent sniffed. The worker re-sniffs anyway — it has the
+    /// bytes and the parent's answer is a hint, not a trust boundary.
+    pub mime: String,
+    /// The file's display name. Used only in card titles; never for dispatch.
+    pub name: String,
+    pub budget: Budget,
+}
+
+impl Default for Request {
+    fn default() -> Self {
+        Self {
+            width: 1600,
+            height: 1200,
+            page: 1,
+            zoom: 1.0,
+            mime: String::new(),
+            name: String::new(),
+            budget: Budget::default(),
+        }
+    }
+}
+
+/// How much of the file the sniffer sees. The shared-mime-info magic rules do
+/// not look further than this.
+const SNIFF_BYTES: usize = 4096;
+
+/// Worker entry point. Returns the process exit code.
+///
+/// Never propagates an error to the parent as a non-zero exit when it could
+/// instead say *why* on the wire: "unavailable, and here is the reason" is a
+/// preview, and a dead worker is not.
+pub fn run_worker(request: Request) -> i32 {
+    // SAFETY: the worker's own `main` runs before any thread is started, and
+    // the parent applied the same limits pre-exec. Applying them again covers
+    // what could not survive `execve`.
+    if let Err(err) = unsafe { sandbox::apply(request.budget) } {
+        // Refuse to decode rather than decode uncontained.
+        let fallback = payload::unavailable(format!("could not sandbox the previewer: {err}"));
+        let _ = payload::write_to(&fallback, &mut std::io::stdout());
+        return 0;
+    }
+
+    // SAFETY: the parent guarantees this descriptor is open and read-only.
+    let mut file = unsafe { File::from_raw_fd(FILE_FD) };
+
+    let payload = decode(&mut file, &request);
+    let mut stdout = std::io::stdout();
+    if payload::write_to(&payload, &mut stdout).is_err() || stdout.flush().is_err() {
+        return 1;
+    }
+    0
+}
+
+/// Choose a previewer and run it.
+fn decode(file: &mut File, request: &Request) -> PreviewPayload {
+    let metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(err) => return payload::unavailable(format!("cannot stat the file: {err}")),
+    };
+
+    if metadata.is_dir() {
+        return listing::directory(file, request);
+    }
+    if metadata.len() == 0 {
+        return PreviewPayload::Card {
+            title: request.name.clone(),
+            subtitle: "Empty file".into(),
+            facts: vec![],
+            hero: None,
+        };
+    }
+
+    let mut head = vec![0u8; SNIFF_BYTES.min(metadata.len() as usize)];
+    if let Err(err) = file.read_exact(&mut head) {
+        return payload::unavailable(format!("cannot read the file: {err}"));
+    }
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return payload::unavailable("the file is not seekable");
+    }
+
+    // Content decides which decoder runs; the name may only pick a *subtype* of
+    // what the content already proved. `filetype::refine_opt` is that rule, and
+    // it lives in the shared module rather than here so the browser's
+    // thumbnailer and this previewer cannot drift apart on it.
+    //
+    // Why it is needed at all: an SVG behind an XML declaration and a comment
+    // sniffs as `application/xml`, and would be read as source code rather than
+    // drawn — and whether it does so depends on the icon theme, since some
+    // themes' SVGs sniff cleanly and others do not. Refining is what makes that
+    // consistent. It stays safe because a `.png` full of XML is not refined:
+    // `image/png` is not a subclass of `application/xml`, so the PNG decoder
+    // remains unreachable.
+    //
+    // `None` in, `None` out: `sniff` already falls back to `text/plain` for
+    // anything textual, so a `None` means "binary, no signature matched", and
+    // unidentifiable content does not become identifiable through its name.
+    let Some(mime) = filetype::refine_opt(filetype::sniff(&head), &request.name) else {
+        return media::generic(&metadata, request, "application/octet-stream");
+    };
+
+    dispatch(mime, file, &metadata, request)
+}
+
+fn dispatch(
+    mime: &str,
+    file: &mut File,
+    metadata: &std::fs::Metadata,
+    request: &Request,
+) -> PreviewPayload {
+    // Order matters only where types overlap: SVG is `image/svg+xml` and also
+    // a subclass of text, and it should be drawn rather than read.
+    if mime == "image/svg+xml" {
+        return image::svg(file, request);
+    }
+    if mime == "application/pdf" {
+        return pdf::render(file, request);
+    }
+    if mime.starts_with("image/") {
+        return image::raster(file, request);
+    }
+    if mime == "application/zip" || filetype::is_subclass_of(mime, "application/zip") {
+        return listing::zip(file, metadata, request);
+    }
+    if mime == "application/x-tar" {
+        return listing::tar(file, metadata, request);
+    }
+    if mime.starts_with("audio/") {
+        return media::audio(file, metadata, request, mime);
+    }
+    if mime.starts_with("video/") {
+        return media::video(file, metadata, request, mime);
+    }
+    // Text last, and via the hierarchy rather than a language list: every
+    // source file in existence is a subclass of text/plain, and enumerating
+    // them would be a losing game.
+    if mime == "text/plain" || filetype::is_subclass_of(mime, "text/plain") {
+        return text::read(file, request, mime);
+    }
+
+    media::generic(metadata, request, mime)
+}
+
+/// Parse the worker's own arguments.
+///
+/// Lives here rather than in the binary because every embedding host re-execs
+/// itself as a worker, so all of them must parse these identically.
+///
+/// Deliberately total: a worker that cannot understand an argument still
+/// previews, with defaults, rather than dying and looking like a decoder
+/// failure.
+pub fn parse_request(arguments: &[String]) -> Request {
+    let mut request = Request::default();
+    let mut rest = arguments.iter();
+    while let Some(argument) = rest.next() {
+        let mut value = || rest.next().cloned().unwrap_or_default();
+        match argument.as_str() {
+            "--width" => request.width = value().parse().unwrap_or(request.width),
+            "--height" => request.height = value().parse().unwrap_or(request.height),
+            "--page" => request.page = value().parse().unwrap_or(request.page),
+            "--zoom" => request.zoom = value().parse().unwrap_or(request.zoom),
+            "--name" => request.name = value(),
+            "--mime" => request.mime = value(),
+            _ => {}
+        }
+    }
+    request
+}
+
+/// A bounded read. Every decoder goes through this rather than `read_to_end`:
+/// the budget is the difference between previewing a 2 GB video and trying to
+/// hold one in memory.
+pub(crate) fn read_capped(file: &mut File, cap: u64) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    file.take(cap).read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// Human-readable byte count, for the facts on a card.
+pub(crate) fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["bytes", "KB", "MB", "GB", "TB"];
+    if bytes < 1024 {
+        return format!("{bytes} bytes");
+    }
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    format!("{value:.1} {}", UNITS[unit])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_size_reads_naturally() {
+        assert_eq!(human_size(0), "0 bytes");
+        assert_eq!(human_size(999), "999 bytes");
+        assert_eq!(human_size(1024), "1.0 KB");
+        assert_eq!(human_size(1024 * 1024 * 3 / 2), "1.5 MB");
+    }
+}

--- a/components/otto-quickview/src/decode/pdf.rs
+++ b/components/otto-quickview/src/decode/pdf.rs
@@ -1,0 +1,387 @@
+//! PDF, rendered by exec'ing a rasteriser that is already on the system.
+//!
+//! No PDF library is linked into anything Otto builds. The worker is *already*
+//! a separate, sandboxed, rlimited process spawned per preview, so running an
+//! existing rasteriser costs one more `exec` in a place that was doing one
+//! regardless — and the dependency becomes a package a distribution almost
+//! certainly installed rather than a large C++ blob in the tree.
+//!
+//! It also sidesteps MuPDF's AGPL, which constrains *linking* and says nothing
+//! about running a program.
+//!
+//! The same table generalises: video poster frames arrive later as more rows,
+//! without GStreamer entering the default build. See `specs/quickview.md`.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::process::{Command, Stdio};
+
+use skia_safe::{Codec, Data};
+
+use crate::payload;
+use crate::payload::{Fact, PreviewPayload};
+
+use super::{human_size, Request};
+
+/// A rasteriser, and how to ask it for one page as a PNG on stdout.
+struct Rasteriser {
+    /// The binary, looked up on `PATH`.
+    command: &'static str,
+    /// The package to name in the fallback card, so a user who has none of
+    /// these knows what to install.
+    package: &'static str,
+    /// Arguments, given the page number and the target width in pixels.
+    args: fn(page: u32, width: u32) -> Vec<String>,
+}
+
+/// Tried in order; the first one present wins.
+const RASTERISERS: &[Rasteriser] = &[
+    Rasteriser {
+        command: "pdftoppm",
+        package: "poppler-utils",
+        args: |page, width| {
+            vec![
+                "-png".into(),
+                "-f".into(),
+                page.to_string(),
+                "-l".into(),
+                page.to_string(),
+                "-scale-to-x".into(),
+                width.to_string(),
+                // Preserve the aspect ratio rather than forcing a height.
+                "-scale-to-y".into(),
+                "-1".into(),
+                // Read the document from standard input.
+                "-".into(),
+            ]
+        },
+    },
+    Rasteriser {
+        command: "pdftocairo",
+        package: "poppler-utils",
+        args: |page, width| {
+            vec![
+                "-png".into(),
+                "-singlefile".into(),
+                "-f".into(),
+                page.to_string(),
+                "-l".into(),
+                page.to_string(),
+                "-scale-to-x".into(),
+                width.to_string(),
+                "-scale-to-y".into(),
+                "-1".into(),
+                "-".into(),
+                // pdftocairo writes to a named file unless the output is `-`.
+                "-".into(),
+            ]
+        },
+    },
+    Rasteriser {
+        command: "mutool",
+        package: "mupdf-tools",
+        args: |page, width| {
+            vec![
+                "draw".into(),
+                "-F".into(),
+                "png".into(),
+                "-o".into(),
+                "-".into(),
+                "-w".into(),
+                width.to_string(),
+                "-".into(),
+                page.to_string(),
+            ]
+        },
+    },
+    Rasteriser {
+        command: "gs",
+        package: "ghostscript",
+        args: |page, width| {
+            vec![
+                "-dNOPAUSE".into(),
+                "-dBATCH".into(),
+                "-dSAFER".into(),
+                "-sDEVICE=png16m".into(),
+                format!("-dFirstPage={page}"),
+                format!("-dLastPage={page}"),
+                format!("-dDEVICEWIDTHPOINTS={width}"),
+                "-sOutputFile=-".into(),
+                "-".into(),
+            ]
+        },
+    },
+];
+
+/// The widest a page is ever rasterised, whatever the panel asks for.
+///
+/// A ceiling in its own right rather than a safety valve: a PDF page is
+/// re-rendered from vectors at whatever size it is asked for, and the cost
+/// climbs faster than the area does, so the last doublings buy detail that a
+/// panel-sized preview cannot show at a price the user waits through. This is
+/// comfortably above a full-screen panel's own pixels on a HiDPI display.
+const MAX_WIDTH: u32 = 2_048;
+
+pub fn render(file: &mut File, request: &Request) -> PreviewPayload {
+    // Read the document once and hand it to the rasteriser on stdin. Passing
+    // bytes rather than a path is the point: the child never resolves a name,
+    // so nothing can be substituted between the worker's stat and its open.
+    let bytes = match super::read_capped(file, request.budget.max_read.min(512 * 1024 * 1024)) {
+        Ok(bytes) => bytes,
+        Err(err) => return payload::unavailable(format!("cannot read the document: {err}")),
+    };
+
+    let pages = count_pages(&bytes).unwrap_or(1).max(1);
+    let page = request.page.clamp(1, pages);
+
+    let Some(rasteriser) = RASTERISERS.iter().find(|r| on_path(r.command)) else {
+        return no_rasteriser(file, &bytes, request, pages);
+    };
+
+    // The width the host asked for, which is already twice the panel — the
+    // oversampling is applied there, once, for every kind of preview.
+    //
+    // It used to be doubled again here, and the two doublings compounded: a
+    // full-screen panel asked for a page four times its own width, hit the
+    // ceiling below, and spent seventeen seconds in the rasteriser for a page
+    // nobody could see at that size. Rasterising is superlinear in width, so
+    // the mistake was not 4× the cost, it was worse.
+    let width = (request.width as f32 * request.zoom.max(1.0)).ceil() as u32;
+    let width = width.clamp(320, MAX_WIDTH);
+
+    match rasterise(rasteriser, &bytes, page, width) {
+        Some(png) => match decode_png(&png) {
+            Some(pixels) => PreviewPayload::Pixels {
+                pixels,
+                pages,
+                page,
+            },
+            None => payload::unavailable("the rendered page could not be read"),
+        },
+        None => no_rasteriser(file, &bytes, request, pages),
+    }
+}
+
+/// Run one rasteriser and collect its PNG.
+fn rasterise(rasteriser: &Rasteriser, document: &[u8], page: u32, width: u32) -> Option<Vec<u8>> {
+    let mut child = Command::new(rasteriser.command)
+        .args((rasteriser.args)(page, width))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // A rasteriser's complaints belong in the log, not interleaved with the
+        // payload on our own stdout.
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Write the document and read the page concurrently: a document larger than
+    // a pipe buffer would otherwise deadlock, each side waiting for the other.
+    let mut stdin = child.stdin.take()?;
+    let document = document.to_vec();
+    let writer = std::thread::spawn(move || {
+        use std::io::Write;
+        // A rasteriser that has seen enough closes its input early; that is a
+        // success, not an error.
+        let _ = stdin.write_all(&document);
+    });
+
+    let mut png = Vec::new();
+    let read = child
+        .stdout
+        .as_mut()
+        .and_then(|out| out.read_to_end(&mut png).ok());
+    let status = child.wait().ok();
+    let _ = writer.join();
+
+    // A non-zero exit with usable output still counts: some rasterisers
+    // complain about a malformed document and render it anyway.
+    read?;
+    if png.is_empty() {
+        return None;
+    }
+    let _ = status;
+    Some(png)
+}
+
+fn decode_png(png: &[u8]) -> Option<crate::payload::Pixels> {
+    let mut codec = Codec::from_data(Data::new_copy(png))?;
+    let info = codec
+        .info()
+        .with_color_type(skia_safe::ColorType::RGBA8888)
+        .with_alpha_type(skia_safe::AlphaType::Premul);
+    let dimensions = codec.dimensions();
+    let image = codec.get_image(info, None).ok()?;
+    super::image::to_pixels(&image, dimensions)
+}
+
+/// Is this command on `PATH`?
+///
+/// Resolved by hand rather than by spawning something: the worker has a tight
+/// descriptor budget and no reason to fork twice per lookup.
+fn on_path(command: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|directory| {
+        let candidate = directory.join(command);
+        // Existence is enough; if it is not executable the spawn fails and the
+        // next rasteriser is tried.
+        candidate.is_file()
+    })
+}
+
+/// Page count, read out of the document's own structure.
+///
+/// Counts `/Type /Page` objects, which is approximate for documents using
+/// object streams or unusual page trees — good enough for "3 of 12", and it
+/// costs no parser. A rasteriser that disagrees is not contradicted, because
+/// the count is only ever shown, never used to index.
+fn count_pages(bytes: &[u8]) -> Option<u32> {
+    let needle = b"/Type";
+    let mut count = 0u32;
+    let mut at = 0usize;
+    while let Some(found) = find(&bytes[at..], needle) {
+        let start = at + found + needle.len();
+        // Look at what follows, clamped to the end of the buffer — a match in
+        // the last few bytes must not abandon the count so far.
+        let window = &bytes[start..(start + 16).min(bytes.len())];
+        let value = window
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .map(|offset| &window[offset..])
+            .unwrap_or_default();
+
+        // `/Page` and `/Pages` share a prefix, so the delimiter decides: a page
+        // object's name ends there, the page *tree*'s does not. Testing the
+        // following byte rather than listing suffixes means `/PageLabels` and
+        // anything else added later is excluded for free.
+        if let Some(after) = value.strip_prefix(b"/Page".as_slice()) {
+            let ends_here = after
+                .first()
+                .is_none_or(|byte| !byte.is_ascii_alphanumeric());
+            if ends_here {
+                count += 1;
+            }
+        }
+        at = start;
+    }
+    (count > 0).then_some(count)
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// No rasteriser installed, or every one of them failed.
+///
+/// The card names the package that would fix it. A previewer that silently
+/// shows nothing looks broken; one that says what is missing is a preview of a
+/// different kind.
+fn no_rasteriser(file: &mut File, bytes: &[u8], request: &Request, pages: u32) -> PreviewPayload {
+    let size = file
+        .seek(SeekFrom::End(0))
+        .ok()
+        .unwrap_or(bytes.len() as u64);
+
+    let mut facts = vec![
+        Fact {
+            key: "Pages".into(),
+            value: pages.to_string(),
+        },
+        Fact {
+            key: "Size".into(),
+            value: human_size(size),
+        },
+    ];
+    if let Some(title) = document_title(bytes) {
+        facts.insert(
+            0,
+            Fact {
+                key: "Title".into(),
+                value: title,
+            },
+        );
+    }
+
+    let wanted = RASTERISERS
+        .iter()
+        .map(|r| r.package)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    PreviewPayload::Card {
+        title: request.name.clone(),
+        subtitle: format!("Install one of: {wanted} — to see the pages"),
+        facts,
+        hero: None,
+    }
+}
+
+/// The `/Title` from the document information dictionary, when it is a plain
+/// literal string. Anything encoded or hexadecimal is skipped rather than
+/// guessed at.
+fn document_title(bytes: &[u8]) -> Option<String> {
+    let at = find(bytes, b"/Title")? + b"/Title".len();
+    let rest = bytes.get(at..(at + 512).min(bytes.len()))?;
+    let open = rest.iter().position(|byte| *byte == b'(')?;
+    // Only accept a title that starts promptly after the key, or `/Title` was
+    // a coincidence somewhere else in the file.
+    if open > 4 {
+        return None;
+    }
+    let mut title = Vec::new();
+    let mut escaped = false;
+    for byte in &rest[open + 1..] {
+        if escaped {
+            escaped = false;
+            title.push(*byte);
+            continue;
+        }
+        match byte {
+            b'\\' => escaped = true,
+            b')' => break,
+            _ => title.push(*byte),
+        }
+        if title.len() > 200 {
+            break;
+        }
+    }
+    let title = String::from_utf8_lossy(&title).trim().to_string();
+    (!title.is_empty()).then_some(title)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_pages_without_counting_the_page_tree() {
+        let document = b"<< /Type /Pages /Count 2 >> << /Type /Page >> << /Type /Page >>";
+        assert_eq!(count_pages(document), Some(2));
+    }
+
+    #[test]
+    fn a_document_with_no_page_objects_reports_no_count() {
+        assert_eq!(count_pages(b"%PDF-1.7 nothing useful here"), None);
+    }
+
+    #[test]
+    fn reads_a_literal_title_and_skips_a_coincidental_one() {
+        assert_eq!(
+            document_title(b"/Title (Quarterly Report)").as_deref(),
+            Some("Quarterly Report")
+        );
+        // `/Title` followed by something that is not promptly a literal string.
+        assert!(document_title(b"/Title <FEFF0041> and later (nope)").is_none());
+    }
+
+    #[test]
+    fn an_escaped_paren_stays_in_the_title() {
+        assert_eq!(
+            document_title(br"/Title (Report \(final\))").as_deref(),
+            Some("Report (final)")
+        );
+    }
+}

--- a/components/otto-quickview/src/decode/text.rs
+++ b/components/otto-quickview/src/decode/text.rs
@@ -1,0 +1,144 @@
+//! Text and source code.
+//!
+//! No syntax highlighting in v1 — see `specs/quickview.md` for why, and for
+//! what it will be when it arrives (a hand-written token scanner, not
+//! `syntect`). The `language` field is carried on the wire already so that
+//! adding it later is not a wire change.
+//!
+//! This decoder does the encoding work too. The parent must never see bytes it
+//! has to interpret: it receives validated UTF-8 lines, bounded in both
+//! directions, or nothing.
+
+use std::fs::File;
+
+use crate::payload;
+use crate::payload::PreviewPayload;
+
+use super::{read_capped, Request};
+
+/// How much of a file is worth showing. A preview is a look, not a reader —
+/// and this bounds what the parent has to lay out.
+const MAX_LINES: usize = 4_000;
+const MAX_LINE_BYTES: usize = 2_000;
+/// A text file larger than this is truncated before it is even decoded. Minified
+/// bundles and log files run to hundreds of megabytes.
+const MAX_TEXT_BYTES: u64 = 8 * 1024 * 1024;
+
+pub fn read(file: &mut File, request: &Request, mime: &str) -> PreviewPayload {
+    let bytes = match read_capped(file, MAX_TEXT_BYTES) {
+        Ok(bytes) => bytes,
+        Err(err) => return payload::unavailable(format!("cannot read the file: {err}")),
+    };
+    let read_everything = (bytes.len() as u64) < MAX_TEXT_BYTES;
+
+    let Some(text) = decode_text(&bytes) else {
+        return payload::unavailable("this file is not text in any encoding we read");
+    };
+
+    let mut lines: Vec<String> = Vec::new();
+    let mut truncated = !read_everything;
+    for line in text.lines() {
+        if lines.len() >= MAX_LINES {
+            truncated = true;
+            break;
+        }
+        lines.push(clamp_line(line));
+    }
+
+    PreviewPayload::Text {
+        lines,
+        truncated,
+        language: language_for(mime, &request.name),
+    }
+}
+
+/// UTF-8, then Latin-1 as the fallback that cannot fail.
+///
+/// A file that is neither is reported as not-text rather than shown as mojibake:
+/// the sniffer already said it was text, so disagreeing loudly is more useful
+/// than rendering nonsense.
+fn decode_text(bytes: &[u8]) -> Option<String> {
+    // A NUL in the first few kilobytes means binary, whatever the type said.
+    if bytes.iter().take(4096).any(|byte| *byte == 0) {
+        return None;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(text) => Some(strip_bom(text).to_string()),
+        Err(_) => {
+            // Latin-1 maps every byte to a codepoint, so this always succeeds.
+            // It is the right guess for the old files that are not UTF-8.
+            Some(bytes.iter().map(|byte| *byte as char).collect())
+        }
+    }
+}
+
+fn strip_bom(text: &str) -> &str {
+    text.strip_prefix('\u{feff}').unwrap_or(text)
+}
+
+/// Keep a pathological line from becoming a pathological layout. Cut on a char
+/// boundary — a minified file is one line and slicing it by bytes would panic.
+fn clamp_line(line: &str) -> String {
+    let line = line.trim_end_matches('\r');
+    if line.len() <= MAX_LINE_BYTES {
+        return line.to_string();
+    }
+    let mut end = MAX_LINE_BYTES;
+    while end > 0 && !line.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &line[..end])
+}
+
+/// A hint for the highlighter that does not exist yet. Derived from the MIME
+/// type where it says something (`text/x-rust`), from the extension otherwise.
+fn language_for(mime: &str, name: &str) -> String {
+    if let Some(rest) = mime.strip_prefix("text/x-") {
+        return rest.to_string();
+    }
+    if let Some(rest) = mime.strip_prefix("application/x-") {
+        return rest.to_string();
+    }
+    name.rsplit_once('.')
+        .map(|(_, extension)| extension.to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_is_refused_rather_than_shown() {
+        assert!(decode_text(b"abc\0def").is_none());
+    }
+
+    #[test]
+    fn latin1_falls_back_instead_of_failing() {
+        // 0xE9 is not valid UTF-8 but is 'é' in Latin-1.
+        let decoded = decode_text(&[b'c', b'a', b'f', 0xE9]).expect("latin-1 fallback");
+        assert_eq!(decoded, "café");
+    }
+
+    #[test]
+    fn a_bom_does_not_become_a_visible_character() {
+        let decoded = decode_text("\u{feff}hello".as_bytes()).unwrap();
+        assert_eq!(decoded, "hello");
+    }
+
+    #[test]
+    fn a_very_long_line_is_cut_on_a_char_boundary() {
+        // Multi-byte characters straddling the cut must not panic.
+        let line = "é".repeat(MAX_LINE_BYTES);
+        let clamped = clamp_line(&line);
+        assert!(clamped.len() <= MAX_LINE_BYTES + 4);
+        assert!(clamped.ends_with('…'));
+    }
+
+    #[test]
+    fn language_comes_from_the_type_then_the_name() {
+        assert_eq!(language_for("text/x-rust", "a.rs"), "rust");
+        assert_eq!(language_for("text/plain", "notes.MD"), "md");
+        assert_eq!(language_for("text/plain", "LICENSE"), "");
+    }
+}

--- a/components/otto-quickview/src/lib.rs
+++ b/components/otto-quickview/src/lib.rs
@@ -1,0 +1,70 @@
+//! Quick View — press space on a file and see it.
+//!
+//! A **library the file views embed**, not a service they call. The preview is
+//! a subsurface of whichever window is showing files, which is what makes it
+//! feel attached to the file rather than summoned on top of it: a subsurface's
+//! parent must be a `wl_surface` owned by the same client, so being parented
+//! and being a separate process are mutually exclusive. Choosing parented also
+//! dissolves the anchor problem — the host already knows where the row is in
+//! its own surface — and hands stacking, focus and dismissal to the parent
+//! window instead of leaving them to be managed by hand.
+//!
+//! Three hosts embed it: the file browser, the save/open file dialog, and the
+//! desktop's file view. The `otto-quickview` binary remains for previewing a
+//! path from a terminal.
+//!
+//! # What lives where
+//!
+//! * [`otto_kit::preview`] — the drawing half. Canvas-pure, no `AppContext`,
+//!   no wayland-client, so a host draws it into its own surface and the
+//!   compositor can draw the same thing server-side.
+//! * [`decode`] — the decoders, which run **only** inside the sandboxed worker.
+//! * [`spawn`] — the host-side entry point: open a file, run a contained
+//!   worker, enforce the deadline.
+//! * [`opening`] — the entrance geometry, now usable for real: the host has the
+//!   item's rect, so the card can grow out of the file.
+//!
+//! # Embedding
+//!
+//! Untrusted files are parsed in a separate process, and that process is *this
+//! binary re-executed*. Since the host is the binary once it embeds the
+//! library, the host must give the worker a way in — one line, first thing in
+//! `main`, before any thread or Wayland connection exists:
+//!
+//! ```no_run
+//! fn main() {
+//!     otto_quickview::run_worker_if_requested();
+//!     // ... the host's own startup
+//! }
+//! ```
+//!
+//! Without it the previewer would re-exec the host as a *host*, which would
+//! start a second file browser instead of decoding anything.
+
+pub mod decode;
+pub mod opening;
+pub mod payload;
+pub mod sandbox;
+pub mod spawn;
+pub mod uri;
+
+pub use otto_kit::preview::{Fact, Pixels, Preview, PreviewLayout, Row};
+pub use spawn::{decode_path, open, Opened};
+
+/// Run the sandboxed decode worker if this process was started as one.
+///
+/// Returns `false` for a normal start, so the caller carries on. Never returns
+/// at all when it *is* a worker: it decodes one file, writes one payload to
+/// stdout and exits.
+///
+/// Must be called before the host starts threads, connects to Wayland, or
+/// touches the environment — the worker inherits whatever exists at that
+/// moment, and the point of the sandbox is that it inherits almost nothing.
+pub fn run_worker_if_requested() -> bool {
+    let mut arguments = std::env::args().skip(1);
+    if arguments.next().as_deref() != Some("--decode-worker") {
+        return false;
+    }
+    let rest: Vec<String> = arguments.collect();
+    std::process::exit(decode::run_worker(decode::parse_request(&rest)));
+}

--- a/components/otto-quickview/src/main.rs
+++ b/components/otto-quickview/src/main.rs
@@ -1,0 +1,300 @@
+//! otto-quickview — the previewer's binary.
+//!
+//! The preview itself is a *library* the file views embed
+//! ([`otto_quickview`]); this binary exists for the cases that have no host:
+//!
+//! * `--decode-worker` — the sandboxed decoder, re-executed per preview with
+//!   one file on descriptor 3 and a payload on stdout. Never run by hand, and
+//!   the reason every embedding host must call
+//!   [`otto_quickview::run_worker_if_requested`] first thing in `main`;
+//! * `--describe` — decode one file and print what the previewer made of it,
+//!   which exercises the decoders with no display attached;
+//! * `--render OUT.png` — draw a preview through the same
+//!   `otto_kit::preview::draw` a host uses, so a PNG here is what a host will
+//!   show. This is the integration check between the previewer and its hosts;
+//! * `--filmstrip OUT.png` — the entrance, sampled.
+//!
+//! Why the preview is embedded rather than a service of its own is in
+//! `specs/quickview.md`.
+
+mod render;
+
+use std::path::PathBuf;
+
+use otto_quickview::decode::Request;
+use otto_quickview::payload::PreviewPayload;
+use otto_quickview::{opening, sandbox, spawn};
+
+#[tokio::main]
+async fn main() {
+    // The worker must not initialise logging to a shared sink or inherit the
+    // parent's subscriber; it writes a payload on stdout and nothing else.
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    // The self-test runs in a child with a piped stdout, exactly as a worker
+    // does. It cannot run in this process: `RLIMIT_FSIZE = 0` means the very
+    // first write to a *file-backed* stdout raises SIGXFSZ, so running it with
+    // output redirected would kill the reporter before it reported. The worker
+    // is unaffected because the parent always hands it a pipe — but the hazard
+    // is real enough to be worth reproducing here rather than designing around.
+    if arguments.first().map(String::as_str) == Some("--sandbox-selftest") {
+        match std::process::Command::new(std::env::current_exe().expect("own path"))
+            .arg("--sandbox-selftest-child")
+            .stdout(std::process::Stdio::piped())
+            .output()
+        {
+            Ok(output) => {
+                print!("{}", String::from_utf8_lossy(&output.stdout));
+                if !output.status.success() {
+                    eprintln!("self-test child exited with {}", output.status);
+                }
+            }
+            Err(err) => eprintln!("could not run the self-test: {err}"),
+        }
+        return;
+    }
+    if arguments.first().map(String::as_str) == Some("--sandbox-selftest-child") {
+        // SAFETY: nothing else is running in this process yet, which is the
+        // same condition the worker applies it under.
+        if let Err(err) = unsafe { sandbox::apply(sandbox::Budget::default()) } {
+            eprintln!("could not apply the sandbox: {err}");
+            std::process::exit(1);
+        }
+        let result = sandbox::self_test();
+        println!("address space capped     {}", result.address_space_capped);
+        println!("cannot grow a file       {}", result.cannot_grow_a_file);
+        println!("network unreachable      {}", result.network_unreachable);
+        println!(
+            "can open other files     {}  {}",
+            result.can_still_open_other_files,
+            if result.can_still_open_other_files {
+                "← not contained; see sandbox.rs"
+            } else {
+                ""
+            }
+        );
+        return;
+    }
+    // The same entry point every embedding host calls, so the worker path is
+    // identical whether it was re-executed from here or from a file browser.
+    otto_quickview::run_worker_if_requested();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    // The icon theme comes from the XDG settings portal, and the watcher that
+    // reads it needs a tokio runtime present — which is why `main` is async.
+    // Without it `current_icon_theme()` stays empty, `freedesktop-icons`
+    // searches `hicolor` alone, and since hicolor ships no mimetype icons a
+    // listing draws with no icons at all. That looks like an icon bug and is
+    // really a runtime one.
+    otto_kit::icon_theme::spawn_icon_theme_watcher();
+
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let mut describe = false;
+    let mut png_out: Option<String> = None;
+    let mut filmstrip: Option<String> = None;
+    let mut dark = false;
+    let mut request = Request::default();
+    let mut index = 0usize;
+
+    let mut rest = arguments.iter().peekable();
+    while let Some(argument) = rest.next() {
+        match argument.as_str() {
+            // What the .service file passes. It means "no paths": be the
+            // service and wait for an Open.
+            "--serve" => {}
+            "--describe" => describe = true,
+            "--render" => png_out = rest.next().cloned(),
+            "--filmstrip" => filmstrip = rest.next().cloned(),
+            "--dark" => dark = true,
+            "--page" => {
+                request.page = rest.next().and_then(|v| v.parse().ok()).unwrap_or(1);
+            }
+            "--zoom" => {
+                request.zoom = rest.next().and_then(|v| v.parse().ok()).unwrap_or(1.0);
+            }
+            "--width" => {
+                request.width = rest.next().and_then(|v| v.parse().ok()).unwrap_or(1600);
+            }
+            "--height" => {
+                request.height = rest.next().and_then(|v| v.parse().ok()).unwrap_or(1200);
+            }
+            "--index" => {
+                index = rest.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+            }
+            "--help" | "-h" => {
+                println!(
+                    "usage: otto-quickview [--describe] [--render OUT.png] [--dark] [--index N] [--page N] [--zoom F] [--width W] [--height H] PATH..."
+                );
+                return;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("otto-quickview: unknown option {other}");
+                std::process::exit(2);
+            }
+            other => paths.push(PathBuf::from(other)),
+        }
+    }
+
+    if paths.is_empty() {
+        eprintln!("otto-quickview: nothing to preview");
+        eprintln!(
+            "usage: otto-quickview [--describe|--render OUT.png|--filmstrip OUT.png] PATH..."
+        );
+        std::process::exit(2);
+    }
+    let selected = paths
+        .get(index)
+        .cloned()
+        .unwrap_or_else(|| paths[0].clone());
+
+    if describe {
+        let payload = spawn::decode_path(&selected, &request);
+        print_payload(&selected, &payload);
+        return;
+    }
+
+    let payload = spawn::decode_path(&selected, &request);
+
+    if let Some(out) = filmstrip {
+        let title = selected
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let frames = [0.0, 0.08, 0.18, 0.32, 0.55, 0.78, 0.9, 1.0];
+        match render::opening_filmstrip(&payload, &title, &frames, dark) {
+            Some(png) => {
+                let _ = std::fs::write(&out, png);
+                println!("{out}");
+            }
+            None => eprintln!("otto-quickview: could not render the filmstrip"),
+        }
+        return;
+    }
+
+    // `--render` draws through the same `otto_kit::preview::draw` the window
+    // will use, so a PNG here is what the window will show.
+    if let Some(out) = png_out {
+        let title = selected
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        match render::to_png(
+            &payload,
+            &title,
+            request.width as i32,
+            request.height as i32,
+            dark,
+        ) {
+            Some(png) => match std::fs::write(&out, png) {
+                Ok(()) => println!("{out}"),
+                Err(err) => {
+                    eprintln!("otto-quickview: cannot write {out}: {err}");
+                    std::process::exit(1);
+                }
+            },
+            None => {
+                eprintln!("otto-quickview: could not render the preview");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    print_payload(&selected, &payload);
+}
+
+/// Render a payload as text. This is what `--describe` prints, and it is the
+/// fastest way to see what a decoder actually produced.
+fn print_payload(path: &std::path::Path, payload: &PreviewPayload) {
+    println!("{}", path.display());
+    match payload {
+        PreviewPayload::Pixels {
+            pixels,
+            pages,
+            page,
+        } => {
+            println!(
+                "  pixels    {}×{} (source {}×{}, native scale {:.2}×)",
+                pixels.width,
+                pixels.height,
+                pixels.intrinsic_width,
+                pixels.intrinsic_height,
+                pixels.native_scale()
+            );
+            if *pages > 1 {
+                println!("  page      {page} of {pages}");
+            }
+            println!("  buffer    {} bytes", pixels.data.len());
+        }
+        PreviewPayload::Text {
+            lines,
+            truncated,
+            language,
+        } => {
+            println!(
+                "  text      {} lines{}{}",
+                lines.len(),
+                if *truncated { ", truncated" } else { "" },
+                if language.is_empty() {
+                    String::new()
+                } else {
+                    format!(", {language}")
+                }
+            );
+            for line in lines.iter().take(5) {
+                println!("    │ {line}");
+            }
+            if lines.len() > 5 {
+                println!("    │ …");
+            }
+        }
+        PreviewPayload::Rows {
+            rows,
+            truncated,
+            summary,
+        } => {
+            println!(
+                "  listing   {summary}{}",
+                if *truncated { " (truncated)" } else { "" }
+            );
+            for row in rows.iter().take(8) {
+                println!(
+                    "    {} {}{}",
+                    if row.is_dir { "📁" } else { "  " },
+                    row.name,
+                    if row.size > 0 {
+                        format!("  ({})", otto_kit::preview::human_size(row.size))
+                    } else {
+                        String::new()
+                    }
+                );
+            }
+            if rows.len() > 8 {
+                println!("    … {} more", rows.len() - 8);
+            }
+        }
+        PreviewPayload::Card {
+            title,
+            subtitle,
+            facts,
+            hero,
+        } => {
+            println!("  card      {title}");
+            println!("            {subtitle}");
+            for fact in facts {
+                println!("    {:<12} {}", fact.key, fact.value);
+            }
+            if let Some(hero) = hero {
+                println!("    (artwork  {}×{})", hero.width, hero.height);
+            }
+        }
+        PreviewPayload::Unavailable { reason } => {
+            println!("  no preview: {reason}");
+        }
+    }
+}

--- a/components/otto-quickview/src/opening.rs
+++ b/components/otto-quickview/src/opening.rs
@@ -1,0 +1,286 @@
+//! The opening animation's geometry.
+//!
+//! The preview grows out of the file. `anchor` is the rect of the item the user
+//! pressed space on, and the card animates from there to its resting rect —
+//! which is what makes the preview feel attached to the file rather than
+//! summoned on top of it.
+//!
+//! The *motion* is run by the compositor through surface-style transactions,
+//! the same way otto-launcher's card animates, so it costs this process no
+//! frames — which matters more here than for the launcher, because this process
+//! is also supervising a decode. What lives in this module is the geometry the
+//! transaction is given, and the curve, so both can be reasoned about and
+//! tested without a display.
+
+use std::time::Duration;
+
+/// How long the card takes to arrive. It does not fade: the card is opaque
+/// from its first frame and only its geometry animates, so what the eye
+/// follows is one thing moving rather than a shape resolving out of nothing.
+///
+/// Overridable at run time — `OTTO_QUICKVIEW_OPEN_MS` — because the only way
+/// to settle how an entrance feels is to watch it at several speeds.
+pub fn geometry_in() -> Duration {
+    static V: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *V.get_or_init(|| env_ms("OTTO_QUICKVIEW_OPEN_MS").unwrap_or(Duration::from_millis(300)))
+}
+
+fn env_ms(name: &str) -> Option<Duration> {
+    let ms: u64 = std::env::var(name).ok()?.parse().ok()?;
+    Some(Duration::from_millis(ms.clamp(1, 10_000)))
+}
+
+/// And how it leaves — quicker, and without a bounce. There is nothing to
+/// settle into on the way out, and an exit that lingers reads as the card
+/// being reluctant rather than as the card going home.
+///
+/// Overridable at run time — `OTTO_QUICKVIEW_CLOSE_MS`.
+pub fn geometry_out() -> Duration {
+    static V: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *V.get_or_init(|| env_ms("OTTO_QUICKVIEW_CLOSE_MS").unwrap_or(Duration::from_millis(180)))
+}
+
+/// How far the entrance overshoots. Deliberately smaller than the launcher's
+/// 0.35: this surface is much larger, and the same overshoot on a large card
+/// stops reading as life and starts reading as wobble.
+///
+/// Overridable at run time — `OTTO_QUICKVIEW_BOUNCE`. Zero is a clean ease
+/// with no overshoot at all.
+pub fn bounce() -> f32 {
+    static V: std::sync::OnceLock<f32> = std::sync::OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("OTTO_QUICKVIEW_BOUNCE")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(0.07f32)
+            .clamp(0.0, 1.0)
+    })
+}
+
+pub const IN_PLACE_SCALE: f32 = 0.96;
+
+/// A rectangle in logical screen coordinates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl Rect {
+    pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn center(&self) -> (f32, f32) {
+        (self.x + self.width / 2.0, self.y + self.height / 2.0)
+    }
+
+    /// An anchor is usable only if it has area. Callers are asked to send an
+    /// empty rect rather than a stale one, so this is the documented signal for
+    /// "there is nothing to open from", not a guess.
+    pub fn is_empty(&self) -> bool {
+        self.width <= 0.0 || self.height <= 0.0
+    }
+}
+
+/// The start of the entrance, expressed the way a surface-style transaction
+/// wants it: a scale and a translation applied about the card's centre.
+///
+/// Scaling rather than animating width and height is what keeps this
+/// compositor-side. The card's buffer is drawn once at its resting size and the
+/// compositor transforms it — so the entrance never re-lays-out the content and
+/// never asks the previewer for another frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Entrance {
+    pub scale_x: f32,
+    pub scale_y: f32,
+    /// Where the card's centre starts, relative to where it will rest.
+    pub offset_x: f32,
+    pub offset_y: f32,
+}
+
+/// Compute the entrance for a card resting at `resting`, opening from `anchor`.
+///
+/// With no usable anchor this degrades to the launcher's in-place swell rather
+/// than to nothing: an invocation with no item still deserves an entrance.
+pub fn entrance(anchor: Rect, resting: Rect) -> Entrance {
+    if anchor.is_empty() || resting.width <= 0.0 || resting.height <= 0.0 {
+        return Entrance {
+            scale_x: IN_PLACE_SCALE,
+            scale_y: IN_PLACE_SCALE,
+            offset_x: 0.0,
+            offset_y: 0.0,
+        };
+    }
+
+    // One scale for both axes, from the anchor's larger relative dimension.
+    // Scaling the axes independently would stretch the card's content on the
+    // way in — a row is wide and short, and a card matching that aspect would
+    // arrive squashed before snapping square.
+    let scale = (anchor.width / resting.width)
+        .max(anchor.height / resting.height)
+        .clamp(0.04, 1.0);
+
+    let (anchor_cx, anchor_cy) = anchor.center();
+    let (resting_cx, resting_cy) = resting.center();
+
+    Entrance {
+        scale_x: scale,
+        scale_y: scale,
+        offset_x: anchor_cx - resting_cx,
+        offset_y: anchor_cy - resting_cy,
+    }
+}
+
+/// Interpolate the entrance for a filmstrip or a test. `t` runs 0 → 1.
+///
+/// The compositor runs the real curve; this reproduces it closely enough to
+/// reason about and to look at.
+pub fn sample(anchor: Rect, resting: Rect, t: f32) -> Rect {
+    let start = entrance(anchor, resting);
+    place(start, resting, spring(t.clamp(0.0, 1.0), bounce()))
+}
+
+/// The same geometry, run backwards: the card returning to the item it came
+/// out of. `t` runs 0 → 1, resting → anchor.
+///
+/// Not `sample` with a reversed `t`. The entrance overshoots, and an overshoot
+/// played backwards puts the bounce at the *start* of the exit, which reads as
+/// the card being knocked rather than dismissed. This eases instead, so the
+/// card leaves the way it would if you had never let it settle.
+pub fn sample_out(anchor: Rect, resting: Rect, t: f32) -> Rect {
+    let start = entrance(anchor, resting);
+    place(start, resting, 1.0 - smoothstep(t.clamp(0.0, 1.0)))
+}
+
+/// Place the card partway along its path, where `eased` is 0 at the anchor and
+/// 1 at rest. Shared so the way in and the way out cannot drift apart: only
+/// the curve that feeds this differs between them.
+fn place(start: Entrance, resting: Rect, eased: f32) -> Rect {
+    let scale = start.scale_x + (1.0 - start.scale_x) * eased;
+    let offset_x = start.offset_x * (1.0 - eased);
+    let offset_y = start.offset_y * (1.0 - eased);
+
+    let width = resting.width * scale;
+    let height = resting.height * scale;
+    let (cx, cy) = resting.center();
+    Rect::new(
+        cx + offset_x - width / 2.0,
+        cy + offset_y - height / 2.0,
+        width,
+        height,
+    )
+}
+
+/// Ease in and out, settling at both ends and overshooting at neither.
+fn smoothstep(t: f32) -> f32 {
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// A spring that settles at 1.0, overshooting by roughly `bounce`.
+///
+/// Critically shaped rather than physically simulated: it has to finish inside
+/// the transaction's duration, so the bounce is a shape rather than a length.
+fn spring(t: f32, bounce: f32) -> f32 {
+    if t >= 1.0 {
+        return 1.0;
+    }
+    let decay = (-7.0 * t).exp();
+    let frequency = std::f32::consts::PI * (1.0 + bounce * 6.0);
+    1.0 - decay * (frequency * t).cos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RESTING: Rect = Rect {
+        x: 400.0,
+        y: 200.0,
+        width: 800.0,
+        height: 600.0,
+    };
+
+    #[test]
+    fn opens_from_the_item_not_the_centre() {
+        // A row near the top-left of a file list.
+        let anchor = Rect::new(40.0, 120.0, 220.0, 24.0);
+        let start = entrance(anchor, RESTING);
+        // The card starts small, and off toward the item.
+        assert!(start.scale_x < 0.3, "scale was {}", start.scale_x);
+        assert!(start.offset_x < 0.0 && start.offset_y < 0.0);
+    }
+
+    /// The exit is the entrance's mirror in where it starts and ends, but not
+    /// in how it gets there: it must not overshoot, or the card lurches
+    /// outwards before going home.
+    #[test]
+    fn the_exit_returns_to_the_item_without_a_bounce() {
+        let anchor = Rect::new(40.0, 120.0, 24.0, 24.0);
+
+        let at_rest = sample_out(anchor, RESTING, 0.0);
+        assert!((at_rest.width - RESTING.width).abs() < 1.0, "{at_rest:?}");
+
+        let gone = sample_out(anchor, RESTING, 1.0);
+        let (cx, cy) = gone.center();
+        let (ax, ay) = anchor.center();
+        assert!((cx - ax).abs() < 1.0 && (cy - ay).abs() < 1.0, "{gone:?}");
+        assert!(gone.width < RESTING.width * 0.1, "{gone:?}");
+
+        // Never larger than its resting size at any point along the way.
+        for step in 0..=20 {
+            let rect = sample_out(anchor, RESTING, step as f32 / 20.0);
+            assert!(rect.width <= RESTING.width + 0.5, "at {step}: {rect:?}");
+        }
+    }
+
+    #[test]
+    fn no_anchor_falls_back_to_an_in_place_swell() {
+        let start = entrance(Rect::new(0.0, 0.0, 0.0, 0.0), RESTING);
+        assert_eq!(start.scale_x, IN_PLACE_SCALE);
+        assert_eq!((start.offset_x, start.offset_y), (0.0, 0.0));
+    }
+
+    #[test]
+    fn both_axes_scale_together_so_content_never_arrives_squashed() {
+        // A wide, short row: independent axis scaling would stretch it.
+        let start = entrance(Rect::new(0.0, 0.0, 400.0, 20.0), RESTING);
+        assert_eq!(start.scale_x, start.scale_y);
+    }
+
+    #[test]
+    fn the_card_ends_exactly_at_its_resting_rect() {
+        let anchor = Rect::new(40.0, 120.0, 220.0, 24.0);
+        let rect = sample(anchor, RESTING, 1.0);
+        assert!((rect.x - RESTING.x).abs() < 0.01, "{rect:?}");
+        assert!((rect.y - RESTING.y).abs() < 0.01, "{rect:?}");
+        assert!((rect.width - RESTING.width).abs() < 0.01, "{rect:?}");
+    }
+
+    /// The card is legible for the whole entrance because it never fades —
+    /// what moves is geometry alone, and at a third of the way in there is
+    /// still geometry left to run.
+    #[test]
+    fn the_card_is_still_arriving_partway_through() {
+        let anchor = Rect::new(40.0, 120.0, 220.0, 24.0);
+        let rect = sample(anchor, RESTING, 0.35);
+        assert!(
+            rect.width < RESTING.width * 1.05,
+            "still arriving at t=0.35"
+        );
+    }
+
+    #[test]
+    fn a_tiny_anchor_does_not_collapse_the_card_to_nothing() {
+        // A 1×1 anchor would otherwise scale to ~0.001 and read as a flash.
+        let start = entrance(Rect::new(10.0, 10.0, 1.0, 1.0), RESTING);
+        assert!(start.scale_x >= 0.04);
+    }
+}

--- a/components/otto-quickview/src/payload.rs
+++ b/components/otto-quickview/src/payload.rs
@@ -1,0 +1,355 @@
+//! Getting a [`PreviewPayload`] across the process boundary.
+//!
+//! The payload *types* live in `otto_kit::preview`, with the code that draws
+//! them — the drawing side owns the vocabulary, and this module is only the
+//! wire. That is why encoding is free functions rather than methods: the types
+//! are not ours to hang an impl on, which is the orphan rule usefully pointing
+//! at where the boundary is.
+//!
+//! The format is hand-rolled rather than serde: both ends are this binary, the
+//! shapes are fixed and closed, and the project prefers writing a hundred lines
+//! to taking a dependency. Every read is bounds-checked, because the parent is
+//! parsing bytes produced by a process it expects to sometimes die badly.
+
+use std::io::{self, Write};
+
+pub use otto_kit::preview::{Fact, Pixels, Preview as PreviewPayload, Row};
+
+/// Wire magic. Bumped if the encoding below ever changes shape.
+const MAGIC: &[u8; 4] = b"OQV1";
+
+/// Ceiling on any single length field. A corrupt worker must not be able to
+/// make the parent allocate a gigabyte because a length byte flipped.
+const MAX_LEN: u32 = 512 * 1024 * 1024;
+
+/// Nothing could be shown, and why.
+pub fn unavailable(reason: impl Into<String>) -> PreviewPayload {
+    PreviewPayload::Unavailable {
+        reason: reason.into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+fn put_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_str(out: &mut Vec<u8>, value: &str) {
+    put_u32(out, value.len() as u32);
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn put_pixels(out: &mut Vec<u8>, pixels: &Pixels) {
+    put_u32(out, pixels.width);
+    put_u32(out, pixels.height);
+    put_u32(out, pixels.intrinsic_width);
+    put_u32(out, pixels.intrinsic_height);
+    put_u32(out, pixels.data.len() as u32);
+    out.extend_from_slice(&pixels.data);
+}
+
+pub fn encode(payload: &PreviewPayload) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4096);
+    out.extend_from_slice(MAGIC);
+    match payload {
+        PreviewPayload::Pixels {
+            pixels,
+            pages,
+            page,
+        } => {
+            out.push(1);
+            put_pixels(&mut out, pixels);
+            put_u32(&mut out, *pages);
+            put_u32(&mut out, *page);
+        }
+        PreviewPayload::Text {
+            lines,
+            truncated,
+            language,
+        } => {
+            out.push(2);
+            put_u32(&mut out, lines.len() as u32);
+            for line in lines {
+                put_str(&mut out, line);
+            }
+            out.push(*truncated as u8);
+            put_str(&mut out, language);
+        }
+        PreviewPayload::Rows {
+            rows,
+            truncated,
+            summary,
+        } => {
+            out.push(3);
+            put_u32(&mut out, rows.len() as u32);
+            for row in rows {
+                put_str(&mut out, &row.name);
+                put_u64(&mut out, row.size);
+                put_u64(&mut out, row.mtime as u64);
+                put_str(&mut out, &row.icon);
+                out.push(row.is_dir as u8);
+            }
+            out.push(*truncated as u8);
+            put_str(&mut out, summary);
+        }
+        PreviewPayload::Card {
+            title,
+            subtitle,
+            facts,
+            hero,
+        } => {
+            out.push(4);
+            put_str(&mut out, title);
+            put_str(&mut out, subtitle);
+            put_u32(&mut out, facts.len() as u32);
+            for fact in facts {
+                put_str(&mut out, &fact.key);
+                put_str(&mut out, &fact.value);
+            }
+            match hero {
+                Some(pixels) => {
+                    out.push(1);
+                    put_pixels(&mut out, pixels);
+                }
+                None => out.push(0),
+            }
+        }
+        PreviewPayload::Unavailable { reason } => {
+            out.push(5);
+            put_str(&mut out, reason);
+        }
+    }
+    out
+}
+
+pub fn write_to(payload: &PreviewPayload, sink: &mut impl Write) -> io::Result<()> {
+    sink.write_all(&encode(payload))
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+/// A cursor that refuses to read past the end rather than panicking. The input
+/// is the output of a process that may have been killed mid-write.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    at: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn take(&mut self, count: usize) -> Option<&'a [u8]> {
+        let end = self.at.checked_add(count)?;
+        let slice = self.bytes.get(self.at..end)?;
+        self.at = end;
+        Some(slice)
+    }
+
+    fn u8(&mut self) -> Option<u8> {
+        Some(self.take(1)?[0])
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.take(4)?.try_into().ok()?))
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.take(8)?.try_into().ok()?))
+    }
+
+    /// A length field, rejected if it is implausible before it is used to
+    /// allocate anything.
+    fn len(&mut self) -> Option<usize> {
+        let value = self.u32()?;
+        (value <= MAX_LEN).then_some(value as usize)
+    }
+
+    fn string(&mut self) -> Option<String> {
+        let count = self.len()?;
+        String::from_utf8(self.take(count)?.to_vec()).ok()
+    }
+
+    fn pixels(&mut self) -> Option<Pixels> {
+        let width = self.u32()?;
+        let height = self.u32()?;
+        let intrinsic_width = self.u32()?;
+        let intrinsic_height = self.u32()?;
+        let count = self.len()?;
+        // The buffer must be exactly the size the dimensions imply, or the
+        // drawing side would read past the end of it.
+        let expected = (width as usize)
+            .checked_mul(height as usize)?
+            .checked_mul(4)?;
+        if count != expected {
+            return None;
+        }
+        Some(Pixels {
+            width,
+            height,
+            intrinsic_width,
+            intrinsic_height,
+            data: self.take(count)?.to_vec(),
+        })
+    }
+}
+
+/// Parse a payload. `None` means the worker produced something malformed,
+/// which the caller reports as an unavailable preview — never a panic.
+pub fn decode(bytes: &[u8]) -> Option<PreviewPayload> {
+    let mut cursor = Cursor { bytes, at: 0 };
+    if cursor.take(4)? != MAGIC {
+        return None;
+    }
+    match cursor.u8()? {
+        1 => {
+            let pixels = cursor.pixels()?;
+            Some(PreviewPayload::Pixels {
+                pixels,
+                pages: cursor.u32()?,
+                page: cursor.u32()?,
+            })
+        }
+        2 => {
+            let count = cursor.len()?;
+            let mut lines = Vec::with_capacity(count.min(4096));
+            for _ in 0..count {
+                lines.push(cursor.string()?);
+            }
+            Some(PreviewPayload::Text {
+                lines,
+                truncated: cursor.u8()? != 0,
+                language: cursor.string()?,
+            })
+        }
+        3 => {
+            let count = cursor.len()?;
+            let mut rows = Vec::with_capacity(count.min(4096));
+            for _ in 0..count {
+                rows.push(Row {
+                    name: cursor.string()?,
+                    size: cursor.u64()?,
+                    mtime: cursor.u64()? as i64,
+                    icon: cursor.string()?,
+                    is_dir: cursor.u8()? != 0,
+                });
+            }
+            Some(PreviewPayload::Rows {
+                rows,
+                truncated: cursor.u8()? != 0,
+                summary: cursor.string()?,
+            })
+        }
+        4 => {
+            let title = cursor.string()?;
+            let subtitle = cursor.string()?;
+            let count = cursor.len()?;
+            let mut facts = Vec::with_capacity(count.min(256));
+            for _ in 0..count {
+                facts.push(Fact {
+                    key: cursor.string()?,
+                    value: cursor.string()?,
+                });
+            }
+            let hero = match cursor.u8()? {
+                0 => None,
+                _ => Some(cursor.pixels()?),
+            };
+            Some(PreviewPayload::Card {
+                title,
+                subtitle,
+                facts,
+                hero,
+            })
+        }
+        5 => Some(PreviewPayload::Unavailable {
+            reason: cursor.string()?,
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_every_variant() {
+        let pixels = Pixels {
+            width: 2,
+            height: 2,
+            intrinsic_width: 8,
+            intrinsic_height: 8,
+            data: vec![0xAB; 16],
+        };
+        let cases = vec![
+            PreviewPayload::Pixels {
+                pixels: pixels.clone(),
+                pages: 3,
+                page: 2,
+            },
+            PreviewPayload::Text {
+                lines: vec!["fn main() {".into(), "}".into()],
+                truncated: true,
+                language: "rust".into(),
+            },
+            PreviewPayload::Rows {
+                rows: vec![Row {
+                    name: "a.txt".into(),
+                    size: 12,
+                    mtime: 99,
+                    icon: "text-x-generic".into(),
+                    is_dir: false,
+                }],
+                truncated: false,
+                summary: "1 item".into(),
+            },
+            PreviewPayload::Card {
+                title: "Song".into(),
+                subtitle: "Artist".into(),
+                facts: vec![Fact {
+                    key: "Duration".into(),
+                    value: "3:21".into(),
+                }],
+                hero: Some(pixels),
+            },
+            unavailable("no decoder"),
+        ];
+        for case in cases {
+            let decoded = decode(&encode(&case)).expect("round trip");
+            assert_eq!(format!("{case:?}"), format!("{decoded:?}"));
+        }
+    }
+
+    #[test]
+    fn rejects_truncated_and_corrupt_input() {
+        let good = encode(&unavailable("x"));
+        // Every prefix of a valid payload must be rejected, not panic.
+        for cut in 0..good.len() {
+            assert!(decode(&good[..cut]).is_none());
+        }
+        assert!(decode(b"XXXX\x01").is_none());
+    }
+
+    #[test]
+    fn rejects_pixel_buffer_that_contradicts_its_dimensions() {
+        // A length that does not match width*height*4 must be refused: the
+        // drawing side trusts these dimensions when it wraps the buffer.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(MAGIC);
+        bytes.push(1);
+        for value in [4u32, 4, 4, 4, 8] {
+            put_u32(&mut bytes, value);
+        }
+        bytes.extend_from_slice(&[0; 8]);
+        put_u32(&mut bytes, 1);
+        put_u32(&mut bytes, 1);
+        assert!(decode(&bytes).is_none());
+    }
+}

--- a/components/otto-quickview/src/render.rs
+++ b/components/otto-quickview/src/render.rs
@@ -1,0 +1,231 @@
+//! Rendering a preview to a PNG, with no display attached.
+//!
+//! This is not a debug detour: it draws through exactly the path the window
+//! will use — `otto_kit::preview::draw` onto a Skia canvas — so what it
+//! produces is what the window will show. It makes the drawing half reviewable
+//! and testable before any Wayland code exists, and it keeps working afterwards
+//! as the way to see a preview without a session.
+
+use otto_kit::preview::{self, Preview};
+use otto_kit::theme::Theme;
+use skia_safe::{Canvas, Color, Paint, Rect};
+
+/// The card's chrome: the header a window draws around the content.
+///
+/// Kept here rather than in `otto_kit::preview` because it belongs to the
+/// *window*, not to the preview — the dock drawing a thumbnail server-side
+/// wants the content and none of this.
+const HEADER: f32 = 52.0;
+const RADIUS: f32 = 12.0;
+
+/// Draw a complete preview card and encode it as a PNG.
+pub fn to_png(
+    preview: &Preview,
+    title: &str,
+    width: i32,
+    height: i32,
+    dark: bool,
+) -> Option<Vec<u8>> {
+    let theme = if dark { Theme::dark() } else { Theme::light() };
+    let mut surface = skia_safe::surfaces::raster_n32_premul((width, height))?;
+    let canvas = surface.canvas();
+
+    draw_card(
+        canvas,
+        &theme,
+        preview,
+        title,
+        width as f32,
+        height as f32,
+        dark,
+    );
+
+    let image = surface.image_snapshot();
+    let data = image.encode(None, skia_safe::EncodedImageFormat::PNG, None)?;
+    Some(data.as_bytes().to_vec())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_card(
+    canvas: &Canvas,
+    theme: &Theme,
+    preview: &Preview,
+    title: &str,
+    width: f32,
+    height: f32,
+    dark: bool,
+) {
+    // The desktop behind the card. A preview always floats over something, and
+    // a flat backdrop would misrepresent how the material reads.
+    canvas.clear(if dark {
+        Color::from_argb(0xFF, 0x1C, 0x1C, 0x1E)
+    } else {
+        Color::from_argb(0xFF, 0xE8, 0xE8, 0xED)
+    });
+
+    let card = Rect::from_xywh(0.0, 0.0, width, height);
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    // The card itself. The compositor supplies the frost behind a real window;
+    // here the material colour is composited over the backdrop directly, which
+    // is the closest a screenshot can get to it.
+    paint.set_color(preview::background(theme));
+    canvas.draw_round_rect(card, RADIUS, RADIUS, &paint);
+
+    // Header: the file's name, and a hairline under it.
+    use otto_kit::common::Renderable;
+    otto_kit::components::label::Label::new(title.to_string())
+        .with_style(otto_kit::typography::styles::HEADLINE_EMPHASIZED)
+        .with_color(theme.text_primary)
+        .with_width(width)
+        .with_align(otto_kit::components::label::TextAlign::Center)
+        // Centred in the header band, not a hardcoded baseline: `HEADER * 0.62`
+        // happened to look right at one font size and at no other.
+        .centered_on(0.0, HEADER / 2.0)
+        .render(canvas);
+
+    paint.set_color(theme.fill_tertiary);
+    canvas.draw_rect(Rect::from_xywh(0.0, HEADER - 1.0, width, 1.0), &paint);
+
+    let content = Rect::from_ltrb(0.0, HEADER, width, height);
+    canvas.save();
+    canvas.clip_rect(content, None, true);
+    // Fit, always: this is the offline renderer, and there is nobody here to
+    // pinch.
+    preview::draw(
+        canvas,
+        content,
+        preview,
+        theme,
+        0,
+        preview::Zoom::FIT,
+        &resolve_icon,
+    );
+    canvas.restore();
+}
+
+/// Resolve a row's icon from the desktop icon theme.
+///
+/// `preview::draw` takes this as a callback so the toolkit's drawing half stays
+/// free of the icon cache, and therefore of any runtime — the compositor
+/// resolves icons differently from an application, and neither dependency
+/// belongs in the draw path.
+fn resolve_icon(name: &str, size: i32) -> Option<skia_safe::Image> {
+    // `cached_icon_chain`, not `cached_file_icon` — the latter takes a *file
+    // path*, and handing it an icon *name* silently resolves nothing. The chain
+    // lookup also never reads `AppContext`, so it works from a bare canvas.
+    otto_kit::icons::cached_icon_chain(&[name], size)
+}
+
+/// A filmstrip of the opening: the same card drawn at several points along the
+/// entrance, over a mock desktop with the anchor marked.
+///
+/// The compositor runs the real transaction; this samples the same geometry
+/// from [`crate::opening`], so it shows the motion's shape rather than a
+/// screenshot of it.
+pub fn opening_filmstrip(
+    preview: &Preview,
+    title: &str,
+    frames: &[f32],
+    dark: bool,
+) -> Option<Vec<u8>> {
+    use crate::opening;
+
+    // A mock desktop with a file list down the left, so the anchor has
+    // somewhere to be and the motion has something to be relative to.
+    let (cell_w, cell_h) = (420.0f32, 300.0f32);
+    let columns = frames.len().min(4) as f32;
+    let rows = (frames.len() as f32 / columns).ceil();
+    let width = (cell_w * columns) as i32;
+    let height = (cell_h * rows) as i32;
+
+    let theme = if dark { Theme::dark() } else { Theme::light() };
+    let mut surface = skia_safe::surfaces::raster_n32_premul((width, height))?;
+    let canvas = surface.canvas();
+    canvas.clear(if dark {
+        Color::from_argb(0xFF, 0x14, 0x14, 0x16)
+    } else {
+        Color::from_argb(0xFF, 0xDE, 0xDE, 0xE4)
+    });
+
+    // The item being previewed, and where the card comes to rest.
+    let anchor = opening::Rect::new(24.0, 96.0, 150.0, 18.0);
+    let resting = opening::Rect::new(96.0, 40.0, 300.0, 220.0);
+
+    for (index, t) in frames.iter().enumerate() {
+        let col = (index as f32) % columns;
+        let row = (index as f32 / columns).floor();
+        canvas.save();
+        canvas.translate((col * cell_w, row * cell_h));
+        canvas.clip_rect(Rect::from_xywh(0.0, 0.0, cell_w, cell_h), None, false);
+
+        draw_mock_desktop(canvas, &theme, anchor, dark);
+
+        let rect = opening::sample(anchor, resting, *t);
+        let card = Rect::from_xywh(rect.x, rect.y, rect.width, rect.height);
+
+        // The card is drawn once at its resting size and *transformed* — which
+        // is what the compositor does with it, and why the entrance never
+        // re-lays-out the content or asks for another frame.
+        canvas.save();
+        canvas.clip_rect(card, None, true);
+        canvas.translate((card.left, card.top));
+        let scale = rect.width / resting.width;
+        canvas.scale((scale, scale));
+        draw_card(
+            canvas,
+            &theme,
+            preview,
+            title,
+            resting.width,
+            resting.height,
+            dark,
+        );
+        canvas.restore();
+
+        let mut label = Paint::default();
+        label.set_anti_alias(true);
+        use otto_kit::common::Renderable;
+        otto_kit::components::label::Label::new(format!("t = {t:.2}"))
+            .with_style(otto_kit::typography::styles::CAPTION_1)
+            .with_color(theme.text_tertiary)
+            .at(24.0, cell_h - 18.0)
+            .render(canvas);
+
+        canvas.restore();
+    }
+
+    let image = surface.image_snapshot();
+    let data = image.encode(None, skia_safe::EncodedImageFormat::PNG, None)?;
+    Some(data.as_bytes().to_vec())
+}
+
+/// A stand-in file list, with the previewed row highlighted — the thing the
+/// card is growing out of.
+fn draw_mock_desktop(canvas: &Canvas, theme: &Theme, anchor: crate::opening::Rect, dark: bool) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(if dark {
+        Color::from_argb(0xFF, 0x24, 0x24, 0x28)
+    } else {
+        Color::from_argb(0xFF, 0xF6, 0xF6, 0xF8)
+    });
+    canvas.draw_round_rect(Rect::from_xywh(12.0, 24.0, 174.0, 250.0), 8.0, 8.0, &paint);
+
+    for index in 0..9 {
+        let y = 44.0 + index as f32 * 26.0;
+        let selected = (y - anchor.y).abs() < 1.0;
+        paint.set_color(if selected {
+            theme.accent
+        } else {
+            theme.fill_tertiary
+        });
+        canvas.draw_round_rect(
+            Rect::from_xywh(24.0, y, if selected { anchor.width } else { 120.0 }, 18.0),
+            4.0,
+            4.0,
+            &paint,
+        );
+    }
+}

--- a/components/otto-quickview/src/sandbox.rs
+++ b/components/otto-quickview/src/sandbox.rs
@@ -1,0 +1,234 @@
+//! Containment for the decode worker.
+//!
+//! The worker parses files nobody vetted. It is spawned per preview, it is
+//! handed exactly one file descriptor, and it is expected to sometimes die
+//! badly — that is the design, not a failure of it.
+//!
+//! **What is actually enforced** — measured by [`self_test`], not assumed:
+//!
+//! * memory is capped (`RLIMIT_AS`), so a decompression bomb dies instead of
+//!   swapping the desktop;
+//! * no file can be written or grown at all (`RLIMIT_FSIZE = 0`);
+//! * the network is unreachable (`CLONE_NEWNET`);
+//! * no privilege can be gained (`PR_SET_NO_NEW_PRIVS`);
+//! * no descriptor is inherited beyond the one file
+//!   ([`close_inherited_fds`]), so there is no Wayland or bus connection to
+//!   misuse;
+//! * CPU time is capped, and the parent kills on a wall-clock deadline —
+//!   which is the thing a *thread* could never have offered.
+//!
+//! **What is not enforced, and is a known gap:** the worker can still `open`
+//! and read unrelated files. Nothing here is a filesystem jail — `chdir("/")`
+//! stops relative-path surprises and nothing more. Closing this needs either a
+//! seccomp filter denying `openat` (cheap for the in-process decoders, but it
+//! would break the PDF path, which must `exec` a rasteriser that opens its own
+//! libraries) or a mount namespace with `pivot_root` (correct, and it must
+//! then bind in enough of `/usr` for those rasterisers to run). Until one of
+//! those lands, the containment story is: one process, one descriptor, hard
+//! budgets, no network, no writes — and reading is not contained.
+//!
+//! Run `otto-quickview --sandbox-selftest` to see the current answer rather
+//! than trusting this comment.
+//!
+//! Everything here is raw `libc`. There is no sandboxing crate in the tree and
+//! the calls involved are a dozen lines each.
+
+use std::io;
+
+/// The descriptor the file to preview always arrives on in the worker. Fixed
+/// so the worker never has to be told a path, and so a path cannot be
+/// substituted between the parent's `fstat` and the child's `open`.
+pub const FILE_FD: i32 = 3;
+
+/// Budgets applied to a worker. Deliberately generous enough that a real
+/// 200 MP photograph decodes, and tight enough that a decompression bomb does
+/// not take the machine with it.
+#[derive(Debug, Clone, Copy)]
+pub struct Budget {
+    /// Address space ceiling. The single most important limit: it is what turns
+    /// a memory bomb into a dead worker instead of a swapping desktop.
+    pub address_space: u64,
+    /// CPU seconds. A backstop for the parent's wall-clock deadline, which is
+    /// the limit that normally fires first.
+    pub cpu_seconds: u64,
+    /// How many bytes a decoder may read from the file. Metadata-only
+    /// previewers stop long before this.
+    pub max_read: u64,
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self {
+            address_space: 1024 * 1024 * 1024,
+            cpu_seconds: 10,
+            max_read: 512 * 1024 * 1024,
+        }
+    }
+}
+
+/// Drop every capability the worker will not need, before it looks at a byte
+/// of the file.
+///
+/// Called in the child between `fork` and `exec` and again at the top of the
+/// worker's own `main` — the pre-exec half cannot survive `execve` for the
+/// `no_new_privs` bit alone, and the post-exec half cannot unshare namespaces
+/// as reliably. Applying both is cheap and neither is sufficient alone.
+///
+/// # Safety
+///
+/// Must only be called in a freshly forked child, before `exec`, where the only
+/// other thing running is this code. It calls async-signal-unsafe-adjacent
+/// functions in the narrow way that is permitted there.
+pub unsafe fn apply(budget: Budget) -> io::Result<()> {
+    // No path to resolve relative names against. Combined with holding no
+    // directory descriptor, the worker has nowhere to walk to.
+    if libc::chdir(c"/".as_ptr()) != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // A setuid binary reached from here must not gain anything. This also makes
+    // a seccomp filter installable without privileges, should one be added.
+    if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    set_limit(libc::RLIMIT_AS, budget.address_space)?;
+    set_limit(libc::RLIMIT_CPU, budget.cpu_seconds)?;
+    // No file the worker creates may contain anything. It has no reason to
+    // write, and this makes that structural rather than a matter of trust.
+    set_limit(libc::RLIMIT_FSIZE, 0)?;
+    // Enough for the inherited descriptors, a rasteriser's pipes, and nothing
+    // resembling a file-descriptor exhaustion attack.
+    set_limit(libc::RLIMIT_NOFILE, 64)?;
+    // No core dump: a crashed previewer would otherwise write the contents of
+    // the file it was parsing into the filesystem.
+    set_limit(libc::RLIMIT_CORE, 0)?;
+
+    // Network namespace last, and advisory. It needs either privilege or
+    // unprivileged-userns support, and a kernel that refuses is not a reason to
+    // decline to preview — the worker still has no socket it is allowed to
+    // open a useful connection from, and no credentials to use. The rlimits
+    // above are the load-bearing part.
+    unshare_network();
+
+    Ok(())
+}
+
+fn set_limit(resource: libc::__rlimit_resource_t, value: u64) -> io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: value,
+        rlim_max: value,
+    };
+    // SAFETY: `limit` is fully initialised and `resource` is a valid constant.
+    if unsafe { libc::setrlimit(resource, &limit) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Best-effort network isolation.
+///
+/// Tries an unprivileged user namespace first, since that is what makes
+/// `CLONE_NEWNET` available to a normal desktop process. Failure is not
+/// reported: this is a second lock on a door the worker has no key to anyway.
+fn unshare_network() {
+    // SAFETY: `unshare` with these flags affects only the calling process.
+    unsafe {
+        if libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNET) == 0 {
+            return;
+        }
+        libc::unshare(libc::CLONE_NEWNET);
+    }
+}
+
+/// What containment is actually in force, established by trying each thing
+/// rather than by assuming the syscall that set it up worked.
+///
+/// This exists because a security property nobody measures is a security
+/// property nobody has. `otto-quickview --sandbox-selftest` prints it.
+#[derive(Debug, Default)]
+pub struct SelfTest {
+    pub address_space_capped: bool,
+    pub cannot_grow_a_file: bool,
+    pub network_unreachable: bool,
+    /// Whether an unrelated file can still be opened. **Currently true**: the
+    /// rlimits and namespaces below do not restrict the filesystem, and the
+    /// honest containment story is the process boundary plus the budgets, not
+    /// a filesystem jail. Recorded so the gap is visible rather than assumed
+    /// away.
+    pub can_still_open_other_files: bool,
+}
+
+/// Measure the sandbox from inside it. Call only after [`apply`].
+pub fn self_test() -> SelfTest {
+    let mut result = SelfTest::default();
+
+    // SAFETY: every call below is a plain query or a deliberate attempt that is
+    // expected to fail; none of them mutate state this process depends on.
+    unsafe {
+        let mut limit: libc::rlimit = std::mem::zeroed();
+        if libc::getrlimit(libc::RLIMIT_AS, &mut limit) == 0 {
+            result.address_space_capped = limit.rlim_cur != libc::RLIM_INFINITY;
+        }
+        if libc::getrlimit(libc::RLIMIT_FSIZE, &mut limit) == 0 {
+            result.cannot_grow_a_file = limit.rlim_cur == 0;
+        }
+
+        // A UDP socket needs no peer to prove the point: in a fresh network
+        // namespace there is no route to anywhere.
+        let socket = libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0);
+        if socket < 0 {
+            result.network_unreachable = true;
+        } else {
+            let mut address: libc::sockaddr_in = std::mem::zeroed();
+            address.sin_family = libc::AF_INET as libc::sa_family_t;
+            address.sin_port = 53u16.to_be();
+            // 1.1.1.1
+            address.sin_addr.s_addr = u32::from_be_bytes([1, 1, 1, 1]).to_be();
+            let connected = libc::connect(
+                socket,
+                &address as *const _ as *const libc::sockaddr,
+                std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            );
+            result.network_unreachable = connected != 0;
+            libc::close(socket);
+        }
+
+        let probe = b"/etc/passwd\0";
+        let fd = libc::open(probe.as_ptr() as *const libc::c_char, libc::O_RDONLY);
+        if fd >= 0 {
+            result.can_still_open_other_files = true;
+            libc::close(fd);
+        }
+    }
+
+    result
+}
+
+/// Close every descriptor above the ones the worker is meant to have.
+///
+/// The parent controls what it passes, but a descriptor leaked by something
+/// earlier in the process's life — a Wayland socket, the session bus — would
+/// otherwise be inherited straight into the previewer.
+///
+/// # Safety
+///
+/// Child-side only, as for [`apply`].
+pub unsafe fn close_inherited_fds(keep_up_to: i32) {
+    // `close_range` is the clean way and exists on every kernel Otto targets;
+    // the fallback loop is there because it costs three lines.
+    #[allow(clippy::useless_conversion)]
+    let closed = libc::syscall(
+        libc::SYS_close_range,
+        (keep_up_to + 1) as libc::c_uint,
+        libc::c_uint::MAX,
+        0,
+    );
+    if closed == 0 {
+        return;
+    }
+    let max = libc::sysconf(libc::_SC_OPEN_MAX).clamp(64, 4096) as i32;
+    for fd in (keep_up_to + 1)..max {
+        libc::close(fd);
+    }
+}

--- a/components/otto-quickview/src/spawn.rs
+++ b/components/otto-quickview/src/spawn.rs
@@ -1,0 +1,207 @@
+//! The parent half of decoding: open the file, spawn a contained worker, and
+//! enforce the deadline the worker cannot enforce on itself.
+//!
+//! This is where the process boundary earns its keep. A runaway *thread* cannot
+//! be killed; a runaway *process* can, which is what makes the wall-clock
+//! budget real rather than aspirational.
+
+use std::fs::File;
+use std::io::Read;
+use std::os::fd::IntoRawFd;
+use std::os::unix::fs::FileTypeExt;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::decode::Request;
+use crate::payload;
+use crate::payload::PreviewPayload;
+use crate::sandbox::{self, FILE_FD};
+
+/// How long a preview may take before the worker is killed. Generous next to
+/// the 100 ms interaction budget because it is a backstop, not a target: the
+/// common case is served from the thumbnail cache long before this matters.
+const DEADLINE: Duration = Duration::from_secs(8);
+
+/// A file opened for preview, with what we learned by opening it.
+///
+/// The metadata is carried because the thumbnail cache needs it and the parent
+/// is the only side that can use it: `thumbnails::lookup` takes the source
+/// mtime rather than statting again, and storing is parent-side because the
+/// worker runs under `RLIMIT_FSIZE = 0` and physically cannot write.
+#[allow(
+    dead_code,
+    reason = "read by the thumbnail cache wiring, not yet built"
+)]
+pub struct Opened {
+    pub file: File,
+    pub len: u64,
+    pub is_dir: bool,
+    pub mtime: std::time::SystemTime,
+}
+
+/// Open a path for previewing, refusing everything that is not safely readable.
+///
+/// The refusal list is not paranoia: opening a FIFO blocks until a writer
+/// appears, and reading a character device can block forever. A previewer that
+/// hangs on a named pipe in a directory listing is a previewer that hangs.
+pub fn open(path: &Path) -> Result<Opened, String> {
+    // `O_NONBLOCK` so a FIFO that slipped through cannot block the open itself.
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|err| format!("{err}"))?;
+
+    let metadata = file.metadata().map_err(|err| format!("{err}"))?;
+    let kind = metadata.file_type();
+    if kind.is_fifo() || kind.is_socket() || kind.is_char_device() || kind.is_block_device() {
+        return Err("this is not a file that can be previewed".into());
+    }
+    if !kind.is_file() && !kind.is_dir() {
+        return Err("this is not a file that can be previewed".into());
+    }
+
+    Ok(Opened {
+        len: metadata.len(),
+        is_dir: kind.is_dir(),
+        mtime: metadata
+            .modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+        file,
+    })
+}
+
+/// Trait needed for `custom_flags` on the open above.
+use std::os::unix::fs::OpenOptionsExt;
+
+/// Run one decode. Blocks until the worker answers, dies, or overruns.
+///
+/// Always returns a payload: a worker that crashed, hung, or produced nonsense
+/// becomes an `Unavailable` with a reason, because "cannot preview this, here
+/// is why" is itself a preview and a blank window is not.
+pub fn decode(opened: Opened, request: &Request) -> PreviewPayload {
+    let started = Instant::now();
+    let executable = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(err) => return payload::unavailable(format!("cannot find the previewer: {err}")),
+    };
+
+    let budget = request.budget;
+    // The child receives the file on a fixed descriptor and nothing else.
+    let file_fd = opened.file.into_raw_fd();
+
+    let mut command = Command::new(executable);
+    command
+        .arg("--decode-worker")
+        .arg("--width")
+        .arg(request.width.to_string())
+        .arg("--height")
+        .arg(request.height.to_string())
+        .arg("--page")
+        .arg(request.page.to_string())
+        .arg("--zoom")
+        .arg(format!("{:.4}", request.zoom))
+        .arg("--name")
+        .arg(&request.name)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        // A previewer has no business inheriting the session's environment: the
+        // Wayland and bus addresses in particular are capabilities.
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env(
+            "RUST_LOG",
+            std::env::var("RUST_LOG").unwrap_or_else(|_| "error".into()),
+        );
+
+    // SAFETY: runs in the forked child between `fork` and `exec`. Everything
+    // called here is either async-signal-safe or is a raw syscall wrapper.
+    unsafe {
+        command.pre_exec(move || {
+            // Put the file where the worker will look for it.
+            //
+            // `dup2` is also what clears `FD_CLOEXEC`, which Rust sets on every
+            // file it opens — so when the file already happens to *be* on
+            // descriptor 3, skipping the `dup2` would leave the flag set and
+            // the worker would exec into an empty descriptor. Clear it by hand
+            // in that case rather than skipping the step.
+            if file_fd == FILE_FD {
+                if libc::fcntl(FILE_FD, libc::F_SETFD, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            } else if libc::dup2(file_fd, FILE_FD) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // Drop anything else this process happened to be holding — a
+            // leaked Wayland socket would otherwise be inherited straight into
+            // the previewer.
+            sandbox::close_inherited_fds(FILE_FD);
+            sandbox::apply(budget)?;
+            Ok(())
+        });
+    }
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            // SAFETY: the descriptor was not consumed by a successful spawn.
+            unsafe { libc::close(file_fd) };
+            return payload::unavailable(format!("cannot start the previewer: {err}"));
+        }
+    };
+    // The child has its own copy now.
+    unsafe { libc::close(file_fd) };
+
+    // Read on a thread so the deadline is enforceable: reading inline would
+    // block in `read_to_end` with no way to notice time passing.
+    let mut stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => return payload::unavailable("the previewer produced no output"),
+    };
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout.read_to_end(&mut bytes).map(|_| bytes);
+        let _ = sender.send(result);
+    });
+
+    let payload = match receiver.recv_timeout(DEADLINE) {
+        Ok(Ok(bytes)) => payload::decode(&bytes)
+            .unwrap_or_else(|| payload::unavailable("the previewer produced something unreadable")),
+        Ok(Err(err)) => payload::unavailable(format!("the previewer failed: {err}")),
+        Err(_) => {
+            // Overran. This is the case a thread could not have recovered from.
+            let _ = child.kill();
+            payload::unavailable("this file took too long to preview")
+        }
+    };
+
+    let _ = child.wait();
+    tracing::debug!(
+        ms = started.elapsed().as_millis(),
+        name = %request.name,
+        "decoded"
+    );
+    payload
+}
+
+/// One-shot decode from a path, for the command line and for tests.
+pub fn decode_path(path: &Path, request: &Request) -> PreviewPayload {
+    match open(path) {
+        Ok(opened) => {
+            let mut request = request.clone();
+            if request.name.is_empty() {
+                request.name = path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+            }
+            decode(opened, &request)
+        }
+        Err(reason) => payload::unavailable(reason),
+    }
+}

--- a/components/otto-quickview/src/uri.rs
+++ b/components/otto-quickview/src/uri.rs
@@ -1,0 +1,149 @@
+//! `file://` URIs — how every host names the file to preview, and how the
+//! file picker names the file it returns.
+//!
+//! Hand-rolled because it is twenty lines and the alternative is a URL crate
+//! for one scheme. The encoder and the decoder live together so the pair
+//! stays honest: whatever one escapes, the other must give back.
+
+/// `file://` URI to a path, with percent-decoding.
+///
+/// Hand-rolled because it is twenty lines and the alternative is a URL crate
+/// for one scheme. Anything that is not a plain local `file://` URI is refused
+/// rather than guessed at — the contract says `file://` only.
+pub fn uri_to_path(uri: &str) -> Option<std::path::PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    // An authority component is either empty or "localhost"; anything else is a
+    // remote location, which is out of scope by design.
+    let path = match rest.find('/') {
+        Some(0) => rest,
+        Some(slash) => {
+            let authority = &rest[..slash];
+            if !authority.is_empty() && authority != "localhost" {
+                return None;
+            }
+            &rest[slash..]
+        }
+        None => return None,
+    };
+
+    let mut out = Vec::with_capacity(path.len());
+    let bytes = path.as_bytes();
+    let mut at = 0;
+    while at < bytes.len() {
+        if bytes[at] == b'%' && at + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[at + 1..at + 3]).ok()?;
+            match u8::from_str_radix(hex, 16) {
+                Ok(byte) => {
+                    out.push(byte);
+                    at += 3;
+                    continue;
+                }
+                // A stray '%' is a literal '%', not a failure: filenames
+                // contain them.
+                Err(_) => {}
+            }
+        }
+        out.push(bytes[at]);
+        at += 1;
+    }
+
+    use std::os::unix::ffi::OsStringExt;
+    Some(std::path::PathBuf::from(std::ffi::OsString::from_vec(out)))
+}
+
+/// A path as a percent-encoded `file://` URI — the inverse of
+/// [`uri_to_path`].
+///
+/// Encoding works on the path's **bytes**, not on a lossy UTF-8 rendering of
+/// them: Linux file names are bytes, and a file must survive the round trip
+/// whether or not it happens to be nameable in Unicode. Every byte outside
+/// RFC 3986's unreserved set is escaped, except `/`, which is the URI's own
+/// separator and here means what it means in the path.
+pub fn path_to_uri(path: &std::path::Path) -> String {
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut uri = String::from("file://");
+    for &byte in path.as_os_str().as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                uri.push(byte as char)
+            }
+            _ => uri.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    uri
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_uri_keeps_the_path_separators_unescaped() {
+        assert_eq!(
+            path_to_uri(std::path::Path::new("/a/b/c.txt")),
+            "file:///a/b/c.txt"
+        );
+    }
+
+    #[test]
+    fn a_name_full_of_reserved_characters_round_trips() {
+        // The single most likely place for a silent data bug in the picker.
+        let path = std::path::PathBuf::from("/home/u/a b&c#d?e+f%g.txt");
+        let uri = path_to_uri(&path);
+        assert!(!uri.contains(' '));
+        assert_eq!(uri_to_path(&uri), Some(path));
+    }
+
+    #[test]
+    fn a_non_utf8_name_round_trips() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = std::path::PathBuf::from(OsString::from_vec(b"/tmp/bad\xffname".to_vec()));
+        let uri = path_to_uri(&path);
+        assert!(uri.contains("%FF"));
+        assert_eq!(uri_to_path(&uri), Some(path));
+    }
+
+    #[test]
+    fn decodes_ordinary_and_escaped_paths() {
+        assert_eq!(
+            uri_to_path("file:///home/me/a.txt"),
+            Some("/home/me/a.txt".into())
+        );
+        assert_eq!(
+            uri_to_path("file:///home/me/holiday%20photo.jpg"),
+            Some("/home/me/holiday photo.jpg".into())
+        );
+        assert_eq!(
+            uri_to_path("file://localhost/etc/hosts"),
+            Some("/etc/hosts".into())
+        );
+    }
+
+    #[test]
+    fn refuses_anything_that_is_not_a_local_file_uri() {
+        assert!(uri_to_path("http://example.com/a").is_none());
+        assert!(uri_to_path("file://remote-host/share/a").is_none());
+        assert!(uri_to_path("/not/a/uri").is_none());
+    }
+
+    #[test]
+    fn a_stray_percent_is_a_literal_percent() {
+        // Filenames really do contain these, and refusing would be worse than
+        // taking it literally.
+        assert_eq!(
+            uri_to_path("file:///tmp/100%.txt"),
+            Some("/tmp/100%.txt".into())
+        );
+    }
+
+    #[test]
+    fn a_percent_encoded_byte_that_is_not_utf8_still_round_trips() {
+        // Paths are bytes, not strings. A Latin-1 filename must survive.
+        let path = uri_to_path("file:///tmp/caf%E9").expect("decodes");
+        use std::os::unix::ffi::OsStrExt;
+        assert_eq!(path.file_name().unwrap().as_bytes(), b"caf\xe9");
+    }
+}

--- a/components/otto-settings/Cargo.toml
+++ b/components/otto-settings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "otto-settings"
+version = "0.1.0"
+edition = "2021"
+description = "Settings application for Otto — see specs/settings-app.md"
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
+zbus = "4"
+serde = { version = "1", features = ["derive"] }
+
+[dependencies.skia-safe]
+version = "=0.93"
+features = ["gl", "textlayout", "svg"]

--- a/components/otto-settings/src/discovery.rs
+++ b/components/otto-settings/src/discovery.rs
@@ -1,0 +1,404 @@
+//! Discovers the valid choices for settings whose set is not fixed at
+//! compile time — it depends on what is installed on this machine, not on
+//! anything the compositor's schema can declare. `Describe` only marks six
+//! settings as `enum`; the rest (fonts, cursor/icon/sound themes, the lock
+//! and greeter commands) are `string` on the wire because the compositor
+//! should not have to know what fonts a given machine has installed.
+//!
+//! Every lookup here touches the filesystem or spawns a process, so results
+//! are cached for the lifetime of the app: `open_menu` runs on a pointer
+//! press and must not block visibly, and re-scanning `/usr/share/icons` on
+//! every click would be a needless stat storm.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+/// One entry in a discovered dropdown: what the field shows, and what gets
+/// sent in a `Set`. They differ exactly once — the auto-detect entry, whose
+/// label says so but whose value is the empty string the compositor already
+/// uses to mean "no override".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Choice {
+    pub label: String,
+    pub value: String,
+}
+
+/// The setting ids this module knows how to discover choices for. Anything
+/// else is not ours to answer — `open_menu` falls back to this only when the
+/// served schema has no `choices` of its own.
+pub fn choices_for(id: &str, current: &str) -> Option<Vec<Choice>> {
+    let discovered: &'static [String] = match id {
+        "font_family" => font_families(),
+        "cursor_theme" => cursor_themes(),
+        "icon_theme" => icon_themes(),
+        "audio.sound_theme" => sound_themes(),
+        "lock.locker_command" => locker_commands(),
+        "login.greeter_command" => greeter_commands(),
+        _ => return None,
+    };
+
+    // Nothing found, and nothing already set: there is genuinely nothing to
+    // offer, so no menu — not a menu with zero rows.
+    if discovered.is_empty() && current.is_empty() {
+        return None;
+    }
+
+    Some(merge_with_current(discovered, current))
+}
+
+/// Combine a discovered, sorted, de-duplicated list with whatever is
+/// currently set, so the menu always shows the live value even if discovery
+/// missed it (a theme installed by hand outside the usual directories, a
+/// locker command this list does not know about).
+fn merge_with_current(discovered: &[String], current: &str) -> Vec<Choice> {
+    let mut out = Vec::with_capacity(discovered.len() + 1);
+
+    if current.is_empty() {
+        // An empty effective value means "auto-detect", which is a real
+        // state worth its own row rather than a blank one.
+        out.push(Choice {
+            label: "Automatic".to_string(),
+            value: String::new(),
+        });
+    } else if !discovered.iter().any(|d| d == current) {
+        out.push(Choice {
+            label: current.to_string(),
+            value: current.to_string(),
+        });
+    }
+
+    out.extend(discovered.iter().map(|d| Choice {
+        label: d.clone(),
+        value: d.clone(),
+    }));
+
+    out
+}
+
+// ---------------------------------------------------------------------
+// Fonts, via fontconfig's `fc-list`. The project deliberately keeps its
+// dependency count low, and fontconfig's own crate pulls in a build-time
+// bindgen dependency for what is, from here, one command's output — so this
+// shells out instead of linking it.
+// ---------------------------------------------------------------------
+
+static FONT_FAMILIES: OnceLock<Vec<String>> = OnceLock::new();
+
+fn font_families() -> &'static [String] {
+    FONT_FAMILIES.get_or_init(|| {
+        let output = match Command::new("fc-list").arg(":").arg("family").output() {
+            Ok(output) if output.status.success() => output,
+            Ok(output) => {
+                eprintln!(
+                    "settings: fc-list exited with {}; font list unavailable",
+                    output.status
+                );
+                return Vec::new();
+            }
+            Err(err) => {
+                eprintln!("settings: fc-list not available ({err}); font list unavailable");
+                return Vec::new();
+            }
+        };
+        parse_fc_list(&String::from_utf8_lossy(&output.stdout))
+    })
+}
+
+/// Parse `fc-list : family` output: one family (or comma-separated aliases,
+/// commonly a Latin name and a localised one) per line. Only the first alias
+/// is kept — good enough for a picker, and it keeps the list from doubling
+/// up on every CJK font.
+fn parse_fc_list(text: &str) -> Vec<String> {
+    let mut names = BTreeSet::new();
+    for line in text.lines() {
+        if let Some(first) = line.split(',').next() {
+            let name = first.trim();
+            if !name.is_empty() {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+// ---------------------------------------------------------------------
+// Cursor and icon themes, per the XDG icon theme spec: a directory under an
+// icon search path is a theme if it declares itself with the files the spec
+// looks for. Sound themes follow the analogous freedesktop Sound Theme spec.
+// ---------------------------------------------------------------------
+
+static CURSOR_THEMES: OnceLock<Vec<String>> = OnceLock::new();
+static ICON_THEMES: OnceLock<Vec<String>> = OnceLock::new();
+static SOUND_THEMES: OnceLock<Vec<String>> = OnceLock::new();
+
+fn cursor_themes() -> &'static [String] {
+    CURSOR_THEMES.get_or_init(|| scan_themes(&icon_search_dirs(), is_cursor_theme_dir))
+}
+
+fn icon_themes() -> &'static [String] {
+    ICON_THEMES.get_or_init(|| scan_themes(&icon_search_dirs(), is_icon_theme_dir))
+}
+
+fn sound_themes() -> &'static [String] {
+    SOUND_THEMES.get_or_init(|| scan_themes(&sound_search_dirs(), is_sound_theme_dir))
+}
+
+/// A cursor theme is a directory containing a `cursors/` subdirectory of
+/// cursor files (the XDG cursor spec). It need not have an `index.theme` —
+/// plenty of hand-installed cursor themes skip it.
+fn is_cursor_theme_dir(dir: &Path) -> bool {
+    dir.join("cursors").is_dir()
+}
+
+/// An icon theme declares itself with `index.theme` (XDG icon theme spec).
+fn is_icon_theme_dir(dir: &Path) -> bool {
+    dir.join("index.theme").is_file()
+}
+
+/// A sound theme declares itself with `index.theme` too (freedesktop Sound
+/// Theme spec, which mirrors the icon theme one).
+fn is_sound_theme_dir(dir: &Path) -> bool {
+    dir.join("index.theme").is_file()
+}
+
+fn icon_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/usr/share/icons"),
+        PathBuf::from("/usr/local/share/icons"),
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        dirs.push(home.join(".local/share/icons"));
+        dirs.push(home.join(".icons"));
+    }
+    if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
+        dirs.push(PathBuf::from(xdg_data_home).join("icons"));
+    }
+    dirs
+}
+
+fn sound_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/usr/share/sounds"),
+        PathBuf::from("/usr/local/share/sounds"),
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(PathBuf::from(home).join(".local/share/sounds"));
+    }
+    if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
+        dirs.push(PathBuf::from(xdg_data_home).join("sounds"));
+    }
+    dirs
+}
+
+/// Every subdirectory of `dirs` that `is_theme` accepts, named for its
+/// directory basename, sorted and de-duplicated (the same theme often lives
+/// under more than one search path).
+fn scan_themes(dirs: &[PathBuf], is_theme: impl Fn(&Path) -> bool) -> Vec<String> {
+    let mut names = BTreeSet::new();
+    for dir in dirs {
+        let Ok(entries) = fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || !is_theme(&path) {
+                continue;
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+// ---------------------------------------------------------------------
+// Lock and greeter commands: rather than list every executable on `PATH` —
+// a menu of 3000 entries is not a menu — offer the plausible candidates and
+// keep only the ones that actually exist.
+// ---------------------------------------------------------------------
+
+static LOCKER_COMMANDS: OnceLock<Vec<String>> = OnceLock::new();
+static GREETER_COMMANDS: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Screen lockers otto might plausibly be pointed at: Otto's own, plus the
+/// common wlroots/GTK ones.
+const LOCKER_CANDIDATES: &[&str] = &["otto-lock", "swaylock", "gtklock", "hyprlock", "waylock"];
+
+/// Greeters a display manager might plausibly hand off to: Otto's own, plus
+/// the common greetd/LightDM/SDDM ones.
+const GREETER_CANDIDATES: &[&str] = &[
+    "otto-greeter",
+    "gtkgreet",
+    "regreet",
+    "lightdm-gtk-greeter",
+    "sddm-greeter",
+];
+
+fn locker_commands() -> &'static [String] {
+    LOCKER_COMMANDS.get_or_init(|| find_on_path(LOCKER_CANDIDATES))
+}
+
+fn greeter_commands() -> &'static [String] {
+    GREETER_COMMANDS.get_or_init(|| find_on_path(GREETER_CANDIDATES))
+}
+
+/// Which of `candidates` exist as executable files somewhere on `PATH`, in
+/// candidate order (not sorted — the list is hand-curated and short enough
+/// that "Otto's own first" reads better than alphabetical).
+fn find_on_path(candidates: &[&str]) -> Vec<String> {
+    let dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).collect())
+        .unwrap_or_default();
+    find_in_dirs(candidates, &dirs)
+}
+
+fn find_in_dirs(candidates: &[&str], dirs: &[PathBuf]) -> Vec<String> {
+    candidates
+        .iter()
+        .filter(|candidate| {
+            dirs.iter()
+                .any(|dir| is_executable_file(&dir.join(candidate)))
+        })
+        .map(|candidate| candidate.to_string())
+        .collect()
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "otto-settings-discovery-test-{label}-{}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parses_fc_list_output_taking_first_alias_and_dedup_sorting() {
+        let text =
+            "DejaVu Sans,DejaVu Sans\nNoto Sans CJK JP,Noto Sans CJK JP\nDejaVu Sans\nInter\n";
+        let names = parse_fc_list(text);
+        assert_eq!(names, vec!["DejaVu Sans", "Inter", "Noto Sans CJK JP"]);
+    }
+
+    #[test]
+    fn parses_fc_list_output_ignoring_blank_lines() {
+        let names = parse_fc_list("\n\nMono\n");
+        assert_eq!(names, vec!["Mono"]);
+    }
+
+    #[test]
+    fn scan_themes_finds_only_matching_dirs_and_dedups_across_search_paths() {
+        let a = scratch_dir("a");
+        let b = scratch_dir("b");
+
+        fs::create_dir_all(a.join("Adwaita/cursors")).unwrap();
+        fs::create_dir_all(a.join("NotATheme")).unwrap();
+        fs::File::create(a.join("not-a-dir")).unwrap();
+        // Same theme name present under both search paths.
+        fs::create_dir_all(b.join("Adwaita/cursors")).unwrap();
+        fs::create_dir_all(b.join("Breeze/cursors")).unwrap();
+
+        let found = scan_themes(&[a.clone(), b.clone()], is_cursor_theme_dir);
+        assert_eq!(found, vec!["Adwaita", "Breeze"]);
+
+        fs::remove_dir_all(&a).ok();
+        fs::remove_dir_all(&b).ok();
+    }
+
+    #[test]
+    fn scan_themes_recognises_icon_theme_via_index_theme() {
+        let dir = scratch_dir("icons");
+        fs::create_dir_all(dir.join("Papirus")).unwrap();
+        fs::write(dir.join("Papirus/index.theme"), "[Icon Theme]\n").unwrap();
+        fs::create_dir_all(dir.join("Incomplete")).unwrap();
+
+        let found = scan_themes(&[dir.clone()], is_icon_theme_dir);
+        assert_eq!(found, vec!["Papirus"]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_themes_missing_directory_yields_empty_not_a_panic() {
+        let missing = PathBuf::from("/does/not/exist/otto-settings-test");
+        assert!(scan_themes(&[missing], is_icon_theme_dir).is_empty());
+    }
+
+    #[test]
+    fn find_in_dirs_keeps_candidate_order_and_skips_non_executables() {
+        let dir = scratch_dir("bin");
+        let exe = dir.join("otto-lock");
+        fs::write(&exe, "#!/bin/sh\n").unwrap();
+        let mut perms = fs::metadata(&exe).unwrap().permissions();
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+        fs::set_permissions(&exe, perms).unwrap();
+
+        // Present but not executable: must not count.
+        fs::write(dir.join("swaylock"), "not executable").unwrap();
+
+        let found = find_in_dirs(&["otto-lock", "swaylock", "hyprlock"], &[dir.clone()]);
+        assert_eq!(found, vec!["otto-lock"]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn merge_with_current_marks_empty_current_as_automatic() {
+        let discovered = vec!["Adwaita".to_string(), "Breeze".to_string()];
+        let choices = merge_with_current(&discovered, "");
+        assert_eq!(choices[0].label, "Automatic");
+        assert_eq!(choices[0].value, "");
+        assert_eq!(choices.len(), 3);
+    }
+
+    #[test]
+    fn merge_with_current_does_not_duplicate_a_current_value_already_discovered() {
+        let discovered = vec!["Adwaita".to_string(), "Breeze".to_string()];
+        let choices = merge_with_current(&discovered, "Breeze");
+        assert_eq!(choices.len(), 2);
+        assert!(choices.iter().any(|c| c.value == "Breeze"));
+    }
+
+    #[test]
+    fn merge_with_current_adds_a_current_value_discovery_missed() {
+        let discovered = vec!["Adwaita".to_string()];
+        let choices = merge_with_current(&discovered, "HandInstalled");
+        assert_eq!(choices[0].value, "HandInstalled");
+        assert_eq!(choices.len(), 2);
+    }
+
+    #[test]
+    fn choices_for_unknown_id_returns_none() {
+        assert!(choices_for("dock.position", "bottom").is_none());
+    }
+
+    #[test]
+    fn choices_for_never_returns_an_empty_menu() {
+        // font_family discovery may legitimately find nothing in a minimal
+        // test environment; with no current value either there is nothing
+        // to show, and that must mean no menu rather than an empty one.
+        if let Some(choices) = choices_for("font_family", "") {
+            assert!(!choices.is_empty());
+        }
+    }
+}

--- a/components/otto-settings/src/file_picker.rs
+++ b/components/otto-settings/src/file_picker.rs
@@ -1,0 +1,193 @@
+//! Opening a file through the XDG desktop portal.
+//!
+//! This goes through the **frontend** (`org.freedesktop.portal.Desktop`), the
+//! same door any other application uses — not straight to Otto's backend. That
+//! is the point: it exercises the whole chain, including the `portals.conf`
+//! routing that decides Otto's picker serves `FileChooser` at all. A misrouted
+//! frontend is the most likely thing to be wrong, and calling the backend
+//! directly would hide exactly that.
+//!
+//! The call blocks for as long as the dialog is up, so it runs on a thread of
+//! its own — the same shape, and for the same reason, as
+//! [`crate::settings_client::spawn_change_listener`]: the client only has
+//! `zbus::blocking`, and blocking the main thread would freeze drawing and
+//! input for as long as the user is choosing a file.
+
+use std::collections::HashMap;
+
+use zbus::blocking::Connection;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value as ZValue};
+
+const PORTAL_NAME: &str = "org.freedesktop.portal.Desktop";
+const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+const FILE_CHOOSER: &str = "org.freedesktop.portal.FileChooser";
+const REQUEST: &str = "org.freedesktop.portal.Request";
+
+/// What a finished request came back with.
+pub enum Outcome {
+    /// The user chose something. Absolute local paths, in view order.
+    Chosen(Vec<std::path::PathBuf>),
+    /// The user cancelled, or the request ended without an answer.
+    Dismissed,
+    /// The request never got as far as a dialog.
+    Failed(String),
+}
+
+/// Open a file chooser and block until it is answered.
+///
+/// `filters` are `(label, [glob])` pairs, translated into the portal's
+/// `(sa(us))` filter shape with rule kind `0` (glob).
+pub fn open_file(title: &str, filters: &[(&str, &[&str])]) -> Outcome {
+    let connection = match Connection::session() {
+        Ok(connection) => connection,
+        Err(err) => return Outcome::Failed(format!("no session bus: {err}")),
+    };
+
+    // The frontend derives the request's object path from our unique name and
+    // the token we hand it, so we can subscribe *before* calling and never
+    // race the reply. Deriving it is part of the portal contract precisely so
+    // this race has an answer.
+    let token = format!("otto_settings_{}", std::process::id());
+    let Some(unique) = connection.unique_name().map(|n| n.to_string()) else {
+        return Outcome::Failed("no unique bus name".into());
+    };
+    let sender = unique.trim_start_matches(':').replace('.', "_");
+    let request_path = format!("/org/freedesktop/portal/desktop/request/{sender}/{token}");
+
+    let request = match zbus::blocking::Proxy::new(
+        &connection,
+        PORTAL_NAME,
+        request_path.as_str(),
+        REQUEST,
+    ) {
+        Ok(proxy) => proxy,
+        Err(err) => return Outcome::Failed(format!("cannot watch the request: {err}")),
+    };
+    let mut responses = match request.receive_signal("Response") {
+        Ok(signals) => signals,
+        Err(err) => return Outcome::Failed(format!("cannot subscribe to Response: {err}")),
+    };
+
+    let portal =
+        match zbus::blocking::Proxy::new(&connection, PORTAL_NAME, PORTAL_PATH, FILE_CHOOSER) {
+            Ok(proxy) => proxy,
+            Err(err) => return Outcome::Failed(format!("no portal: {err}")),
+        };
+
+    // `(label, [(kind, pattern)])`, kind 0 = glob.
+    let filters: Vec<(String, Vec<(u32, String)>)> = filters
+        .iter()
+        .map(|(label, globs)| {
+            (
+                (*label).to_string(),
+                globs.iter().map(|g| (0u32, (*g).to_string())).collect(),
+            )
+        })
+        .collect();
+
+    let mut options: HashMap<&str, ZValue> = HashMap::new();
+    options.insert("handle_token", ZValue::from(token.as_str()));
+    options.insert("modal", ZValue::from(true));
+    if !filters.is_empty() {
+        options.insert("filters", ZValue::from(filters));
+    }
+
+    // The returned handle is discarded: we derived the same path above and
+    // are already listening on it. Owned, because a borrowed `ObjectPath`
+    // cannot outlive the reply it was deserialised from.
+    let handle: zbus::Result<OwnedObjectPath> = portal.call("OpenFile", &("", title, options));
+    if let Err(err) = handle {
+        return Outcome::Failed(format!("OpenFile failed: {err}"));
+    }
+
+    // Blocks until the dialog is answered. There is no timeout on purpose:
+    // the user may reasonably take minutes, and a timeout would leave the
+    // picker on screen answering to nobody.
+    let Some(message) = responses.next() else {
+        return Outcome::Failed("the portal closed without answering".into());
+    };
+
+    let (response, results): (u32, HashMap<String, OwnedValue>) = match message.body().deserialize()
+    {
+        Ok(body) => body,
+        Err(err) => return Outcome::Failed(format!("malformed Response: {err}")),
+    };
+
+    if response != 0 {
+        return Outcome::Dismissed;
+    }
+
+    let uris = results
+        .get("uris")
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| Vec::<String>::try_from(v).ok())
+        .unwrap_or_default();
+
+    let paths: Vec<std::path::PathBuf> = uris.iter().filter_map(|u| uri_to_path(u)).collect();
+    if paths.is_empty() {
+        // Accepted with nothing usable in it. Saying "dismissed" would be a
+        // lie, and returning an empty selection would look like success.
+        return Outcome::Failed(format!("no local file in the reply ({uris:?})"));
+    }
+    Outcome::Chosen(paths)
+}
+
+/// Percent-decode a `file://` URI into a path.
+///
+/// Deliberately a local copy rather than a dependency on otto-quickview: this
+/// app links otto-kit and nothing else, and pulling in an image-decoding crate
+/// for twenty lines of URI handling would be a poor trade. If a third consumer
+/// appears, the pair belongs in otto-kit.
+fn uri_to_path(uri: &str) -> Option<std::path::PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+
+    let rest = uri.strip_prefix("file://")?;
+    let path = match rest.find('/') {
+        Some(0) => rest,
+        Some(slash) => {
+            let authority = &rest[..slash];
+            if !authority.is_empty() && authority != "localhost" {
+                return None;
+            }
+            &rest[slash..]
+        }
+        None => return None,
+    };
+
+    let bytes = path.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut at = 0;
+    while at < bytes.len() {
+        if bytes[at] == b'%' && at + 2 < bytes.len() {
+            if let Ok(byte) =
+                u8::from_str_radix(std::str::from_utf8(&bytes[at + 1..at + 3]).ok()?, 16)
+            {
+                out.push(byte);
+                at += 3;
+                continue;
+            }
+        }
+        out.push(bytes[at]);
+        at += 1;
+    }
+    Some(std::path::PathBuf::from(std::ffi::OsString::from_vec(out)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_escaped_uri_decodes_to_its_path() {
+        assert_eq!(
+            uri_to_path("file:///home/me/holiday%20photo.jpg"),
+            Some("/home/me/holiday photo.jpg".into())
+        );
+    }
+
+    #[test]
+    fn a_remote_uri_is_refused() {
+        assert!(uri_to_path("file://elsewhere/share/a").is_none());
+        assert!(uri_to_path("http://example.com/a").is_none());
+    }
+}

--- a/components/otto-settings/src/glyphs.rs
+++ b/components/otto-settings/src/glyphs.rs
@@ -1,0 +1,136 @@
+//! Sidebar glyphs.
+//!
+//! otto-kit bundles only a handful of icons and none of the ones the panes
+//! need, so they are drawn here: one stroke weight, one 16pt box, rounded
+//! caps. Placeholders — replace with real icon assets once the set exists.
+
+use otto_kit::prelude::*;
+use skia_safe::{paint::Cap, paint::Join, PaintStyle, PathBuilder, Point, RRect};
+
+/// Draw `name` centred on (`cx`, `cy`) at `size` points.
+pub fn draw(canvas: &Canvas, name: &str, cx: f32, cy: f32, size: f32, color: Color) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_style(PaintStyle::Stroke);
+    paint.set_stroke_width(size / 11.0);
+    paint.set_stroke_cap(Cap::Round);
+    paint.set_stroke_join(Join::Round);
+    paint.set_color(color);
+
+    canvas.save();
+    canvas.translate((cx, cy));
+    // Every glyph is drawn in a 16×16 box centred on the origin.
+    canvas.scale((size / 16.0, size / 16.0));
+
+    match name {
+        "settings" => settings(canvas, &paint),
+        "monitor" => monitor(canvas, &paint),
+        "dock" => dock(canvas, &paint),
+        "keyboard" => keyboard(canvas, &paint),
+        "pointer" => pointer(canvas, &paint, color),
+        "sound" => sound(canvas, &paint),
+        "battery" => battery(canvas, &paint),
+        "lock" => lock(canvas, &paint),
+        _ => {
+            canvas.draw_circle(Point::new(0.0, 0.0), 2.5, &paint);
+        }
+    }
+
+    canvas.restore();
+}
+
+/// Three horizontal sliders.
+fn settings(canvas: &Canvas, paint: &Paint) {
+    for (i, y) in [-5.0_f32, 0.0, 5.0].iter().enumerate() {
+        canvas.draw_line(Point::new(-7.0, *y), Point::new(7.0, *y), paint);
+        let knob_x = [-2.0, 3.0, -4.0][i];
+        canvas.draw_circle(Point::new(knob_x, *y), 2.0, paint);
+    }
+}
+
+/// Screen on a stand.
+fn monitor(canvas: &Canvas, paint: &Paint) {
+    let screen = Rect::from_ltrb(-7.0, -6.5, 7.0, 3.0);
+    canvas.draw_rrect(RRect::new_rect_xy(screen, 1.5, 1.5), paint);
+    canvas.draw_line(Point::new(0.0, 3.0), Point::new(0.0, 6.0), paint);
+    canvas.draw_line(Point::new(-4.0, 6.5), Point::new(4.0, 6.5), paint);
+}
+
+/// A strip of tiles along the bottom edge.
+fn dock(canvas: &Canvas, paint: &Paint) {
+    let tray = Rect::from_ltrb(-7.5, 1.0, 7.5, 6.5);
+    canvas.draw_rrect(RRect::new_rect_xy(tray, 2.0, 2.0), paint);
+    for x in [-4.0_f32, 0.0, 4.0] {
+        canvas.draw_line(Point::new(x, 2.8), Point::new(x, 4.7), paint);
+    }
+}
+
+/// Key grid with a spacebar.
+fn keyboard(canvas: &Canvas, paint: &Paint) {
+    let body = Rect::from_ltrb(-7.5, -5.0, 7.5, 5.0);
+    canvas.draw_rrect(RRect::new_rect_xy(body, 2.0, 2.0), paint);
+    for x in [-4.5_f32, -1.5, 1.5, 4.5] {
+        canvas.draw_line(Point::new(x, -2.2), Point::new(x, -2.2), paint);
+        canvas.draw_line(Point::new(x, 0.4), Point::new(x, 0.4), paint);
+    }
+    canvas.draw_line(Point::new(-3.0, 2.8), Point::new(3.0, 2.8), paint);
+}
+
+/// Arrow cursor. Filled, so it reads at 16pt.
+fn pointer(canvas: &Canvas, paint: &Paint, color: Color) {
+    let mut builder = PathBuilder::new();
+    builder.move_to(Point::new(-4.0, -6.5));
+    builder.line_to(Point::new(5.5, 1.5));
+    builder.line_to(Point::new(0.5, 2.0));
+    builder.line_to(Point::new(-1.5, 6.5));
+    builder.close();
+
+    let mut fill = paint.clone();
+    fill.set_style(PaintStyle::Fill);
+    fill.set_color(color);
+    canvas.draw_path(&builder.detach(), &fill);
+}
+
+/// Speaker with two waves.
+fn sound(canvas: &Canvas, paint: &Paint) {
+    let mut builder = PathBuilder::new();
+    builder.move_to(Point::new(-6.0, -2.0));
+    builder.line_to(Point::new(-3.5, -2.0));
+    builder.line_to(Point::new(-0.5, -5.5));
+    builder.line_to(Point::new(-0.5, 5.5));
+    builder.line_to(Point::new(-3.5, 2.0));
+    builder.line_to(Point::new(-6.0, 2.0));
+    builder.close();
+    canvas.draw_path(&builder.detach(), paint);
+
+    for (r, sweep) in [(3.0_f32, 90.0_f32), (5.5, 100.0)] {
+        let arc = Rect::from_ltrb(2.0 - r, -r, 2.0 + r, r);
+        canvas.draw_arc(arc, -sweep / 2.0, sweep, false, paint);
+    }
+}
+
+/// Battery with a bolt.
+fn battery(canvas: &Canvas, paint: &Paint) {
+    let body = Rect::from_ltrb(-7.0, -4.0, 5.0, 4.0);
+    canvas.draw_rrect(RRect::new_rect_xy(body, 2.0, 2.0), paint);
+    let cap = Rect::from_ltrb(5.5, -1.8, 7.0, 1.8);
+    canvas.draw_rrect(RRect::new_rect_xy(cap, 0.8, 0.8), paint);
+
+    let mut bolt = PathBuilder::new();
+    bolt.move_to(Point::new(-0.5, -2.4));
+    bolt.line_to(Point::new(-3.0, 0.3));
+    bolt.line_to(Point::new(-1.2, 0.3));
+    bolt.line_to(Point::new(-1.8, 2.4));
+    bolt.line_to(Point::new(0.8, -0.4));
+    bolt.line_to(Point::new(-1.0, -0.4));
+    bolt.close();
+    canvas.draw_path(&bolt.detach(), paint);
+}
+
+/// Padlock, shackle closed.
+fn lock(canvas: &Canvas, paint: &Paint) {
+    let body = Rect::from_ltrb(-5.5, -1.0, 5.5, 6.5);
+    canvas.draw_rrect(RRect::new_rect_xy(body, 2.0, 2.0), paint);
+    let shackle = Rect::from_ltrb(-3.5, -6.5, 3.5, 0.5);
+    canvas.draw_arc(shackle, 180.0, 180.0, false, paint);
+}

--- a/components/otto-settings/src/main.rs
+++ b/components/otto-settings/src/main.rs
@@ -1,0 +1,1069 @@
+//! Settings app for Otto — see `specs/settings-app.md`.
+//!
+//! Nothing is wired to the compositor yet: the values come from `model.rs`
+//! and changing a control does nothing. What works is the window itself and
+//! moving between panes, so the layout can be judged in place.
+//!
+//! ```sh
+//! cargo run -p otto-settings                    # open the window
+//! cargo run -p otto-settings -- --png out.png   # offscreen render instead
+//! ```
+
+mod discovery;
+mod file_picker;
+mod glyphs;
+mod model;
+mod panes;
+mod preview;
+mod settings_client;
+mod view;
+mod widgets;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use otto_kit::components::color_picker::{ColorPickerPopup, Swatch};
+use otto_kit::components::dropdown::DropdownMenu;
+use otto_kit::components::scroll::ScrollSurfaces;
+use otto_kit::components::titlebar::{WindowControl, WindowControlsState};
+use otto_kit::components::window::resize;
+use otto_kit::prelude::*;
+use otto_kit::protocols::otto_surface_style_v1;
+use otto_kit::CursorShape;
+use smithay_client_toolkit::reexports::client::Proxy;
+use smithay_client_toolkit::seat::pointer::{AxisScroll, PointerEventKind};
+use smithay_client_toolkit::shell::xdg::XdgSurface;
+use view::{Settings, WINDOW_H, WINDOW_W};
+
+struct SettingsApp {
+    window: Option<Window>,
+    /// Shared with the draw and pointer callbacks, which outlive this struct's
+    /// borrow of itself.
+    selected: Arc<Mutex<usize>>,
+    /// The pane content's scroll position. Lives here rather than inside
+    /// `Settings` because `Settings` is rebuilt fresh every frame, while the
+    /// scroll offset — like `selected` — has to survive across frames.
+    scroll: Arc<Mutex<ScrollView>>,
+    /// The subsurfaces the pane is drawn into, so the compositor does the
+    /// scrolling. `None` until the window exists to parent them to.
+    surfaces: Rc<RefCell<Option<ScrollSurfaces>>>,
+    /// Set when something other than the scroll changed what the pane should
+    /// look like, so the next update repaints its band. See
+    /// [`SettingsApp::sync_pane`].
+    pane_dirty: Arc<Mutex<bool>>,
+    /// Identifier of the slider currently being dragged, if any.
+    dragging: Arc<Mutex<Option<String>>>,
+    /// Switches whose knob is mid-flip, keyed by setting id. A switch is in
+    /// here only while it is moving: the value itself changed on the press,
+    /// this is the travel between the two ends. See [`toggle::Flip`].
+    toggle_flips: Arc<Mutex<HashMap<&'static str, toggle::Flip>>>,
+    /// One menu per pop-up button, built once at startup and reused.
+    ///
+    /// `ContextMenu::new` registers a pointer callback that can never be
+    /// unregistered, and building one inside a pointer handler deadlocks on
+    /// `AppContext`'s callback list — so these are constructed eagerly, before
+    /// any event can arrive. See `otto_kit::components::dropdown::menu`.
+    dropdowns: Rc<HashMap<&'static str, DropdownMenu>>,
+    /// Identifier of the dropdown whose menu is up, so its field draws open.
+    open_dropdown: Arc<Mutex<Option<&'static str>>>,
+    /// One picker per colour well, built once at startup for the same reason
+    /// the dropdown menus are.
+    pickers: Rc<HashMap<&'static str, ColorPickerPopup>>,
+    /// Identifier of the well whose picker is up.
+    open_picker: Arc<Mutex<Option<&'static str>>>,
+    /// The surface's current size, from the last configure.
+    ///
+    /// The draw closure has to be `Send`, and `Window` is not, so the size
+    /// travels through here rather than being read off the window inside it.
+    size: Arc<Mutex<(f32, f32)>>,
+    /// Hover and press state of the traffic lights, shared between the window's
+    /// pointer handler and its draw closure.
+    controls: Arc<Mutex<WindowControlsState>>,
+}
+
+/// Every setting in the app that a colour well edits.
+fn color_ids() -> Vec<&'static str> {
+    let mut ids = Vec::new();
+    for pane in model::panes() {
+        for group in pane.groups {
+            for row in group.rows {
+                if let (Some(id), model::Control::Color(_)) = (row.id, &row.control) {
+                    ids.push(id);
+                }
+            }
+        }
+    }
+    ids
+}
+
+/// The presets a colour well offers.
+///
+/// `accent_color` is an enumeration on the compositor side, so its swatches
+/// come from the served schema and picking anything else would be refused.
+/// A free-form colour setting gets a general palette instead.
+fn swatches_for(id: &str) -> Vec<Swatch> {
+    if let Some(desc) = settings_client::describe(id) {
+        if !desc.choices.is_empty() {
+            return desc
+                .choices
+                .iter()
+                .filter_map(|name| named_color(name).map(|c| Swatch::new(name.clone(), c)))
+                .collect();
+        }
+    }
+
+    [
+        ("Blue", 0xFF0A84FF),
+        ("Purple", 0xFFBF5AF2),
+        ("Pink", 0xFFFF375F),
+        ("Red", 0xFFFF453A),
+        ("Orange", 0xFFFF9F0A),
+        ("Yellow", 0xFFFFD60A),
+        ("Green", 0xFF32D74B),
+        ("Teal", 0xFF40C8E0),
+        ("Graphite", 0xFF8E8E93),
+    ]
+    .into_iter()
+    .map(|(name, argb)| Swatch::new(name, Color::from(argb)))
+    .collect()
+}
+
+/// The compositor names its accent colours rather than taking hex, so a name
+/// has to map to something drawable.
+fn named_color(name: &str) -> Option<Color> {
+    model::named_argb(name).map(Color::from)
+}
+
+/// Open a colour well's picker.
+///
+/// What a change sends depends on the setting: an enumerated one (accent
+/// colour) takes the swatch's NAME, a free-form one takes hex. Sending hex to
+/// an enumerated setting would be refused with `OutOfRange`.
+fn open_picker_for(
+    pickers: &HashMap<&'static str, ColorPickerPopup>,
+    open_picker: &Arc<Mutex<Option<&'static str>>>,
+    pane_dirty: &Arc<Mutex<bool>>,
+    window: &Window,
+    hit: view::ColorHit,
+    serial: u32,
+    dark: bool,
+) {
+    let Some(picker) = pickers.get(hit.id) else {
+        return;
+    };
+    // Clicking the well again closes the picker, rather than doing nothing
+    // because a popup is already up.
+    if picker.is_open() {
+        picker.close();
+        *open_picker.lock().unwrap() = None;
+        mark_pane_dirty(pane_dirty);
+        window.request_frame();
+        return;
+    }
+    let Some(parent) = window
+        .surface()
+        .map(|s| s.xdg_window().xdg_surface().clone())
+    else {
+        return;
+    };
+
+    let id = hit.id;
+    let enumerated = settings_client::describe(id)
+        .map(|d| !d.choices.is_empty())
+        .unwrap_or(false);
+
+    let changed_window = window.clone();
+    let changed_dirty = pane_dirty.clone();
+    let closed_open = open_picker.clone();
+    let closed_dirty = pane_dirty.clone();
+    let closed_window = window.clone();
+
+    *open_picker.lock().unwrap() = Some(id);
+
+    picker.open(
+        &parent,
+        hit.rect,
+        serial,
+        hit.current,
+        if dark { Theme::dark() } else { Theme::light() },
+        move |color| {
+            let value = if enumerated {
+                let Some(name) = swatch_name_for(id, color) else {
+                    // Dragging in HSV cannot name a colour, and this setting
+                    // only accepts names — ignore rather than be refused.
+                    return;
+                };
+                settings_client::Value::Text(name)
+            } else {
+                settings_client::Value::Text(format!(
+                    "#{:02X}{:02X}{:02X}",
+                    color.r(),
+                    color.g(),
+                    color.b()
+                ))
+            };
+            apply(id, value);
+            mark_pane_dirty(&changed_dirty);
+            changed_window.request_frame();
+        },
+        move || {
+            *closed_open.lock().unwrap() = None;
+            mark_pane_dirty(&closed_dirty);
+            closed_window.request_frame();
+        },
+    );
+}
+
+/// The schema choice whose swatch is exactly `color`, for settings that take
+/// a name rather than a value.
+fn swatch_name_for(id: &str, color: Color) -> Option<String> {
+    swatches_for(id)
+        .into_iter()
+        .find(|s| s.color == color)
+        .map(|s| s.name)
+}
+
+/// Every setting in the app that a pop-up button edits.
+///
+/// Walked once at startup: the menus have to exist before the first pointer
+/// event, and rebuilding them per frame is not an option.
+fn select_ids() -> Vec<&'static str> {
+    let mut ids = Vec::new();
+    for pane in model::panes() {
+        for group in pane.groups {
+            for row in group.rows {
+                if let (Some(id), model::Control::Select(_)) = (row.id, &row.control) {
+                    ids.push(id);
+                }
+            }
+        }
+    }
+    ids
+}
+
+/// The view model for the pane on screen right now.
+///
+/// Rebuilt on demand rather than cached: it reads current values out of the
+/// settings store, so a `Set` that just landed is reflected immediately.
+fn current_settings(
+    selected: &Arc<Mutex<usize>>,
+    size: &Arc<Mutex<(f32, f32)>>,
+    toggle_flips: &Arc<Mutex<HashMap<&'static str, toggle::Flip>>>,
+) -> Settings {
+    let (w, h) = *size.lock().unwrap();
+    let flips = toggle_flips
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(id, flip)| (*id, flip.fraction()))
+        .collect();
+    Settings::new(
+        *selected.lock().unwrap(),
+        current_color_scheme() == ColorScheme::Dark,
+    )
+    .with_size(w, h)
+    .with_toggle_flips(flips)
+}
+
+/// The pane viewport for the surface's current size, clamped exactly the way
+/// [`Settings::with_size`] clamps it so hit-testing and drawing agree on where
+/// the pane is.
+fn viewport_for(size: &Arc<Mutex<(f32, f32)>>) -> Rect {
+    let (w, h) = *size.lock().unwrap();
+    view::pane_viewport(w.max(view::MIN_W), h.max(view::MIN_H))
+}
+
+/// Ask for the pane's band to be repainted on the next update.
+///
+/// The pane's surfaces repaint only when a scroll runs out of painted content.
+/// Anything else that changes what a row looks like — a value applied, a menu
+/// opening, the window resizing — has to say so explicitly, or the band keeps
+/// showing what it was painted with.
+fn mark_pane_dirty(dirty: &Arc<Mutex<bool>>) {
+    *dirty.lock().unwrap() = true;
+}
+
+/// Feed one axis event to the scroll view.
+///
+/// Shared by the window and the pane's surfaces: a wheel anywhere over the
+/// window scrolls the pane, as it did when the window was a single surface.
+fn handle_wheel(scroll: &Mutex<ScrollView>, vertical: &AxisScroll) {
+    let mut scroll = scroll.lock().unwrap();
+    // A notched wheel reports discrete steps and should move exactly one step
+    // per click; a touchpad reports a continuous stream, which is what
+    // momentum and rubber banding are for.
+    if vertical.stop {
+        // Fingers off the touchpad: whatever the gesture was carrying becomes
+        // a fling, and anything pulled past an end springs back.
+        scroll.on_wheel_end();
+    } else if vertical.discrete != 0 {
+        scroll.on_wheel_discrete(vertical.absolute as f32);
+    } else {
+        scroll.on_wheel(vertical.absolute as f32);
+    }
+}
+
+/// Width of the strip `ScrollSurfaces` gives its scrollbar, in points.
+///
+/// Private there, so it is restated here: it is the x offset of the scrollbar
+/// surface within the pane, and without it an event that landed on the
+/// scrollbar cannot be put back into the pane's coordinates.
+const THUMB_STRIP_W: f32 = 16.0;
+
+/// Which of the pane's surfaces a pointer event landed on.
+///
+/// The pane is three subsurfaces (see `ScrollSurfaces`), and the pointer is
+/// hit-tested against them rather than against the window, so an event over
+/// the pane never reaches the window's own handler and arrives in that
+/// surface's local coordinates instead of the window's. Each variant is one
+/// way of putting those coordinates back into the pane's own space, which is
+/// where every hit test below happens.
+enum PaneTarget {
+    /// The band holding the content. It is the surface that *moves* to
+    /// scroll, so its origin sits `band_origin - offset` points down the
+    /// pane — which is also why a coordinate translated through it stays
+    /// still when the pointer does, however far the content has scrolled.
+    Content,
+    /// The scrollbar, which sits over the band and never moves: it is drawn
+    /// where it belongs through its style node, while the subsurface the
+    /// pointer is hit-tested against stays at the top of the gutter. So its
+    /// local y *is* the pane's y, and events on it are handled exactly like
+    /// events on the band — the scroll view's own hit tests decide what a
+    /// press in the gutter means.
+    Thumb,
+}
+
+/// The serial of a press, which the compositor requires to open a popup.
+fn event_serial(kind: &PointerEventKind) -> u32 {
+    match kind {
+        PointerEventKind::Press { serial, .. } => *serial,
+        _ => 0,
+    }
+}
+
+/// Open a pop-up button's menu.
+///
+/// Six settings are `enum` in the served schema and carry their `choices`
+/// with them. Everything else a pop-up button edits — fonts, cursor/icon/
+/// sound themes, the lock and greeter commands — is `string`, because its
+/// valid set depends on what is installed on this machine rather than
+/// anything the compositor's schema can declare; those fall back to
+/// [`discovery`]. A setting with neither — or a compositor that is not
+/// serving a schema at all — gets no menu rather than an empty one.
+fn open_menu(
+    dropdowns: &HashMap<&'static str, DropdownMenu>,
+    open_dropdown: &Arc<Mutex<Option<&'static str>>>,
+    pane_dirty: &Arc<Mutex<bool>>,
+    window: &Window,
+    select: view::SelectHit,
+    serial: u32,
+) {
+    let Some(menu) = dropdowns.get(select.id) else {
+        return;
+    };
+    // Clicking the field again closes the menu, the way clicking a colour
+    // well again closes its picker — without this the press is swallowed by
+    // the menu already being up, and a pop-up button becomes the one control
+    // in the pane that cannot undo its own click.
+    if menu.is_open() {
+        menu.close();
+        *open_dropdown.lock().unwrap() = None;
+        mark_pane_dirty(pane_dirty);
+        window.request_frame();
+        return;
+    }
+    let Some(desc) = settings_client::describe(select.id) else {
+        return;
+    };
+    let Some(parent) = window
+        .surface()
+        .map(|s| s.xdg_window().xdg_surface().clone())
+    else {
+        return;
+    };
+
+    let choices: Vec<discovery::Choice> = if !desc.choices.is_empty() {
+        desc.choices
+            .iter()
+            .map(|c| discovery::Choice {
+                label: desc.display(c),
+                value: c.clone(),
+            })
+            .collect()
+    } else {
+        match discovery::choices_for(select.id, &select.current) {
+            Some(choices) => choices,
+            None => return,
+        }
+    };
+    if choices.is_empty() {
+        return;
+    }
+
+    let selected = choices.iter().position(|c| c.value == select.current);
+    let id = select.id;
+
+    let chosen_open = open_dropdown.clone();
+    let chosen_dirty = pane_dirty.clone();
+    let chosen_window = window.clone();
+    // The menu shows `label`s but applies `value`s — they differ only for
+    // the synthetic "Automatic" entry a discovered dropdown may add.
+    let labels: Vec<String> = choices.iter().map(|c| c.label.clone()).collect();
+    let values: Vec<String> = choices.into_iter().map(|c| c.value).collect();
+
+    let dismissed_open = open_dropdown.clone();
+    let dismissed_dirty = pane_dirty.clone();
+    let dismissed_window = window.clone();
+
+    *open_dropdown.lock().unwrap() = Some(id);
+
+    menu.open(
+        &parent,
+        select.rect,
+        serial,
+        &labels,
+        selected,
+        move |index| {
+            if let Some(value) = values.get(index) {
+                apply(id, settings_client::Value::Text(value.clone()));
+            }
+            *chosen_open.lock().unwrap() = None;
+            mark_pane_dirty(&chosen_dirty);
+            chosen_window.request_frame();
+        },
+        move || {
+            *dismissed_open.lock().unwrap() = None;
+            mark_pane_dirty(&dismissed_dirty);
+            dismissed_window.request_frame();
+        },
+    );
+}
+
+/// Push one change to the compositor, reporting a refusal rather than letting
+/// the UI show a value that was never accepted.
+fn apply(id: &str, value: settings_client::Value) {
+    match settings_client::set(id, value) {
+        settings_client::SetOutcome::Applied => {}
+        settings_client::SetOutcome::PendingRestart => {
+            println!("{id}: saved, takes effect after a restart");
+        }
+        settings_client::SetOutcome::Failed(why) => {
+            eprintln!("{id}: {why}");
+        }
+    }
+}
+
+/// Open the portal's file picker for `id`, on a thread of its own, and apply
+/// whatever comes back.
+///
+/// The call blocks for as long as the dialog is up — minutes, if the user
+/// browses — so it cannot happen on the main thread: drawing and input both
+/// run there. The thread only ever touches the settings store (which is
+/// `RwLock`-guarded) and then wakes the main loop, which is the same
+/// arrangement `settings_client::spawn_change_listener` uses and is
+/// documented as safe from any thread.
+fn open_file_picker(id: &'static str) {
+    let spawned = std::thread::Builder::new()
+        .name("file-picker".into())
+        .spawn(move || {
+            // Wallpapers are the only file setting so far, so the filter is
+            // written here. When a second one appears this belongs on the row.
+            let filters: &[(&str, &[&str])] = &[
+                (
+                    "Images",
+                    &["*.png", "*.jpg", "*.jpeg", "*.webp", "*.bmp", "*.gif"],
+                ),
+                ("All Files", &["*"]),
+            ];
+
+            match file_picker::open_file("Choose a Background Image", filters) {
+                file_picker::Outcome::Chosen(paths) => {
+                    if let Some(path) = paths.first() {
+                        apply(
+                            id,
+                            settings_client::Value::Text(path.to_string_lossy().into_owned()),
+                        );
+                    }
+                }
+                file_picker::Outcome::Dismissed => {}
+                file_picker::Outcome::Failed(why) => {
+                    eprintln!("{id}: the file picker failed ({why})");
+                }
+            }
+            // Either way the row may need redrawing, and the main thread is
+            // asleep in `poll` until something says otherwise.
+            AppContext::request_wakeup();
+        });
+
+    if let Err(err) = spawned {
+        eprintln!("{id}: cannot start the file picker ({err})");
+    }
+}
+
+impl SettingsApp {
+    /// Bring the pane's surfaces in line with the model: where the viewport
+    /// is, how tall the content is, and where the scroll has put it.
+    ///
+    /// `repaint` says the content itself changed — a value applied, a menu
+    /// opened, the window resized — rather than merely scrolled. The surfaces
+    /// repaint their band only when a scroll runs off its edge, which is the
+    /// whole point of them and no help at all here, so anything else that
+    /// changes how the pane looks has to invalidate it explicitly.
+    fn sync_pane(&mut self, repaint: bool) {
+        let settings = current_settings(&self.selected, &self.size, &self.toggle_flips)
+            .with_open_dropdown(*self.open_dropdown.lock().unwrap())
+            .with_open_picker(*self.open_picker.lock().unwrap());
+
+        let mut scroll = self.scroll.lock().unwrap();
+        // The scroll view drives surfaces that live inside the pane, so its
+        // viewport is the pane's own, not the window-local one the all-in-one
+        // render path uses.
+        scroll.set_viewport(settings.local_viewport());
+        // Re-measured every time rather than cached: it is cheap, and it keeps
+        // the scroll range correct if the pane's content changes shape (a row
+        // gaining a detail line, say) without the window resizing.
+        scroll.set_content_length(settings.pane_content_height());
+
+        let mut guard = self.surfaces.borrow_mut();
+        let Some(surfaces) = guard.as_mut() else {
+            return;
+        };
+
+        surfaces.set_viewport(settings.viewport());
+        // The pane's ground lives in the clip surface, which is painted once
+        // and then left alone, so a light/dark switch has to be pushed in or
+        // it keeps the old scheme under freshly themed content.
+        surfaces.set_background(view::pane_background(settings.dark));
+        if repaint {
+            surfaces.invalidate();
+        }
+
+        surfaces.sync(&scroll, &settings.theme, |canvas, band| {
+            if std::env::var_os("OTTO_PANE_DEBUG").is_some() {
+                eprintln!(
+                    "[panedbg] band {:.0}..{:.0} offset={:.0} vp={:?} content_h={:.0} width={:.0}",
+                    band.top,
+                    band.bottom,
+                    scroll.offset(),
+                    settings.local_viewport(),
+                    settings.pane_content_height(),
+                    settings.width
+                );
+            }
+            settings.render_content(canvas, band)
+        });
+    }
+}
+
+impl App for SettingsApp {
+    fn on_app_ready(&mut self, _ctx: &AppContext) -> Result<(), Box<dyn std::error::Error>> {
+        let mut window = Window::new("Settings", WINDOW_W as i32, WINDOW_H as i32)?;
+        window.set_background(Color::TRANSPARENT);
+        window.set_min_size(view::MIN_W as u32, view::MIN_H as u32);
+
+        // The window paints its own rounded body, so ask the compositor to
+        // clip and round the surface to match.
+        // The sidebar is drawn as a translucent material, so ask the
+        // compositor to blur what is behind the surface. Whether that request
+        // was honoured is not reported back, so the view is told blur is on
+        // only when the style object exists at all.
+        // `OTTO_SETTINGS_NO_BLUR=1` paints the sidebar flat instead, which is
+        // the only way to tell a working blur from a missing one when the
+        // backdrop happens to be a flat colour.
+        let want_blur = std::env::var("OTTO_SETTINGS_NO_BLUR").is_err();
+        if window.surface_style().is_none() {
+            eprintln!("settings: no surface style — sidebar cannot be a material");
+        }
+        let mut blurred = false;
+        if let Some(style) = window.surface_style() {
+            style.set_corner_radius(view::CORNER as f64);
+            style.set_masks_to_bounds(otto_surface_style_v1::ClipMode::Enabled);
+            // The pane scrolls in subsurfaces that sit over the window's own
+            // buffer, so the window's rounded outline does not contain them:
+            // without this the content runs square into the bottom-right
+            // corner. Clipping the descendants to the window's style bounds
+            // rounds them with it.
+            style.set_clip_children(otto_surface_style_v1::ClipMode::Enabled);
+            if want_blur {
+                style.set_blend_mode(otto_surface_style_v1::BlendMode::BackgroundBlur);
+                blurred = true;
+            }
+            eprintln!("settings: surface style present, blur requested = {want_blur}");
+        }
+
+        // Built here, at window setup, and never later: a `DropdownMenu`
+        // constructed from inside a pointer handler deadlocks on
+        // `AppContext`'s callback list.
+        self.dropdowns = Rc::new(
+            select_ids()
+                .into_iter()
+                .map(|id| (id, DropdownMenu::new()))
+                .collect(),
+        );
+        self.pickers = Rc::new(
+            color_ids()
+                .into_iter()
+                .map(|id| (id, ColorPickerPopup::new(swatches_for(id))))
+                .collect(),
+        );
+
+        // The window surface paints the chrome and nothing else. The pane's
+        // content lives in its own subsurfaces, which the compositor crops and
+        // scrolls, so a frame of scrolling never reaches this closure.
+        let selected = self.selected.clone();
+        let size = self.size.clone();
+        let controls = self.controls.clone();
+        window.on_draw(move |canvas| {
+            let index = *selected.lock().unwrap();
+            let (w, h) = *size.lock().unwrap();
+            Settings::new(index, current_color_scheme() == ColorScheme::Dark)
+                .with_size(w, h)
+                .with_blur(blurred)
+                .with_controls(*controls.lock().unwrap())
+                .render_chrome(canvas);
+        });
+
+        // The pane's surfaces, parented to the window. The background colour
+        // they are given is the one the chrome paints under them, so the two
+        // agree wherever an overscroll pulls the content away from an edge.
+        let parent = window
+            .surface()
+            .map(|s| s.wl_surface().clone())
+            .ok_or("window has no surface to hang the pane from")?;
+        let surfaces = ScrollSurfaces::new(
+            &parent,
+            view::pane_viewport(WINDOW_W, WINDOW_H),
+            AppContext::scale_factor() as f32,
+            view::pane_background(current_color_scheme() == ColorScheme::Dark),
+        )?;
+        let content_id = surfaces.content_surface().id();
+        let window_id = parent.id();
+        *self.surfaces.borrow_mut() = Some(surfaces);
+
+        // What the window surface itself is still pointed at: its resize
+        // edges, its titlebar, and the sidebar. Clicking a sidebar row selects
+        // that pane.
+        let selected = self.selected.clone();
+        let scroll = self.scroll.clone();
+        let pane_dirty = self.pane_dirty.clone();
+        let size_hit = self.size.clone();
+        let controls_hit = self.controls.clone();
+        let redraw = window.clone();
+        window.on_pointer_event(move |events| {
+            let mut needs_redraw = false;
+            for event in events {
+                let (x, y) = event.position;
+                let (x, y) = (x as f32, y as f32);
+                match &event.kind {
+                    PointerEventKind::Press { serial, .. } => {
+                        // The window draws its own decoration, so its edges
+                        // are its own resize handles too.
+                        let (win_w, win_h) = *size_hit.lock().unwrap();
+                        if let Some(edge) = resize::edge_at(Rect::from_wh(win_w, win_h), x, y) {
+                            if let Some(seat) = AppContext::seat_state().seats().next() {
+                                redraw.start_resize(&seat, *serial, edge);
+                            }
+                            continue;
+                        }
+
+                        // The titlebar is the app's own decoration, so moving
+                        // and closing the window are the app's job too.
+                        if let Some(hit) = view::titlebar_hit(x, y, size_hit.lock().unwrap().0) {
+                            match hit {
+                                view::TitlebarHit::Control(control) => {
+                                    // Arming rather than acting: a control
+                                    // fires on release, and only over the dot
+                                    // the press landed on.
+                                    controls_hit.lock().unwrap().on_press(Some(control));
+                                    needs_redraw = true;
+                                }
+                                view::TitlebarHit::Drag => {
+                                    if let Some(seat) = AppContext::seat_state().seats().next() {
+                                        redraw.start_move(&seat, *serial);
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
+                        // Everything else the window still owns is the
+                        // sidebar: the pane is hit-tested on its own surface,
+                        // further down.
+                        if let Some(index) = view::pane_at(x, y) {
+                            let mut current = selected.lock().unwrap();
+                            if *current != index {
+                                *current = index;
+                                // A different pane has an unrelated content
+                                // height, so its old scroll position means
+                                // nothing here.
+                                scroll.lock().unwrap().state.set_offset(0.0);
+                                mark_pane_dirty(&pane_dirty);
+                                needs_redraw = true;
+                            }
+                        }
+                    }
+                    PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+                        // Show which way an edge will move before it is
+                        // grabbed; anywhere else is the ordinary pointer.
+                        let (win_w, win_h) = *size_hit.lock().unwrap();
+                        match resize::edge_at(Rect::from_wh(win_w, win_h), x, y) {
+                            Some(edge) => AppContext::set_cursor_shape(edge.cursor()),
+                            None => AppContext::set_cursor_shape(CursorShape::Default),
+                        }
+
+                        // The traffic lights reveal their glyphs while the
+                        // pointer is over the group.
+                        let control = view::titlebar_control_at(x, y, win_w);
+                        if controls_hit.lock().unwrap().on_motion(control) {
+                            needs_redraw = true;
+                        }
+                    }
+                    // A wheel over the chrome still scrolls the pane, as it
+                    // did when the window was a single surface.
+                    PointerEventKind::Axis { vertical, .. } => handle_wheel(&scroll, vertical),
+                    PointerEventKind::Release { .. } => {
+                        let win_w = size_hit.lock().unwrap().0;
+                        let control = view::titlebar_control_at(x, y, win_w);
+                        let fired = {
+                            let mut state = controls_hit.lock().unwrap();
+                            if state.pressed().is_some() {
+                                needs_redraw = true;
+                            }
+                            state.on_release(control)
+                        };
+                        match fired {
+                            Some(WindowControl::Close) => std::process::exit(0),
+                            Some(WindowControl::Minimize) => redraw.minimize(),
+                            Some(WindowControl::Zoom) => redraw.toggle_maximized(),
+                            None => {}
+                        }
+                    }
+                    PointerEventKind::Leave { .. } => {
+                        // The pointer is off the window, so nothing in the bar
+                        // is hovered any more — without this the glyphs stay
+                        // drawn on a window that was left behind.
+                        if controls_hit.lock().unwrap().on_leave() {
+                            needs_redraw = true;
+                        }
+                    }
+                }
+            }
+            if needs_redraw {
+                redraw.request_frame();
+            }
+        });
+
+        // The pane is no longer part of the window surface, so its events
+        // arrive here rather than in the handler above — and in the local
+        // coordinates of whichever of its surfaces they landed on.
+        let selected = self.selected.clone();
+        let scroll = self.scroll.clone();
+        let surfaces = self.surfaces.clone();
+        let dragging = self.dragging.clone();
+        let dropdowns = self.dropdowns.clone();
+        let open_dropdown = self.open_dropdown.clone();
+        let toggle_flips = self.toggle_flips.clone();
+        let pickers = self.pickers.clone();
+        let open_picker = self.open_picker.clone();
+        let pane_dirty = self.pane_dirty.clone();
+        let size_hit = self.size.clone();
+        let redraw = window.clone();
+        AppContext::register_pointer_callback(move |events| {
+            for event in events {
+                let surface = event.surface.id();
+                let target = if surface == content_id {
+                    PaneTarget::Content
+                } else if surface == window_id {
+                    // The handler above has this one.
+                    continue;
+                } else if open_dropdown.lock().unwrap().is_some()
+                    || open_picker.lock().unwrap().is_some()
+                {
+                    // A popup of ours is up and handles its own events.
+                    continue;
+                } else {
+                    // `ScrollSurfaces` does not hand out its scrollbar
+                    // surface, so it is recognised by elimination: the only
+                    // other surface of this app the pointer can be over.
+                    PaneTarget::Thumb
+                };
+
+                let viewport = viewport_for(&size_hit);
+                let (lx, ly) = event.position;
+                let (lx, ly) = (lx as f32, ly as f32);
+                // Into the pane's own coordinates, which is where the scroll
+                // view's viewport, gutter and thumb live.
+                let (px, py) = match target {
+                    PaneTarget::Content => {
+                        let band_origin = surfaces
+                            .borrow()
+                            .as_ref()
+                            .map(|s| s.band_origin())
+                            .unwrap_or(0.0);
+                        let offset = scroll.lock().unwrap().offset();
+                        (lx, ly + band_origin - offset)
+                    }
+                    PaneTarget::Thumb => (lx + viewport.width() - THUMB_STRIP_W, ly),
+                };
+                // And on into window coordinates, which is what the pane's
+                // hit tests take and what the popups anchor against.
+                let (x, y) = (px + viewport.left, py + viewport.top);
+
+                match &event.kind {
+                    PointerEventKind::Press { serial, .. } => {
+                        // The pane reaches the window's right and bottom
+                        // edges, so two of its resize handles are over it.
+                        let (win_w, win_h) = *size_hit.lock().unwrap();
+                        if let Some(edge) = resize::edge_at(Rect::from_wh(win_w, win_h), x, y) {
+                            if let Some(seat) = AppContext::seat_state().seats().next() {
+                                redraw.start_resize(&seat, *serial, edge);
+                            }
+                            continue;
+                        }
+
+                        // A press anywhere in the pane catches an in-flight
+                        // fling; on the scrollbar it also starts a drag, and
+                        // then it is not a press on a control.
+                        if scroll.lock().unwrap().on_pointer_down(px, py) {
+                            continue;
+                        }
+
+                        // A control in the pane. The settings state is rebuilt
+                        // here rather than cached because a successful Set
+                        // changes what the next one would hit.
+                        let offset = scroll.lock().unwrap().offset();
+                        let settings = current_settings(&selected, &size_hit, &toggle_flips);
+
+                        if let Some(color) = settings.color_hit(x, y, offset) {
+                            open_picker_for(
+                                &pickers,
+                                &open_picker,
+                                &pane_dirty,
+                                &redraw,
+                                color,
+                                event_serial(&event.kind),
+                                settings.dark,
+                            );
+                            mark_pane_dirty(&pane_dirty);
+                        } else if let Some(select) = settings.select_hit(x, y, offset) {
+                            open_menu(
+                                &dropdowns,
+                                &open_dropdown,
+                                &pane_dirty,
+                                &redraw,
+                                select,
+                                event_serial(&event.kind),
+                            );
+                            mark_pane_dirty(&pane_dirty);
+                        } else if let Some(id) = settings.file_hit(x, y, offset) {
+                            open_file_picker(id);
+                        } else if let Some(hit) = settings.hit(x, y, offset) {
+                            // A switch slides to its new position rather than
+                            // jumping. Started from where the knob is right
+                            // now, so a second click part-way through turns
+                            // it back from there.
+                            if let settings_client::Value::Bool(on) = hit.value {
+                                let mut flips = toggle_flips.lock().unwrap();
+                                let current = flips
+                                    .get(hit.id)
+                                    .map(|flip| flip.fraction())
+                                    .unwrap_or_else(|| toggle::knob_fraction_for(!on));
+                                flips.insert(hit.id, toggle::Flip::start(current, on));
+                            }
+                            apply(hit.id, hit.value);
+                            *dragging.lock().unwrap() = hit.draggable.then(|| hit.id.to_string());
+                            mark_pane_dirty(&pane_dirty);
+                        }
+                    }
+                    PointerEventKind::Release { .. } => {
+                        scroll.lock().unwrap().on_pointer_up();
+                        *dragging.lock().unwrap() = None;
+                    }
+                    PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+                        let (win_w, win_h) = *size_hit.lock().unwrap();
+                        match resize::edge_at(Rect::from_wh(win_w, win_h), x, y) {
+                            Some(edge) => AppContext::set_cursor_shape(edge.cursor()),
+                            None => AppContext::set_cursor_shape(CursorShape::Default),
+                        }
+
+                        {
+                            let mut scroll = scroll.lock().unwrap();
+                            // Hovering the scrollbar keeps it up and widens
+                            // it; dragging it moves the content.
+                            scroll.on_pointer_move(px, py);
+                            scroll.on_pointer_drag(px, py);
+                        }
+                        let held = dragging.lock().unwrap().clone();
+                        if let Some(id) = held {
+                            let settings = current_settings(&selected, &size_hit, &toggle_flips);
+                            if let Some(value) = settings.drag_value(&id, x) {
+                                apply(&id, value);
+                                mark_pane_dirty(&pane_dirty);
+                            }
+                        }
+                    }
+                    PointerEventKind::Axis { vertical, .. } => handle_wheel(&scroll, vertical),
+                    PointerEventKind::Leave { .. } => {
+                        scroll.lock().unwrap().on_pointer_leave();
+                    }
+                }
+            }
+        });
+
+        self.window = Some(window);
+        Ok(())
+    }
+
+    /// The compositor decides the surface's size; the app follows it.
+    fn on_configure(
+        &mut self,
+        _ctx: &AppContext,
+        configure: smithay_client_toolkit::shell::xdg::window::WindowConfigure,
+        _serial: u32,
+    ) {
+        let (w, h) = configure.new_size;
+        let Some(window) = self.window.as_ref() else {
+            return;
+        };
+        // A configure with no size is the compositor letting the client
+        // choose, so keep what we have.
+        let width = w
+            .map(|v| v.get() as f32)
+            .unwrap_or(self.size.lock().unwrap().0);
+        let height = h
+            .map(|v| v.get() as f32)
+            .unwrap_or(self.size.lock().unwrap().1);
+
+        // Configures arrive for far more than resizes — activation, tiling
+        // state, a bare re-configure with the size we already have — and the
+        // compositor sends them steadily while the window is up. Only a size
+        // that actually moved changes what the pane looks like, so anything
+        // else must not repaint: the band is the expensive thing here, and
+        // repainting it on every configure is what the cropped scrolling path
+        // exists to avoid.
+        let mut size = self.size.lock().unwrap();
+        if *size == (width, height) {
+            return;
+        }
+        *size = (width, height);
+        drop(size);
+
+        // The pane's surfaces are placed against the window's size, so they
+        // have to be told about the new one and repainted at it.
+        mark_pane_dirty(&self.pane_dirty);
+        window.request_frame();
+    }
+
+    /// Runs once per event loop iteration, on the main thread. This is where
+    /// a `Changed` signal that landed on the background listener thread
+    /// finally becomes a repaint: the listener only ever touches the
+    /// (thread-safe) store and a dirty flag, because `Window` is not `Send`
+    /// and cannot be handed to it.
+    fn on_update(&mut self, _ctx: &AppContext) {
+        if settings_client::take_dirty() {
+            // Values, not chrome: only the pane has to be repainted.
+            mark_pane_dirty(&self.pane_dirty);
+        }
+
+        // Scroll momentum, the overscroll bounce and the scrollbar's fade all
+        // advance here rather than on input, since they keep running after
+        // the gesture ends. `idle_timeout` keeps the loop turning while
+        // there is something left to animate.
+        let animating = {
+            let mut scroll = self.scroll.lock().unwrap();
+            let animating = scroll.is_animating();
+            if animating {
+                scroll.tick();
+            }
+            animating
+        };
+
+        // A flip that has landed is dropped rather than left at 1.0: the row
+        // then draws from the value itself again, and nothing keeps asking
+        // for frames. Dropping the last one still repaints once, so the
+        // switch is never left a frame short of its end.
+        let flipping = {
+            let mut flips = self.toggle_flips.lock().unwrap();
+            let before = flips.len();
+            flips.retain(|_, flip| flip.is_running());
+            !flips.is_empty() || flips.len() != before
+        };
+
+        let dirty = std::mem::replace(&mut *self.pane_dirty.lock().unwrap(), false);
+        if animating || flipping || dirty {
+            // A flip changes what a row looks like, not where the pane is
+            // scrolled, so it has to repaint the band like any other value
+            // change.
+            self.sync_pane(dirty || flipping);
+        }
+    }
+
+    /// The accent or the colour scheme changed. The pane repaints from the
+    /// dirty flag, but the sidebar and titlebar live on the window's own
+    /// surface, which only repaints when a frame is asked for — so ask.
+    fn on_theme_changed(&mut self, _ctx: &AppContext) {
+        mark_pane_dirty(&self.pane_dirty);
+        if let Some(window) = self.window.as_ref() {
+            window.request_frame();
+        }
+    }
+
+    /// A hand laid on the touchpad stops a gliding pane, the way a finger on a
+    /// spinning wheel does. Nothing else in the pointer stream says so: a hold
+    /// carries no motion and no button.
+    fn on_pointer_hold_begin(&mut self, _ctx: &AppContext, _fingers: u32) {
+        self.scroll.lock().unwrap().stop();
+        mark_pane_dirty(&self.pane_dirty);
+    }
+
+    /// While the scroll view is animating the app needs a steady clock, not
+    /// just the next input event.
+    fn idle_timeout(&self) -> Option<std::time::Duration> {
+        let animating = self.scroll.lock().unwrap().is_animating()
+            || !self.toggle_flips.lock().unwrap().is_empty();
+        animating.then(|| std::time::Duration::from_millis(8))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().map(String::as_str) == Some("--png") {
+        preview::render_to_png(args.get(1), args.get(2));
+        return Ok(());
+    }
+
+    // Populate the settings store before the first frame, so panes draw live
+    // values rather than placeholders and then flicker.
+    settings_client::connect();
+    if settings_client::is_online() {
+        // Only worth watching once there is something to watch — an offline
+        // store has no bus connection for a listener to subscribe on.
+        settings_client::spawn_change_listener();
+    } else {
+        eprintln!("settings: showing placeholder values; changes will not be saved");
+    }
+
+    AppRunner::new(SettingsApp {
+        window: None,
+        selected: Arc::new(Mutex::new(0)),
+        scroll: Arc::new(Mutex::new(ScrollView::new(view::pane_viewport_local(
+            view::WINDOW_W,
+            view::WINDOW_H,
+        )))),
+        surfaces: Rc::new(RefCell::new(None)),
+        // The pane has never been painted, so the first update has to.
+        pane_dirty: Arc::new(Mutex::new(true)),
+        dragging: Arc::new(Mutex::new(None)),
+        toggle_flips: Arc::new(Mutex::new(HashMap::new())),
+        dropdowns: Rc::new(HashMap::new()),
+        open_dropdown: Arc::new(Mutex::new(None)),
+        pickers: Rc::new(HashMap::new()),
+        open_picker: Arc::new(Mutex::new(None)),
+        size: Arc::new(Mutex::new((view::WINDOW_W, view::WINDOW_H))),
+        controls: Arc::new(Mutex::new(WindowControlsState::new())),
+    })
+    .run()?;
+    Ok(())
+}

--- a/components/otto-settings/src/model.rs
+++ b/components/otto-settings/src/model.rs
@@ -1,0 +1,305 @@
+//! Static stand-in for the settings schema.
+//!
+//! The real app fetches this from the compositor over `org.otto.Settings`
+//! (see `specs/settings-app.md`). Nothing here is wired: the values are
+//! plausible constants chosen to exercise every control the panes need.
+
+use std::borrow::Cow;
+
+use crate::panes;
+use crate::settings_client::{self, Value};
+
+/// One row in a pane.
+pub enum Control {
+    /// On/off switch.
+    Toggle(bool),
+    /// Continuous value: current, min, max, and the formatted readout.
+    Slider {
+        value: f32,
+        min: f32,
+        max: f32,
+        readout: String,
+    },
+    /// Pop-up button showing the current choice.
+    Select(String),
+    /// Colour swatch plus its hex value.
+    Color(u32),
+    /// Free text (paths, command lines, font names). No pane uses it since
+    /// the background image became a [`Control::File`]; kept because it is
+    /// the natural control for the next free-text setting that appears.
+    #[allow(dead_code)]
+    Text(String),
+    /// A file the user picks through the desktop portal. Holds the chosen
+    /// path, empty until one is chosen.
+    File(String),
+    /// Static informational value, not editable here.
+    Value(String),
+}
+
+pub struct Row {
+    pub label: &'static str,
+    /// Secondary line under the label. `None` keeps the row single-height.
+    ///
+    /// Usually the served schema's description — help text belongs to the
+    /// compositor, which owns the setting — but a pane can write its own for
+    /// something the schema cannot know, such as a caveat about where a
+    /// setting takes effect.
+    pub detail: Option<Cow<'static, str>>,
+    pub control: Control,
+    /// Row differs from the inherited value, so it offers a reset.
+    pub overridden: bool,
+    /// Change is persisted but needs a restart to take effect.
+    pub restart_required: bool,
+    /// The `org.otto.Settings` identifier this row edits. `None` means the row
+    /// is not wired to the compositor yet and is display-only.
+    pub id: Option<&'static str>,
+}
+
+impl Row {
+    pub(crate) fn new(label: &'static str, control: Control) -> Self {
+        Self {
+            label,
+            detail: None,
+            control,
+            overridden: false,
+            restart_required: false,
+            id: None,
+        }
+    }
+
+    /// Bind the row to a settings identifier, and take its current value and
+    /// override state from the compositor when it is serving them.
+    pub(crate) fn id(mut self, id: &'static str) -> Self {
+        self.id = Some(id);
+        self.overridden = settings_client::is_overridden(id);
+
+        let desc = settings_client::describe(id);
+        let step = desc.as_ref().and_then(|d| d.step);
+
+        // The schema owns the range. A pane's min/max is a placeholder written
+        // before the contract existed, and where the two disagree the pane is
+        // simply wrong — a slider that stops at 1000 ms cannot reach a value
+        // the compositor will happily accept up to 2000.
+        if let Some(desc) = desc.as_ref() {
+            if let Control::Slider {
+                value,
+                min,
+                max,
+                readout,
+            } = self.control
+            {
+                self.control = Control::Slider {
+                    value,
+                    min: desc.min.map(|m| m as f32).unwrap_or(min),
+                    max: desc.max.map(|m| m as f32).unwrap_or(max),
+                    readout,
+                };
+            }
+        }
+
+        if let Some(value) = settings_client::value(id) {
+            self.control = self.control.with_value(&value, step);
+        }
+        // Only badge a setting that has actually been changed and is waiting
+        // on a restart. Almost everything is `Apply::Restart` today, so
+        // badging from the schema alone would put a pill on every row and say
+        // nothing.
+        self.restart_required = settings_client::is_pending_restart(id);
+
+        // Help text comes from the schema so there is one source of truth: the
+        // compositor owns the setting, so it owns the sentence explaining it.
+        // A pane that already wrote its own detail keeps it.
+        if self.detail.is_none() {
+            if let Some(desc) = desc {
+                if !desc.description.is_empty() {
+                    self.detail = Some(Cow::Owned(desc.description));
+                }
+            }
+        }
+        self
+    }
+
+    pub(crate) fn detail(mut self, detail: impl Into<Cow<'static, str>>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub(crate) fn overridden(mut self) -> Self {
+        self.overridden = true;
+        self
+    }
+
+    /// Mark a row as restart-required by hand.
+    ///
+    /// Bound rows take this from the served schema instead, so this is only
+    /// for rows that have no identifier yet and are known to need a restart.
+    #[allow(dead_code)]
+    pub(crate) fn restart(mut self) -> Self {
+        self.restart_required = true;
+        self
+    }
+}
+
+impl Control {
+    /// Replace the control's value with one served by the compositor, keeping
+    /// everything the schema does not own — the readout format the app chose
+    /// for it. `step` sets how many decimals that readout needs.
+    fn with_value(self, value: &Value, step: Option<f64>) -> Self {
+        match (self, value) {
+            (Control::Toggle(_), Value::Bool(on)) => Control::Toggle(*on),
+            (
+                Control::Slider {
+                    min, max, readout, ..
+                },
+                value,
+            ) => {
+                let new = value.as_f32().unwrap_or(min);
+                Control::Slider {
+                    // The readout is a format, not a value: re-render it
+                    // around the new number rather than keeping stale text.
+                    readout: reformat_readout(&readout, new, step),
+                    value: new,
+                    min,
+                    max,
+                }
+            }
+            (Control::Select(_), Value::Text(text)) => Control::Select(text.clone()),
+            (Control::Text(_), Value::Text(text)) => Control::Text(text.clone()),
+            (Control::File(_), Value::Text(text)) => Control::File(text.clone()),
+            // Enumerated colour settings (the accent) carry a name rather than
+            // hex, so a well that only understood hex drew them as black.
+            (Control::Color(_), Value::Text(text)) => Control::Color(
+                parse_hex(text)
+                    .or_else(|| named_argb(text))
+                    .unwrap_or(0xFF000000),
+            ),
+            (Control::Value(_), Value::List(items)) => Control::Value(items.join(", ")),
+            (Control::Value(_), Value::Text(text)) => Control::Value(text.clone()),
+            // A value whose type does not fit the control it was bound to:
+            // keep drawing the placeholder rather than inventing something.
+            (control, _) => control,
+        }
+    }
+}
+
+/// Rebuild a readout string around a new number, preserving whatever unit or
+/// formatting the pane chose ("24 px", "150%", "0.50").
+fn reformat_readout(previous: &str, value: f32, step: Option<f64>) -> String {
+    if previous.ends_with('%') {
+        format!("{:.0}%", value * 100.0)
+    } else if let Some(unit) = previous.split_once(char::is_whitespace).map(|(_, u)| u) {
+        format!("{value:.0} {unit}")
+    } else if previous.contains('.') {
+        format!("{value:.precision$}", precision = decimals(step))
+    } else {
+        format!("{value:.0}")
+    }
+}
+
+/// Decimals a readout needs to show every position its slider can stop on.
+/// Showing more is how `0.0` became `-0.01`; showing fewer would make two
+/// distinct steps read identically.
+fn decimals(step: Option<f64>) -> usize {
+    match step {
+        Some(step) if step >= 1.0 => 0,
+        Some(step) if step >= 0.1 => 1,
+        _ => 2,
+    }
+}
+
+/// The compositor's accent palette, keyed by the name it stores.
+///
+/// These are the values `src/theme/colors_dark.rs` paints with, so the swatch
+/// the user picks is the colour they get.
+pub fn named_argb(name: &str) -> Option<u32> {
+    Some(match name.to_ascii_lowercase().as_str() {
+        "red" => 0xFFFF453A,
+        "orange" => 0xFFFF9F0A,
+        "yellow" => 0xFFFFD60A,
+        "green" => 0xFF32D74B,
+        "mint" => 0xFF66D4CF,
+        "teal" => 0xFF6AC4DC,
+        "cyan" => 0xFF5AC8F5,
+        "blue" => 0xFF0A84FF,
+        "indigo" => 0xFF5E5CE6,
+        "purple" => 0xFFBF5AF2,
+        "pink" => 0xFFFF375F,
+        "gray" | "grey" | "graphite" => 0xFF98989D,
+        "brown" => 0xFFAC8E68,
+        _ => return None,
+    })
+}
+
+fn parse_hex(text: &str) -> Option<u32> {
+    let digits = text.strip_prefix('#')?;
+    u32::from_str_radix(digits, 16)
+        .ok()
+        .map(|rgb| 0xFF00_0000 | rgb)
+}
+
+/// A titled run of rows inside a pane.
+pub struct Group {
+    pub title: Option<&'static str>,
+    pub rows: Vec<Row>,
+}
+
+pub struct Pane {
+    pub name: &'static str,
+    /// Sidebar glyph name, drawn by `glyphs::draw`.
+    pub icon: &'static str,
+    pub groups: Vec<Group>,
+}
+
+/// The eight panes from the spec, in sidebar order.
+pub fn panes() -> Vec<Pane> {
+    vec![
+        panes::general::build(),
+        panes::displays::build(),
+        panes::dock::build(),
+        panes::keyboard::build(),
+        panes::pointing::build(),
+        panes::sound::build(),
+        panes::power::build(),
+        panes::lock_and_login::build(),
+    ]
+}
+
+pub(crate) fn group(title: Option<&'static str>, rows: Vec<Row>) -> Group {
+    Group { title, rows }
+}
+
+/// Outputs shown in the Displays arrangement canvas. Positions and sizes are
+/// in compositor logical pixels; the canvas scales them to fit.
+pub struct Output {
+    pub name: &'static str,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub primary: bool,
+    /// Whose settings the pane is showing below the canvas.
+    pub selected: bool,
+}
+
+pub fn outputs() -> Vec<Output> {
+    vec![
+        Output {
+            name: "eDP-1",
+            x: 0.0,
+            y: 560.0,
+            width: 1128.0,
+            height: 752.0,
+            primary: true,
+            selected: false,
+        },
+        Output {
+            name: "HDMI-A-1",
+            x: 1128.0,
+            y: 0.0,
+            width: 2560.0,
+            height: 1440.0,
+            primary: false,
+            selected: true,
+        },
+    ]
+}

--- a/components/otto-settings/src/panes/displays.rs
+++ b/components/otto-settings/src/panes/displays.rs
@@ -1,0 +1,52 @@
+//! The displays pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+//!
+//! Resolution, refresh rate and "use as primary" are per-output settings —
+//! in the compositor's config they live under `displays.named.<connector>`
+//! (`DisplaysConfig`/`DisplayProfile` in `src/config/mod.rs`), keyed by
+//! connector name. The wire contract
+//! (`docs/developer/settings-dbus-api.md`, "Open" section) explicitly leaves
+//! that identity unresolved: settings are meant to follow the panel, not the
+//! port, and connector names do not survive a display moving to a different
+//! port or a docking-station reshuffle. Inventing an identifier now (e.g.
+//! `displays.named.HDMI-A-1.resolution`) would bake a wire contract we would
+//! have to support forever even after a real display-identity scheme lands,
+//! so these three rows stay unbound.
+//!
+//! Scale is different: `DisplayProfile` has no per-output scale field at
+//! all today, only the single top-level `screen_scale` (see
+//! `src/settings/schema.rs`). So although this row is drawn under a
+//! per-display header, it is bound to that global identifier — it is the
+//! only scale setting Otto actually has.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Displays",
+        icon: "monitor",
+        // The arrangement canvas is drawn by the pane itself, not as a row.
+        // Below it sit the settings for whichever display is selected there.
+        groups: vec![group(
+            Some("HDMI-A-1 — Dell U2720Q"),
+            vec![
+                Row::new("Resolution", Control::Select("3840 × 2160".into())).overridden(),
+                Row::new("Refresh rate", Control::Select("60.00 Hz".into())),
+                Row::new(
+                    "Scale",
+                    Control::Slider {
+                        value: 2.0,
+                        min: 0.5,
+                        max: 4.0,
+                        readout: "200%".into(),
+                    },
+                )
+                .id("screen_scale"),
+                Row::new("Use as primary", Control::Toggle(false))
+                    .detail("The dock and the bar live on the primary display"),
+            ],
+        )],
+    }
+}

--- a/components/otto-settings/src/panes/dock.rs
+++ b/components/otto-settings/src/panes/dock.rs
@@ -1,0 +1,71 @@
+//! The dock pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Dock",
+        icon: "dock",
+        groups: vec![
+            group(
+                None,
+                vec![
+                    Row::new(
+                        "Size",
+                        Control::Slider {
+                            value: 1.0,
+                            min: 0.5,
+                            max: 2.0,
+                            readout: "100%".into(),
+                        },
+                    )
+                    .id("dock.size"),
+                    Row::new("Position on screen", Control::Select("Bottom".into()))
+                        .id("dock.position"),
+                    Row::new("Automatically hide", Control::Toggle(false)).id("dock.autohide"),
+                    Row::new("Magnification", Control::Toggle(true)).id("dock.magnification"),
+                ],
+            ),
+            group(
+                Some("Magnification & icons"),
+                vec![
+                    Row::new(
+                        "Magnification amount",
+                        Control::Slider {
+                            value: 0.5,
+                            min: 0.0,
+                            max: 1.0,
+                            readout: "0.50".into(),
+                        },
+                    )
+                    .id("dock.genie_scale"),
+                    Row::new(
+                        "Magnification spread",
+                        Control::Slider {
+                            value: 10.0,
+                            min: 0.0,
+                            max: 100.0,
+                            readout: "10.0".into(),
+                        },
+                    )
+                    .id("dock.genie_span"),
+                    Row::new("Tint icons", Control::Toggle(false)).id("dock.colorize_icons"),
+                    Row::new("Icon tint", Control::Color(0xFF3B82F6)).id("dock.colorize_color"),
+                    Row::new(
+                        "Icon tint strength",
+                        Control::Slider {
+                            value: 0.5,
+                            min: 0.0,
+                            max: 1.0,
+                            readout: "0.50".into(),
+                        },
+                    )
+                    .id("dock.colorize_intensity"),
+                ],
+            ),
+        ],
+    }
+}

--- a/components/otto-settings/src/panes/general.rs
+++ b/components/otto-settings/src/panes/general.rs
@@ -1,0 +1,68 @@
+//! The general pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "General",
+        icon: "settings",
+        groups: vec![
+            group(
+                Some("Appearance"),
+                vec![
+                    Row::new("Appearance", Control::Select("Light".into())).id("theme_scheme"),
+                    Row::new("Accent colour", Control::Color(0xFF0A84FF)).id("accent_color"),
+                    Row::new("Font", Control::Select("Inter".into())).id("font_family"),
+                    // Applies to GTK clients rather than to Otto's own
+                    // interface, so it sits with the other appearance rows but
+                    // is deliberately not called "Appearance".
+                    Row::new("GTK theme", Control::Value(String::new())).id("gtk_theme"),
+                ],
+            ),
+            group(
+                Some("Desktop"),
+                vec![
+                    Row::new("Background colour", Control::Color(0xFF2C2CA0))
+                        .id("background_color"),
+                    Row::new("Background image", Control::File("".into()))
+                        .detail("Chosen through the desktop portal's file picker")
+                        .id("background_image"),
+                ],
+            ),
+            group(
+                Some("Pointer & icons"),
+                vec![
+                    Row::new("Cursor theme", Control::Select("Notwaita-Black".into()))
+                        .id("cursor_theme"),
+                    Row::new(
+                        "Cursor size",
+                        Control::Slider {
+                            value: 24.0,
+                            min: 16.0,
+                            max: 96.0,
+                            readout: "24 px".into(),
+                        },
+                    )
+                    .id("cursor_size"),
+                    Row::new("Icon theme", Control::Select("".into())).id("icon_theme"),
+                ],
+            ),
+            // The app switcher has no pane of its own — the workspaces pane
+            // was dropped — and this is the only setting it owns.
+            group(
+                Some("Window switcher"),
+                vec![
+                    Row::new("Show on the pointer's display", Control::Toggle(false))
+                        .id("appswitcher.follow_cursor"),
+                ],
+            ),
+            group(
+                Some("Language"),
+                vec![Row::new("Preferred languages", Control::Value("en".into())).id("locales")],
+            ),
+        ],
+    }
+}

--- a/components/otto-settings/src/panes/keyboard.rs
+++ b/components/otto-settings/src/panes/keyboard.rs
@@ -1,0 +1,64 @@
+//! The keyboard pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Keyboard",
+        icon: "keyboard",
+        groups: vec![
+            group(
+                None,
+                vec![
+                    Row::new(
+                        "Key repeat delay",
+                        Control::Slider {
+                            value: 300.0,
+                            min: 100.0,
+                            max: 1000.0,
+                            readout: "300 ms".into(),
+                        },
+                    )
+                    .id("keyboard_repeat_delay"),
+                    Row::new(
+                        "Key repeat rate",
+                        Control::Slider {
+                            value: 30.0,
+                            min: 5.0,
+                            max: 60.0,
+                            readout: "30 / s".into(),
+                        },
+                    )
+                    .id("keyboard_repeat_rate"),
+                ],
+            ),
+            group(
+                Some("Input source"),
+                vec![
+                    // Shown, not editable: these are free text with no
+                    // discoverable choice list, and the app has no text entry
+                    // yet. Binding them at least stops the pane from hiding
+                    // what the session is actually using.
+                    Row::new("Layout", Control::Value(String::new())).id("input.xkb_layout"),
+                    Row::new("Variant", Control::Value(String::new())).id("input.xkb_variant"),
+                    Row::new("Options", Control::Value(String::new())).id("input.xkb_options"),
+                ],
+            ),
+            group(
+                Some("Shortcuts"),
+                vec![
+                    Row::new("Open terminal", Control::Value("Ctrl + Return".into())),
+                    Row::new("Show all windows", Control::Value("Page Up".into())),
+                    Row::new("Show desktop", Control::Value("Page Down".into())),
+                    Row::new("Switch application", Control::Value("Ctrl + Tab".into())),
+                    Row::new("Maximise window", Control::Value("Ctrl + ↑".into())).overridden(),
+                    Row::new("Tile window left", Control::Value("Ctrl + ←".into())),
+                    Row::new("Quit Otto", Control::Value("Ctrl + Esc".into())),
+                ],
+            ),
+        ],
+    }
+}

--- a/components/otto-settings/src/panes/lock_and_login.rs
+++ b/components/otto-settings/src/panes/lock_and_login.rs
@@ -1,0 +1,48 @@
+//! The lock and login pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Lock & Login",
+        icon: "lock",
+        groups: vec![
+            group(
+                Some("Lock"),
+                vec![
+                    // Seconds, matching the setting's own unit — a select of
+                    // pretty intervals would have to invent choices the
+                    // schema does not serve, and the type would not match.
+                    Row::new(
+                        "Lock after",
+                        Control::Slider {
+                            value: 600.0,
+                            min: 0.0,
+                            max: 86400.0,
+                            readout: "600 s".into(),
+                        },
+                    )
+                    .id("lock.auto_lock_timeout"),
+                    Row::new("Lock screen", Control::Select("otto-lock".into()))
+                        .detail("Applies the next time the screen locks")
+                        .id("lock.locker_command"),
+                    Row::new("Lock screen arguments", Control::Value(String::new()))
+                        .id("lock.locker_args"),
+                ],
+            ),
+            group(
+                Some("Login"),
+                vec![
+                    Row::new("Greeter", Control::Select("otto-greeter".into()))
+                        .detail("Applies at the next login")
+                        .id("login.greeter_command"),
+                    Row::new("Greeter arguments", Control::Value(String::new()))
+                        .id("login.greeter_args"),
+                ],
+            ),
+        ],
+    }
+}

--- a/components/otto-settings/src/panes/mod.rs
+++ b/components/otto-settings/src/panes/mod.rs
@@ -1,0 +1,13 @@
+//! One module per settings pane.
+//!
+//! Each owns its own rows and their bindings, so panes can be worked on
+//! independently.
+
+pub mod displays;
+pub mod dock;
+pub mod general;
+pub mod keyboard;
+pub mod lock_and_login;
+pub mod pointing;
+pub mod power;
+pub mod sound;

--- a/components/otto-settings/src/panes/pointing.rs
+++ b/components/otto-settings/src/panes/pointing.rs
@@ -1,0 +1,60 @@
+//! The pointing pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Trackpad & Mouse",
+        icon: "pointer",
+        groups: vec![
+            group(
+                Some("Trackpad"),
+                vec![
+                    Row::new("Tap to click", Control::Toggle(true)).id("input.tap_enabled"),
+                    Row::new("Tap and drag", Control::Toggle(true)).id("input.tap_drag_enabled"),
+                    Row::new("Drag lock", Control::Toggle(false)).id("input.tap_drag_lock_enabled"),
+                    Row::new("Click method", Control::Select("Click with fingers".into()))
+                        .id("input.touchpad_click_method"),
+                    Row::new("Ignore while typing", Control::Toggle(true))
+                        .id("input.touchpad_dwt_enabled"),
+                    Row::new("Natural scrolling", Control::Toggle(true))
+                        .id("input.touchpad_natural_scroll_enabled"),
+                    Row::new("Left-handed", Control::Toggle(false))
+                        .id("input.touchpad_left_handed"),
+                    Row::new("Middle-click emulation", Control::Toggle(false))
+                        .id("input.touchpad_middle_emulation_enabled"),
+                ],
+            ),
+            group(
+                Some("Pointer"),
+                vec![
+                    Row::new(
+                        "Tracking speed",
+                        Control::Slider {
+                            value: 0.0,
+                            min: -1.0,
+                            max: 1.0,
+                            readout: "0.0".into(),
+                        },
+                    )
+                    .id("input.pointer_accel_speed"),
+                    Row::new("Acceleration", Control::Select("Adaptive".into()))
+                        .id("input.pointer_accel_profile"),
+                    Row::new(
+                        "Scrolling speed",
+                        Control::Slider {
+                            value: 1.0,
+                            min: 0.0,
+                            max: 10.0,
+                            readout: "1.0".into(),
+                        },
+                    )
+                    .id("input.scroll_speed"),
+                ],
+            ),
+        ],
+    }
+}

--- a/components/otto-settings/src/panes/power.rs
+++ b/components/otto-settings/src/panes/power.rs
@@ -1,0 +1,28 @@
+//! The power pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Power",
+        icon: "battery",
+        groups: vec![group(
+            None,
+            vec![
+                Row::new("Handle the lid switch", Control::Toggle(true))
+                    .detail("Otto suspends on lid close instead of logind")
+                    .id("power_management.manage_lid_switch"),
+                Row::new("When the lid closes", Control::Select("Automatic".into()))
+                    .id("power_management.on_lid_close"),
+                Row::new(
+                    "When the power button is pressed",
+                    Control::Select("Lock".into()),
+                )
+                .id("power_management.on_power_button"),
+            ],
+        )],
+    }
+}

--- a/components/otto-settings/src/panes/sound.rs
+++ b/components/otto-settings/src/panes/sound.rs
@@ -1,0 +1,20 @@
+//! The sound pane.
+//!
+//! Rows carrying an `id` are bound to `org.otto.Settings`; rows without one
+//! are not wired to the compositor yet.
+
+use crate::model::{group, Control, Pane, Row};
+
+pub fn build() -> Pane {
+    Pane {
+        name: "Sound",
+        icon: "sound",
+        groups: vec![group(
+            None,
+            vec![
+                Row::new("Interface sounds", Control::Toggle(true)).id("audio.sound_enabled"),
+                Row::new("Sound theme", Control::Select("Auto".into())).id("audio.sound_theme"),
+            ],
+        )],
+    }
+}

--- a/components/otto-settings/src/preview.rs
+++ b/components/otto-settings/src/preview.rs
@@ -1,0 +1,86 @@
+//! Offscreen render of every pane to a PNG.
+//!
+//! Useful for iterating on layout without a compositor session, and for
+//! comparing light against dark side by side.
+
+use skia_safe::{surfaces, Color, EncodedImageFormat, Paint, Rect};
+
+use crate::model;
+use crate::view::{self, Settings, WINDOW_H, WINDOW_W};
+use crate::widgets;
+
+const MARGIN: f32 = 40.0;
+const CAPTION_H: f32 = 26.0;
+const COLS: usize = 2;
+
+/// `out` defaults to `otto-settings.png`; `only` limits it to one pane by name.
+pub fn render_to_png(out: Option<&String>, only: Option<&String>) {
+    let out = out
+        .cloned()
+        .unwrap_or_else(|| "otto-settings.png".to_string());
+
+    let mut cells: Vec<(String, Settings)> = Vec::new();
+    for (i, pane) in model::panes().iter().enumerate() {
+        if let Some(only) = only {
+            if !pane.name.eq_ignore_ascii_case(only) {
+                continue;
+            }
+        }
+        cells.push((format!("{} · light", pane.name), Settings::new(i, false)));
+        cells.push((format!("{} · dark", pane.name), Settings::new(i, true)));
+    }
+
+    if cells.is_empty() {
+        eprintln!("no pane matched; known panes:");
+        for pane in model::panes() {
+            eprintln!("  {}", pane.name);
+        }
+        std::process::exit(1);
+    }
+
+    let cell_w = WINDOW_W + MARGIN * 2.0;
+    let cell_h = WINDOW_H + MARGIN * 2.0 + CAPTION_H;
+    let cols = COLS.min(cells.len());
+    let rows = cells.len().div_ceil(cols);
+    let width = (cell_w * cols as f32) as i32;
+    let height = (cell_h * rows as f32) as i32;
+
+    let mut surface = surfaces::raster_n32_premul((width, height)).expect("raster surface");
+    let canvas = surface.canvas();
+
+    for (i, (caption, settings)) in cells.iter().enumerate() {
+        let col = i % cols;
+        let row = i / cols;
+        canvas.save();
+        canvas.translate((col as f32 * cell_w, row as f32 * cell_h));
+
+        // A flat wallpaper stand-in so the window edge and shadow are judged
+        // against something realistic.
+        let mut bg = Paint::default();
+        bg.set_color(if settings.dark {
+            Color::from_rgb(0x1B, 0x1F, 0x27)
+        } else {
+            Color::from_rgb(0x7E, 0x91, 0xAD)
+        });
+        canvas.draw_rect(Rect::from_wh(cell_w, cell_h), &bg);
+
+        widgets::text_centered_y(
+            canvas,
+            caption,
+            MARGIN,
+            MARGIN / 2.0,
+            otto_kit::typography::styles::CAPTION_1,
+            Color::from_argb(0xD0, 0xFF, 0xFF, 0xFF),
+        );
+
+        view::render_on_desktop(canvas, settings, MARGIN, MARGIN + CAPTION_H);
+        canvas.restore();
+    }
+
+    let image = surface.image_snapshot();
+    let data = image
+        .encode(None, EncodedImageFormat::PNG, 100)
+        .expect("encode png");
+    std::fs::write(&out, data.as_bytes()).expect("write png");
+    println!("wrote {out} ({width}x{height})");
+}

--- a/components/otto-settings/src/settings_client.rs
+++ b/components/otto-settings/src/settings_client.rs
@@ -1,0 +1,542 @@
+//! Client for `org.otto.Settings`.
+//!
+//! Speaks the contract in `docs/developer/settings-dbus-api.md`. The schema,
+//! the current values and the overridden set are fetched once at startup and
+//! kept in a process-wide store, so the draw path — which runs on every frame
+//! and cannot block — reads them without touching the bus.
+//!
+//! The compositor side is still being built. Until it answers, the store stays
+//! **offline**: panes fall back to the placeholder values in [`crate::model`]
+//! and the app presents itself as read-only rather than pretending a `Set`
+//! landed.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{OnceLock, RwLock};
+
+use zbus::blocking::Connection;
+use zbus::zvariant::{OwnedValue, Type, Value as ZValue};
+
+const BUS_NAME: &str = "org.otto.Settings";
+const OBJECT_PATH: &str = "/org/otto/Settings";
+const INTERFACE: &str = "org.otto.Settings";
+
+/// A setting's value, in the shapes the contract's `type` column allows.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Bool(bool),
+    Int(i32),
+    Double(f64),
+    Text(String),
+    List(Vec<String>),
+}
+
+#[allow(dead_code)] // the full accessor set is used as more panes are wired
+impl Value {
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            Value::Double(v) => Some(*v as f32),
+            Value::Int(v) => Some(*v as f32),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::Text(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    fn from_zbus(value: &OwnedValue) -> Option<Self> {
+        match &**value {
+            ZValue::Bool(v) => Some(Value::Bool(*v)),
+            ZValue::I32(v) => Some(Value::Int(*v)),
+            ZValue::U32(v) => Some(Value::Int(*v as i32)),
+            ZValue::F64(v) => Some(Value::Double(*v)),
+            ZValue::Str(v) => Some(Value::Text(v.to_string())),
+            ZValue::Array(array) => Some(Value::List(
+                array
+                    .iter()
+                    .filter_map(|item| match item {
+                        ZValue::Str(s) => Some(s.to_string()),
+                        _ => None,
+                    })
+                    .collect(),
+            )),
+            _ => None,
+        }
+    }
+
+    fn to_zbus(&self) -> ZValue<'static> {
+        match self {
+            Value::Bool(v) => ZValue::Bool(*v),
+            Value::Int(v) => ZValue::I32(*v),
+            Value::Double(v) => ZValue::F64(*v),
+            Value::Text(v) => ZValue::Str(v.clone().into()),
+            Value::List(v) => {
+                let mut array = zbus::zvariant::Array::new(<&str>::signature());
+                for item in v {
+                    // The element type is fixed above, so this cannot fail.
+                    let _ = array.append(ZValue::Str(item.clone().into()));
+                }
+                ZValue::Array(array)
+            }
+        }
+    }
+}
+
+/// The type the schema declares for a setting.
+///
+/// The compositor never coerces — sending a double to an `int` setting is
+/// refused — so a control has to emit the declared shape rather than whatever
+/// its own arithmetic produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Kind {
+    Bool,
+    Int,
+    Double,
+    #[default]
+    Text,
+    List,
+}
+
+impl Kind {
+    fn parse(raw: &str) -> Self {
+        match raw {
+            "bool" => Kind::Bool,
+            "int" => Kind::Int,
+            "double" => Kind::Double,
+            "string-list" => Kind::List,
+            _ => Kind::Text,
+        }
+    }
+}
+
+/// What the compositor says happens when a setting is changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Apply {
+    Live,
+    Restart,
+    Unsupported,
+}
+
+impl Apply {
+    fn parse(raw: &str) -> Self {
+        match raw {
+            "live" => Apply::Live,
+            "restart" => Apply::Restart,
+            _ => Apply::Unsupported,
+        }
+    }
+}
+
+/// One entry of the served schema. Only the fields the app actually renders
+/// from are kept; unknown keys in the reply are ignored, as the contract
+/// requires, so the compositor can add more without breaking this build.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // ditto: panes read more of the schema as they are wired
+pub struct Desc {
+    pub id: String,
+    pub kind: Kind,
+    pub label: String,
+    pub description: String,
+    pub apply: Apply,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    /// Granularity to snap a slider to, when the setting has one.
+    pub step: Option<f64>,
+    /// The inherited value, used as a detent so a slider can land exactly on
+    /// it rather than a hair either side.
+    pub default: Option<f64>,
+    pub choices: Vec<String>,
+    /// Human names for `choices`, in the same order, when the configuration
+    /// tokens are not fit to show. Empty when they are.
+    pub choice_labels: Vec<String>,
+}
+
+impl Desc {
+    /// What to show the user in place of a stored value. Falls back to the
+    /// value itself, which covers every setting the compositor did not bother
+    /// to label and every value it does not recognise.
+    pub fn display(&self, value: &str) -> String {
+        self.choices
+            .iter()
+            .position(|c| c == value)
+            .and_then(|i| self.choice_labels.get(i))
+            .cloned()
+            .unwrap_or_else(|| value.to_string())
+    }
+}
+
+#[derive(Default)]
+struct Store {
+    online: bool,
+    /// Settings changed in this session that the compositor said need a
+    /// restart. Not the same as the schema's `apply` field: most settings
+    /// need a restart, but the badge is only meaningful once one has actually
+    /// been changed.
+    pending_restart: HashSet<String>,
+    schema: HashMap<String, Desc>,
+    values: HashMap<String, Value>,
+    overridden: HashSet<String>,
+}
+
+static STORE: OnceLock<RwLock<Store>> = OnceLock::new();
+static CONNECTION: OnceLock<Option<Connection>> = OnceLock::new();
+
+fn store() -> &'static RwLock<Store> {
+    STORE.get_or_init(|| RwLock::new(Store::default()))
+}
+
+/// Whether the compositor answered and the app is showing live values.
+pub fn is_online() -> bool {
+    store().read().map(|s| s.online).unwrap_or(false)
+}
+
+/// The current value of a setting, if the compositor served one.
+pub fn value(id: &str) -> Option<Value> {
+    store().read().ok()?.values.get(id).cloned()
+}
+
+/// Whether a setting is set in the user's own config file, and so offers a
+/// revert.
+pub fn is_overridden(id: &str) -> bool {
+    store()
+        .read()
+        .map(|s| s.overridden.contains(id))
+        .unwrap_or(false)
+}
+
+/// Whether this session has changed a setting that is waiting on a restart.
+pub fn is_pending_restart(id: &str) -> bool {
+    store()
+        .read()
+        .map(|s| s.pending_restart.contains(id))
+        .unwrap_or(false)
+}
+
+/// The schema entry for a setting, if the compositor served one.
+/// Quantise a slider's raw drag position to something the user meant.
+///
+/// A drag lands on whatever float the pixel maps to, which is how a pointer
+/// speed ends up reading `-0.01`. Snapping to the schema's step fixes that,
+/// and a detent at the default lets the value land exactly back on it — the
+/// one position a user is most likely to be aiming for.
+pub fn snap(id: &str, raw: f32) -> f32 {
+    let store = STORE.get_or_init(Default::default).read().unwrap();
+    let Some(desc) = store.schema.get(id) else {
+        return raw;
+    };
+
+    let raw = raw as f64;
+    let mut value = match desc.step {
+        Some(step) if step > 0.0 => (raw / step).round() * step,
+        _ => raw,
+    };
+
+    if let (Some(default), Some(step)) = (desc.default, desc.step) {
+        if (raw - default).abs() <= step / 2.0 {
+            value = default;
+        }
+    }
+
+    if let Some(min) = desc.min {
+        value = value.max(min);
+    }
+    if let Some(max) = desc.max {
+        value = value.min(max);
+    }
+    value as f32
+}
+
+/// The human name for a stored enum value, for display only. Controls keep
+/// holding the configuration token, so hit-testing and `Set` are unaffected.
+pub fn display_choice(id: &str, value: &str) -> String {
+    let store = STORE.get_or_init(Default::default).read().unwrap();
+    match store.schema.get(id) {
+        Some(desc) => desc.display(value),
+        None => value.to_string(),
+    }
+}
+
+pub fn describe(id: &str) -> Option<Desc> {
+    store().read().ok()?.schema.get(id).cloned()
+}
+
+/// Connect and populate the store. Failure is not fatal: the app stays usable
+/// against a compositor that does not serve the interface yet.
+pub fn connect() {
+    let connection = CONNECTION.get_or_init(|| match Connection::session() {
+        Ok(connection) => Some(connection),
+        Err(err) => {
+            eprintln!("settings: no session bus ({err}); running offline");
+            None
+        }
+    });
+
+    let Some(connection) = connection.as_ref() else {
+        return;
+    };
+
+    let schema = match fetch_schema(connection) {
+        Ok(schema) => schema,
+        Err(err) => {
+            eprintln!("settings: {BUS_NAME} unavailable ({err}); running offline");
+            return;
+        }
+    };
+
+    let values = fetch_values(connection).unwrap_or_default();
+    let overridden = fetch_overridden(connection).unwrap_or_default();
+
+    if let Ok(mut store) = store().write() {
+        store.online = true;
+        store.schema = schema;
+        store.values = values;
+        store.overridden = overridden;
+    }
+}
+
+/// Set when a `Changed` signal has updated the store and a redraw is owed.
+/// Cleared by [`take_dirty`], which the app polls from `App::on_update` —
+/// `AppRunner` calls that on the main thread every time round the event
+/// loop, which is also the only thread allowed to touch `Window`.
+static DIRTY: AtomicBool = AtomicBool::new(false);
+
+/// Whether a `Changed` signal has landed since the last call. `on_update`
+/// polls this and, if it's set, calls `Window::request_frame()` itself —
+/// this module never touches `Window` because the listener thread that sets
+/// the flag is not the main thread, and `Window` is not `Send`.
+pub fn take_dirty() -> bool {
+    DIRTY.swap(false, Ordering::Relaxed)
+}
+
+/// Watch `Changed` on a background thread and fold every update into the
+/// store, so a change from anywhere — another client's `Set`, an
+/// in-compositor interaction like dragging the dock handle, an external edit
+/// of the config file, or this app's own `Set` echoing back — is reflected
+/// without the draw path ever touching the bus.
+///
+/// This runs on its own thread rather than folding into the app's poll loop
+/// because the client only has `zbus::blocking`: a `SignalIterator::next()`
+/// blocks until a message arrives, and blocking the main thread on the bus
+/// would freeze drawing and pointer handling for as long as nothing changes.
+/// The thread is deliberately kept thin — it only ever touches the
+/// (thread-safe, `RwLock`-guarded) store and the `DIRTY` flag, then wakes the
+/// main loop with `AppContext::request_wakeup()`, which is documented as
+/// safe to call from any thread. The actual `request_frame()` happens back
+/// on the main thread, in `on_update`, once the wakeup's `poll()` returns.
+pub fn spawn_change_listener() {
+    let Some(Some(connection)) = CONNECTION.get() else {
+        return;
+    };
+    let connection = connection.clone();
+
+    let spawned = std::thread::Builder::new()
+        .name("settings-changed".into())
+        .spawn(move || {
+            let proxy =
+                match zbus::blocking::Proxy::new(&connection, BUS_NAME, OBJECT_PATH, INTERFACE) {
+                    Ok(proxy) => proxy,
+                    Err(err) => {
+                        eprintln!(
+                            "settings: cannot watch {BUS_NAME} ({err}); \
+                             external changes will not be reflected"
+                        );
+                        return;
+                    }
+                };
+            let signals = match proxy.receive_signal("Changed") {
+                Ok(signals) => signals,
+                Err(err) => {
+                    eprintln!("settings: cannot subscribe to Changed ({err})");
+                    return;
+                }
+            };
+
+            for message in signals {
+                let changed: HashMap<String, OwnedValue> = match message.body().deserialize() {
+                    Ok(changed) => changed,
+                    Err(err) => {
+                        eprintln!("settings: malformed Changed signal ({err})");
+                        continue;
+                    }
+                };
+
+                let mut any = false;
+                if let Ok(mut store) = store().write() {
+                    for (id, value) in &changed {
+                        if let Some(value) = Value::from_zbus(value) {
+                            store.values.insert(id.clone(), value);
+                            any = true;
+                        }
+                    }
+                }
+
+                // No recognisable value in the signal body: nothing to
+                // redraw for, and waking the main loop would just spin it.
+                if any {
+                    DIRTY.store(true, Ordering::Relaxed);
+                    otto_kit::AppContext::request_wakeup();
+                }
+            }
+        });
+
+    if let Err(err) = spawned {
+        eprintln!("settings: could not start the Changed listener thread ({err})");
+    }
+}
+
+fn call<B, R>(connection: &Connection, method: &str, body: &B) -> zbus::Result<R>
+where
+    B: serde::ser::Serialize + zbus::zvariant::DynamicType,
+    R: serde::de::DeserializeOwned + zbus::zvariant::Type,
+{
+    connection
+        .call_method(Some(BUS_NAME), OBJECT_PATH, Some(INTERFACE), method, body)?
+        .body()
+        .deserialize()
+}
+
+fn fetch_schema(connection: &Connection) -> zbus::Result<HashMap<String, Desc>> {
+    let raw: Vec<HashMap<String, OwnedValue>> = call(connection, "Describe", &())?;
+
+    Ok(raw
+        .into_iter()
+        .filter_map(|entry| {
+            let id = string_field(&entry, "id")?;
+            let desc = Desc {
+                kind: Kind::parse(&string_field(&entry, "type").unwrap_or_default()),
+                label: string_field(&entry, "label").unwrap_or_else(|| id.clone()),
+                description: string_field(&entry, "description").unwrap_or_default(),
+                apply: Apply::parse(&string_field(&entry, "apply").unwrap_or_default()),
+                min: entry.get("min").and_then(number_field),
+                max: entry.get("max").and_then(number_field),
+                step: entry.get("step").and_then(number_field),
+                default: entry.get("default").and_then(number_field),
+                choices: string_list(&entry, "choices"),
+                choice_labels: string_list(&entry, "choice_labels"),
+                id: id.clone(),
+            };
+            Some((id, desc))
+        })
+        .collect())
+}
+
+fn fetch_values(connection: &Connection) -> zbus::Result<HashMap<String, Value>> {
+    let raw: HashMap<String, OwnedValue> = call(connection, "GetAll", &())?;
+    Ok(raw
+        .iter()
+        .filter_map(|(id, value)| Value::from_zbus(value).map(|v| (id.clone(), v)))
+        .collect())
+}
+
+fn fetch_overridden(connection: &Connection) -> zbus::Result<HashSet<String>> {
+    let raw: Vec<String> = call(connection, "GetOverridden", &())?;
+    Ok(raw.into_iter().collect())
+}
+
+fn string_field(entry: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
+    match Value::from_zbus(entry.get(key)?)? {
+        Value::Text(text) => Some(text),
+        _ => None,
+    }
+}
+
+fn string_list(entry: &HashMap<String, OwnedValue>, key: &str) -> Vec<String> {
+    match entry.get(key).and_then(Value::from_zbus) {
+        Some(Value::List(items)) => items,
+        _ => Vec::new(),
+    }
+}
+
+fn number_field(value: &OwnedValue) -> Option<f64> {
+    match Value::from_zbus(value)? {
+        Value::Double(v) => Some(v),
+        Value::Int(v) => Some(v as f64),
+        _ => None,
+    }
+}
+
+/// Wrap a number as the schema declares it, so a slider bound to an `int`
+/// setting does not send a double and get refused.
+pub fn number_for(id: &str, value: f32) -> Value {
+    match describe(id).map(|d| d.kind) {
+        Some(Kind::Int) => Value::Int(value.round() as i32),
+        _ => Value::Double(value as f64),
+    }
+}
+
+/// Outcome of a `Set`, as the app needs to present it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetOutcome {
+    Applied,
+    PendingRestart,
+    /// The compositor refused, or is not there. Carries a message to show.
+    Failed(String),
+}
+
+/// Set a value, and reflect it in the store so the next frame draws it.
+///
+/// The store is updated from the value we sent rather than by re-reading:
+/// `Changed` will arrive too, and agreeing with it is the point. A failure
+/// leaves the store untouched, so the UI snaps back to the real value.
+pub fn set(id: &str, value: Value) -> SetOutcome {
+    let Some(Some(connection)) = CONNECTION.get() else {
+        return SetOutcome::Failed("not connected to the compositor".into());
+    };
+
+    let status: zbus::Result<String> = call(connection, "Set", &(id, value.to_zbus()));
+
+    match status {
+        Ok(status) => {
+            if let Ok(mut store) = store().write() {
+                store.values.insert(id.to_string(), value);
+                store.overridden.insert(id.to_string());
+            }
+            match status.as_str() {
+                "pending-restart" => {
+                    if let Ok(mut store) = store().write() {
+                        store.pending_restart.insert(id.to_string());
+                    }
+                    SetOutcome::PendingRestart
+                }
+                _ => SetOutcome::Applied,
+            }
+        }
+        Err(err) => SetOutcome::Failed(err.to_string()),
+    }
+}
+
+/// Drop a setting back to whatever the lower config layers provide.
+#[allow(dead_code)] // wired when rows grow a revert affordance
+pub fn reset(id: &str) -> SetOutcome {
+    let Some(Some(connection)) = CONNECTION.get() else {
+        return SetOutcome::Failed("not connected to the compositor".into());
+    };
+
+    let status: zbus::Result<String> = call(connection, "Reset", &(id,));
+
+    match status {
+        Ok(_) => {
+            // The effective value now comes from a lower layer and we do not
+            // know it, so re-read rather than guess.
+            if let Ok(values) = fetch_values(connection) {
+                if let Ok(mut store) = store().write() {
+                    store.values = values;
+                    store.overridden.remove(id);
+                }
+            }
+            SetOutcome::Applied
+        }
+        Err(err) => SetOutcome::Failed(err.to_string()),
+    }
+}

--- a/components/otto-settings/src/view.rs
+++ b/components/otto-settings/src/view.rs
@@ -1,0 +1,1348 @@
+//! Window layout: titlebar, sidebar, and the selected pane.
+
+use otto_kit::components::color_picker::{self, WellInteraction};
+use otto_kit::components::dropdown::{self, DropdownInteraction};
+use otto_kit::components::titlebar::{
+    Titlebar, TitlebarGroup, WindowControls, WindowControlsState,
+};
+use otto_kit::prelude::*;
+use skia_safe::{ClipOp, Contains, Point, RRect};
+
+use crate::glyphs;
+use crate::model::{self, Control, Pane, Row};
+use crate::settings_client::{self, Value};
+use crate::widgets;
+use std::collections::HashMap;
+
+/// The size the window asks for on first map. After that the compositor is in
+/// charge, and everything draws against [`Settings::width`]/`height` instead —
+/// these two are a starting point, not a layout constant.
+pub const WINDOW_W: f32 = 900.0;
+pub const WINDOW_H: f32 = 640.0;
+/// Below this the sidebar and a content column stop both fitting.
+pub const MIN_W: f32 = 560.0;
+pub const MIN_H: f32 = 360.0;
+pub const CORNER: f32 = 12.0;
+const TITLEBAR_H: f32 = 38.0;
+const SIDEBAR_W: f32 = 214.0;
+const CONTENT_PAD: f32 = 26.0;
+const ROW_H: f32 = 42.0;
+const ROW_H_DETAIL: f32 = 56.0;
+const GROUP_GAP: f32 = 22.0;
+/// Top padding of the pane content, in content-local points (origin at the
+/// pane viewport's top-left, i.e. `(SIDEBAR_W, TITLEBAR_H)`).
+const CONTENT_TOP_PAD: f32 = 16.0;
+/// Height the displays arrangement canvas adds ahead of the groups: the
+/// 168pt area plus the 30pt gap `render_arrangement` leaves below it. Kept
+/// as one constant, alongside that function, so [`Settings::pane_content_height`]
+/// cannot drift from what it actually draws.
+const ARRANGEMENT_HEIGHT: f32 = 168.0 + 30.0;
+
+/// The scrollable pane viewport: everything right of the sidebar, below the
+/// titlebar, in window-local coordinates. Where the pane's subsurfaces are
+/// placed, and what the popup anchors are measured against.
+pub fn pane_viewport(width: f32, height: f32) -> Rect {
+    Rect::from_ltrb(SIDEBAR_W, TITLEBAR_H, width, height)
+}
+
+/// The same viewport in the pane's *own* coordinates, origin at its top-left.
+///
+/// This is the space the pane's subsurfaces live in, so it is also the space
+/// the [`ScrollView`](otto_kit::components::scroll::ScrollView) driving them
+/// has to be told about: `ScrollSurfaces` positions the scrollbar from the
+/// thumb rect the view computes, relative to the pane, not to the window.
+pub fn pane_viewport_local(width: f32, height: f32) -> Rect {
+    let viewport = pane_viewport(width, height);
+    Rect::from_wh(viewport.width(), viewport.height())
+}
+
+/// The flat ground the pane's content sits on. Forms want a high-contrast,
+/// opaque backdrop rather than the sidebar's material.
+pub fn pane_background(dark: bool) -> Color {
+    if dark {
+        Color::from_rgb(0x24, 0x26, 0x2B)
+    } else {
+        Color::from_rgb(0xFA, 0xFA, 0xFA)
+    }
+}
+
+/// The titlebar band over the content area: the pane's ground, thinned just
+/// enough that the compositor's blur shows through it. It stays much more
+/// opaque than the sidebar — the band is a hairline away from a wall of form
+/// text and cannot start competing with it.
+pub fn titlebar_material(dark: bool) -> Color {
+    if dark {
+        Color::from_argb(0xE6, 0x24, 0x26, 0x2B)
+    } else {
+        Color::from_argb(0xE6, 0xFA, 0xFA, 0xFA)
+    }
+}
+
+/// Sidebar row geometry. Drawing and hit-testing both go through this so the
+/// clickable area cannot drift away from the painted one.
+fn sidebar_item_rect(index: usize) -> Rect {
+    const FIRST_ITEM_Y: f32 = TITLEBAR_H + 10.0 + 26.0 + 12.0;
+    const ITEM_H: f32 = 30.0;
+    const ITEM_STEP: f32 = 32.0;
+    Rect::from_xywh(
+        8.0,
+        FIRST_ITEM_Y + index as f32 * ITEM_STEP,
+        SIDEBAR_W - 16.0,
+        ITEM_H,
+    )
+}
+
+/// The pane whose sidebar row contains `(x, y)`, if any.
+pub fn pane_at(x: f32, y: f32) -> Option<usize> {
+    (0..model::panes().len()).find(|&i| sidebar_item_rect(i).contains(Point::new(x, y)))
+}
+
+/// The pop-up button's rect within a row, given the row's trailing edge and
+/// vertical centre. Drawing, hit-testing and popup anchoring all come through
+/// here so a click can never land somewhere different from what was drawn.
+fn select_rect(right: f32, cy: f32) -> Rect {
+    Rect::from_xywh(
+        right - widgets::SELECT_W,
+        cy - dropdown::field::HEIGHT / 2.0,
+        widgets::SELECT_W,
+        dropdown::field::HEIGHT,
+    )
+}
+
+/// The colour well's rect within a row. Its width follows the hex text, so
+/// the control is measured rather than fixed; drawing, hit-testing and popup
+/// anchoring all come through here.
+fn well_rect(right: f32, cy: f32, color: Color) -> Rect {
+    let width = color_picker::well::measure(color);
+    Rect::from_xywh(right - width, cy - 22.0 / 2.0, width, 22.0)
+}
+
+/// Padding `Titlebar` is given, which is also where it places its leading
+/// group — so the traffic lights end up at `(TITLEBAR_PAD, TITLEBAR_PAD)`.
+const TITLEBAR_PAD: f32 = (TITLEBAR_H - 12.0) / 2.0;
+
+/// The traffic lights for hit-testing, in window-local coordinates.
+///
+/// The drawn group is positioned by `Titlebar` itself and so is built at the
+/// origin; only the hit-test needs the absolute offset. Getting this wrong in
+/// the other direction — handing the *positioned* group to `Titlebar` — makes
+/// it apply the padding twice and the dots sit low.
+fn window_controls_hit() -> WindowControls {
+    WindowControls::new().at(TITLEBAR_PAD, TITLEBAR_PAD)
+}
+
+/// What a press in the titlebar means.
+pub enum TitlebarHit {
+    /// One of the traffic lights.
+    Control(otto_kit::components::titlebar::WindowControl),
+    /// Bare titlebar: the press starts a window move.
+    Drag,
+}
+
+/// What a window-local point hits in the titlebar, if anything.
+pub fn titlebar_hit(x: f32, y: f32, width: f32) -> Option<TitlebarHit> {
+    if y < 0.0 || y > TITLEBAR_H || x < 0.0 || x > width {
+        return None;
+    }
+    match window_controls_hit().control_at(x, y) {
+        Some(control) => Some(TitlebarHit::Control(control)),
+        None => Some(TitlebarHit::Drag),
+    }
+}
+
+/// The traffic light under a window-local point, if any — the hover test,
+/// which unlike [`titlebar_hit`] does not care about the draggable bar.
+pub fn titlebar_control_at(
+    x: f32,
+    y: f32,
+    width: f32,
+) -> Option<otto_kit::components::titlebar::WindowControl> {
+    match titlebar_hit(x, y, width) {
+        Some(TitlebarHit::Control(control)) => Some(control),
+        _ => None,
+    }
+}
+
+/// A colour well the pointer landed on, with everything needed to open it.
+pub struct ColorHit {
+    pub id: &'static str,
+    /// The well's rect in window-local coordinates, for anchoring the popup.
+    pub rect: Rect,
+    pub current: Color,
+}
+
+/// A pop-up button the pointer landed on, with everything needed to open it.
+pub struct SelectHit {
+    pub id: &'static str,
+    /// The field's rect in window-local coordinates, for anchoring the menu.
+    pub rect: Rect,
+    pub current: String,
+}
+
+/// A click that landed on a control bound to a setting.
+pub struct Hit {
+    pub id: &'static str,
+    /// The value the click implies — a toggle's opposite, or the slider value
+    /// at the pointer.
+    pub value: Value,
+    /// Whether continuing to move the pointer should keep changing the value.
+    pub draggable: bool,
+}
+
+/// One group of a pane, placed by [`Settings::pane_layout`].
+struct GroupLayout<'a> {
+    title: Option<&'static str>,
+    /// Top of the title's 24pt band, where the group has a title.
+    title_y: Option<f32>,
+    /// The grouped-list card behind the rows.
+    card: Rect,
+    rows: Vec<(&'a Row, Rect)>,
+}
+
+impl GroupLayout<'_> {
+    /// Everything the group paints, title band included.
+    fn bounds(&self) -> Rect {
+        match self.title_y {
+            Some(top) => Rect::from_ltrb(self.card.left, top, self.card.right, self.card.bottom),
+            None => self.card,
+        }
+    }
+}
+
+/// A whole pane placed in content-local coordinates.
+struct PaneLayout<'a> {
+    /// The displays arrangement canvas, on the pane that has one.
+    arrangement: Option<Rect>,
+    groups: Vec<GroupLayout<'a>>,
+    /// Where the walk ended — the pane's content height.
+    height: f32,
+}
+
+/// Does `rect` fall inside the band of content being asked for?
+///
+/// Only the vertical extent is compared: a pane is a single column that
+/// always spans the full content width, so a horizontal test would reject
+/// nothing and would misjudge anything (a badge, a restart pill) that a
+/// measured control pushes past the nominal right edge. The comparison is
+/// inclusive so a row ending exactly on the band's top edge survives, and
+/// with it the separator hairline it draws on that edge.
+fn intersects_band(rect: Rect, band: Rect) -> bool {
+    rect.bottom >= band.top && rect.top <= band.bottom
+}
+
+pub struct Settings {
+    /// The surface's current size in logical points, from the last configure.
+    pub width: f32,
+    pub height: f32,
+    pub panes: Vec<Pane>,
+    pub selected: usize,
+    pub theme: Theme,
+    pub dark: bool,
+    /// Identifier of the row whose dropdown is currently open, so its field
+    /// draws in the open state while the menu is up.
+    pub open_dropdown: Option<&'static str>,
+    /// Same, for the row whose colour picker is open.
+    pub open_picker: Option<&'static str>,
+    /// Knob positions for switches that are mid-flip, keyed by setting id.
+    /// A row not listed here draws its switch at rest — see
+    /// [`Settings::with_toggle_flips`].
+    pub toggle_flips: HashMap<&'static str, f32>,
+    /// Whether the surface carries compositor background blur, so the sidebar
+    /// can be painted as a translucent material rather than a flat fill.
+    pub blurred: bool,
+    /// Pointer state of the traffic lights: the app draws its own decoration,
+    /// so revealing the glyphs on hover is the app's job too.
+    pub controls: WindowControlsState,
+}
+
+impl Settings {
+    pub fn new(selected: usize, dark: bool) -> Self {
+        Self {
+            width: WINDOW_W,
+            height: WINDOW_H,
+            panes: model::panes(),
+            selected,
+            theme: if dark { Theme::dark() } else { Theme::light() },
+            dark,
+            open_dropdown: None,
+            open_picker: None,
+            toggle_flips: HashMap::new(),
+            blurred: false,
+            controls: WindowControlsState::new(),
+        }
+    }
+
+    /// The surface has compositor blur behind it.
+    pub fn with_blur(mut self, blurred: bool) -> Self {
+        self.blurred = blurred;
+        self
+    }
+
+    /// Draw against the surface's actual size rather than the size it was
+    /// created at. Clamped so a very small surface still lays out.
+    pub fn with_size(mut self, width: f32, height: f32) -> Self {
+        self.width = width.max(MIN_W);
+        self.height = height.max(MIN_H);
+        self
+    }
+
+    /// The scrollable pane viewport at this window's current size, in
+    /// window-local coordinates.
+    pub fn viewport(&self) -> Rect {
+        pane_viewport(self.width, self.height)
+    }
+
+    /// The same viewport in the pane's own coordinates — see
+    /// [`pane_viewport_local`].
+    pub fn local_viewport(&self) -> Rect {
+        pane_viewport_local(self.width, self.height)
+    }
+
+    /// Where each mid-flip switch's knob currently is, 0.0 off to 1.0 on.
+    ///
+    /// The value itself is already in the store by the time a flip runs — the
+    /// change is applied on press, not when the animation lands — so this is
+    /// purely how the switch is drawn on the way there.
+    pub fn with_toggle_flips(mut self, flips: HashMap<&'static str, f32>) -> Self {
+        self.toggle_flips = flips;
+        self
+    }
+
+    /// Mark one row's dropdown as open.
+    pub fn with_open_dropdown(mut self, id: Option<&'static str>) -> Self {
+        self.open_dropdown = id;
+        self
+    }
+
+    /// Carry the traffic lights' hover/press state into this frame.
+    pub fn with_controls(mut self, controls: WindowControlsState) -> Self {
+        self.controls = controls;
+        self
+    }
+
+    /// Mark one row's colour picker as open.
+    pub fn with_open_picker(mut self, id: Option<&'static str>) -> Self {
+        self.open_picker = id;
+        self
+    }
+
+    fn fill(&self, color: Color) -> Paint {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(color);
+        paint
+    }
+
+    /// Render with the pane content unscrolled — what `--png` previews and
+    /// any caller without an interactive scroll position want.
+    pub fn render(&self, canvas: &Canvas) {
+        self.render_with_scroll(canvas, 0.0);
+    }
+
+    /// Render with the pane content's vertical scroll at `pane_scroll_offset`
+    /// (content-local points, as tracked by an externally-owned
+    /// [`ScrollView`](otto_kit::components::scroll::ScrollView)). The window
+    /// chrome — titlebar, sidebar — never scrolls.
+    pub fn render_with_scroll(&self, canvas: &Canvas, pane_scroll_offset: f32) {
+        let mut scroll = ScrollState::new(self.viewport());
+        scroll.set_content_length(self.pane_content_height());
+        scroll.set_offset(pane_scroll_offset);
+        // A still render has no gesture to fade the overlay bar in, so show
+        // it outright — a screenshot of a scrolled pane should say so.
+        scroll.set_scrollbar_opacity(1.0);
+        self.render_with_scroll_state(canvas, &scroll);
+    }
+
+    /// Render from a live [`ScrollState`] — the interactive path, where the
+    /// offset comes with an overscroll bounce and a fading scrollbar that
+    /// [`ScrollView`](otto_kit::components::scroll::ScrollView) is animating.
+    pub fn render_with_scroll_state(&self, canvas: &Canvas, scroll: &ScrollState) {
+        canvas.save();
+        canvas.clip_rrect(self.frame(), ClipOp::Intersect, true);
+
+        self.render_ground(canvas);
+        self.render_sidebar(canvas);
+
+        let content_width = self.width - SIDEBAR_W;
+        ScrollRenderer::draw(canvas, scroll, &self.theme, |canvas, content| {
+            self.render_pane(canvas, content_width, content);
+        });
+
+        self.render_titlebar(canvas);
+        self.render_divider(canvas, SIDEBAR_W);
+
+        canvas.restore();
+    }
+
+    /// Everything the window surface itself paints: the two grounds, the
+    /// sidebar, the titlebar and the divider — and no pane content.
+    ///
+    /// The pane scrolls in its own compositor-cropped subsurfaces (see
+    /// `main.rs`), which sit over the whole viewport. Painting the content
+    /// here as well would only be overdraw the window would have to repaint on
+    /// every frame of a scroll, which is the cost the subsurfaces exist to
+    /// remove.
+    pub fn render_chrome(&self, canvas: &Canvas) {
+        canvas.save();
+        canvas.clip_rrect(self.frame(), ClipOp::Intersect, true);
+
+        self.render_ground(canvas);
+        self.render_sidebar(canvas);
+        self.render_titlebar(canvas);
+        // The pane surface starts exactly at `SIDEBAR_W`, so a hairline
+        // centred there would lose its right half underneath it. Nudging it
+        // half a point left keeps the whole stroke on the window's own side.
+        self.render_divider(canvas, SIDEBAR_W - 0.5);
+
+        canvas.restore();
+    }
+
+    /// The pane's content for one band of it, in content-local coordinates —
+    /// what the pane's own surface paints. See [`Self::render_pane`] for the
+    /// coordinate space and for what `band` licenses.
+    pub fn render_content(&self, canvas: &Canvas, band: Rect) {
+        self.render_pane(canvas, self.width - SIDEBAR_W, band);
+    }
+
+    /// The window's rounded outline, which everything is clipped to.
+    fn frame(&self) -> RRect {
+        RRect::new_rect_xy(Rect::from_wh(self.width, self.height), CORNER, CORNER)
+    }
+
+    /// The two backdrops: the opaque content area and the sidebar's material.
+    ///
+    /// The content area is painted even though the pane's own surface covers
+    /// it — it is what shows through wherever that surface does not reach, in
+    /// particular the gap a rubber-band overscroll opens at either end.
+    fn render_ground(&self, canvas: &Canvas) {
+        // Only below the titlebar: the band itself is a translucent material
+        // (see `render_titlebar`), so it must not have an opaque ground under
+        // it.
+        canvas.draw_rect(
+            Rect::from_ltrb(SIDEBAR_W, TITLEBAR_H, self.width, self.height),
+            &self.fill(pane_background(self.dark)),
+        );
+
+        // The sidebar is a translucent material over whatever the compositor
+        // blurs behind the surface. It only reads as a material if the
+        // surface actually carries `BackgroundBlur` — otherwise this is a
+        // tint over the raw desktop. See `main.rs`, where the blend mode is
+        // set.
+        canvas.draw_rect(
+            Rect::from_wh(SIDEBAR_W, self.height),
+            &self.fill(if self.blurred {
+                self.theme.material_sidebar
+            } else if self.dark {
+                Color::from_rgb(0x1C, 0x1E, 0x22)
+            } else {
+                Color::from_rgb(0xEE, 0xEE, 0xF0)
+            }),
+        );
+    }
+
+    /// Sidebar/content divider, drawn last so it sits above both.
+    fn render_divider(&self, canvas: &Canvas, x: f32) {
+        let mut hairline = Paint::default();
+        hairline.set_color(self.theme.fill_tertiary);
+        hairline.set_stroke_width(1.0);
+        canvas.draw_line(Point::new(x, 0.0), Point::new(x, self.height), &hairline);
+    }
+
+    /// Place the selected pane's content in content-local coordinates.
+    ///
+    /// Drawing, measuring and hit-testing all go through this one walk, so
+    /// the painted geometry, the height the scroll view is told about and the
+    /// clickable rects cannot drift apart.
+    fn pane_layout(&self, content_width: f32) -> PaneLayout<'_> {
+        let pane = &self.panes[self.selected];
+        let x0 = CONTENT_PAD;
+        let x1 = content_width - CONTENT_PAD;
+        let mut y = CONTENT_TOP_PAD;
+
+        let arrangement = (pane.name == "Displays").then(|| {
+            let area = Rect::from_ltrb(x0, y, x1, y + ARRANGEMENT_HEIGHT);
+            y += ARRANGEMENT_HEIGHT;
+            area
+        });
+
+        let mut groups = Vec::with_capacity(pane.groups.len());
+        for group in &pane.groups {
+            let title_y = group.title.map(|_| {
+                let top = y;
+                y += 24.0;
+                top
+            });
+
+            let card_top = y;
+            let rows: Vec<_> = group
+                .rows
+                .iter()
+                .map(|row| {
+                    let height = Self::row_height(row);
+                    let rect = Rect::from_ltrb(x0, y, x1, y + height);
+                    y += height;
+                    (row, rect)
+                })
+                .collect();
+            let card = Rect::from_ltrb(x0, card_top, x1, y);
+            y += GROUP_GAP;
+
+            groups.push(GroupLayout {
+                title: group.title,
+                title_y,
+                card,
+                rows,
+            });
+        }
+
+        PaneLayout {
+            arrangement,
+            groups,
+            height: y,
+        }
+    }
+
+    /// Total height of the selected pane's content, in the same
+    /// content-local coordinate space `render_pane` draws in.
+    pub fn pane_content_height(&self) -> f32 {
+        self.pane_layout(self.width - SIDEBAR_W).height
+    }
+
+    /// Every row of the selected pane, with the rect it is drawn in, in
+    /// content-local coordinates.
+    fn row_rects(&self, content_width: f32) -> Vec<(&Row, Rect)> {
+        self.pane_layout(content_width)
+            .groups
+            .into_iter()
+            .flat_map(|group| group.rows)
+            .collect()
+    }
+
+    /// The setting a click lands on, given a window-local point and the pane's
+    /// current scroll offset. Returns the row's identifier, the value the
+    /// click implies, and whether the caller should keep tracking a drag.
+    pub fn hit(&self, x: f32, y: f32, scroll_offset: f32) -> Option<Hit> {
+        let viewport = self.viewport();
+        if !viewport.contains(Point::new(x, y)) {
+            return None;
+        }
+
+        let content_width = self.width - SIDEBAR_W;
+        let local = Point::new(x - viewport.left, y - viewport.top + scroll_offset);
+
+        let (row, rect) = self
+            .row_rects(content_width)
+            .into_iter()
+            .find(|(_, rect)| rect.contains(local))?;
+        let id = row.id?;
+        let right = rect.right - 14.0;
+        let cy = rect.center_y();
+
+        match &row.control {
+            Control::Toggle(on) => {
+                let toggle = Rect::from_xywh(
+                    right - widgets::TOGGLE_W,
+                    cy - widgets::TOGGLE_H / 2.0,
+                    widgets::TOGGLE_W,
+                    widgets::TOGGLE_H,
+                );
+                toggle.contains(local).then(|| Hit {
+                    id,
+                    value: Value::Bool(!on),
+                    draggable: false,
+                })
+            }
+            Control::Slider {
+                min, max, readout, ..
+            } => {
+                let readout_w = styles::BODY.font().measure_str(readout, None).0;
+                let track_x = right - readout_w - 12.0 - widgets::SLIDER_W;
+                // Generous vertically: the track is 4pt tall, which is not a
+                // realistic click target.
+                let track = Rect::from_xywh(track_x, cy - 12.0, widgets::SLIDER_W, 24.0);
+                track.contains(local).then(|| {
+                    let t = ((local.x - track_x) / widgets::SLIDER_W).clamp(0.0, 1.0);
+                    Hit {
+                        id,
+                        value: settings_client::number_for(id, min + t * (max - min)),
+                        draggable: true,
+                    }
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// The identifier of the file row whose "Choose…" button a click lands
+    /// on. Separate from [`Self::hit`] for the same reason a dropdown is: it
+    /// does not carry a new value, it starts something that will produce one.
+    pub fn file_hit(&self, x: f32, y: f32, scroll_offset: f32) -> Option<&'static str> {
+        let viewport = self.viewport();
+        if !viewport.contains(Point::new(x, y)) {
+            return None;
+        }
+
+        let content_width = self.width - SIDEBAR_W;
+        let local = Point::new(x - viewport.left, y - viewport.top + scroll_offset);
+
+        let (row, rect) = self
+            .row_rects(content_width)
+            .into_iter()
+            .find(|(_, rect)| rect.contains(local))?;
+        let id = row.id?;
+        if !matches!(row.control, Control::File(_)) {
+            return None;
+        }
+        widgets::choose_rect(rect.right - 14.0, rect.center_y())
+            .contains(local)
+            .then_some(id)
+    }
+
+    /// The pop-up button a click lands on, if any. Separate from [`Self::hit`]
+    /// because a dropdown does not change a value on press — it opens a menu,
+    /// and the value changes when something in that menu is chosen.
+    pub fn select_hit(&self, x: f32, y: f32, scroll_offset: f32) -> Option<SelectHit> {
+        let viewport = self.viewport();
+        if !viewport.contains(Point::new(x, y)) {
+            return None;
+        }
+
+        let content_width = self.width - SIDEBAR_W;
+        let local = Point::new(x - viewport.left, y - viewport.top + scroll_offset);
+
+        let (row, rect) = self
+            .row_rects(content_width)
+            .into_iter()
+            .find(|(_, rect)| rect.contains(local))?;
+        let id = row.id?;
+        let Control::Select(current) = &row.control else {
+            return None;
+        };
+
+        let field = select_rect(rect.right - 14.0, rect.center_y());
+        if !dropdown::field::hit_test(field, local.x, local.y) {
+            return None;
+        }
+
+        // Back into window-local coordinates for the popup's anchor rect: the
+        // menu is positioned against the surface, not against scrolled content.
+        Some(SelectHit {
+            id,
+            rect: Rect::from_xywh(
+                field.left + viewport.left,
+                field.top + viewport.top - scroll_offset,
+                field.width(),
+                field.height(),
+            ),
+            current: current.clone(),
+        })
+    }
+
+    /// The colour well a click lands on, if any. Like a dropdown, a well does
+    /// not change a value on press — it opens a picker.
+    pub fn color_hit(&self, x: f32, y: f32, scroll_offset: f32) -> Option<ColorHit> {
+        let viewport = self.viewport();
+        if !viewport.contains(Point::new(x, y)) {
+            return None;
+        }
+
+        let content_width = self.width - SIDEBAR_W;
+        let local = Point::new(x - viewport.left, y - viewport.top + scroll_offset);
+
+        let (row, rect) = self
+            .row_rects(content_width)
+            .into_iter()
+            .find(|(_, rect)| rect.contains(local))?;
+        let id = row.id?;
+        let Control::Color(argb) = &row.control else {
+            return None;
+        };
+
+        let color = Color::from(*argb);
+        let well = well_rect(rect.right - 14.0, rect.center_y(), color);
+        if !color_picker::well::hit_test(well, local.x, local.y) {
+            return None;
+        }
+
+        Some(ColorHit {
+            id,
+            rect: Rect::from_xywh(
+                well.left + viewport.left,
+                well.top + viewport.top - scroll_offset,
+                well.width(),
+                well.height(),
+            ),
+            current: color,
+        })
+    }
+
+    /// The value a drag to `x` implies, for a slider already being dragged.
+    pub fn drag_value(&self, id: &str, x: f32) -> Option<Value> {
+        let content_width = self.width - SIDEBAR_W;
+        let local_x = x - SIDEBAR_W;
+
+        let (row, rect) = self
+            .row_rects(content_width)
+            .into_iter()
+            .find(|(row, _)| row.id == Some(id))?;
+
+        match &row.control {
+            Control::Slider {
+                min, max, readout, ..
+            } => {
+                let readout_w = styles::BODY.font().measure_str(readout, None).0;
+                let track_x = rect.right - 14.0 - readout_w - 12.0 - widgets::SLIDER_W;
+                let t = ((local_x - track_x) / widgets::SLIDER_W).clamp(0.0, 1.0);
+                let raw = min + t * (max - min);
+                Some(settings_client::number_for(
+                    id,
+                    settings_client::snap(id, raw),
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    fn render_titlebar(&self, canvas: &Canvas) {
+        // The band over the content is slightly translucent, so the frosted
+        // backdrop carries across the whole top of the window instead of
+        // stopping at the sidebar's edge. Without compositor blur it would be
+        // a tint over the raw desktop, so paint it flat there.
+        canvas.draw_rect(
+            Rect::from_ltrb(SIDEBAR_W, 0.0, self.width, TITLEBAR_H),
+            &self.fill(if self.blurred {
+                titlebar_material(self.dark)
+            } else {
+                pane_background(self.dark)
+            }),
+        );
+
+        // Traffic lights sit over the sidebar; the pane name titles the bar.
+        Titlebar::new()
+            .at(0.0, 0.0)
+            .with_width(self.width)
+            .with_height(TITLEBAR_H)
+            .with_corner_radius(CORNER)
+            .with_padding(TITLEBAR_PAD)
+            .with_background(Color::TRANSPARENT)
+            .with_leading(
+                TitlebarGroup::new().add(
+                    self.controls
+                        .apply(WindowControls::new().with_active(true).with_dark(self.dark)),
+                ),
+            )
+            .render(canvas);
+
+        widgets::text_centered_y(
+            canvas,
+            self.panes[self.selected].name,
+            SIDEBAR_W + CONTENT_PAD,
+            TITLEBAR_H / 2.0,
+            styles::TITLE_3_EMPHASIZED,
+            self.theme.text_primary,
+        );
+
+        // Hairline under the bar, separating it from the pane. Like the
+        // vertical divider it is nudged half a point onto the window's own
+        // side, since the pane's surface starts exactly at `TITLEBAR_H` and
+        // would take the lower half of a centred stroke with it. It stops at
+        // the sidebar, which runs the full height of the window.
+        let mut hairline = Paint::default();
+        hairline.set_color(self.theme.fill_tertiary);
+        hairline.set_stroke_width(1.0);
+        canvas.draw_line(
+            Point::new(SIDEBAR_W, TITLEBAR_H - 0.5),
+            Point::new(self.width, TITLEBAR_H - 0.5),
+            &hairline,
+        );
+    }
+
+    fn render_sidebar(&self, canvas: &Canvas) {
+        // Search field
+        let field = Rect::from_xywh(12.0, TITLEBAR_H + 10.0, SIDEBAR_W - 24.0, 26.0);
+        let rrect = RRect::new_rect_xy(field, 7.0, 7.0);
+        canvas.draw_rrect(rrect, &self.fill(self.theme.fill_tertiary));
+        self.magnifier(canvas, field.left + 10.0, field.center_y());
+        widgets::text_centered_y(
+            canvas,
+            "Search",
+            field.left + 24.0,
+            field.center_y(),
+            styles::BODY,
+            self.theme.text_tertiary,
+        );
+
+        for (i, pane) in self.panes.iter().enumerate() {
+            let item = sidebar_item_rect(i);
+            let selected = i == self.selected;
+            if selected {
+                canvas.draw_rrect(
+                    RRect::new_rect_xy(item, 7.0, 7.0),
+                    &self.fill(self.theme.material_selection_focused),
+                );
+            }
+            let tint = if selected {
+                Color::WHITE
+            } else {
+                self.theme.text_primary
+            };
+
+            glyphs::draw(
+                canvas,
+                pane.icon,
+                item.left + 17.0,
+                item.center_y(),
+                15.0,
+                tint,
+            );
+
+            widgets::text_centered_y(
+                canvas,
+                pane.name,
+                item.left + 33.0,
+                item.center_y(),
+                if selected {
+                    styles::BODY_EMPHASIZED
+                } else {
+                    styles::BODY
+                },
+                tint,
+            );
+        }
+    }
+
+    fn magnifier(&self, canvas: &Canvas, cx: f32, cy: f32) {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_style(skia_safe::PaintStyle::Stroke);
+        paint.set_stroke_width(1.3);
+        paint.set_color(self.theme.text_tertiary);
+        canvas.draw_circle(Point::new(cx - 0.5, cy - 0.5), 4.0, &paint);
+        canvas.draw_line(
+            Point::new(cx + 2.5, cy + 2.5),
+            Point::new(cx + 5.0, cy + 5.0),
+            &paint,
+        );
+    }
+
+    /// Draws in content-local coordinates: `(0, 0)` is the pane viewport's
+    /// top-left, i.e. `(SIDEBAR_W, TITLEBAR_H)`. The caller is responsible
+    /// for the clip and scroll translation (see [`Self::render_with_scroll`]).
+    ///
+    /// `content` is the band of that space the caller wants painted. Anything
+    /// lying entirely outside it is skipped — text a scrolled-away row would
+    /// have shaped is the expensive part of a frame, and it is invisible. A
+    /// caller that wants the whole pane passes a band tall enough to hold it.
+    fn render_pane(&self, canvas: &Canvas, content_width: f32, content: Rect) {
+        let layout = self.pane_layout(content_width);
+        let x0 = CONTENT_PAD;
+        let x1 = content_width - CONTENT_PAD;
+
+        if let Some(area) = layout.arrangement {
+            if intersects_band(area, content) {
+                self.render_arrangement(canvas, x0, x1, area.top);
+            }
+        }
+
+        for group in &layout.groups {
+            if std::env::var_os("OTTO_PANE_DEBUG").is_some() {
+                eprintln!(
+                    "[groupdbg] {:?} bounds {:?} band {:?} drawn={}",
+                    group.title,
+                    group.bounds(),
+                    content,
+                    intersects_band(group.bounds(), content)
+                );
+            }
+            if !intersects_band(group.bounds(), content) {
+                continue;
+            }
+
+            if let (Some(title), Some(title_y)) = (group.title, group.title_y) {
+                widgets::text_centered_y(
+                    canvas,
+                    title,
+                    x0 + 2.0,
+                    title_y + 9.0,
+                    styles::SUBHEADLINE_EMPHASIZED,
+                    self.theme.text_secondary,
+                );
+            }
+
+            // Grouped-list card behind the rows.
+            let rrect = RRect::new_rect_xy(group.card, 9.0, 9.0);
+            canvas.draw_rrect(
+                rrect,
+                &self.fill(if self.dark {
+                    Color::from_argb(0x14, 0xFF, 0xFF, 0xFF)
+                } else {
+                    Color::WHITE
+                }),
+            );
+            let mut border = Paint::default();
+            border.set_anti_alias(true);
+            border.set_style(skia_safe::PaintStyle::Stroke);
+            border.set_stroke_width(1.0);
+            border.set_color(self.theme.fill_tertiary);
+            canvas.draw_rrect(rrect, &border);
+
+            for (i, (row, rect)) in group.rows.iter().enumerate() {
+                if !intersects_band(*rect, content) {
+                    continue;
+                }
+                self.render_row(canvas, row, x0, x1, rect.top, rect.height());
+                if i + 1 < group.rows.len() {
+                    widgets::separator(canvas, x0 + 14.0, x1, rect.bottom, &self.theme);
+                }
+            }
+        }
+    }
+
+    fn row_height(row: &Row) -> f32 {
+        if row.detail.is_some() {
+            ROW_H_DETAIL
+        } else {
+            ROW_H
+        }
+    }
+
+    fn render_row(&self, canvas: &Canvas, row: &Row, x0: f32, x1: f32, y: f32, h: f32) {
+        let cy = y + h / 2.0;
+        let label_x = x0 + 14.0;
+        let right = x1 - 14.0;
+
+        match row.detail.as_deref() {
+            Some(detail) => {
+                widgets::text_centered_y(
+                    canvas,
+                    row.label,
+                    label_x,
+                    cy - 9.0,
+                    styles::BODY,
+                    self.theme.text_primary,
+                );
+                widgets::text_centered_y(
+                    canvas,
+                    detail,
+                    label_x,
+                    cy + 9.0,
+                    styles::SUBHEADLINE,
+                    self.theme.text_secondary,
+                );
+            }
+            None => widgets::text_centered_y(
+                canvas,
+                row.label,
+                label_x,
+                cy,
+                styles::BODY,
+                self.theme.text_primary,
+            ),
+        }
+
+        if row.overridden {
+            let label_w = styles::BODY.font().measure_str(row.label, None).0;
+            let badge_y = if row.detail.is_some() { cy - 9.0 } else { cy };
+            widgets::revert_badge(canvas, label_x + label_w + 12.0, badge_y, &self.theme);
+        }
+
+        match &row.control {
+            Control::Toggle(on) => {
+                let fraction = row
+                    .id
+                    .and_then(|id| self.toggle_flips.get(id).copied())
+                    .unwrap_or_else(|| toggle::knob_fraction_for(*on));
+                widgets::toggle(canvas, right - widgets::TOGGLE_W, cy, fraction, &self.theme)
+            }
+            Control::Slider {
+                value,
+                min,
+                max,
+                readout,
+            } => {
+                let readout_w = styles::BODY.font().measure_str(readout, None).0;
+                let x = right - readout_w - 12.0 - widgets::SLIDER_W;
+                widgets::slider(canvas, x, cy, *value, *min, *max, readout, &self.theme);
+            }
+            Control::Select(value) => {
+                let open = row.id.is_some() && row.id == self.open_dropdown;
+                // The control holds the configuration token; the field shows
+                // the schema's human name for it where there is one.
+                let shown = match row.id {
+                    Some(id) => settings_client::display_choice(id, value),
+                    None => value.clone(),
+                };
+                dropdown::field::draw(
+                    canvas,
+                    select_rect(right, cy),
+                    &shown,
+                    if open {
+                        DropdownInteraction::Open
+                    } else {
+                        DropdownInteraction::Normal
+                    },
+                    &self.theme,
+                );
+            }
+            Control::Color(argb) => {
+                let color = Color::from(*argb);
+                let open = row.id.is_some() && row.id == self.open_picker;
+                color_picker::well::draw(
+                    canvas,
+                    well_rect(right, cy, color),
+                    color,
+                    if open {
+                        WellInteraction::Open
+                    } else {
+                        WellInteraction::Normal
+                    },
+                    &self.theme,
+                );
+            }
+            Control::Text(value) => widgets::text_field(canvas, right, cy, value, &self.theme),
+            Control::File(value) => widgets::file_field(canvas, right, cy, value, &self.theme),
+            Control::Value(value) => {
+                // Shortcut rows read as key combinations; everything else is
+                // plain secondary text.
+                if value.contains('+') {
+                    widgets::key_combo(canvas, right, cy, value, &self.theme)
+                } else {
+                    widgets::text_right(
+                        canvas,
+                        value,
+                        right,
+                        cy,
+                        styles::BODY,
+                        self.theme.text_secondary,
+                    )
+                }
+            }
+        }
+
+        // The pill trails the text it belongs to — the detail line if there is
+        // one, otherwise the label — so it can never sit on top of either.
+        if row.restart_required {
+            let (text, style, pill_cy) = match row.detail.as_deref() {
+                Some(detail) => (detail, styles::SUBHEADLINE, cy + 9.0),
+                None => (row.label, styles::BODY, cy),
+            };
+            let after_text = label_x + style.font().measure_str(text, None).0 + 10.0;
+            // A row that also carries the override badge has to clear that too.
+            let x = if row.overridden && row.detail.is_none() {
+                after_text + 14.0
+            } else {
+                after_text
+            };
+            widgets::restart_pill(canvas, x, pill_cy);
+        }
+    }
+
+    /// Displays arrangement canvas, drawn from `y` down. It occupies
+    /// [`ARRANGEMENT_HEIGHT`], which is what the pane walk reserves for it.
+    fn render_arrangement(&self, canvas: &Canvas, x0: f32, x1: f32, y: f32) {
+        let outputs = model::outputs();
+        let area = Rect::from_ltrb(x0, y, x1, y + 168.0);
+        let rrect = RRect::new_rect_xy(area, 9.0, 9.0);
+        canvas.draw_rrect(
+            rrect,
+            &self.fill(if self.dark {
+                Color::from_argb(0x14, 0xFF, 0xFF, 0xFF)
+            } else {
+                Color::from_argb(0x08, 0x00, 0x00, 0x00)
+            }),
+        );
+
+        // Fit the desktop bounding box into the area with a margin.
+        let min_x = outputs.iter().map(|o| o.x).fold(f32::MAX, f32::min);
+        let min_y = outputs.iter().map(|o| o.y).fold(f32::MAX, f32::min);
+        let max_x = outputs
+            .iter()
+            .map(|o| o.x + o.width)
+            .fold(f32::MIN, f32::max);
+        let max_y = outputs
+            .iter()
+            .map(|o| o.y + o.height)
+            .fold(f32::MIN, f32::max);
+        let margin = 22.0;
+        let scale = ((area.width() - margin * 2.0) / (max_x - min_x))
+            .min((area.height() - margin * 2.0) / (max_y - min_y));
+        let ox = area.left + (area.width() - (max_x - min_x) * scale) / 2.0 - min_x * scale;
+        let oy = area.top + (area.height() - (max_y - min_y) * scale) / 2.0 - min_y * scale;
+
+        widgets::dashed_rect(
+            canvas,
+            Rect::from_ltrb(
+                ox + min_x * scale - 6.0,
+                oy + min_y * scale - 6.0,
+                ox + max_x * scale + 6.0,
+                oy + max_y * scale + 6.0,
+            ),
+            self.theme.fill_tertiary,
+        );
+
+        for output in &outputs {
+            let rect = Rect::from_xywh(
+                ox + output.x * scale,
+                oy + output.y * scale,
+                output.width * scale,
+                output.height * scale,
+            );
+            let rrect = RRect::new_rect_xy(rect, 4.0, 4.0);
+            canvas.draw_rrect(
+                rrect,
+                &self.fill(if self.dark {
+                    Color::from_rgb(0x33, 0x39, 0x45)
+                } else {
+                    Color::from_rgb(0xD5, 0xDC, 0xE6)
+                }),
+            );
+            // Selection is the accent ring; being primary is the bar strip.
+            // They are different states and a display can have either.
+            let mut border = Paint::default();
+            border.set_anti_alias(true);
+            border.set_style(skia_safe::PaintStyle::Stroke);
+            border.set_stroke_width(if output.selected { 2.0 } else { 1.0 });
+            border.set_color(if output.selected {
+                self.theme.accent
+            } else {
+                self.theme.fill_primary
+            });
+            canvas.draw_rrect(rrect, &border);
+
+            if output.primary {
+                let strip = Rect::from_ltrb(rect.left, rect.top, rect.right, rect.top + 4.0);
+                canvas.save();
+                canvas.clip_rrect(rrect, ClipOp::Intersect, true);
+                canvas.draw_rect(strip, &self.fill(self.theme.text_secondary));
+                canvas.restore();
+            }
+
+            let style = styles::SUBHEADLINE;
+            let width = style.font().measure_str(output.name, None).0;
+            widgets::text_centered_y(
+                canvas,
+                output.name,
+                rect.center_x() - width / 2.0,
+                rect.center_y(),
+                style,
+                self.theme.text_primary,
+            );
+        }
+
+        widgets::text_centered_y(
+            canvas,
+            "Drag a display to rearrange it",
+            x0 + 2.0,
+            area.bottom + 12.0,
+            styles::SUBHEADLINE,
+            self.theme.text_tertiary,
+        );
+    }
+}
+
+/// Rounded window with a drop shadow, drawn on a desktop backdrop.
+pub fn render_on_desktop(canvas: &Canvas, settings: &Settings, x: f32, y: f32) {
+    let frame = Rect::from_xywh(x, y, settings.width, settings.height);
+    let rrect = RRect::new_rect_xy(frame, CORNER, CORNER);
+
+    let mut shadow = Paint::default();
+    shadow.set_anti_alias(true);
+    shadow.set_color(Color::from_argb(0x59, 0, 0, 0));
+    shadow.set_mask_filter(skia_safe::MaskFilter::blur(
+        skia_safe::BlurStyle::Normal,
+        18.0,
+        false,
+    ));
+    canvas.save();
+    canvas.translate((0.0, 10.0));
+    canvas.draw_rrect(rrect, &shadow);
+    canvas.restore();
+
+    canvas.save();
+    canvas.translate((x, y));
+    settings.render(canvas);
+    canvas.restore();
+
+    // Hairline edge so the window reads as separate from the wallpaper.
+    let mut edge = Paint::default();
+    edge.set_anti_alias(true);
+    edge.set_style(skia_safe::PaintStyle::Stroke);
+    edge.set_stroke_width(1.0);
+    edge.set_color(Color::from_argb(0x2E, 0xFF, 0xFF, 0xFF));
+    canvas.draw_rrect(rrect, &edge);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skia_safe::PictureRecorder;
+
+    /// The pane with the most content, so there is something to scroll past.
+    fn tallest_pane() -> Settings {
+        (0..model::panes().len())
+            .map(|i| Settings::new(i, false))
+            .max_by(|a, b| a.pane_content_height().total_cmp(&b.pane_content_height()))
+            .expect("at least one pane")
+    }
+
+    /// Draw ops `render_pane` emits for one band of content.
+    fn ops_for_band(settings: &Settings, band: Rect) -> usize {
+        let content_width = settings.width - SIDEBAR_W;
+        let mut recorder = PictureRecorder::new();
+        let canvas = recorder.begin_recording(
+            Rect::from_wh(content_width, settings.pane_content_height()),
+            false,
+        );
+        settings.render_pane(canvas, content_width, band);
+        recorder
+            .finish_recording_as_picture(None)
+            .expect("recorded picture")
+            .approximate_op_count()
+    }
+
+    /// The pixel at window-local `(x, y)` after `draw` has painted a window.
+    fn pixel_at(settings: &Settings, draw: impl FnOnce(&Canvas), x: i32, y: i32) -> [u8; 4] {
+        let mut surface =
+            skia_safe::surfaces::raster_n32_premul((settings.width as i32, settings.height as i32))
+                .expect("raster surface");
+        surface.canvas().clear(Color::TRANSPARENT);
+        draw(surface.canvas());
+        let info = skia_safe::ImageInfo::new(
+            (1, 1),
+            skia_safe::ColorType::RGBA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+        let mut pixel = [0u8; 4];
+        assert!(surface.read_pixels(&info, &mut pixel, 4, (x, y)));
+        pixel
+    }
+
+    #[test]
+    fn the_chrome_paints_the_ground_under_the_pane_but_none_of_its_content() {
+        // The pane's own surface paints the content now, so anything the
+        // window paints inside the viewport is overdraw it would have to
+        // repaint on every frame of a scroll.
+        let settings = Settings::new(0, false);
+        let card = settings.pane_layout(settings.width - SIDEBAR_W).groups[0].card;
+        let x = (SIDEBAR_W + card.left + 40.0) as i32;
+        let y = (TITLEBAR_H + card.top + 20.0) as i32;
+
+        let whole = pixel_at(&settings, |canvas| settings.render(canvas), x, y);
+        let chrome = pixel_at(&settings, |canvas| settings.render_chrome(canvas), x, y);
+        let ground = pane_background(false);
+
+        assert_ne!(whole, chrome, "the all-in-one render paints a card here");
+        assert_eq!(chrome, [ground.r(), ground.g(), ground.b(), 0xFF]);
+    }
+
+    #[test]
+    fn the_chrome_still_paints_the_sidebar_and_the_titlebar() {
+        let settings = Settings::new(0, false);
+        let item = sidebar_item_rect(0);
+        for (x, y) in [
+            (item.center_x() as i32, item.center_y() as i32),
+            (SIDEBAR_W as i32 + 60, (TITLEBAR_H / 2.0) as i32),
+        ] {
+            assert_eq!(
+                pixel_at(&settings, |canvas| settings.render(canvas), x, y),
+                pixel_at(&settings, |canvas| settings.render_chrome(canvas), x, y),
+            );
+        }
+    }
+
+    #[test]
+    fn the_panes_own_viewport_is_the_windows_with_its_origin_at_zero() {
+        // What the surfaces the pane lives in are placed and sized against.
+        let settings = Settings::new(0, false);
+        let window = settings.viewport();
+        assert_eq!(
+            settings.local_viewport(),
+            Rect::from_wh(window.width(), window.height())
+        );
+    }
+
+    #[test]
+    fn the_content_pass_draws_the_band_it_is_given() {
+        // The band closure hands `render_content` a rect in content space and
+        // expects exactly what the all-in-one path would have drawn for it.
+        let settings = tallest_pane();
+        let viewport = settings.viewport();
+        let band = Rect::from_xywh(0.0, 400.0, viewport.width(), viewport.height());
+
+        let mut recorder = PictureRecorder::new();
+        let canvas = recorder.begin_recording(
+            Rect::from_wh(viewport.width(), settings.pane_content_height()),
+            false,
+        );
+        settings.render_content(canvas, band);
+        let ops = recorder
+            .finish_recording_as_picture(None)
+            .expect("recorded picture")
+            .approximate_op_count();
+
+        assert_eq!(ops, ops_for_band(&settings, band));
+        assert!(ops > 0, "the band should hold something to draw");
+    }
+
+    fn rows_in_band(settings: &Settings, band: Rect) -> usize {
+        settings
+            .row_rects(settings.width - SIDEBAR_W)
+            .into_iter()
+            .filter(|(_, rect)| intersects_band(*rect, band))
+            .count()
+    }
+
+    #[test]
+    fn a_pane_taller_than_its_viewport_draws_only_the_visible_band() {
+        let settings = tallest_pane();
+        let viewport = settings.viewport();
+        assert!(
+            settings.pane_content_height() > viewport.height(),
+            "the test needs a pane that overflows"
+        );
+
+        let whole = Rect::from_wh(viewport.width(), settings.pane_content_height());
+        let visible = Rect::from_xywh(0.0, 0.0, viewport.width(), viewport.height());
+
+        assert!(ops_for_band(&settings, visible) < ops_for_band(&settings, whole));
+        assert!(rows_in_band(&settings, visible) < rows_in_band(&settings, whole));
+    }
+
+    #[test]
+    fn scrolling_draws_a_different_set_of_rows_not_a_larger_one() {
+        let settings = tallest_pane();
+        let viewport = settings.viewport();
+        let max_offset = settings.pane_content_height() - viewport.height();
+
+        let top = Rect::from_xywh(0.0, 0.0, viewport.width(), viewport.height());
+        let bottom = Rect::from_xywh(0.0, max_offset, viewport.width(), viewport.height());
+
+        let whole = Rect::from_wh(viewport.width(), settings.pane_content_height());
+        assert!(ops_for_band(&settings, bottom) < ops_for_band(&settings, whole));
+
+        // The last row is out of the first band and in the last one, which is
+        // what makes this a band and not a prefix.
+        let rows = settings.row_rects(settings.width - SIDEBAR_W);
+        let last = rows.last().expect("rows").1;
+        assert!(!intersects_band(last, top));
+        assert!(intersects_band(last, bottom));
+    }
+
+    #[test]
+    fn hit_testing_still_reaches_a_row_that_is_only_visible_when_scrolled() {
+        let settings = tallest_pane();
+        let viewport = settings.viewport();
+        let offset = settings.pane_content_height() - viewport.height();
+
+        let (_, rect) = settings
+            .row_rects(settings.width - SIDEBAR_W)
+            .into_iter()
+            .rfind(|(row, _)| matches!(row.control, Control::Toggle(_)))
+            .expect("a toggle somewhere in the pane");
+
+        let x = viewport.left + rect.right - 14.0 - widgets::TOGGLE_W / 2.0;
+        let y = viewport.top + rect.center_y() - offset;
+        assert!(settings.hit(x, y, offset).is_some());
+    }
+}

--- a/components/otto-settings/src/widgets.rs
+++ b/components/otto-settings/src/widgets.rs
@@ -1,0 +1,276 @@
+//! Controls used by the settings rows.
+//!
+//! Each one draws itself into a rect and reports nothing back — there is no
+//! hit-testing or state here yet. They exist so the panes can be looked at
+//! before any of them is wired to the compositor.
+
+use otto_kit::prelude::*;
+use skia_safe::{BlurStyle, ClipOp, MaskFilter, PaintStyle, PathBuilder, PathEffect, Point, RRect};
+
+/// Trailing-edge control width, so labels can be laid out against it.
+pub const TOGGLE_W: f32 = 40.0;
+pub const TOGGLE_H: f32 = 24.0;
+pub const SLIDER_W: f32 = 160.0;
+/// Width of a row's pop-up button. The control itself is
+/// `otto_kit::components::dropdown::field`; only the width is the pane's
+/// choice.
+pub const SELECT_W: f32 = 176.0;
+pub const CONTROL_H: f32 = 24.0;
+
+fn fill(color: Color) -> Paint {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(color);
+    paint
+}
+
+fn stroke(color: Color, width: f32) -> Paint {
+    let mut paint = fill(color);
+    paint.set_style(PaintStyle::Stroke);
+    paint.set_stroke_width(width);
+    paint
+}
+
+/// Text drawn so its optical centre sits on `cy`.
+pub fn text_centered_y(
+    canvas: &Canvas,
+    text: &str,
+    x: f32,
+    cy: f32,
+    style: TextStyle,
+    color: Color,
+) {
+    Label::new(text)
+        .with_style(style)
+        .with_color(color)
+        .centered_on(x, cy)
+        .render(canvas);
+}
+
+pub fn text_right(
+    canvas: &Canvas,
+    text: &str,
+    right: f32,
+    cy: f32,
+    style: TextStyle,
+    color: Color,
+) {
+    let width = style.font().measure_str(text, None).0;
+    text_centered_y(canvas, text, right - width, cy, style, color);
+}
+
+/// iOS-style switch, drawn by the toolkit's own control.
+///
+/// `knob_fraction` is where the knob sits: 0.0 off, 1.0 on, in between while
+/// a flip is animating. The track colour follows it, so the pane gets the
+/// slide and the colour change from one number.
+pub fn toggle(canvas: &Canvas, x: f32, cy: f32, knob_fraction: f32, theme: &Theme) {
+    let rect = Rect::from_xywh(x, cy - TOGGLE_H / 2.0, TOGGLE_W, TOGGLE_H);
+    toggle::draw(
+        canvas,
+        rect,
+        knob_fraction,
+        ToggleInteraction::Normal,
+        theme,
+    );
+}
+
+/// Track, filled portion, and knob. The readout sits to the right of the track.
+pub fn slider(
+    canvas: &Canvas,
+    x: f32,
+    cy: f32,
+    value: f32,
+    min: f32,
+    max: f32,
+    readout: &str,
+    theme: &Theme,
+) {
+    let t = ((value - min) / (max - min)).clamp(0.0, 1.0);
+    let track = Rect::from_xywh(x, cy - 2.0, SLIDER_W, 4.0);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(track, 2.0, 2.0),
+        &fill(theme.fill_secondary),
+    );
+    let filled = Rect::from_xywh(x, cy - 2.0, SLIDER_W * t, 4.0);
+    canvas.draw_rrect(RRect::new_rect_xy(filled, 2.0, 2.0), &fill(theme.accent));
+
+    let knob_x = x + SLIDER_W * t;
+    let mut shadow = fill(Color::from_argb(0x38, 0, 0, 0));
+    shadow.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, 2.0, false));
+    canvas.draw_circle(Point::new(knob_x, cy + 1.0), 8.0, &shadow);
+    canvas.draw_circle(Point::new(knob_x, cy), 8.0, &fill(Color::WHITE));
+    canvas.draw_circle(
+        Point::new(knob_x, cy),
+        8.0,
+        &stroke(theme.fill_tertiary, 0.5),
+    );
+
+    text_centered_y(
+        canvas,
+        readout,
+        x + SLIDER_W + 12.0,
+        cy,
+        styles::SUBHEADLINE,
+        theme.text_secondary,
+    );
+}
+
+/// Editable-looking text field, right-aligned like the other controls.
+pub fn text_field(canvas: &Canvas, right: f32, cy: f32, value: &str, theme: &Theme) {
+    let width = 220.0;
+    let rect = Rect::from_xywh(right - width, cy - CONTROL_H / 2.0, width, CONTROL_H);
+    let rrect = RRect::new_rect_xy(rect, 6.0, 6.0);
+    canvas.draw_rrect(rrect, &fill(theme.fill_quaternary));
+    canvas.draw_rrect(rrect, &stroke(theme.fill_secondary, 1.0));
+    canvas.save();
+    canvas.clip_rrect(rrect, ClipOp::Intersect, true);
+    text_centered_y(
+        canvas,
+        value,
+        rect.left + 9.0,
+        cy,
+        styles::SUBHEADLINE,
+        theme.text_primary,
+    );
+    canvas.restore();
+}
+
+/// The "Choose…" button's width, and the gap between it and the path field.
+pub const CHOOSE_W: f32 = 84.0;
+const CHOOSE_GAP: f32 = 8.0;
+/// The path field beside it.
+const FILE_FIELD_W: f32 = 196.0;
+
+/// Where the "Choose…" button sits, for drawing and for hit-testing.
+pub fn choose_rect(right: f32, cy: f32) -> Rect {
+    Rect::from_xywh(right - CHOOSE_W, cy - CONTROL_H / 2.0, CHOOSE_W, CONTROL_H)
+}
+
+/// A file setting: the chosen path, and the button that changes it.
+///
+/// The path is shown from its *end* when it does not fit — the file's own
+/// name is what identifies it, and truncating that away to keep `/home/user/`
+/// would leave the one part nobody needs.
+pub fn file_field(canvas: &Canvas, right: f32, cy: f32, value: &str, theme: &Theme) {
+    let button = choose_rect(right, cy);
+    let field = Rect::from_xywh(
+        button.left - CHOOSE_GAP - FILE_FIELD_W,
+        cy - CONTROL_H / 2.0,
+        FILE_FIELD_W,
+        CONTROL_H,
+    );
+
+    let rrect = RRect::new_rect_xy(field, 6.0, 6.0);
+    canvas.draw_rrect(rrect, &fill(theme.fill_quaternary));
+    canvas.draw_rrect(rrect, &stroke(theme.fill_secondary, 1.0));
+    canvas.save();
+    canvas.clip_rrect(rrect, ClipOp::Intersect, true);
+    let style = styles::SUBHEADLINE;
+    let (width, _) = style.font().measure_str(value, None);
+    let inner = FILE_FIELD_W - 18.0;
+    // Overflow to the left, so the tail stays put against the right edge.
+    let x = if width > inner {
+        field.left + 9.0 - (width - inner)
+    } else {
+        field.left + 9.0
+    };
+    let (text, color) = if value.is_empty() {
+        ("No file chosen", theme.text_tertiary)
+    } else {
+        (value, theme.text_primary)
+    };
+    text_centered_y(canvas, text, x, cy, style, color);
+    canvas.restore();
+
+    let brrect = RRect::new_rect_xy(button, 6.0, 6.0);
+    canvas.draw_rrect(brrect, &fill(theme.fill_tertiary));
+    canvas.draw_rrect(brrect, &stroke(theme.fill_secondary, 1.0));
+    let label = "Choose…";
+    let label_w = style.font().measure_str(label, None).0;
+    text_centered_y(
+        canvas,
+        label,
+        button.center_x() - label_w / 2.0,
+        cy,
+        style,
+        theme.text_primary,
+    );
+}
+
+/// Key combination shown as individual keycaps.
+pub fn key_combo(canvas: &Canvas, right: f32, cy: f32, combo: &str, theme: &Theme) {
+    let keys: Vec<&str> = combo.split('+').map(|k| k.trim()).collect();
+    let style = styles::FOOTNOTE;
+    let gap = 4.0;
+    let pad = 7.0;
+
+    let widths: Vec<f32> = keys
+        .iter()
+        .map(|k| style.font().measure_str(k, None).0 + pad * 2.0)
+        .collect();
+    let total: f32 = widths.iter().sum::<f32>() + gap * (keys.len() as f32 - 1.0);
+
+    let mut x = right - total;
+    for (key, width) in keys.iter().zip(&widths) {
+        let rect = Rect::from_xywh(x, cy - 11.0, *width, 22.0);
+        let rrect = RRect::new_rect_xy(rect, 5.0, 5.0);
+        canvas.draw_rrect(rrect, &fill(theme.fill_tertiary));
+        canvas.draw_rrect(rrect, &stroke(theme.fill_secondary, 1.0));
+        text_centered_y(canvas, key, x + pad, cy, style, theme.text_primary);
+        x += width + gap;
+    }
+}
+
+/// Small circular arrow marking a row that overrides its inherited value.
+pub fn revert_badge(canvas: &Canvas, cx: f32, cy: f32, theme: &Theme) {
+    let mut paint = stroke(theme.accent, 1.4);
+    paint.set_stroke_cap(skia_safe::paint::Cap::Round);
+    let r = 5.5;
+    let arc = Rect::from_xywh(cx - r, cy - r, r * 2.0, r * 2.0);
+    canvas.draw_arc(arc, 40.0, 280.0, false, &paint);
+
+    let mut head = PathBuilder::new();
+    head.move_to(Point::new(cx + r - 1.0, cy - r + 1.5));
+    head.line_to(Point::new(cx + r + 2.5, cy - r + 2.0));
+    head.line_to(Point::new(cx + r + 0.5, cy - r + 5.0));
+    head.close();
+    canvas.draw_path(&head.detach(), &fill(theme.accent));
+}
+
+/// "Restart required" pill. Amber regardless of theme — it is a status, not
+/// a surface.
+pub fn restart_pill(canvas: &Canvas, x: f32, cy: f32) {
+    let text = "Restart required";
+    let style = styles::CAPTION_2;
+    let width = style.font().measure_str(text, None).0 + 14.0;
+    let rect = Rect::from_xywh(x, cy - 9.0, width, 18.0);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(rect, 9.0, 9.0),
+        &fill(Color::from_argb(0x24, 0xFF, 0x9F, 0x0A)),
+    );
+    text_centered_y(
+        canvas,
+        text,
+        x + 7.0,
+        cy,
+        style,
+        Color::from_argb(0xE0, 0xB2, 0x6A, 0x00),
+    );
+}
+
+/// Hairline between rows, inset from the leading edge like a grouped list.
+pub fn separator(canvas: &Canvas, x0: f32, x1: f32, y: f32, theme: &Theme) {
+    canvas.draw_line(
+        Point::new(x0, y),
+        Point::new(x1, y),
+        &stroke(theme.fill_tertiary, 1.0),
+    );
+}
+
+/// Dashed rectangle used by the displays canvas for the desktop bounds.
+pub fn dashed_rect(canvas: &Canvas, rect: Rect, color: Color) {
+    let mut paint = stroke(color, 1.0);
+    paint.set_path_effect(PathEffect::dash(&[4.0, 4.0], 0.0));
+    canvas.draw_rect(rect, &paint);
+}

--- a/components/xdg-desktop-portal-otto/otto.portal
+++ b/components/xdg-desktop-portal-otto/otto.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.otto
-Interfaces=org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.Settings
+Interfaces=org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.FileChooser
 UseIn=otto

--- a/components/xdg-desktop-portal-otto/portals.conf.example
+++ b/components/xdg-desktop-portal-otto/portals.conf.example
@@ -5,6 +5,8 @@
 # Use GTK portal as default fallback for most portals
 default=gtk
 
-# Use Otto portal for screen sharing and settings
+# Use Otto portal for screen sharing, settings, dialogs and screenshots
 org.freedesktop.impl.portal.ScreenCast=otto
 org.freedesktop.impl.portal.Settings=otto
+org.freedesktop.impl.portal.Access=otto
+org.freedesktop.impl.portal.Screenshot=otto

--- a/components/xdg-desktop-portal-otto/src/main.rs
+++ b/components/xdg-desktop-portal-otto/src/main.rs
@@ -13,7 +13,8 @@ use zbus::ConnectionBuilder;
 
 use xdg_desktop_portal_otto::otto_client::OttoClient;
 use xdg_desktop_portal_otto::portal::{
-    desktop_path, AccessPortal, ScreenCastPortal, SettingsPortal,
+    desktop_path, spawn_change_relay, AccessPortal, FileChooserPortal, ScreenCastPortal,
+    ScreenshotPortal, SettingsPortal,
 };
 
 /// Well-known D-Bus name for the Otto portal backend.
@@ -40,10 +41,25 @@ async fn main() -> Result<()> {
         .at(desktop_path(), settings_portal)
         .await?;
 
-    let access_portal = AccessPortal::new(sc_client);
+    // Settings changes are pushed to applications rather than polled.
+    spawn_change_relay(connection.clone(), sc_client.clone()).await?;
+
+    let access_portal = AccessPortal::new(sc_client.clone());
     connection
         .object_server()
         .at(desktop_path(), access_portal)
+        .await?;
+
+    let file_chooser_portal = FileChooserPortal::new(sc_client.clone());
+    connection
+        .object_server()
+        .at(desktop_path(), file_chooser_portal)
+        .await?;
+
+    let screenshot_portal = ScreenshotPortal::new(sc_client);
+    connection
+        .object_server()
+        .at(desktop_path(), screenshot_portal)
         .await?;
 
     // Claim the name only once every interface is exported, and claim it even
@@ -73,7 +89,7 @@ async fn main() -> Result<()> {
 
     info!(
         name = DBUS_NAME,
-        "ScreenCast, Settings and Access portal backends running"
+        "ScreenCast, Settings, Access, FileChooser and Screenshot portal backends running"
     );
 
     // Wait for a shutdown signal, or for a newer instance to take the name —

--- a/components/xdg-desktop-portal-otto/src/otto_client/file_picker.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/file_picker.rs
@@ -1,0 +1,74 @@
+//! Client for `org.otto.FilePicker1`, the file picker Otto brokers
+//! `org.freedesktop.impl.portal.FileChooser` requests to.
+//!
+//! The same broker/renderer split as [`super::dialog`], for the same reason:
+//! the portal stays a headless zbus service and the component that draws a
+//! window is a separate, bus-activated process. See `specs/file-picker.md`.
+
+use zbus::Result;
+
+use crate::otto_client::OttoClient;
+
+/// A filter as it goes over the wire: `(label, [(kind, pattern)])`, `kind`
+/// `0` glob and `1` MIME.
+pub type WireFilter = (String, Vec<(u32, String)>);
+
+/// A choice group: `(id, label, [(option_id, option_label)], default)`.
+pub type WireChoice = (String, String, Vec<(String, String)>, String);
+
+/// The `Present` request tuple. Field for field the table in
+/// `specs/file-picker.md`, which is a permanent contract — the names, the
+/// types and the order do not change.
+#[allow(clippy::type_complexity)]
+pub type WireRequest = (
+    u32,             // mode: 0 open, 1 save, 2 save-multiple
+    String,          // handle
+    String,          // app_id
+    String,          // parent_window
+    String,          // title
+    String,          // accept_label
+    bool,            // multiple
+    bool,            // directory
+    bool,            // modal
+    String,          // current_name
+    String,          // current_folder
+    String,          // current_file
+    Vec<String>,     // files
+    Vec<WireFilter>, // filters
+    String,          // current_filter
+    Vec<WireChoice>, // choices
+);
+
+/// What `Present` answers with: `(response, uris, current_filter, choices)`.
+pub type WireOutcome = (u32, Vec<String>, String, Vec<(String, String)>);
+
+/// D-Bus proxy for `org.otto.FilePicker1` (served by otto-files).
+#[zbus::proxy(
+    interface = "org.otto.FilePicker1",
+    default_service = "org.otto.FilePicker1",
+    default_path = "/org/otto/FilePicker"
+)]
+trait FilePicker {
+    /// Present a picker and block until the user answers or the request is
+    /// withdrawn.
+    ///
+    /// Returns `(response, uris, current_filter, choices)`:
+    /// - `response`: `0` accepted, `1` cancelled, `2` ended for another reason.
+    /// - `uris`: percent-encoded absolute `file://` URIs; empty unless `0`.
+    /// - `current_filter`: the label of the filter in force at acceptance.
+    /// - `choices`: `[(group_id, selected_option_id)]`.
+    async fn present(&self, request: WireRequest) -> Result<WireOutcome>;
+
+    /// Withdraw a pending request: its `Present` resolves with `response = 2`.
+    async fn close(&self, handle: &str) -> Result<()>;
+}
+
+impl OttoClient {
+    /// Build a proxy to the picker.
+    ///
+    /// The picker is bus-activated, so this succeeds — and starts it — even
+    /// when nothing is running yet. A failure here is a real one.
+    pub async fn file_picker_proxy(&self) -> Result<FilePickerProxy<'_>> {
+        FilePickerProxy::new(&self.connection).await
+    }
+}

--- a/components/xdg-desktop-portal-otto/src/otto_client/mod.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/mod.rs
@@ -21,5 +21,6 @@ impl OttoClient {
 }
 
 pub mod dialog;
+pub mod file_picker;
 pub mod screencast;
 pub mod settings;

--- a/components/xdg-desktop-portal-otto/src/otto_client/settings.rs
+++ b/components/xdg-desktop-portal-otto/src/otto_client/settings.rs
@@ -3,6 +3,9 @@
 //! This module speaks to `org.otto.Settings` (the backend interface
 //! exposed by the Otto compositor).
 
+use std::collections::HashMap;
+
+use zbus::zvariant::OwnedValue;
 use zbus::{proxy, Result};
 
 /// D-Bus proxy for `org.otto.Settings` service.
@@ -24,4 +27,15 @@ trait OttoSettings {
     ///
     /// Returns an empty string if no theme is configured.
     async fn get_icon_theme(&self) -> Result<String>;
+
+    /// Get the accent colour as sRGB components in `0.0..=1.0`, already in the
+    /// shape `org.freedesktop.appearance accent-color` calls for.
+    async fn get_accent_color(&self) -> Result<(f64, f64, f64)>;
+
+    /// Emitted whenever any setting's effective value changes.
+    ///
+    /// Carries the changed identifiers; the values are re-read rather than
+    /// taken from the signal, so one code path serves both.
+    #[zbus(signal)]
+    async fn changed(&self, values: HashMap<String, OwnedValue>) -> Result<()>;
 }

--- a/components/xdg-desktop-portal-otto/src/portal/file_chooser.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/file_chooser.rs
@@ -1,0 +1,420 @@
+//! `org.freedesktop.impl.portal.FileChooser` backend.
+//!
+//! The portal is the broker, otto-files is the renderer — the shape
+//! [`AccessPortal`](crate::portal::AccessPortal) already established, and for
+//! the same reasons: this binary stays a headless zbus service, and the
+//! component that opens a window is a separate, bus-activated process.
+//!
+//! The job here is mechanical and must not lose information: unpack the
+//! freedesktop `a{sv}` options into the typed `org.otto.FilePicker1` tuple,
+//! and pack the answer back. It does not interpret filters, resolve paths, or
+//! check that the returned files exist — that is the picker's contract with
+//! the user. See `specs/file-picker.md`.
+
+use std::collections::HashMap;
+
+use tracing::{info, warn};
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+use zbus::{interface, ObjectServer};
+
+use crate::otto_client::file_picker::{WireChoice, WireFilter, WireRequest};
+use crate::otto_client::OttoClient;
+
+/// Mode values of the picker's wire contract.
+const MODE_OPEN: u32 = 0;
+const MODE_SAVE: u32 = 1;
+const MODE_SAVE_FILES: u32 = 2;
+
+/// The request object the frontend calls `Close` on when the requesting
+/// application withdraws — because it exited, or because the user closed the
+/// window that asked.
+///
+/// Unlike the portal's shared [`Request`](crate::portal::Request), which only
+/// logs, this one forwards: without it a dialog whose application has gone
+/// stays on screen until somebody dismisses it by hand.
+struct FileChooserRequest {
+    client: OttoClient,
+    handle: String,
+}
+
+#[interface(name = "org.freedesktop.impl.portal.Request")]
+impl FileChooserRequest {
+    async fn close(&self) {
+        info!(handle = %self.handle, "FileChooser request withdrawn");
+        match self.client.file_picker_proxy().await {
+            // Activating the picker just to tell it to close a request it
+            // never received would be absurd, but the proxy is cheap and the
+            // call is a no-op against an unknown handle.
+            Ok(proxy) => {
+                if let Err(err) = proxy.close(&self.handle).await {
+                    warn!(?err, handle = %self.handle, "withdrawing the request failed");
+                }
+            }
+            Err(err) => warn!(?err, "file picker unreachable while withdrawing"),
+        }
+    }
+}
+
+pub struct FileChooserPortal {
+    client: OttoClient,
+}
+
+impl FileChooserPortal {
+    pub fn new(client: OttoClient) -> Self {
+        Self { client }
+    }
+
+    /// Hand one request to the picker and translate the answer back.
+    ///
+    /// Every failure path returns `response = 2` with no URIs. It never
+    /// returns `0` with nothing: an application told "here is your file" and
+    /// handed an empty list will do something worse than fail.
+    async fn present(
+        &self,
+        object_server: &ObjectServer,
+        path: &OwnedObjectPath,
+        request: WireRequest,
+    ) -> (u32, HashMap<String, OwnedValue>) {
+        let handle = request.1.clone();
+
+        // Exported before the call, removed after it: the window is only
+        // withdrawable while it is up.
+        let withdrawable = object_server
+            .at(
+                path.clone(),
+                FileChooserRequest {
+                    client: self.client.clone(),
+                    handle: handle.clone(),
+                },
+            )
+            .await
+            .unwrap_or_else(|err| {
+                warn!(?err, %handle, "could not export the request object");
+                false
+            });
+
+        let result = self.present_inner(request).await;
+
+        if withdrawable {
+            if let Err(err) = object_server
+                .remove::<FileChooserRequest, _>(path.clone())
+                .await
+            {
+                warn!(?err, %handle, "could not remove the request object");
+            }
+        }
+        result
+    }
+
+    async fn present_inner(&self, request: WireRequest) -> (u32, HashMap<String, OwnedValue>) {
+        let handle = request.1.clone();
+        let proxy = match self.client.file_picker_proxy().await {
+            Ok(proxy) => proxy,
+            Err(err) => {
+                warn!(?err, "file picker unreachable");
+                return (2, HashMap::new());
+            }
+        };
+
+        match proxy.present(request).await {
+            Ok((response, uris, current_filter, choices)) => {
+                info!(%handle, response, count = uris.len(), "file picker answered");
+                let mut results = HashMap::new();
+                if response == 0 {
+                    insert(&mut results, "uris", Value::from(uris));
+                    if !current_filter.is_empty() {
+                        // The frontend expects the filter in its own shape.
+                        // Only its label survives the round trip, which is
+                        // all an application uses it for — deciding an output
+                        // format from the filter the user chose.
+                        let filter: WireFilter = (current_filter, Vec::new());
+                        insert(&mut results, "current_filter", Value::from(filter));
+                    }
+                    if !choices.is_empty() {
+                        insert(&mut results, "choices", Value::from(choices));
+                    }
+                }
+                (response, results)
+            }
+            Err(err) => {
+                // Includes the picker dying mid-request: the peer disappears,
+                // the call errors, and the requesting application is told the
+                // request ended rather than being left waiting forever.
+                warn!(?err, %handle, "file picker call failed");
+                (2, HashMap::new())
+            }
+        }
+    }
+}
+
+#[interface(name = "org.freedesktop.impl.portal.FileChooser")]
+impl FileChooserPortal {
+    #[zbus(property, name = "version")]
+    fn version(&self) -> u32 {
+        3
+    }
+
+    async fn open_file(
+        &self,
+        #[zbus(object_server)] object_server: &ObjectServer,
+        handle: OwnedObjectPath,
+        app_id: String,
+        parent_window: String,
+        title: String,
+        options: HashMap<String, OwnedValue>,
+    ) -> (u32, HashMap<String, OwnedValue>) {
+        info!(?app_id, %title, "OpenFile called");
+        let request = build_request(
+            MODE_OPEN,
+            handle.clone(),
+            app_id,
+            parent_window,
+            title,
+            options,
+        );
+        self.present(object_server, &handle, request).await
+    }
+
+    async fn save_file(
+        &self,
+        #[zbus(object_server)] object_server: &ObjectServer,
+        handle: OwnedObjectPath,
+        app_id: String,
+        parent_window: String,
+        title: String,
+        options: HashMap<String, OwnedValue>,
+    ) -> (u32, HashMap<String, OwnedValue>) {
+        info!(?app_id, %title, "SaveFile called");
+        let request = build_request(
+            MODE_SAVE,
+            handle.clone(),
+            app_id,
+            parent_window,
+            title,
+            options,
+        );
+        self.present(object_server, &handle, request).await
+    }
+
+    async fn save_files(
+        &self,
+        #[zbus(object_server)] object_server: &ObjectServer,
+        handle: OwnedObjectPath,
+        app_id: String,
+        parent_window: String,
+        title: String,
+        options: HashMap<String, OwnedValue>,
+    ) -> (u32, HashMap<String, OwnedValue>) {
+        info!(?app_id, %title, "SaveFiles called");
+        let request = build_request(
+            MODE_SAVE_FILES,
+            handle.clone(),
+            app_id,
+            parent_window,
+            title,
+            options,
+        );
+        self.present(object_server, &handle, request).await
+    }
+}
+
+/// Pack a freedesktop request into the picker's tuple.
+fn build_request(
+    mode: u32,
+    handle: OwnedObjectPath,
+    app_id: String,
+    parent_window: String,
+    title: String,
+    options: HashMap<String, OwnedValue>,
+) -> WireRequest {
+    (
+        mode,
+        handle.as_str().to_string(),
+        app_id,
+        parent_window,
+        title,
+        string_opt(&options, "accept_label").unwrap_or_default(),
+        bool_opt(&options, "multiple").unwrap_or(false),
+        bool_opt(&options, "directory").unwrap_or(false),
+        bool_opt(&options, "modal").unwrap_or(true),
+        string_opt(&options, "current_name").unwrap_or_default(),
+        path_opt(&options, "current_folder").unwrap_or_default(),
+        path_opt(&options, "current_file").unwrap_or_default(),
+        strings_opt(&options, "files"),
+        filters_opt(&options, "filters"),
+        // `current_filter` arrives as a whole filter; only its label
+        // identifies it.
+        options
+            .get("current_filter")
+            .and_then(|v| v.try_clone().ok())
+            .and_then(|v| WireFilter::try_from(v).ok())
+            .map(|(label, _)| label)
+            .unwrap_or_default(),
+        choices_opt(&options, "choices"),
+    )
+}
+
+fn insert(results: &mut HashMap<String, OwnedValue>, key: &str, value: Value<'_>) {
+    match OwnedValue::try_from(value) {
+        Ok(owned) => {
+            results.insert(key.to_string(), owned);
+        }
+        Err(err) => warn!(key, ?err, "dropping result value"),
+    }
+}
+
+/// `OwnedValue` is not `Clone`, so every read goes through `try_clone`.
+fn string_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
+    options
+        .get(key)
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| String::try_from(v).ok())
+}
+
+fn bool_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Option<bool> {
+    options.get(key).and_then(|v| bool::try_from(v).ok())
+}
+
+fn strings_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Vec<String> {
+    options
+        .get(key)
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| Vec::<String>::try_from(v).ok())
+        .unwrap_or_default()
+}
+
+fn filters_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Vec<WireFilter> {
+    options
+        .get(key)
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| Vec::<WireFilter>::try_from(v).ok())
+        .unwrap_or_default()
+}
+
+fn choices_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Vec<WireChoice> {
+    options
+        .get(key)
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| Vec::<WireChoice>::try_from(v).ok())
+        .unwrap_or_default()
+}
+
+/// A path option, which the portal sends as `ay` — a NUL-terminated byte
+/// string, not a D-Bus string.
+///
+/// The trailing NUL is stripped. A non-absolute or non-UTF-8 path is dropped
+/// rather than rejected: the picker then falls back as if the hint were
+/// absent, which is friendlier than failing a whole request over it.
+fn path_opt(options: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
+    let bytes = options
+        .get(key)
+        .and_then(|v| v.try_clone().ok())
+        .and_then(|v| Vec::<u8>::try_from(v).ok())?;
+    let bytes = bytes.strip_suffix(&[0]).unwrap_or(&bytes);
+    let path = String::from_utf8(bytes.to_vec()).ok()?;
+    path.starts_with('/').then_some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(pairs: Vec<(&str, Value<'static>)>) -> HashMap<String, OwnedValue> {
+        pairs
+            .into_iter()
+            .filter_map(|(k, v)| Some((k.to_string(), OwnedValue::try_from(v).ok()?)))
+            .collect()
+    }
+
+    #[test]
+    fn a_path_option_loses_its_trailing_nul() {
+        let opts = options(vec![(
+            "current_folder",
+            Value::from(b"/tmp/pics\0".to_vec()),
+        )]);
+        assert_eq!(
+            path_opt(&opts, "current_folder").as_deref(),
+            Some("/tmp/pics")
+        );
+    }
+
+    #[test]
+    fn a_path_option_without_a_nul_is_still_read() {
+        let opts = options(vec![("current_folder", Value::from(b"/tmp/pics".to_vec()))]);
+        assert_eq!(
+            path_opt(&opts, "current_folder").as_deref(),
+            Some("/tmp/pics")
+        );
+    }
+
+    #[test]
+    fn a_relative_path_option_is_dropped() {
+        let opts = options(vec![("current_folder", Value::from(b"pics\0".to_vec()))]);
+        assert!(path_opt(&opts, "current_folder").is_none());
+    }
+
+    #[test]
+    fn a_non_utf8_path_option_is_dropped_rather_than_mangled() {
+        let opts = options(vec![(
+            "current_folder",
+            Value::from(b"/tmp/\xff\0".to_vec()),
+        )]);
+        assert!(path_opt(&opts, "current_folder").is_none());
+    }
+
+    #[test]
+    fn an_absent_option_takes_its_default() {
+        let request = build_request(
+            MODE_OPEN,
+            OwnedObjectPath::try_from("/org/freedesktop/portal/desktop/request/x/1").unwrap(),
+            "org.example.App".into(),
+            String::new(),
+            String::new(),
+            HashMap::new(),
+        );
+        assert_eq!(request.0, MODE_OPEN);
+        assert!(!request.6, "multiple defaults to false");
+        assert!(!request.7, "directory defaults to false");
+        assert!(request.8, "modal defaults to true");
+        assert!(request.13.is_empty());
+    }
+
+    #[test]
+    fn filters_and_the_preselected_one_survive_the_translation() {
+        let filters: Vec<WireFilter> = vec![
+            ("Text".into(), vec![(0u32, "*.txt".into())]),
+            ("Images".into(), vec![(1u32, "image/png".into())]),
+        ];
+        let current: WireFilter = ("Images".into(), vec![(1u32, "image/png".into())]);
+        let opts = options(vec![
+            ("filters", Value::from(filters.clone())),
+            ("current_filter", Value::from(current)),
+            ("multiple", Value::from(true)),
+        ]);
+        let request = build_request(
+            MODE_OPEN,
+            OwnedObjectPath::try_from("/org/freedesktop/portal/desktop/request/x/1").unwrap(),
+            "org.example.App".into(),
+            String::new(),
+            String::new(),
+            opts,
+        );
+        assert_eq!(request.13, filters);
+        assert_eq!(request.14, "Images");
+        assert!(request.6);
+    }
+
+    #[test]
+    fn the_request_handle_is_carried_through_so_close_can_find_it() {
+        let path = "/org/freedesktop/portal/desktop/request/sender/token";
+        let request = build_request(
+            MODE_OPEN,
+            OwnedObjectPath::try_from(path).unwrap(),
+            String::new(),
+            String::new(),
+            String::new(),
+            HashMap::new(),
+        );
+        assert_eq!(request.1, path);
+    }
+}

--- a/components/xdg-desktop-portal-otto/src/portal/mod.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/mod.rs
@@ -3,22 +3,29 @@
 //! This module provides D-Bus interface implementations for:
 //! - `org.freedesktop.impl.portal.ScreenCast`
 //! - `org.freedesktop.impl.portal.Settings`
+//! - `org.freedesktop.impl.portal.Access`
+//! - `org.freedesktop.impl.portal.FileChooser`
+//! - `org.freedesktop.impl.portal.Screenshot`
 
 mod access;
+mod file_chooser;
 mod interface;
 mod request;
 mod restore;
+mod screenshot;
 mod session;
 mod settings;
 mod state;
 mod stream;
 
 pub use access::AccessPortal;
+pub use file_chooser::FileChooserPortal;
 pub use interface::{
     fallback_mapping_id, validate_cursor_mode, validate_persist_mode, ScreenCastPortal,
 };
 pub use restore::{decode_restore_data, encode_restore_data, resolve_restored, RestoredSource};
-pub use settings::SettingsPortal;
+pub use screenshot::ScreenshotPortal;
+pub use settings::{spawn_change_relay, SettingsPortal};
 pub use state::{PortalState, SelectedWindow, SessionState};
 pub use stream::{build_streams_value_from_descriptors, StreamDescriptor};
 

--- a/components/xdg-desktop-portal-otto/src/portal/screenshot.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/screenshot.rs
@@ -1,0 +1,119 @@
+//! `org.freedesktop.impl.portal.Screenshot` backend.
+//!
+//! Capture goes through `grim`, which already talks to Otto's wlr-screencopy
+//! support directly — no new compositor-side capture path needed. Interactive
+//! requests are gated by a confirmation dialog, reusing the same renderer
+//! [`AccessPortal`](crate::portal::AccessPortal) brokers to.
+
+use std::collections::HashMap;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::{info, warn};
+use zbus::interface;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Str, Value};
+
+use crate::otto_client::OttoClient;
+
+pub struct ScreenshotPortal {
+    client: OttoClient,
+}
+
+impl ScreenshotPortal {
+    pub fn new(client: OttoClient) -> Self {
+        Self { client }
+    }
+}
+
+#[interface(name = "org.freedesktop.impl.portal.Screenshot")]
+impl ScreenshotPortal {
+    #[zbus(property, name = "version")]
+    fn version(&self) -> u32 {
+        2
+    }
+
+    /// Capture the screen and return a `file://` URI in `results["uri"]`.
+    /// `response`: `0` success, `1` cancelled, `2` failed.
+    async fn screenshot(
+        &self,
+        _handle: OwnedObjectPath,
+        app_id: String,
+        _parent_window: String,
+        options: HashMap<String, OwnedValue>,
+    ) -> (u32, HashMap<String, OwnedValue>) {
+        info!(?app_id, "Screenshot requested");
+
+        let interactive = options
+            .get("interactive")
+            .and_then(|v| bool::try_from(v).ok())
+            .unwrap_or(false);
+
+        if interactive {
+            let proxy = match self.client.dialog_proxy().await {
+                Ok(p) => p,
+                Err(err) => {
+                    warn!(?err, "no dialog renderer available; denying screenshot");
+                    return (1, HashMap::new());
+                }
+            };
+            let body = format!("{app_id} wants to take a screenshot of your screen.");
+            match proxy
+                .present_access(
+                    &app_id,
+                    "Take Screenshot",
+                    "",
+                    &body,
+                    "",
+                    "Take Screenshot",
+                    "Cancel",
+                    true,
+                    Vec::new(),
+                )
+                .await
+            {
+                Ok((0, _)) => {}
+                Ok((response, _)) => return (response.max(1), HashMap::new()),
+                Err(err) => {
+                    warn!(?err, "dialog renderer call failed; denying screenshot");
+                    return (1, HashMap::new());
+                }
+            }
+        }
+
+        match capture_to_file().await {
+            Ok(path) => {
+                let uri = format!("file://{path}");
+                let mut results = HashMap::new();
+                if let Ok(v) = OwnedValue::try_from(Value::from(Str::from(uri))) {
+                    results.insert("uri".to_string(), v);
+                }
+                info!(?app_id, "Screenshot captured");
+                (0, results)
+            }
+            Err(err) => {
+                warn!(?err, "screenshot capture failed");
+                (2, HashMap::new())
+            }
+        }
+    }
+}
+
+/// Runs `grim` to capture the full output set to a fresh PNG under
+/// `~/Pictures/Screenshots/`, returning the absolute path.
+///
+/// Blocks the calling (zbus executor) thread for the ~100ms `grim` takes —
+/// not a Tokio task, so `spawn_blocking` isn't available here.
+async fn capture_to_file() -> anyhow::Result<String> {
+    let home = std::env::var("HOME").map_err(|_| anyhow::anyhow!("HOME is not set"))?;
+    let dir = format!("{home}/Pictures/Screenshots");
+    std::fs::create_dir_all(&dir)?;
+
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let path = format!("{dir}/screenshot-{ts}.png");
+
+    let status = Command::new("grim").arg(&path).status()?;
+    if !status.success() {
+        anyhow::bail!("grim exited with {status}");
+    }
+    Ok(path)
+}

--- a/components/xdg-desktop-portal-otto/src/portal/settings.rs
+++ b/components/xdg-desktop-portal-otto/src/portal/settings.rs
@@ -3,12 +3,15 @@
 use std::collections::HashMap;
 
 use tracing::{debug, error};
+use zbus::export::futures_util::StreamExt;
 use zbus::fdo;
 use zbus::interface;
 use zbus::zvariant::{OwnedValue, Value};
+use zbus::{Connection, SignalContext};
 
 use crate::otto_client::settings::OttoSettingsProxy;
 use crate::otto_client::OttoClient;
+use crate::portal::desktop_path;
 
 /// Settings portal implementing org.freedesktop.impl.portal.Settings.
 #[derive(Clone)]
@@ -25,11 +28,13 @@ impl SettingsPortal {
     async fn get_all_settings(&self) -> fdo::Result<HashMap<String, HashMap<String, OwnedValue>>> {
         let color_scheme = self.read_color_scheme().await?;
         let icon_theme = self.read_icon_theme().await?;
+        let accent_color = self.read_accent_color().await?;
 
         let mut namespaces = HashMap::new();
         let mut appearance = HashMap::new();
 
         appearance.insert("color-scheme".to_string(), color_scheme.into());
+        appearance.insert("accent-color".to_string(), accent_color);
         appearance.insert(
             "icon-theme".to_string(),
             Value::from(icon_theme).try_into().unwrap(),
@@ -46,6 +51,7 @@ impl SettingsPortal {
                 let color_scheme = self.read_color_scheme().await?;
                 Ok(color_scheme.into())
             }
+            ("org.freedesktop.appearance", "accent-color") => self.read_accent_color().await,
             ("org.freedesktop.appearance", "icon-theme") => {
                 let icon_theme = self.read_icon_theme().await?;
                 Ok(Value::from(icon_theme).try_into().unwrap())
@@ -74,6 +80,22 @@ impl SettingsPortal {
             error!(?err, "Failed to read color scheme from compositor");
             fdo::Error::Failed(format!("Failed to read color scheme: {err}"))
         })
+    }
+
+    /// Reads the accent colour from the compositor as `(ddd)`.
+    ///
+    /// The spec is explicit that this is a plain sRGB triple in `0.0..=1.0`
+    /// with no alpha, so it is passed through exactly as the compositor gives
+    /// it rather than being re-derived here.
+    async fn read_accent_color(&self) -> fdo::Result<OwnedValue> {
+        let proxy = self.get_settings_proxy().await?;
+        let (r, g, b) = proxy.get_accent_color().await.map_err(|err| {
+            error!(?err, "Failed to read accent colour from compositor");
+            fdo::Error::Failed(format!("Failed to read accent colour: {err}"))
+        })?;
+        Value::from((r, g, b))
+            .try_into()
+            .map_err(|err| fdo::Error::Failed(format!("Failed to encode accent colour: {err}")))
     }
 
     /// Reads the icon theme name from the compositor.
@@ -131,9 +153,70 @@ impl SettingsPortal {
         self.get_setting(&namespace, &key).await
     }
 
+    /// Emitted when a setting this portal serves changes, so applications do
+    /// not have to poll. `xdg-desktop-portal` relays it to its own clients.
+    #[zbus(signal)]
+    async fn setting_changed(
+        context: &SignalContext<'_>,
+        namespace: &str,
+        key: &str,
+        value: Value<'_>,
+    ) -> zbus::Result<()>;
+
     /// Lowercase per the impl portal spec — see the ScreenCast interface.
     #[zbus(property, name = "version")]
     fn version(&self) -> u32 {
         1
     }
+}
+
+/// Watches `org.otto.Settings` and re-emits the settings this portal serves as
+/// `SettingChanged`.
+///
+/// Without this the portal is read-only in practice: a client reads the accent
+/// once at startup and never learns that the user changed it.
+pub async fn spawn_change_relay(connection: Connection, client: OttoClient) -> zbus::Result<()> {
+    let proxy = OttoSettingsProxy::new(&client.connection).await?;
+    let mut changes = proxy.receive_changed().await?;
+
+    tokio::spawn(async move {
+        let portal = SettingsPortal::new(client);
+        while let Some(change) = changes.next().await {
+            let Ok(args) = change.args() else { continue };
+            // Otto's identifiers are not the portal's keys, so only the ones
+            // with a counterpart here are forwarded.
+            for id in args.values.keys() {
+                let key = match id.as_str() {
+                    "accent_color" => "accent-color",
+                    "theme_scheme" => "color-scheme",
+                    "icon_theme" => "icon-theme",
+                    _ => continue,
+                };
+                let Ok(value) = portal.get_setting("org.freedesktop.appearance", key).await else {
+                    continue;
+                };
+                let iface = connection
+                    .object_server()
+                    .interface::<_, SettingsPortal>(desktop_path())
+                    .await;
+                match iface {
+                    Ok(iface) => {
+                        if let Err(err) = SettingsPortal::setting_changed(
+                            iface.signal_context(),
+                            "org.freedesktop.appearance",
+                            key,
+                            Value::from(value),
+                        )
+                        .await
+                        {
+                            error!(?err, key, "Failed to emit SettingChanged");
+                        }
+                    }
+                    Err(err) => error!(?err, "Settings portal interface went away"),
+                }
+            }
+        }
+    });
+
+    Ok(())
 }

--- a/resources/otto-files.desktop
+++ b/resources/otto-files.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Name=Files
+GenericName=File Manager
+Comment=Browse and manage files
+Exec=otto-files %f
+TryExec=otto-files
+Icon=system-file-manager
+Terminal=false
+Categories=System;FileTools;FileManager;
+Keywords=files;folders;browser;manager;explorer;finder;otto;
+MimeType=inode/directory;
+StartupNotify=true
+StartupWMClass=otto-files

--- a/resources/otto-settings.desktop
+++ b/resources/otto-settings.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Settings
+GenericName=Settings
+Comment=Configure Otto — appearance, displays, dock, input, sound, power
+Exec=otto-settings
+Icon=preferences-system
+Terminal=false
+Categories=Settings;DesktopSettings;
+Keywords=settings;preferences;configuration;system;otto;dock;display;keyboard;trackpad;
+StartupNotify=true
+StartupWMClass=otto-settings

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -1,0 +1,711 @@
+# File Browser
+
+**Status:** draft — nothing implemented
+**Wire contract:** `org.freedesktop.FileManager1`, defined inline below
+**Related specs:** [file-picker.md](./file-picker.md), [quickview.md](./quickview.md),
+[launcher.md](./launcher.md), [context-menus.md](./context-menus.md),
+[settings-app.md](./settings-app.md)
+
+## Summary
+
+`otto-files`, the standalone application for browsing and managing the
+filesystem — Otto's Finder. It is the second shell over the view layer defined
+in [file-picker.md](./file-picker.md): the same directory model, async I/O,
+watching, sorting, thumbnails and list/icon/column presentations, wrapped in a
+document window that can act on files instead of merely returning their names.
+
+This spec also owns the **shared foundations** that other components depend on:
+the thumbnail cache, file-type detection, and the quick-view invocation
+contract. Those are defined here once, and consumed — not redefined — elsewhere.
+
+## Goals
+
+- Navigate the local filesystem, see what is there, and open a file in its
+  default application.
+- Perform the file operations a desktop is expected to have: rename, new
+  folder, copy, move, move to trash, delete permanently — each on a background
+  worker, with progress, cancellation that leaves nothing half-written, and
+  one level of undo.
+- Open a directory of 10,000 files responsively, with the same guarantees the
+  picker makes: first rows within a frame of the first batch, full frame rate
+  while scrolling, and no filesystem call on the UI thread.
+- Other applications can ask Otto to show a file or folder through the standard
+  `org.freedesktop.FileManager1` interface, so "Open Containing Folder" in a
+  browser or editor lands here.
+- Every part of the window is reachable from the keyboard, with the same
+  navigation, type-ahead and multi-select semantics as the picker — a user who
+  learns one has learned the other.
+- Share the picker's code, not merely its behaviour. A fix to sorting or
+  thumbnailing lands in both at once.
+
+## Non-Goals
+
+- Being a picker. The browser never returns a selection to another process, and
+  has no accept/cancel action.
+- Decoding previews. Pressing space draws a panel, but the bytes are parsed by
+  quick view's sandboxed worker ([quickview.md](./quickview.md)); the browser
+  draws a validated payload and never interprets a file itself.
+- Network and virtual filesystems: `smb://`, `sftp://`, MTP, GVfs backends of any
+  kind. The browser deals in local paths.
+- Mounting, unmounting, formatting or ejecting devices. Already-mounted volumes
+  appear; udisks2 integration is not in v1.
+- Searching file contents, or any persistent index. See Non-Goals in
+  [launcher.md](./launcher.md) — the same reasoning applies.
+- A scripting or plugin interface.
+- Being configurable by theme file. It follows the desktop's colour scheme and
+  icon theme.
+
+## Behavior
+
+### Relationship to the picker
+
+One crate, `components/otto-files`, produces a library and two binaries:
+`otto-files` (this spec) and `otto-file-picker`
+([file-picker.md](./file-picker.md)). The library holds the directory model,
+the worker pool, the watcher, the thumbnail cache, file-type detection, the
+sort comparators, the glob matcher, and the three view presentations. The two
+binaries hold their chrome and their meaning of "done".
+
+Everything in [file-picker.md](./file-picker.md) under *The view model*, *Async
+I/O*, *Thumbnails*, *Filesystem watching* and *Sorting* applies here unchanged
+and is not restated. Where this spec and that one disagree, that one wins for
+the shared layer.
+
+### The window
+
+A client-decorated toplevel. Layout:
+
+- **Titlebar** — the current directory's name.
+- **Toolbar** — back/forward, parent, the view switcher (list / icon), a sort
+  control, a new-folder action, an action menu, and a search field.
+- **Path bar** — clickable ancestor segments; ancestors collapse into an
+  overflow control when the path is too long for the width.
+- **Sidebar** — places: the XDG user directories that exist, the user's
+  bookmarks, Trash, and currently mounted volumes. A directory can be dragged
+  onto the sidebar to bookmark it once drag and drop exists; until then,
+  bookmarking is a menu action on the selection.
+- **File view** — the shared list / icon / column presentation. List and icon
+  ship in v1. Every scrolling pane draws **only the rows its scroll view is
+  asking for**: the visible band, taken from the scroll view's own content
+  rect, and inclusive at both ends so a row resting on an edge keeps its
+  stripe and hairline. A rubber-banded pane draws the rows the pull brings
+  into view, and a Miller column panned off the window draws none. Row
+  geometry comes from one walk shared by drawing, hit-testing and the Quick
+  View anchor, so what is painted and what is clickable cannot disagree. This
+  is what the 10,000-file goal above rests on — measuring and shaping the text
+  of a row nobody can see is most of the cost of a frame.
+- **Row density** — rows are compact and **abut with no gap between them**, in
+  list and column views alike: a listing is scanned rather than read, and the
+  fewer pixels between one name and the next, the more of the directory the
+  eye takes in at once. Because rows touch, a selection highlight fills its
+  row's full height, and a **contiguous run of selected rows is drawn as one
+  shape**: rounded on top only at the run's first row, rounded on the bottom
+  only at its last, square where one selected row meets the next.
+The sidebar and the header band are translucent materials over the
+compositor's backdrop blur, the sidebar heavily tinted and the header only
+slightly, so the frost runs across the whole top of the window. The file area
+below the header is opaque: a wall of small text needs one flat ground.
+
+- **Status bar** — the entry count, the selection count and its total size, and
+  the free space on the filesystem holding the current directory. It is the
+  progress and cancel surface for a running operation.
+
+Multiple windows are supported and are independent. Tabs are not in v1.
+
+### Column view scrolling
+
+The column (Miller) view scrolls on two axes, and they are two independent
+scroll views, not one nested inside the other:
+
+- **Each column scrolls vertically on its own**, with its own overlay bar on
+  its right edge — a column can be scrolled to its end while its neighbour
+  rests at the top.
+- **The stack pans horizontally as a whole**, on a horizontal scroll view
+  whose bar runs along the bottom of the file area. The stack is one
+  continuous strip that happens to be divided into panes, so panning it is a
+  scroll: it flings with momentum, stretches with rising resistance past
+  either end, and springs back — the same physics, from the same widget, as
+  the vertical panes.
+
+The two never fight over one gesture. **A touchpad gesture picks its axis from
+its first delta and keeps it until the fingers lift**, so a diagonal swipe
+pans or scrolls, never both by turns.
+
+**A gesture places the stack freely; navigation aligns it.** A fling rests
+wherever it lands, with a partly visible column at each edge — that is a
+normal resting state and nothing snaps it straight. Moving into a column by
+click or keyboard is what aligns: the stack pans the shortest distance that
+brings that column fully into view, landing on its exact edge, and drops any
+fling still in flight first so the two are never both moving it.
+
+### Column surfaces
+
+Painting every column into the window's one buffer makes a scroll in a single
+column a repaint of the whole window, and — because the toolkit damages the
+whole buffer on commit — tells the compositor that everything changed. Under
+`OTTO_FILES_PANE_SUBS=1` each column instead gets its own Wayland subsurface,
+sized and positioned by `otto_surface_style_v1`. The client still does all the
+drawing, translating and clipping itself; what changes is the *scope*, so a
+scroll damages one column and leaves the toplevel alone.
+
+This is opt-in while it settles. The default path is unchanged.
+
+Three things follow from the columns no longer being in the window's buffer:
+
+- **Input still belongs to the toplevel.** Every column surface carries an
+  empty input region, so pointer events fall through and hit-testing stays in
+  window coordinates exactly as it was.
+- **Nothing above clips the columns.** In the window they were cut off by the
+  content area's clip; a subsurface is a child of the toplevel and has no such
+  parent, so a column panned past the sidebar would draw over it. Each column
+  surface is cropped to its intersection with the content area instead, and
+  its drawing shifted by whatever was cropped off the left.
+- **Scrolling chrome has to move with the content it describes.** A column's
+  vertical bar is drawn into that column's own surface, since the window is no
+  longer repainted for a scroll and a bar left there would fade in and freeze.
+  The stack's horizontal bar belongs to no column, so it gets a surface of its
+  own — a strip along the bottom of the content area, stacked above every
+  column, and restacked whenever the stack grows, because a subsurface created
+  later starts out on top of it.
+
+The hairlines between columns are still drawn in the window, so a sideways pan
+— unlike a vertical scroll — does still repaint it, or they would be left
+behind while the columns slide.
+
+### Places
+
+The sidebar's places come from three sources:
+
+1. The XDG user directories — Desktop, Documents, Downloads, Music, Pictures,
+   Videos, Public, Templates — read from `user-dirs.dirs`, and shown only when
+   the directory exists. Home is always first.
+2. The user's bookmarks, from Otto's own `$XDG_CONFIG_HOME/otto/places`: one
+   absolute path per line, optionally followed by a display name. The browser
+   is the only writer. On first run, if that file does not exist and
+   `$XDG_CONFIG_HOME/gtk-3.0/bookmarks` does, it is read once to seed Otto's,
+   and never read again.
+3. Mounted volumes, from `/proc/self/mounts`, filtered to mounts under
+   `/run/media`, `/media` and `/mnt` and to filesystems that are not virtual.
+
+Bookmarks can be reordered and removed. A bookmark whose path no longer exists
+is shown dimmed and offers removal rather than silently disappearing — a
+disconnected drive is not a deleted bookmark.
+
+Trash is a place. Selecting it lists the trash contents with their original
+locations, and offers Restore and Empty Trash. Files in Trash cannot be opened
+or renamed in place.
+
+### Opening
+
+Double-click, or Enter on the selection:
+
+- A directory is navigated into, in this window.
+- A file is opened in its default application, resolved from the file's MIME
+  type through the desktop's associations. The application is started
+  detached — a new session, its stdio closed — so it outlives the browser.
+- An executable file is *not* run. It is opened in its default application like
+  any other file, or reported as having none. Running a program by
+  double-clicking it in a file manager is a well-known way to be tricked into
+  running one.
+- A file with no association shows an "Open With" chooser listing applications
+  that declare support for its type, plus every other installed application
+  behind a disclosure. Choosing an application optionally sets it as the
+  default, which writes `mimeapps.list`.
+- A broken symlink reports that its target is missing, naming the target.
+
+`Open With` is always available on the context menu.
+
+### Navigation history
+
+Back and Forward are the two halves of one **split button** in the header: a
+single rounded capsule divided by a hairline seam, matching the view switcher
+at the other end of the header. Each half dims when there is nowhere for it to
+go, and neither half is a window-drag area.
+
+Every navigation that moves the window somewhere else — descending into a
+directory, going up, clicking a place — first records where it was; navigating
+anew drops any Forward history, the rule a web browser follows.
+
+A recorded location is the **whole column stack**, not just the deepest path,
+and for each pane both its selection and its cursor. Going back therefore
+restores every pane that was open *and* the entry that was selected in each,
+scrolled back into view. The selection is remembered by name, so it survives
+the re-read of the directory; the cursor is re-derived from that selection once
+the listing lands, so a file added or removed while the user was away cannot
+leave the keyboard one row off from the highlight.
+
+### Selection, keyboard and type-ahead
+
+Identical to the picker, including the type-ahead-is-not-search distinction, the
+anchor-based multi-select rules and rubber-band selection. See
+[file-picker.md](./file-picker.md) under *Keyboard*. The browser adds:
+
+| Key | Effect |
+| --- | --- |
+| Space | quick view of the selection (see below) |
+| Return / F2 | rename the entry at the cursor, inline, with the extension unselected — in every view mode, icon view included |
+| Delete | move the selection to trash |
+| Shift+Delete | delete the selection permanently, after confirmation |
+| Ctrl+C / Ctrl+X / Ctrl+V | copy / cut / paste |
+| Ctrl+Z | undo the last operation |
+| Ctrl+N | new window |
+| Ctrl+I | show info for the selection |
+| Ctrl+1 / Ctrl+2 | list / icon view |
+| Escape | cancel an inline rename, else clear the search field, else clear the selection |
+
+Return renames, in every view mode; F2 is an alias for it, for the Linux
+convention. Opening is a double-click or Right arrow, never a key that is one
+mistake away from launching everything in a selection. The picker is the
+exception: it does no file management, so there Return means "this one" —
+descend into a directory, or accept the selection.
+
+### File operations
+
+Every operation runs on the worker pool. The UI thread starts it, watches its
+progress, and can cancel it.
+
+- **Rename** — inline in the view. A name containing `/`, or empty, or `.`
+  or `..`, is rejected while typing. A name that collides with an existing
+  entry offers to replace it or to keep editing.
+- **New folder** — creates `untitled folder`, disambiguating with a numeric
+  suffix, and immediately enters inline rename on it.
+- **Copy and move** — the clipboard holds paths and a copy/cut intent. Paste
+  into a directory starts the operation. A move within one filesystem is a
+  rename syscall and is instantaneous; a move across filesystems is copy,
+  verify, then unlink the source, and the source is unlinked only after the
+  destination is fully written and fsynced.
+- **Conflicts** — when a destination entry exists, a sheet offers Replace,
+  Skip, Keep Both (numeric suffix), each with an "apply to all remaining"
+  option. Directories merge rather than replace; the conflict question is asked
+  per file inside them.
+- **Cancellation must be clean.** Every copied file is written to a temporary
+  name in the destination directory and renamed into place on completion, so a
+  cancelled or crashed operation leaves no truncated file wearing the real
+  name. Temporary files left by a crash are named recognisably and cleaned on
+  the next operation into that directory.
+- **Move to trash** — the freedesktop trash specification: the file is moved to
+  `$XDG_DATA_HOME/Trash/files/`, with a `.trashinfo` recording its original
+  path and the deletion time, both under a name disambiguated against what is
+  already there. **v1 trashes only files on the same filesystem as the home
+  trash.** Trashing on another mount requires a `.Trash-$uid` directory at that
+  mount's root, with its own rules about creation and stickiness; until that
+  exists, the browser says plainly that the file is on another volume and
+  offers permanent deletion instead. It never silently copies a file across
+  filesystems in the name of trashing it.
+- **Delete permanently** — always confirmed, always says it cannot be undone,
+  and is not undoable.
+- **Undo** — one level, within the session. A move is undone by moving back; a
+  trash by restoring from trash; a copy by deleting what was created; a rename
+  by renaming back; a new folder by removing it if still empty. A permanent
+  delete is not undoable and the undo action says so rather than being silently
+  absent.
+- **Progress** — an operation shorter than 500 ms shows nothing. Beyond that,
+  the status bar shows the current file, the count, and a cancel action; per-byte
+  progress appears for files above 32 MB.
+- **Errors** — a failure part-way through a multi-file operation stops and
+  reports which files were done, which failed and why, and offers to continue
+  with the rest or to stop. It does not abort silently and it does not retry
+  in a loop.
+
+### Get Info
+
+A panel for the selection: name, full path, type, size (recursive for a
+directory, computed on a worker and updating as it counts), created, modified
+and accessed times, permissions, owner and group, the default application, and
+a preview thumbnail. Permissions and the default application are editable;
+everything else is read-only.
+
+**It is a window of its own, not a sheet.** Ctrl+I opens a second toplevel and
+Ctrl+I again closes it; it is dragged by its top strip, dismissed by its close
+dot or by a close asked for from outside, and the compositor gives it the same
+shadow and stacking as any other window. It carries the browser's own `app_id`,
+so it groups under the file manager's dock icon rather than adding one of its
+own.
+
+- **The browser is not dimmed and not blocked.** The panel is not modal: the
+  file list goes on scrolling, selecting and opening behind it while it is up.
+  Escape closes it, taking its turn in the same unwinding order as everything
+  else that is up rather than owning the key outright.
+- **The panel opens on the selection and is not re-targeted.** Arrow-keying in
+  the browser moves the cursor without changing what the open panel is about;
+  a panel for another file is another Ctrl+I.
+- **A close request for the panel closes the panel.** A secondary window's
+  close is not the application's, and must not end the process.
+
+### Quick view
+
+Pressing space with a selection previews it. Quick view
+([quickview.md](./quickview.md)) is a **library the browser embeds**, not a
+service it calls: the panel is drawn into the browser's own surface, and the
+decoding happens in a sandboxed worker process.
+
+**This replaces an earlier `org.otto.QuickView1` D-Bus contract**, which is
+deleted. It is recorded here so nobody reconstructs it: a subsurface's parent
+must be a `wl_surface` owned by the same client, so "the preview is parented to
+the file view" and "the previewer is a separate process" cannot both be true.
+Parenting also dissolves the anchor problem — the row's rect is already in the
+browser's coordinates — and hands stacking, focus and dismissal to the browser's
+window instead of leaving them to be managed by hand on an overlay.
+
+What the browser does:
+
+- **`run_worker_if_requested()` is the first statement in `main`**, before the
+  async runtime starts a thread and before anything connects to Wayland. The
+  sandboxed decoder is this binary re-executed, so without it a preview starts a
+  second file browser instead of decoding a file.
+- **Decoding runs off the UI thread.** The call blocks until the worker answers
+  or its deadline expires; inline it would stall the frame loop for as long as
+  the file takes.
+- **Every decode carries a generation, and a stale result is dropped.**
+  Arrow-keying is much faster than decoding, so a slow PDF must not land on top
+  of a file the user moved off three keys ago. Dismissing also bumps the
+  generation, so an in-flight decode cannot re-open a panel the user closed.
+- **The browser never interprets file bytes.** It receives a validated payload —
+  UTF-8 lines, bounded rows, or a pixel buffer whose dimensions were checked
+  against its length — and draws it with `otto_kit::preview`, which is
+  canvas-pure and shared with every other file view.
+- **The anchor is the selected row's rect in the browser's own surface
+  coordinates**, and the panel grows out of it. **An empty rect when there is
+  nothing to grow from** — no cursor, or a row scrolled out of view or in a
+  panned-away Miller column — is a documented answer meaning "open in place",
+  not a missing value.
+- **The browser keeps the keyboard.** Space toggles the panel, Escape dismisses
+  it before it clears the selection, and the arrow keys move the cursor and
+  re-decode in place rather than dismissing.
+- **The panel owns the pointer while it is up**: a click outside dismisses, the
+  wheel scrolls a listing or text preview, a pinch zooms an image and a
+  two-finger scroll pans a zoomed one, and nothing reaches the file list
+  underneath. Which of the two pointer handlers sees the gesture depends on
+  where the panel is — the panel takes its own input when it is centred on the
+  display and hangs outside the window, and the toplevel takes it otherwise —
+  so both routes feed one decision about what the gesture means.
+- Enter still opens the selection in its default application. The previewer
+  never launches anything.
+
+Quick view **consumes** the thumbnail cache and the file-type detection defined
+below, and may **produce** into the thumbnail cache under the same rules. It
+must not define a second cache, a second cache location, or a second
+type-detection path.
+
+Get Info shows the cached thumbnail and nothing decoded. The preview panel is
+the one place decoded payloads are drawn.
+
+### Wire contract: `org.freedesktop.FileManager1`
+
+The browser owns the standard interface other applications already call — bus
+name `org.freedesktop.FileManager1`, object path `/org/freedesktop/FileManager1`,
+interface `org.freedesktop.FileManager1`, D-Bus activated:
+
+```
+ShowFolders(uris: as, startup_id: s) → ()
+ShowItems(uris: as, startup_id: s) → ()
+ShowItemProperties(uris: as, startup_id: s) → ()
+```
+
+- `ShowFolders` opens a window at each URI that is a directory.
+- `ShowItems` opens a window at each URI's *parent* directory with that entry
+  selected and scrolled into view. This is what "Open Containing Folder" and
+  "Show in Folder" call.
+- `ShowItemProperties` opens the Get Info panel for each URI.
+- URIs that are not `file://`, or that do not exist, are skipped with a log
+  line; the remaining ones are still shown. A call naming only bad URIs opens
+  nothing and returns successfully — it is not the caller's business that the
+  file vanished.
+- Several URIs in one directory are coalesced into one window with a multiple
+  selection, not one window each.
+- If a window is already showing the target directory, it is reused, its
+  selection set, and it is raised.
+- `startup_id` is used for startup notification where the compositor supports
+  it, and ignored otherwise.
+
+This is the standard interoperability contract rather than an invented
+`org.otto.Files1`, so applications that already know how to reveal a file get it
+for free.
+
+## Shared foundations
+
+These three are defined here and consumed by the picker, by quick view, and by
+anything else that grows a need for them.
+
+### 1. The thumbnail cache
+
+**It is the freedesktop shared thumbnail cache, not an Otto-private one.**
+Location, keying and validity follow the freedesktop thumbnail managing
+standard exactly, so Otto reads thumbnails other applications wrote and they
+read Otto's:
+
+- **Location** — `$XDG_CACHE_HOME/thumbnails/<size>/`, with `<size>` one of
+  `normal` (128 px), `large` (256 px), `x-large` (512 px), `xx-large`
+  (1024 px). Failures go in `$XDG_CACHE_HOME/thumbnails/fail/otto-files/`,
+  keyed identically, holding a zero-content PNG.
+- **Key** — the lowercase hex MD5 of the file's absolute, percent-encoded
+  `file://` URI, plus `.png`. The URI is the key, not the path: it must be
+  byte-identical to what another implementation would produce, or the caches do
+  not interoperate. Neither size nor mtime is part of the key.
+- **Validity** — the stored PNG carries `Thumb::URI` and `Thumb::MTime` `tEXt`
+  chunks. A thumbnail is valid when `Thumb::MTime` equals the source file's
+  current modification time in seconds. Anything else — missing chunk, differing
+  time — is stale and regenerated. Size is not compared; the standard says
+  mtime, and a second implementation checking something else means two
+  processes each believing the other's thumbnail is wrong.
+- **Writing** — write to a temporary file in the same directory, `fsync`, then
+  `rename` into place, with mode `0600` and the cache directory `0700`. Two
+  processes generating the same thumbnail concurrently is safe and expected;
+  neither locks, and last writer wins because both wrote the same thing.
+- **Eviction** — none by Otto for valid thumbnails. The cache is shared and
+  contains other applications' data; unilaterally trimming it is not ours to do.
+  Otto does prune its own `fail/otto-files/` entries older than 30 days, on
+  idle.
+- **The API is a library, not a bus interface.** `otto-files`' thumbnail module
+  exposes pure functions over the filesystem — resolve a URI to a cache path,
+  look up and validate, generate, store — and any process that wants a
+  thumbnail links it and calls it. There is no thumbnail daemon and no D-Bus
+  request/ready round trip. The filesystem *is* the cross-process contract, and
+  it already is one: correctness across processes comes from atomic rename and
+  from the mtime check, not from a coordinator. A second process may generate a
+  thumbnail the browser is also generating; the cost is one duplicated decode
+  and the benefit is no protocol.
+- **In-memory decoded images are per process** and never shared. Each process
+  keeps its own LRU bounded by count and bytes.
+- **Other Otto components may write into it**, and quick view does: its decode
+  worker already produces a scaled image of the file the user is looking at, so
+  it stores the thumbnail rather than making the browser decode the same file
+  again in a less isolated process. Any writer obeys the rules above exactly —
+  the standard key, the `Thumb::` chunks, atomic rename, and **only the four
+  standard size buckets**. An entry at a non-standard size is invisible to every
+  other implementation and is not a thumbnail.
+- **The cache holds small images only.** It is never asked for a
+  full-resolution decode, and there is no "decode this at an arbitrary size for
+  someone else" call. A consumer needing a large image decodes it itself.
+- **What Otto generates** — images Skia decodes natively and SVG. It never runs
+  an external `/usr/share/thumbnailers/*.thumbnailer` program, but reads
+  whatever such programs left in the cache. Full reasoning in
+  [file-picker.md](./file-picker.md).
+
+### 2. File-type detection
+
+One implementation, **in otto-kit as `otto_kit::filetype`**, not in
+`otto-files`. It sits beside the icon lookup that already lives there, and every
+component needs it: the picker for portal filters, the browser for icons and
+the Kind column, quick view to choose a renderer. Putting it in the file
+manager's crate would make the previewer depend on the file manager.
+
+It answers two different questions, with two calls, and the distinction is
+load-bearing:
+
+**`mime_for_name(name) -> Option<&str>` — the type of record.** Decided by the
+file's name, against the shared MIME database's `globs2`
+(`weight:mimetype:glob`), highest weight first, a literal match beating a glob
+and a longer glob beating a shorter one — the standard's own precedence.
+`subclasses` supplies the hierarchy, so asking "is this `text/plain`" is true
+for `text/x-rust`. Both files are line-oriented plain text; **no XML parser and
+no `mime.cache` binary format is involved**, which is why the full database is
+affordable rather than a hardcoded table. It has to be the full database: a
+portal request may name any MIME type at all, and the browser's Kind column has
+to name types nobody enumerated in advance.
+
+This is the answer used for the icon, the Kind column, portal filters, and
+default-application association. It is stable, cheap, and needs no I/O beyond
+the database load.
+
+**`sniff(bytes) -> Option<&str>` — what the content looks like.** A bounded
+magic-byte check over at most the first 4 KB, covering the signatures that
+matter for safety and for decoder dispatch. It performs no I/O itself; the
+caller supplies the bytes it already read.
+
+**They do not compete, because they are not asked the same thing.** Display
+follows the name: an empty `.rs` file is Rust source, and an icon that flips
+because a sniff was inconclusive is a bug the user sees. Decoding follows the
+content: **a consumer that is about to parse a file must dispatch its decoder on
+`sniff`, never on the name**, so a `.png` that is really something else is never
+handed to the PNG decoder. Quick view and the thumbnailer both do this. Where a
+consumer wants to report the disagreement — "this file is named `.png` but is
+not one" — it has both answers and can.
+
+- Directories are `inode/directory`. Symlinks resolve to their target's type for
+  display, and report brokenness separately. Devices, sockets and FIFOs get
+  `inode/*` types.
+- A small **kind** classification over MIME types — image, video, audio, text,
+  document, archive, application, folder, other — is what the Kind column
+  shows, what the icon lookup falls back to, what decides whether a thumbnail is
+  attempted, and what quick view dispatches its renderer on. It is a lossy
+  convenience over the MIME type, not a replacement; consumers needing precision
+  use the MIME type.
+- The glob matcher is shared with the picker's portal filters. A portal MIME
+  filter is resolved through exactly this path.
+- `filetype` must be callable from a bare canvas context: no `AppContext`, no
+  `wayland-client`, no runtime — the same constraint every otto-kit draw
+  function is under.
+
+### 3. Icon resolution
+
+The type icon for an entry comes from the icon theme: the MIME type with `/`
+replaced by `-`, then the generic type (`text-x-generic` and friends), then the
+kind's fallback, then a final unknown-file icon. Resolution goes through
+otto-kit's `find_icon_in_theme` / `cached_file_icon`, never `named_icon_sized`,
+which reaches into `AppContext` and is unavailable off the client runtime.
+
+## Constraints & Edge Cases
+
+- **A file operation must never lose data.** The two rules that guarantee it:
+  a cross-filesystem move unlinks the source only after the destination is
+  written and fsynced, and every write goes to a temporary name and is renamed
+  into place. Everything else is recoverable; violating either is not.
+- **Deleting the directory being viewed** navigates to the nearest surviving
+  ancestor, and a pending operation targeting it fails with that reason.
+- **An operation whose source or destination changes underneath it** (the user
+  moves a file being copied) fails that file and continues, reporting it in the
+  summary.
+- **Free space** in the status bar is the filesystem holding the current
+  directory, and a paste that obviously will not fit is refused up front with
+  the numbers, rather than filling the disk and failing part-way.
+- **Trash restore into a directory that no longer exists** recreates the
+  directory path if it can, and otherwise asks where to put the file.
+- **Non-UTF-8 names** survive every operation. Names are bytes throughout;
+  display is lossy, the model is not. A rename dialog on a non-UTF-8 name is
+  editing a lossy rendering and must say so rather than silently rewriting the
+  bytes.
+- **Permissions.** An operation needing privileges the user does not have fails
+  with the reason. The browser never escalates, never invokes `pkexec`, and has
+  no "run as administrator".
+- **The clipboard holds paths, not contents.** A cut whose source disappears
+  before the paste fails cleanly. A cut is not applied until pasted, so the
+  source is never removed on Ctrl+X.
+- **Two windows on the same directory** share the model and the watch; an
+  operation in one is reflected in the other through the ordinary watch path,
+  not through a special case.
+- **The trash can be enormous.** Listing it must be as lazy as any other
+  directory, and Empty Trash is an ordinary cancellable background operation
+  with progress.
+- **Must run under the windowed development backend**, and must not require the
+  compositor to be built with development features.
+
+## Rationale
+
+**Two shells over one view layer, and the browser is where the shared layer
+lives.** The picker is the harder deadline (applications are broken without it)
+but the browser is the fuller consumer of the model — it needs everything the
+picker needs plus mutation. Putting the library with the browser and having the
+picker link it, rather than the reverse, means the shared code is exercised by
+the more demanding caller.
+
+**`org.freedesktop.FileManager1` rather than an Otto interface.** Firefox,
+Thunderbird, editors and chat clients already call it. Implementing the standard
+gets "Show in Folder" working across the desktop with no per-application work,
+and costs three methods.
+
+**The thumbnail cache is the freedesktop one, and its API is a library.** A
+private cache would be a second copy of every thumbnail on the system and would
+interoperate with nothing. A thumbnail *daemon* with a D-Bus request/ready
+protocol would add a process, a protocol, a lifecycle and a failure mode, to
+solve a coordination problem the filesystem already solves: atomic rename makes
+concurrent generation safe, and the mtime check makes it idempotent. Two
+processes occasionally decoding the same JPEG is a cheaper bug than a daemon.
+
+**File-type detection is one implementation in otto-kit, with two calls that
+answer two questions.** A single "what type is this file" call has to pick
+between name and content, and either choice is wrong somewhere: content-wins
+makes an empty source file's icon flip, name-wins hands a mislabelled file to
+the wrong decoder. Splitting it means display is stable and decoding is safe,
+and the two can never *disagree* because they were never asked the same thing.
+It lives in otto-kit rather than in the file manager so that the previewer, the
+picker and the compositor's own icon lookup can all call it without depending on
+a file manager.
+
+**The full shared MIME database, not a table of common types.** `globs2` and
+`subclasses` are line-oriented text — no XML parser, no `mime.cache` — so the
+complete database costs a file read and a hash map. A hardcoded table cannot
+serve a portal filter naming
+`application/vnd.oasis.opendocument.text`, and cannot fill a Kind column with
+types nobody enumerated in advance.
+
+**Return renames and never opens.** Otto follows macOS here rather than the
+Linux Enter-opens convention, for the same reason the browser refuses to run
+executables on double-click: a key that opens whatever is selected is one
+mistake away from launching a screenful of files. Renaming is recoverable —
+Escape cancels, and the field starts with the extension unselected — while
+opening is not. F2 is accepted as an alias so the Linux habit still lands on
+the same action, and Right arrow (or a double-click) opens.
+
+**Executables are not run on double-click.** "Double-click ran the file" is a
+malware delivery mechanism, and the convenience it buys is a keystroke in a
+terminal.
+
+**Trash is home-filesystem-only in v1, and says so.** The alternative that looks
+like it works — copy the file to the home trash — moves gigabytes across a bus
+to "delete" something and breaks restore. The alternative that is correct
+requires `.Trash-$uid` handling with its own security rules. Refusing clearly is
+better than either, and it is a small, self-contained thing to add later.
+
+**Drag and drop is absent, not deferred quietly.** otto-kit has no
+`wl_data_device` support of any kind, so this is a toolkit project first. It is
+named here so its absence is understood as a known gap rather than an oversight.
+
+## Out of scope for v1, explicitly
+
+Column view (the model supports it; the renderer is v2). Drag and drop, in or
+out. Tabs. Split views. Network and virtual filesystems. Mounting and ejecting.
+Content search and any index. Batch rename. Archive browsing or extraction.
+File comparison. Tags, labels, colours, or any metadata Otto would have to store
+itself. Custom per-directory view settings beyond sort order. Templates. Running
+external thumbnailers. Persisted column widths.
+
+## Resolved decisions
+
+### Negotiated with quick view
+
+With [quickview.md](./quickview.md), recorded so they are not reopened:
+
+- The thumbnail cache is a **filesystem layout, not a service**. No daemon, no
+  D-Bus request/ready protocol, no coordinator. Cross-process correctness comes
+  from the standard key, atomic rename, and the `Thumb::MTime` check.
+- Quick view is a **producer as well as a consumer** of the cache. It stores the
+  scaled decode it was making anyway, at the standard buckets only.
+- The cache is **small images only**. Full-resolution decoding is each
+  consumer's own business; the cache never serves it and never brokers it.
+- File-type detection lives in **otto-kit**, not otto-files, and splits into
+  name-based (display, filters, associations) and content-based (decoder
+  dispatch). Content never overrides the name for display.
+- The MIME source is the **full shared database via `globs2`/`subclasses`**, not
+  a hardcoded table. They are plain text; no XML parser is needed.
+- Quick view is **embedded as a library**, and the browser keeps the keyboard,
+  the pointer, and the panel's place in its own window. The earlier decision —
+  that quick view owned a D-Bus invocation interface and held the keyboard —
+  was reversed when it became clear that parenting the preview to the file view
+  and running it as a separate process are mutually exclusive.
+- The **decode worker stays a separate process**, and is the host binary
+  re-executed. The sandbox is about untrusted bytes, not about where the UI
+  lives; embedding the panel does not put a parser in the browser.
+
+### Settled defaults
+
+Questions this spec left open in an earlier draft, resolved with the obvious
+answer rather than carried:
+
+- **Per-directory sort order and view mode live in one central bounded file**,
+  `$XDG_STATE_HOME/otto/file-browser-views`, keyed by absolute path, a
+  least-recently-used cap of 512 entries. **Otto never writes a dotfile into a
+  user's directory** to record its own view state: it pollutes directories the
+  user did not ask us to write to, it travels with the files into archives and
+  version control, and it is visible in every other file manager. A bounded
+  central file is forgettable in the way this state deserves to be — losing an
+  old entry costs a sort order.
+- **`mimeapps.list` is written by the browser directly**, not routed through the
+  settings service. It is a freedesktop file with a defined format and other
+  writers on the system; the settings schema is for Otto's own configuration
+  keys, and putting a shared standard file behind `Set(id, value)` would give it
+  an owner it cannot actually have. This is the same single-writer reasoning as
+  [settings-app.md](./settings-app.md), applied honestly: the owner of
+  `mimeapps.list` is the standard, not Otto.
+- **Recursive directory size streams a running total and is not cached.** A
+  cache would need invalidating on any change anywhere beneath the directory,
+  which is the genuinely hard problem, in exchange for a number the user asks
+  for rarely and watches converge in seconds. The count is cancelled when the
+  panel closes.
+- **`ShowItems` on a directory URI selects it in its parent**, and does not open
+  it. The method's contract is to show items; `ShowFolders` is the one that
+  opens. A caller that wanted the directory opened had a method for that.
+
+## Open Questions
+
+None outstanding.

--- a/specs/file-picker.md
+++ b/specs/file-picker.md
@@ -1,0 +1,707 @@
+# File Picker
+
+**Status:** v1 in progress — `OpenFile` implemented end to end; save modes not started
+**Wire contract:** `org.otto.FilePicker1`, defined inline below
+**Related specs:** [file-browser.md](./file-browser.md),
+[portal-access-dialog.md](./portal-access-dialog.md),
+[settings-app.md](./settings-app.md), [context-menus.md](./context-menus.md)
+
+## Summary
+
+The dialog an application gets when it opens or saves a file. Otto serves it as
+the `org.freedesktop.impl.portal.FileChooser` backend: `otto-portal` brokers the
+request, and a D-Bus-activated picker presents it as a real client-decorated
+toplevel window.
+
+The picker and the file browser ([file-browser.md](./file-browser.md)) are two
+shells over one view layer: the same directory model, the same async I/O,
+watching, sorting and thumbnail machinery, and the same list/icon/column
+presentations. Only the chrome around them differs.
+
+### What is implemented
+
+`OpenFile` works end to end: an application's portal request opens a picker
+window, and the file the user chooses comes back as a `file://` URI.
+
+- `otto-files` is now a **library plus a binary**. `otto-files --picker` claims
+  `org.otto.FilePicker1` and serves requests; `otto-files [path]` is the
+  browser. One `Browser`, one view layer, one process image — the picker is the
+  `Browser::picker` field being `Some`, and every difference between the two
+  shells reads off it.
+- Filters work, including MIME rules, which are expanded to globs through
+  `otto_kit::filetype::globs_for`. Directories are never hidden by a filter.
+- The action row carries the filter control, Cancel, and the request's own
+  `accept_label`.
+- The chrome is titleless: no traffic lights, no window title, one toolbar row.
+- Quick View works in the picker exactly as it does in the browser.
+- URIs are encoded by `otto_quickview::uri::path_to_uri`, which lives beside the
+  decoder every consumer already uses, so the round trip is tested as a pair.
+
+### What is not
+
+- **Save modes.** `SaveFile` and `SaveFiles` are carried through the whole wire
+  contract and refused at the service with `response = 2`, so an application
+  learns it got no file rather than being shown an Open dialog that returns a
+  file it cannot write. The name field, the replace-confirmation sheet and
+  "New Folder" are the work remaining.
+- **Concurrent requests open one window at a time.** A second application's
+  request queues behind the first and is served when it finishes. Neither is
+  dropped and neither hangs, but the second user waits. The app shell is built
+  around a single toplevel; a second, half-supported window would be worse than
+  queueing. This is the one deliberate departure from *Concurrent requests*
+  below.
+- **Choices** (`a(ssa(ss)s)`) are carried over the wire and not yet rendered.
+- **Search, type-ahead and the location popup.** The toolbar's location control
+  says where you are; it does not yet open the ancestor menu.
+- **Per-`app_id` directory memory.** `Request::starting_directory` takes the
+  remembered directory as an argument and is always passed `None`; nothing is
+  persisted yet.
+- **The header is still the browser's 92 px.** The layout is the reference's —
+  one toolbar row, no title bar — but 19 pieces of geometry in `view.rs` are
+  written against the `HEADER_H` constant, so making the picker's strip shorter
+  is a separate, mechanical pass that threads the header height the way
+  `Frame::footer` is threaded today.
+
+## Goals
+
+- An application calling the standard XDG desktop portal `OpenFile`, `SaveFile`
+  or `SaveFiles` gets Otto's own picker, and receives back URIs that satisfy the
+  request it made.
+- Every option the portal request carries is honoured: file-type filters,
+  multi-select, directory-only selection, a proposed name and folder, an accept
+  label, and the app's own extra choice widgets.
+- The picker is fully usable from the keyboard: reaching, filtering, selecting
+  and accepting a file with no pointer at any point.
+- Opening a directory of 10,000 files shows rows within one frame of the first
+  batch landing, scrolls at full frame rate, and never blocks the UI thread on
+  the filesystem — including on a stalled network mount.
+- It reads as part of Otto: the same window chrome, material, typography and
+  icon theme as the settings app and the browser.
+- The picker holds no state between requests that the user would notice as
+  wrong: a second request from a different app does not inherit the first app's
+  directory, filter, or selection.
+
+## Non-Goals
+
+- File management. Copy, move, delete, trash, and drag-and-drop belong to the
+  browser. The picker creates directories (apps need it while saving) and
+  renames nothing.
+- Being the browser's window. The picker is a transient serving someone else's
+  app; the browser is a document window. They share a view layer and nothing
+  else.
+- `org.freedesktop.impl.portal.FileTransfer`. Out of scope entirely.
+- Recursive or content search. The search field filters the current directory.
+- Remote or virtual filesystems (GVfs, MTP, `sftp://`, `trash://` as a namespace
+  the picker can return). The picker deals in local paths that a `file://` URI
+  can name and the requesting app can `open(2)`.
+- Running external `.thumbnailer` programs. See Thumbnails.
+- Serving the GTK or Qt native file choosers. Applications that bypass the
+  portal get their own toolkit's dialog, and that is their choice.
+
+## Behavior
+
+### Shape: who owns the window
+
+`otto-portal` implements `org.freedesktop.impl.portal.FileChooser` and brokers
+each request to `otto-file-picker` over a private, strongly typed interface —
+the same broker/renderer split, and for the same reason, as
+[portal-access-dialog.md](./portal-access-dialog.md): all "which renderer, is
+one available, fall back how" policy stays in one place, and the portal binary
+stays a headless zbus service with no Wayland connection.
+
+The renderer is **not** `otto-islands`, and the picker does **not** follow the
+island-panel pattern. It is its own component with its own toplevel:
+
+- The picker is a window — resizable, remembering its geometry, with a sidebar,
+  a scroll view and a titlebar. An island panel is a fixed-size overlay hung off
+  the bar, and would have to grow a second, window-shaped rendering path to host
+  this.
+- It must be parented to the requesting application's window (see
+  `parent_window` below), which requires an `xdg_toplevel`. An island is
+  layer-shell and cannot be a child of a client's toplevel at all — so choosing
+  a window keeps that door open, where choosing an island would close it
+  permanently.
+- Its lifetime is per request, not per session. `otto-islands` is a permanent
+  daemon; the picker should not be resident when nobody is picking a file.
+- It shares its entire view layer with the browser. Linking that model,
+  thumbnail cache and worker pool into `otto-islands` would put a filesystem
+  watcher and an image decode pool inside the process that draws the always-on
+  status bar.
+
+The picker is therefore **D-Bus activated**: it owns `org.otto.FilePicker1`, is
+started by the bus on the first method call, and exits once it has nothing left
+to serve. If the picker cannot be activated, the portal returns `response = 2` —
+an application that asked for a file and got neither a file nor a dialog must be
+told the request failed, not left waiting.
+
+**As built, the renderer is `otto-files` itself rather than a separate
+`otto-file-picker` binary.** When this spec was written there was no view layer
+to share; there is one now, and it is `otto-files`. Splitting a third crate out
+of it would have meant either duplicating the browser's chrome or extracting a
+library whose only other consumer is the picker. The shape the spec actually
+argues for — the portal brokers, something else renders, and the renderer is a
+window rather than an island — is unchanged; only the binary's name is.
+
+An idle picker holds no window, no Wayland connection and no watchers: the
+process parks on the request queue before it ever calls into otto-kit, so
+activation costs nothing until somebody actually asks for a file.
+
+Activation needs `org.otto.FilePicker1.service` installed alongside the binary,
+and the session's D-Bus activation environment must carry `WAYLAND_DISPLAY`.
+
+### Wire contract: portal → picker
+
+Bus name `org.otto.FilePicker1`, object path `/org/otto/FilePicker`, interface
+`org.otto.FilePicker1`. Both ends are owned by Otto, so the signature is typed
+rather than `a{sv}` — the same decision recorded for `org.otto.Dialog1`.
+
+```
+Present(request: (u s s s s b b b s s s as a(sa(us)) s a(ssa(ss)s)))
+    → (response: u, uris: as, current_filter: s, choices: a(ss))
+
+Close(handle: s) → ()
+```
+
+The request tuple, in order:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `mode` | `u` | `0` open, `1` save, `2` save-multiple |
+| `handle` | `s` | opaque request id, unique per in-flight request |
+| `app_id` | `s` | requesting application, may be empty |
+| `parent_window` | `s` | `wayland:<handle>`, `x11:<xid>`, or empty |
+| `title` | `s` | window title; empty means a mode-appropriate default |
+| `accept_label` | `s` | confirm button text; empty means a default |
+| `multiple` | `b` | open mode only |
+| `directory` | `b` | select directories rather than files |
+| `modal` | `b` | carried for contract parity; not enforced in v1, see *Prerequisites* |
+| `current_name` | `s` | proposed file name (save) |
+| `current_folder` | `s` | absolute path to start in; empty means "decide" |
+| `current_file` | `s` | absolute path of the file being re-saved |
+| `files` | `as` | save-multiple: the names to be written |
+| `filters` | `a(sa(us))` | `(label, [(kind, pattern)])`, `kind` `0` glob, `1` MIME |
+| `current_filter` | `s` | label of the filter to preselect |
+| `choices` | `a(ssa(ss)s)` | `(id, label, [(option_id, option_label)], default)` |
+
+The response: `response` is `0` accepted, `1` cancelled by the user, `2` ended
+for another reason (withdrawn, picker died, request invalid). `uris` are
+percent-encoded absolute `file://` URIs, empty unless `response = 0`.
+`current_filter` is the label of the filter in effect when the user accepted.
+`choices` maps each choice group id to the selected option id (`"true"` /
+`"false"` for a group with no options).
+
+`Close(handle)` withdraws a pending request: the picker dismisses that window
+and its pending `Present` resolves with `response = 2`.
+
+These names, types and the field order are a permanent contract from the first
+release, exactly as settings identifiers are.
+
+### Translation at the portal
+
+The portal's job is mechanical and must not lose information:
+
+- `OpenFile` → `mode = 0`; `SaveFile` → `mode = 1`; `SaveFiles` → `mode = 2`.
+- `current_folder` and `current_file` arrive from the portal as `ay`,
+  NUL-terminated byte strings. The portal strips the trailing NUL and passes the
+  path through; a non-absolute or non-UTF-8 path is dropped rather than
+  rejected, and the picker falls back as if it were absent.
+- `filters` and `choices` pass through unchanged in shape.
+- `multiple`, `directory`, `modal`, `accept_label`, `current_name` pass through;
+  absent options take the defaults in the table above.
+- `Request.Close` on the portal's request object → `Close(handle)`.
+- If the picker is unreachable or its call fails, the portal returns
+  `response = 2` and logs why. It never returns `0` with no URIs.
+
+The portal does not itself interpret filters, resolve paths, or check that the
+returned files exist. That is the picker's contract with the user.
+
+### Presentation
+
+One window per request. Layout:
+
+- **Titlebar** — the request's `title`, or "Open" / "Save As" / "Save Files".
+  Client-decorated, per Otto's convention.
+- **Toolbar** — back/forward, a parent-directory control, the view switcher
+  (list / icon), a sort control, and a search field.
+- **Path bar** — the current directory as clickable ancestor segments; clicking
+  a segment navigates to it.
+- **Sidebar** — the same places list as the browser: the XDG user directories
+  that exist, the user's bookmarks, and currently mounted volumes. The picker's
+  sidebar omits Trash, and omits any place the current request cannot select
+  into.
+- **File view** — the shared list / icon / column presentation.
+- **Name field** — save modes only, pre-filled from `current_name` or the base
+  name of `current_file`, with the extension unselected on focus.
+- **Filter control** — a dropdown of the request's filters, plus "All Files"
+  when the request supplies none. Hidden when the request supplies no filters
+  and the mode is not save.
+- **Choices row** — the app's extra `choices`, each rendered as a labelled
+  dropdown or, for an empty option list, a checkbox. Same semantics as the
+  Access dialog's choices.
+- **Action row** — the accept button (using `accept_label`) and Cancel.
+
+### Selection and acceptance
+
+- **Open, single**: accept is enabled when exactly one entry is selected and it
+  is selectable under the current mode. Double-clicking a directory descends
+  into it; double-clicking a selectable file accepts immediately.
+- **Open, multiple**: accept is enabled when at least one selectable entry is
+  selected; every selected entry is returned, in view order.
+- **Directory mode**: only directories are selectable. Files are still shown,
+  greyed, so the user can see where they are. Accept with nothing selected
+  accepts the directory currently being viewed.
+- **Save**: accept is enabled when the name field is non-empty and does not
+  contain `/`. If the resulting path exists as a file, a confirmation sheet
+  appears — Replace / Cancel — and the request resolves only after the user
+  answers. If it exists as a directory, accept instead navigates into it and
+  clears the name field. If the target directory is not writable, accept is
+  disabled and the reason is shown.
+- **Save-multiple**: the user picks a directory; the picker returns one URI per
+  entry in `files`, all inside that directory, with no name mangling. If any of
+  them already exists, one confirmation sheet lists them all and offers Replace
+  All / Cancel.
+- Accepting a symlink returns the symlink's own path, not its target. Following
+  is the requesting application's decision.
+- The picker does not create, truncate or open the file in save mode. It
+  returns a URI; writing is the application's job.
+
+### Starting directory
+
+In order of preference: the directory of `current_file`; `current_folder`; the
+directory this `app_id` last accepted from, if the picker still remembers it
+(see below); the user's home directory. A path that does not exist, or is not a
+directory, or cannot be read, falls through to the next candidate.
+
+The picker remembers the last accepted directory **per `app_id`**, in its own
+state file, and nothing else across requests. It never remembers a selection, a
+filter, or a scroll position across requests. An empty `app_id` gets no
+memory. This is the one deliberate exception to "no state between requests":
+returning a user to where they were last time is the behaviour they expect, and
+keying it on the app is what stops one app's directory leaking into another's
+dialog.
+
+### Filters
+
+A filter is a list of `(kind, pattern)` rules; an entry passes the filter if it
+matches any rule.
+
+- **Glob rules** (`kind = 0`) match the entry's file name against the pattern.
+  The supported syntax is the shell globbing subset that appears in practice:
+  `*`, `?`, and `[...]` character classes. Matching is case-sensitive, except
+  that a pattern which is entirely lowercase also matches an uppercase
+  extension — `*.png` matches `PHOTO.PNG`, which is what applications mean.
+- **MIME rules** (`kind = 1`) are resolved to globs through
+  `otto_kit::filetype`, defined in [file-browser.md](./file-browser.md) under
+  *Shared foundations*. The shared MIME database's `globs2` maps
+  `weight:mimetype:glob`; a MIME rule expands to the globs registered for that
+  type and for every type declaring it as a parent in `subclasses`.
+  `inode/directory` matches directories. A MIME type with no registered glob
+  matches nothing, and the filter reports that it is empty rather than silently
+  matching everything.
+- Filtering is by name. Content sniffing exists in `otto_kit::filetype` but is
+  not used here: it would mean reading every file in the directory to decide
+  what to display, and an application's filter is a statement about names.
+- **Filters never hide directories.** A directory is always shown and always
+  navigable, whatever the filter says, except that in directory mode the filter
+  applies to directories and files alike.
+- Filtering is applied to the loaded model, not to the read: changing the filter
+  re-filters in place with no filesystem access.
+- The filter in effect at acceptance is returned as `current_filter`, so an
+  application can use it to decide an output format.
+
+### Keyboard
+
+The picker is operable with no pointer. Focus moves between sidebar, path bar,
+search field, file view, name field, choices and buttons with Tab and
+Shift+Tab, and the focused control is visibly ringed. This depends on the focus
+and tab-order work that
+[otto-kit-roadmap](../docs/developer/otto-kit-roadmap.md) records as the
+toolkit's outstanding infrastructure gap; the picker must use it rather than
+inventing a private one.
+
+Within the file view:
+
+| Key | Effect |
+| --- | --- |
+| Arrows | move the cursor; in icon view all four axes, in column view Left/Right change column |
+| Home / End | first / last entry |
+| Page Up / Page Down | one viewport |
+| Enter | descend into a directory, or accept the selection |
+| Backspace, Alt+Up | parent directory |
+| Alt+Left, Alt+Right | back / forward in this window's history |
+| Ctrl+H | toggle hidden entries |
+| Ctrl+F | focus the search field |
+| Ctrl+A | select all (multi-select requests only) |
+| Ctrl+Shift+N | new folder |
+| Escape | close a sheet if one is open; else clear the search field if non-empty; else cancel the request |
+| `~`, `/` | open a location field pre-filled with that character, accepting an absolute or `~`-relative path |
+
+Any key that moves the cursor **scrolls it into view**: the pane scrolls the
+shortest distance that brings the cursor's whole row or cell inside the
+viewport, and does not move at all when it is already there. Walking a long
+directory with the arrow keys therefore never leaves the selection off screen.
+
+**Type-ahead** is distinct from search and must not be conflated with it.
+Typing a printable character while the file view has focus appends to a
+type-ahead buffer and moves the cursor to the first entry whose name starts with
+that buffer, case-insensitively, without changing what is displayed. The buffer
+resets after one second of no typing, or on any navigation key. Repeatedly
+pressing the same single character with no other input cycles through the
+entries beginning with it. Search, reached with Ctrl+F, filters the view instead
+and leaves the cursor where it can see the result.
+
+**Multi-select** applies only when the request set `multiple`. An anchor tracks
+the last entry selected without a modifier. Shift+click and Shift+Arrow select
+the contiguous range from the anchor to the cursor, replacing the previous
+range. Ctrl+click toggles one entry and moves the anchor to it. Ctrl+Arrow moves
+the cursor without changing the selection; Ctrl+Space toggles the entry at the
+cursor. A pointer drag beginning on empty space rubber-band selects. In a
+single-select request every one of these collapses to "select the entry under
+the cursor".
+
+### The view model
+
+One model, three presentations, and the model is shaped for all three from the
+start so that the third is not a rewrite.
+
+The unit is a **directory view**: one directory's entries in display order,
+plus the sort key and direction, the filter and search predicates in force, a
+selection set, an anchor and a cursor. A window holds a **path stack** — a
+vector of directory views from some root to the directory currently being
+viewed — plus a back/forward history of paths.
+
+- **List view** renders the last element of the stack as rows with columns:
+  name, size, kind, date modified. Column headers sort; clicking the active
+  header reverses. Columns are resizable; widths are per window, not persisted
+  in v1.
+- **Icon view** renders the last element as a grid of icon-over-name cells,
+  with a size control. This is where thumbnails matter.
+- **Column view** renders the whole stack as adjacent panes, each a narrow list
+  of the corresponding directory, with the selection in pane *n* determining
+  the contents of pane *n+1*, and horizontal scrolling that keeps the active
+  pane visible.
+
+**List and icon views ship in v1. Column view is deliberately deferred.** The
+path stack exists from the first commit — every navigation pushes and pops it,
+and list and icon views simply render its top — so column view is a third
+renderer over an unchanged model rather than a change to how navigation works.
+
+The view is **virtualised**: laying out and drawing a directory view must cost
+time proportional to the number of visible entries, not to the number of
+entries. This is a requirement of the model's interface, not an optimisation to
+add later — the difference is invisible at 200 files and fatal at 10,000.
+
+Every presentation is an otto-kit component in the established shape: a draw
+function taking a canvas, a rect, a slice of entries and a theme, plus a
+hit-test helper reading the same geometry, with state held by the caller. None
+of them may touch `AppContext` or `wayland-client`, so the compositor can draw
+a file list server-side if it ever needs to.
+
+### Async I/O
+
+The UI thread never performs a filesystem call. Not `readdir`, not `stat`, not
+`open`, not `readlink`. A stalled NFS or SSHFS mount must cost a spinner, never
+a frame.
+
+- A **model thread** owns every loaded directory view and is the only thread
+  that touches the filesystem, delegating to a small pool of **worker threads**
+  (`min(4, available_parallelism)`) for reads, stats and thumbnail decoding.
+- The UI thread holds an immutable snapshot of the directory view it is
+  drawing. When the model produces a new snapshot it sends it over a channel and
+  wakes the event loop; the UI thread swaps it in and requests a frame. It does
+  not paint directly — otto-kit paints on frame callbacks.
+- Reading a directory is one job that streams results in batches (2,000 entries
+  or 50 ms, whichever comes first). The first batch is displayed as soon as it
+  arrives; the view shows a progress indication until the read completes.
+- The initial listing uses only what `readdir` returns: the name and, where the
+  filesystem supplies it, the entry type. **No `stat` on the fast path.** Size,
+  modification time and resolved link target arrive from a second streaming
+  pass, and the columns that need them render as placeholders until they do.
+  Sorting by a not-yet-loaded key waits for that pass and says so.
+- Navigating away cancels the in-flight read of the directory being left. Every
+  job carries a cancellation flag the worker checks between batches.
+- Threads, not an async runtime. There is no async filesystem interface on Linux
+  worth its complexity here, and `tokio`'s file API is a thread pool wearing a
+  costume. tokio stays where zbus already needs it.
+
+### Thumbnails
+
+The cache itself — location, key, validity, atomicity, who may write to it — is
+defined in [file-browser.md](./file-browser.md) under *Shared foundations*, and
+is shared with quick view. What follows is how the picker uses it.
+
+- **Who generates them:** the picker/browser process itself, on the worker pool,
+  never the compositor and never a separate daemon.
+- **What gets thumbnailed in v1:** images Skia decodes natively (PNG, JPEG,
+  WebP, GIF, BMP, ICO) and SVG, which `usvg`/`resvg` already render. Nothing
+  else is decoded.
+- **What is not:** external `/usr/share/thumbnailers/*.thumbnailer` programs are
+  not executed. They are arbitrary binaries run against untrusted files, and
+  sandboxing them properly is a project of its own. The picker still *consumes*
+  thumbnails other applications have already written to the shared cache, so a
+  video another file manager has thumbnailed shows its thumbnail here. Running
+  `.thumbnailer` entries is a later change, behind a setting.
+- **Where they are cached:** the freedesktop shared thumbnail cache,
+  `$XDG_CACHE_HOME/thumbnails/{normal,large,x-large,xx-large}/<md5 of the file's
+  URI>.png`, with the `Thumb::URI` and `Thumb::MTime` PNG text chunks written
+  and honoured. A cached thumbnail whose `Thumb::MTime` differs from the
+  source's modification time is stale and regenerated. Failures are recorded in
+  `thumbnails/fail/otto-files/` so an undecodable file is not retried on every
+  scroll.
+- **In memory:** decoded images live in an LRU cache bounded by both entry count
+  and bytes (512 entries / 64 MB as the starting figures). 10,000 files must
+  never mean 10,000 live images.
+- **What is requested:** thumbnails for the visible range plus one viewport of
+  margin above and below, and nothing else. The request queue is a
+  visibility-keyed priority stack, not a FIFO: scrolling replaces the pending
+  set rather than appending to it, so jumping to the end of a 10,000-entry
+  directory queues one screenful of work, not ten thousand jobs.
+- **Before the thumbnail:** the entry's type icon, resolved through the icon
+  theme, drawn immediately. A thumbnail replacing an icon is a swap, never a
+  reflow.
+- **Size ceiling:** files above a threshold (128 MB as a starting figure) are
+  not thumbnailed, and neither are files on a mount flagged as remote. The type
+  icon stands in.
+
+### Filesystem watching
+
+Only the directories currently displayed are watched — the path stack, plus the
+places file — using inotify directly. Watches are dropped as directories leave
+the stack. Nothing is watched recursively.
+
+`IN_CREATE`, `IN_DELETE`, `IN_MOVED_FROM`, `IN_MOVED_TO`, `IN_CLOSE_WRITE` and
+`IN_ATTRIB` mark the directory dirty. A dirty directory is re-read after a
+100 ms debounce and the result diffed against the current snapshot, so that
+selection, cursor and scroll offset survive an unrelated file appearing.
+`IN_Q_OVERFLOW` forces a full re-read of everything watched.
+`IN_DELETE_SELF` or `IN_MOVE_SELF` on a displayed directory navigates to its
+nearest surviving ancestor and says why.
+
+Removable volumes appear and disappear in the sidebar by watching
+`/proc/self/mounts`, which signals `POLLPRI` on change. Volumes that are not
+already mounted are not shown and cannot be mounted from the picker in v1.
+
+A filesystem that inotify cannot watch (many network mounts) simply produces no
+events; the view is correct when read and refreshes on navigation or on an
+explicit reload. It must not poll.
+
+### Sorting
+
+Sort keys: name, size, kind, date modified. Directories always sort before
+files, in both directions, and this is not configurable in v1.
+
+Name ordering is natural and case-insensitive: runs of digits compare
+numerically, so `file2` precedes `file10`. Comparison is done on Unicode
+scalars with ASCII case folding, without locale collation — a known limitation
+for languages where that is wrong, accepted rather than pulling in a collation
+crate.
+
+The picker does not persist sort order between requests. The browser does, per
+directory.
+
+## Constraints & Edge Cases
+
+- **`parent_window` does not work yet, and v1 does not depend on it.** Otto
+  ignores `xdg_toplevel.set_parent` for toplevels: window order comes from
+  workspace stacking alone, and nothing reads a toplevel's parent. The request
+  is not an error — Smithay records it — so the picker may send it, and it
+  becomes correct for free once the compositor honours it. But **v1 must be
+  designed as if it were absent**, which means:
+  - The picker does not stay above the application that opened it and can be
+    buried by it. Nothing prevents the parent being focused or raised while the
+    picker is up.
+  - **`modal` is accepted and not enforced.** The picker is a plain toplevel.
+    Nothing in this spec may be written as "the user cannot do X while the
+    dialog is open" — the picker must be correct when the user goes away, uses
+    the app, and comes back to it.
+  - Placement uses `parent_window` only as a hint for *which output* to open on,
+    resolved through xdg-foreign where the handle imports; otherwise the output
+    holding the pointer. Position within that output is centred.
+  - The window is titled and attributed clearly enough to be found again after
+    being buried, and the taskbar/switcher entry names both the picker and the
+    requesting `app_id`.
+  See *Prerequisites* below.
+- **The requesting app dies mid-dialog.** The picker keeps the window up — the
+  portal frontend will `Close` the request when it notices, and until then the
+  user is entitled to finish what they were doing without the window vanishing.
+  On `Close` the window disappears immediately.
+- **The picker dies mid-request.** The portal must notice the peer disappear and
+  resolve the pending call with `response = 2`. A file dialog that never returns
+  hangs the requesting application's UI thread.
+- **Concurrent requests.** Multiple windows in one process. They share the
+  thumbnail cache and the worker pool; they share no selection, directory or
+  filter. A per-request window must not be able to starve another's I/O — jobs
+  are round-robined between windows, not served in arrival order.
+- **Unreadable directories.** A directory the user cannot read shows an
+  explanation in place of the listing, not an empty list. An entry that cannot
+  be stat'd shows the name with unknown metadata rather than being dropped.
+- **Non-UTF-8 names.** Linux file names are bytes. An entry whose name is not
+  valid UTF-8 is displayed with the invalid sequences replaced, but the picker
+  keeps the original bytes and returns a URI built from them. Round-tripping a
+  file must never depend on it being nameable in Unicode.
+- **Symlink loops** must not hang navigation. A directory is read as itself; the
+  picker follows no link it was not asked to.
+- **The URI encoding is not optional.** Every byte outside the unreserved set is
+  percent-encoded. A file called `a b&c#d` must survive the round trip; this is
+  the single most likely place for a silent data bug.
+- **Save into a directory that disappears** while the dialog is open: accept
+  fails with an explanation and navigation falls back to the nearest surviving
+  ancestor, rather than returning a URI in a directory that no longer exists.
+- **A filter that matches nothing** in the current directory shows a "no
+  matching files" state naming the filter, with the filter control still
+  reachable. It must be obvious that files exist but are filtered out.
+- **Directory mode with `multiple`** is legal in the portal contract and returns
+  several directories.
+- **Zero visible entries after hidden-file filtering** in a directory that
+  contains only dotfiles must be distinguishable from an empty directory.
+- **The picker must not require the compositor to be built with development
+  features**, and must run under the windowed development backend.
+
+## Prerequisites
+
+Two pieces of work outside this spec that the picker depends on. Both are named
+here with what they block, so neither is discovered late as an assumption.
+
+**1. Toplevel parenting in the compositor — not started.** Otto does not honour
+`xdg_toplevel.set_parent`: nothing in `src/shell/` or `src/workspaces/` reads a
+toplevel's parent, and stacking comes from workspace order alone. Until it does,
+a dialog cannot be kept above the window that opened it and there is no modal
+grouping of any kind. The portal file chooser is the archetypal parented dialog
+and is likely the first thing in Otto to want this.
+
+This is compositor work, and it is a prerequisite for *modality*, not for the
+picker: **v1 ships without it** and is specified above to not need it. When it
+lands, the picker's `modal` handling becomes enforcement rather than a no-op,
+and no other part of this spec changes. Owner: the compositor, not this
+component.
+
+**2. Focus and tab order in otto-kit — not started.** Already the toolkit
+roadmap's named outstanding gap. Unlike parenting, this one genuinely blocks:
+the keyboard goal above cannot be met without it, and the picker must not invent
+a private focus model that later has to be unpicked. `button` and `toggle` also
+need their own hover and press state before they can sit in a toolbar.
+
+## Rationale
+
+**The portal brokers; a separate component renders.** This is the shape
+[portal-access-dialog.md](./portal-access-dialog.md) already established, and it
+holds for the same reasons: the portal binary stays a headless D-Bus service,
+policy about renderers lives in one place, and the renderer can be replaced. The
+one thing that changes is *which* renderer — an island cannot be a window, and
+this dialog has to be one.
+
+**The picker is D-Bus activated rather than resident or spawned per request.**
+Resident costs memory and a filesystem watcher for a dialog most users open a
+few times a day. Spawned per request means a cold process, a fresh Wayland
+connection and an empty thumbnail cache every time, and forces the portal to
+manage a child's lifetime. Activation gives the portal a plain method call, the
+bus the process management, and a run of picks in one session the benefit of a
+warm cache.
+
+**One view layer, two shells.** The picker and the browser differ in chrome and
+in what the accept action means. Everything below that — reading directories
+without blocking, watching them, sorting them, thumbnailing them, drawing them
+three ways, navigating them from the keyboard — is one body of work, and it is
+the hard half. Writing it twice would guarantee the two dialogs diverge in
+exactly the details users notice.
+
+**MIME filters collapse into glob filters.** Resolving a MIME type through
+`globs2` and `subclasses` turns rule kind 1 into rule kind 0, leaving one
+matcher to write and test instead of two mechanisms with different bugs. The
+cost is that a file whose name lies about its type is filtered by its name,
+which is what every other implementation does in practice anyway.
+
+**The shared thumbnail cache, at the cost of writing MD5 and a PNG chunk
+splicer by hand.** Two small pieces of well-specified code — RFC 1321 with
+published test vectors, and PNG `tEXt` chunk framing with a CRC32 — buy
+interoperability with every other thumbnailing application on the system: we
+read what they wrote, and they read what we wrote. Both are the kind of thing
+this project prefers to write rather than depend on. Skia already encodes and
+decodes the PNG itself.
+
+**Threads and channels, not an async runtime, for the filesystem.** The
+requirement is "never block the UI thread", and a worker thread satisfies it
+exactly. Adding an async filesystem abstraction over what is ultimately blocking
+syscalls buys nothing and costs a runtime in a process that would otherwise not
+need one.
+
+**Type-ahead is not search.** Conflating them — typing filters the list —
+destroys the user's spatial memory of the directory and makes arrow navigation
+mean something different depending on what was typed. They are separate
+mechanisms with separate keys, and this is worth the extra state.
+
+**No `stat` on the initial listing.** 10,000 files is 10,000 syscalls before
+anything is drawn, and on a network mount that is seconds. Names first, metadata
+second, is the difference between a dialog that opens and one that hangs.
+
+**The picker remembers a directory per app, and nothing else.** Users expect to
+return to where they last saved. They do not expect the image editor's dialog to
+open in the directory their mail client last attached from, and they do not
+expect a stale selection or filter from an unrelated request. Keying on `app_id`
+and forgetting everything else is the smallest thing that gets the expected
+behaviour without the surprising ones.
+
+## New otto-kit components
+
+Reused as they stand: `source_list` (places sidebar), `scroll`, `text_input`
+(search and name fields), `dropdown` (filters, sort, choices), `context_menu`,
+`list`, `titlebar`, `window`, `button`, `toggle`, and the `icons` lookups that
+do not touch `AppContext` — `cached_file_icon` and `find_icon_in_theme`, never
+`named_icon_sized`.
+
+New, and generic enough to belong in the toolkit:
+
+| Component | Draw + hit-test | Notes |
+| --- | --- | --- |
+| `search_field` | `draw`, `clear_at` | Already recorded as an open toolkit item |
+| `segmented_control` | `draw`, `segment_at` | View switcher; already an open item |
+| `breadcrumb` | `draw`, `segment_at`, `overflow_at` | Path bar, with ancestor collapsing |
+| `table` | `draw`, `row_at`, `header_at`, `divider_at` | Sortable, resizable columns; virtualised over a visible range |
+| `icon_grid` | `draw`, `cell_at`, `cells_in_rect` | Cell grid with rubber-band support |
+
+Prerequisite, and the real blocker: **focus and tab order** in otto-kit. The
+picker's keyboard goal cannot be met without it, and it is already the
+roadmap's named outstanding gap. `button` and `toggle` also need their own hover
+and press state before they can be used in a toolbar.
+
+Also joining otto-kit, because more than the file components need them:
+`filetype` (MIME resolution, magic sniffing, the kind classification) and the
+thumbnail cache, both defined in [file-browser.md](./file-browser.md) under
+*Shared foundations* — quick view consumes both and must not have to depend on
+a file manager to do so.
+
+Staying in the file components, because they encode this application's
+semantics rather than a shape: the directory model, the worker pool and
+watcher, the natural-order comparator, and the confirmation sheet.
+
+## Out of scope for v1, explicitly
+
+Column view. Drag and drop, in or out — otto-kit has no `wl_data_device`
+support at all, so this is a toolkit project before it is a picker feature.
+Recursive search. Content-based type detection. Running external thumbnailers.
+Mounting unmounted volumes. Remote filesystems. Previews beyond the thumbnail.
+Tagging, starring, or any metadata Otto would have to invent a store for.
+Persisted column widths.
+
+## Resolved decisions
+
+- **No "recent files" place in v1.** It needs `recently-used.xbel`, and nothing
+  else in Otto reads or writes it. A recents list containing only what Otto's
+  own picker did is worse than no recents list — it looks broken rather than
+  empty. Revisit when something else in the desktop writes that file.
+- **The per-app last-directory memory is the picker's own state file**, at
+  `$XDG_STATE_HOME/otto/file-picker-dirs`: `app_id` to absolute path, one per
+  line, a bounded LRU of 64 entries. State, not configuration — it is not
+  hand-edited, not a preference, and has no business in the settings schema or
+  in a file the user is invited to edit.
+- **Save-mode accept does not create the file.** The portal contract does not
+  require it, no other implementation does it, and a zero-length file left
+  behind when the application then fails to write is a worse outcome than the
+  race it would close. What does help is checked instead: the destination
+  directory's writability is tested at accept time, and a failure is reported
+  there rather than becoming the application's problem.
+
+## Open Questions
+
+None outstanding. Both remaining dependencies are recorded under
+*Prerequisites*, not here — they are known work, not unresolved requirements.

--- a/specs/launcher.md
+++ b/specs/launcher.md
@@ -1,0 +1,167 @@
+# Launcher
+
+**Status:** draft
+**Related specs:** [context-menus.md](./context-menus.md), [topbar.md](./topbar.md)
+
+## Summary
+
+A keyboard-driven overlay that appears over the desktop, filters a list of things
+as the user types, and acts on the one they pick. It ships knowing about two
+kinds of thing — installed applications and open windows — and is built so a
+third kind (files, clipboard history, a calculator) is another provider rather
+than another launcher.
+
+## Goals
+
+- Opening it, typing a few characters and pressing Enter starts an application
+  or focuses a window, with no pointer involved.
+- Ranking puts what the user meant first: a prefix beats a match in the middle,
+  a run of adjacent characters beats scattered ones, and a short name beats a
+  long one that merely contains the same letters.
+- It reads as part of Otto: the same frosted material, corner radius and shadow
+  as the bar's menus and the islands.
+- It is disposable — started fresh on a keystroke, gone as soon as something is
+  chosen. No daemon, and nothing to keep warm.
+- Adding a new kind of result requires implementing one provider interface and
+  registering it; nothing in the filtering, layout or input handling changes.
+
+## Non-Goals
+
+- Running arbitrary shell commands typed into the field.
+- Searching file contents, or anything that would need an index.
+- Remembering what was picked before, or ranking by frequency.
+- Being configurable by theme file. It follows the desktop's colour scheme and
+  icon theme, and nothing else.
+
+## Behavior
+
+**Appearing.** On start the launcher covers the output and takes the keyboard
+exclusively: every keystroke belongs to it while it is up, including ones the
+previously focused window would have wanted. A card sits above centre, showing
+a query field and the first results. Anything given on the command line is the
+query it starts with, so a binding can open it already narrowed.
+
+**Modes.** A run offers applications, windows, or both, chosen when it starts.
+Applications is the default: the two bindings mean "launch something" and
+"switch to a window", and a mode that quietly does both is neither. The empty
+field names the mode it is in — it is the only thing on screen that says which
+one is up.
+
+**At rest.** With nothing typed, the launcher does not list everything it
+knows. It shows the last three applications launched from it, most recent
+first, and nothing else — nothing at all until something has been launched, in
+which case the card is the query field alone. The window switcher is the
+exception: browsing is its purpose, so an empty query there lists every window,
+most-recently-focused first.
+
+A query that matches nothing says so. An empty query does not: a launcher that
+has just opened has not failed to find anything.
+
+**Typing.** Each keystroke re-ranks the whole list; results and the card's
+height follow immediately. Text typed into the field must be visible in the
+field. Everything a provider has is searchable, whether or not it is shown at
+rest.
+
+**Arithmetic.** A query that is a complete arithmetic expression containing at
+least one operator is answered: the result appears as the first row, above the
+matches, and acting on it copies the result. A bare number is a search, not a
+sum. A comma is a decimal separator; when a number carries both a comma and a
+dot, the last of the two is the decimal separator and the other is grouping.
+The answer is written with whichever separator the question used.
+
+**Choosing.** Up/Down move the selection and wrap at both ends. Tab and
+Shift+Tab do the same. Page Up/Page Down move by a screenful. Ctrl+N and Ctrl+P
+mirror Down and Up. The list scrolls to keep the selection visible; at most
+eight rows are shown at once. Enter acts on the selection. Escape closes the
+launcher without acting.
+
+**Editing.** The field supports caret movement, selection with Shift, word-wise
+motion with Ctrl, select-all with Ctrl+A, deleting the previous word with
+Ctrl+W, and clearing the query with Ctrl+U.
+
+**Pointer.** Moving the pointer over a row selects it. Releasing over a row acts
+on it. Pressing anywhere outside the card closes the launcher, as Escape does.
+The row under the pointer must be the row that highlights.
+
+**Acting.** Choosing an application starts it detached, in its own process
+group, with desktop-entry field codes stripped and `Terminal=true` entries
+wrapped in a terminal, and records it at the front of the launch history. An
+application that failed to start is not recorded. Choosing a window focuses it, un-minimising it first if
+it was minimised. The launcher exits once the action has been carried out; if
+the action fails it stays up and reports the failure rather than vanishing
+having done nothing.
+
+**Losing focus.** If the keyboard is taken away after the user has interacted
+with the launcher, it closes. Before the first interaction it does not — that
+would be closing on the way up.
+
+**Changing state.** A window opening or closing while the launcher is up updates
+the list, keeping the selection on the same item where that item still exists.
+
+## Constraints & Edge Cases
+
+- **The card must not dim what it frosts.** A scrim painted by the launcher
+  covers the desktop that the compositor's blur samples, so the frost becomes a
+  blur of flat grey. Any dimming has to come from the compositor, not from a
+  client-painted layer behind the card.
+- **Drawn position and Wayland position must agree.** The card is a subsurface
+  whose material the compositor supplies. Moving it by surface style alone moves
+  only where it is drawn: the compositor still hit-tests the pointer against the
+  subsurface's own position and reports coordinates relative to it, so hover
+  lands on the wrong row. Both must be set.
+- **The query field must be laid out before it is drawn.** A field with no width
+  scrolls its own text out of its clip, and the launcher then looks like it is
+  ignoring the keyboard while the list filters correctly.
+- **Icon lookup is on the typing path.** Resolving an icon must be cached and
+  must not re-scan the icon theme directories per lookup; a screenful of
+  uncached icons is otherwise seconds of work between keystrokes.
+- Desktop entries that are hidden, that say `NoDisplay`, or that have no `Exec`
+  are not offered. A user-level entry shadows the system entry of the same name
+  rather than appearing twice.
+- Windows with no title are not offered: there is nothing to type against.
+- The launch history is state, not configuration: it is written by the program,
+  and losing it costs nothing but the resting list. It must be written whole and
+  moved into place, so a launcher killed mid-write leaves the previous history
+  rather than half of a new one. Entries naming an application that is no longer
+  installed are skipped rather than shown.
+- An answer cannot be put on the clipboard by the launcher itself: a Wayland
+  selection dies with the client that offered it, and the launcher exits as soon
+  as the answer is taken. Something that outlives it has to own the offer.
+- If the compositor does not offer foreign-toplevel management, the launcher
+  runs with applications only.
+
+## Rationale
+
+- **Exclusive keyboard, not on-demand.** The launcher is modal for as long as it
+  is up. Anything less means a keystroke can go to the window behind it, which
+  for a tool whose whole interface is typing is the one unacceptable failure.
+- **A subsurface for the card.** The blur belongs to the card, not to the whole
+  screen, and a surface's material applies to the whole surface — so the card
+  needs a surface of its own. It also puts the launcher on the same material as
+  the rest of the desktop for free.
+- **Buffer allocated at full height, clipped shorter.** A shorter list is the
+  same buffer with the compositor showing less of it, so the card can change
+  height without reallocating or re-laying-out anything.
+- **No frecency, but a resting list.** Ranking that changes with history makes
+  the same query mean different things on different days, and the muscle memory
+  of "type three letters, press Enter" is worth more than a better first guess.
+  History earns its place only where nothing has been typed, where the
+  alternative is a wall of names nobody reads.
+- **A material that still frosts.** The card is opaque enough for small text to
+  read against a busy desktop, and no more. Past roughly 85% the frost stops
+  reading as frost and the card may as well be opaque, which throws away the
+  blur the compositor is doing anyway.
+- **Three, and nothing when there are none.** A resting list long enough to
+  scan is a list worth reading instead of typing. Three is small enough to take
+  in at a glance, and an empty one is honest: a launcher that has never been
+  used knows nothing about what you want.
+- **Wrapping selection.** A list that stops at the end makes the user check
+  where the end was.
+
+## Open Questions
+
+- Should the launcher be bound to a key by default, and to which one?
+- Should a query that matches nothing offer to run it as a command?
+- Should the arithmetic answer offer a second action — opening the expression in
+  the calculator application — and on what key?
+- Files as a third provider: what is searched, and how is the result acted on?

--- a/specs/quickview.md
+++ b/specs/quickview.md
@@ -1,0 +1,761 @@
+# Quick View
+
+**Status:** draft — nothing implemented
+**Related specs:** [file-browser.md](./file-browser.md) — in particular its *Shared foundations*, which defines the thumbnail cache and file-type detection this spec consumes — [file-picker.md](./file-picker.md), [launcher.md](./launcher.md), [portal-access-dialog.md](./portal-access-dialog.md), [settings-app.md](./settings-app.md), [context-menus.md](./context-menus.md)
+
+## Summary
+
+Press space on a selected file and see it, instantly, without launching the
+application that owns it. Quick View is a **component the file views embed** —
+the file browser, the save/open dialog, and the desktop's file view — drawn as a
+subsurface of the window showing the files, so it is parented, stacked and
+dismissed by that window rather than managing any of it itself. Everything that
+interprets file bytes runs in a short-lived, sandboxed worker process that has
+one file descriptor and no network.
+
+## Goals
+
+- Pressing space with a file selected shows that file's content over the host's
+  window. Pressing space again closes it. Nothing else about the host changes.
+- While the preview is open, moving the selection swaps its content in place,
+  without a new surface and without a new process.
+- The preview grows out of the selected row and shrinks back into it, because
+  the host knows where that row is.
+- All three hosts embed one implementation. Adding a fourth means calling the
+  same library, not re-implementing a previewer.
+- A malformed, hostile, or absurdly large file can waste one worker process and
+  produce a blank preview. It cannot reach the network, write anything, outlive
+  the preview, or affect the compositor's frame loop. Reading other files is
+  *not* yet contained — see Sandboxing for what that costs to close.
+- The panel appears within 50 ms of the keypress and shows real content within
+  100 ms for anything already thumbnailed. It never appears empty and never
+  appears late.
+- Images, PDFs, and text documents are previewed properly — not as a card
+  describing the file. A photograph can be zoomed into and stays sharp; a PDF
+  shows its pages and can be paged through; a text file shows its text. These
+  three carry the feature, and no other type may be traded against them.
+- Adding a content type means writing a decoder, not a new surface, a new IPC
+  shape, or a new drawing path.
+- Previews and every file view's thumbnails come from one cache in one format,
+  written by whichever process got there first. Three consumers share it with no
+  daemon and no coordination, because the filesystem is the coordination.
+
+## Non-Goals
+
+- Editing, annotating, cropping, rotating, converting, exporting, printing, or
+  sharing. Quick View is read-only, and the escape hatch is "open in the real
+  application".
+- File management: rename, delete, move, copy, permissions. That is the
+  browser's job.
+- Playback in v1. Audio and video show a poster and metadata; a transport is a
+  later stage, not a hidden v1 requirement.
+- HTML, EPUB, and anything else whose faithful rendering implies a browser
+  engine. This is a permanent exclusion, not a deferral.
+- Out-of-tree previewer plug-ins. The seam for new content types is in-tree; a
+  loadable third-party previewer reintroduces exactly the untrusted-code problem
+  the sandbox exists to solve.
+- Remote or virtual locations. `file://` only — no network fetch, ever, by any
+  part of the system.
+- A second thumbnail cache, a content index, or full-text search.
+- A preview process, a preview service, or a preview daemon. There is no bus
+  name and nothing to activate.
+
+## Behavior
+
+### What this is, and what it is not
+
+Three things could have been built. Only one of them is Quick View.
+
+**It is not a compositor feature.** A previewer's entire job is parsing
+untrusted bytes, and the compositor is a single process whose death takes the
+session with it. That argument survives everything below: decoding happens in a
+separate sandboxed process no matter who draws the result.
+
+**It is not a standalone application either, and an earlier draft of this spec
+was wrong to say so.** That draft reasoned from the sandbox to a separate
+*application*, which does not follow: parsing untrusted bytes requires a
+separate *decoder*, and says nothing about where the UI lives. Building it that
+way cost real things — the preview could not be stacked above the window that
+opened it, could not know where the file was on screen, and had to hand-manage
+focus and dismissal that a parent window gives for free.
+
+**It is a component the file views embed.** The preview is a subsurface of
+whichever window is showing files. That is forced by the protocol and is the
+point: `wl_subcompositor.get_subsurface` takes two surfaces from the *same*
+client, as do `xdg_popup` and `xdg_toplevel.set_parent`, so "parented to the
+file view" and "separate process" are mutually exclusive. Choosing parented
+dissolves the hardest open problem in this spec — the host already knows where
+the row is in its own surface, so the entrance can grow out of the file with no
+protocol, no compositor change, and no `anchor` in screen coordinates that
+nobody could compute.
+
+Three hosts embed it: the file browser, the save/open file dialog, and the
+desktop's file view. The `otto-quickview` binary remains for previewing a path
+named on a command line, and for being the sandboxed decode worker.
+
+The layers, and the split is load-bearing:
+
+1. `otto_kit::preview` — draw functions over an already-decoded payload, plus
+   hit-test helpers. Pure Skia: a canvas, a rect, a payload, a theme. No
+   `AppContext`, no `wayland-client`. A host draws it into its own surface, and
+   the compositor can draw the same thing server-side for a dock thumbnail.
+2. `otto_kit::filetype` and `otto_kit::thumbnails` — type detection and the
+   shared on-disk thumbnail cache, used identically by all three hosts.
+3. `otto-quickview` — the library: the sandboxed decode worker, the payload
+   wire format, and the entrance geometry. Hosts call it; they do not
+   re-implement it.
+
+**Embedding obligation.** The worker is this binary re-executed, and the binary
+*is* the host once the library is embedded — so every host must call
+`run_worker_if_requested()` first thing in `main`, before any thread or Wayland
+connection exists. Without it a preview would re-exec the host as a host, which
+starts a second file browser instead of decoding anything.
+
+### The embedding contract
+
+This is the contract; everything else in this spec is downstream of it. It is a
+Rust API rather than a wire protocol, because the preview runs inside its host.
+
+```rust
+// Once, first thing in main — before any thread or Wayland connection.
+otto_quickview::run_worker_if_requested();
+
+// Per preview: open the file, decode it in a contained worker.
+let opened = otto_quickview::open(path)?;                  // refuses FIFOs, devices
+let preview = otto_quickview::decode_path(path, &request); // always returns something
+
+// Draw it into the host's own surface, at whatever rect the host chose.
+// `zoom` magnifies an image and drags it about; a host with no zoom gesture
+// passes `Zoom::FIT` and gets what it got before there was one.
+otto_kit::preview::draw(canvas, rect, &preview, &theme, first_row, zoom, &resolve_icon);
+let layout = otto_kit::preview::layout(rect, &preview, first_row, zoom);
+layout.row_at(x, y);                                       // hit-testing
+
+// Gesture geometry, so every host clamps the same way.
+let zoom = otto_kit::preview::zoom_about(rect, &preview, zoom, scale, focus);
+let zoom = otto_kit::preview::clamp_zoom(rect, &preview, zoom);
+
+// The entrance, from the row the user pressed space on.
+let entrance = otto_quickview::opening::entrance(row_rect, panel_rect);
+```
+
+Rules the host must honour:
+
+- **Call `run_worker_if_requested()` first.** The worker is the host binary
+  re-executed; without this the preview re-execs the host as a host.
+- **Decode off the UI thread.** `decode_path` blocks until the worker answers or
+  its deadline expires. A host that calls it inline stalls its own frame loop
+  for as long as the file takes.
+- **Tag decodes with a generation and drop stale ones.** Arrow-keying is faster
+  than decoding; a result that arrives after the selection moved must be
+  discarded, not painted.
+- **Never interpret file bytes in the host.** Everything the host receives is a
+  `Preview` — validated text, bounded rows, or a pixel buffer whose dimensions
+  have already been checked against its length.
+
+What the host owns, because it is better placed to: the panel's rect, the
+keyboard (it never loses focus, so there is nothing to hand back), dismissal,
+and the selection. There is no `Navigate`, no `Activated` and no `Closed` — the
+host already has the keypress, already knows the selection, and already knows
+when it closed the panel.
+
+### The keyboard, and the panel
+
+The host never loses focus, which removes the hardest part of the old design.
+There is no hand-back: the host already has the keypress.
+
+- **Space, Escape** — close the preview.
+- **Arrows, Home, End, Page Up/Down** — the host moves its own selection and
+  tells the preview the new path. When the content has pages, Page Up/Down
+  paginate instead.
+- **Enter** — the host opens the file in its default application and closes the
+  preview.
+- **`+` / `-` / `0`** — zoom, which is the preview's own business; past fit,
+  the arrows pan rather than moving the selection. *Not implemented yet — the
+  pointer gets there first, see below.*
+
+### The pointer, and zooming an image
+
+Zoom applies to **images only**. Text, listings and cards are laid out to fit
+by construction and go on scrolling exactly as they did; a pinch over one of
+them does nothing rather than something surprising.
+
+- **Pinch zooms**, centred on the focal point between the fingers, so the
+  gesture grabs the picture rather than the panel. The protocol
+  (`zwp_pointer_gesture_pinch_v1`) reports only how far that point has drifted
+  since the gesture began, so the host carries the pointer's last position over
+  the panel and adds the drift to it.
+- **The range is fit → 8×**, measured against the *fitted* size rather than the
+  source's own, so a pinch means the same thing on a thumbnail and on a
+  photograph. Past the top it stops; near the bottom it snaps back to fit
+  exactly, because there is no useful state between "the whole picture" and
+  "visibly zoomed in".
+- **A two-finger scroll pans a zoomed image**, and scrolls everything else —
+  including an image at fit, which has nothing to pan to. Panning stops with
+  the picture still covering the box it is looked at through: it can never be
+  dragged off and leave the panel empty.
+- **Zoom belongs to the picture, not to the panel.** Changing file or closing
+  the preview puts it back to fit.
+
+The geometry — the clamp, the snap, the pan limits and the focal-point
+transform — lives in `otto_kit::preview` beside the layout, not in the host, so
+the browser and the file picker cannot end up with different ideas of how far a
+picture zooms. The host owns only the state: one `Zoom` per open session.
+
+### The panel
+
+A subsurface of the host's window, positioned by the host: centred over the
+file view, sized to the content and clamped to 80% of the host's window with a
+floor of 400×300. Content smaller than the floor is centred in it rather than
+upscaled.
+
+It carries the file's name, its size and modification date, a close affordance
+on the trailing edge, and "Open with <app>". The close is a single control, not
+the toolkit's traffic lights: those belong to a window — something you minimise,
+zoom and arrange — and this has exactly one exit.
+
+The material is the compositor's, declared through surface-style: the popup
+token, background-blurred, with the desktop's corner radius and shadow. It reads
+as the same kind of surface as the bar's menus and the launcher's card, because
+it is.
+
+Dismissal: space, Escape, the close control, a click outside the panel, or the
+host closing it for any reason of its own. There is no focus-loss rule — the
+host's window losing focus is the host's business, and a preview inside it
+simply goes when the host says so.
+
+### Opening and dismissing
+
+**The opening is animated, and it opens out of the file.** The card grows and
+fades from `anchor` — the rect of the item the user pressed space on — to its
+resting rect. That motion is the thing that makes the preview feel attached to
+the file rather than summoned on top of it, and it is why `anchor` is the item's
+rectangle and not the caller's window.
+
+- **Geometry** — anchor rect → resting rect, ~260 ms, spring with a slight
+  overshoot. Deliberately less bounce than the launcher's card: this surface is
+  much larger, and on a large surface the same overshoot stops reading as life
+  and starts reading as wobble.
+- **Opacity** — 0 → 1 in ~90 ms, ease-out, and therefore finished long before
+  the geometry settles. The card should be legible almost at once and still be
+  arriving; the two are out of step on purpose.
+- **No anchor** — with an empty `anchor` there is nothing to grow out of, so the
+  card scales in place from ~0.96, which is the launcher's entrance. Same code
+  path, different starting rect.
+- **Dismissal reverses it**, and faster: ~160 ms back toward the anchor,
+  ease-in, with the opacity going in the same 90 ms. Leaving does not bounce —
+  there is nothing to settle into. If the anchor is no longer valid (the caller
+  scrolled, moved, or closed), the card fades in place rather than flying to a
+  stale rectangle.
+
+Two things the opening must **not** do:
+
+- It must not wait for content. The window is mapped and animating inside 50 ms
+  with the file's name and icon on it; the decoded content arrives during or
+  after the motion and does not restart it. An animation that waits for a
+  decoder is an animation whose duration is set by the file.
+- It must not re-run on `SetIndex`. Arrow-keying through a directory swaps
+  content inside a card that is already open and already still — the card
+  cross-fades its content, and resizes if the content type changed, animated
+  from the centre so the frame does not jump to a corner. Replaying the entrance
+  per keystroke would be unusable.
+
+The animation is declared through the compositor's surface-style transactions —
+the same mechanism otto-launcher's card uses — so it runs compositor-side and
+costs the previewer no frames. That matters here more than it does for the
+launcher: this process is also supervising a decode, and the entrance must not
+share a thread with it.
+
+Dismissal, for ephemeral sessions: space, Escape, the close affordance, a click
+outside the card, focus loss (when `close_on_focus_loss`), `Close` from the
+caller, or the caller vanishing. Every path emits `Closed` with its reason.
+
+Modality: Quick View is **not** modal. It takes the keyboard while it is up
+because it is an overlay, but it does not block the caller, does not prevent
+the caller from repainting, and imposes no ordering on anything. The
+anti-spoofing requirements that apply to a permission grant
+([portal-access-dialog.md](./portal-access-dialog.md)) do not apply here, because
+nothing is being consented to.
+
+The rule that keeps this from eroding, on **both** surface paths: nothing in
+this spec may be phrased as "the user cannot do X while the preview is open".
+Quick View holds the keyboard and it may be buried by the window that opened it;
+those are the only two facts about its relationship to other windows. Any
+requirement that needs more than that is a requirement Otto cannot currently
+enforce, and writing it down as though it could is how a spec acquires a
+dependency nobody costed.
+
+### Content types
+
+Ranked by what v1 ships, and honest about the ones needing a decoder Otto does
+not have.
+
+| Type | v1 | Needs |
+|---|---|---|
+The three that matter most are images, PDF, and text documents. Those three are
+**fully previewed in v1** — real pixels, real pages, real text — and the rest of
+the table is arranged around not compromising them.
+
+| Type | v1 | Needs |
+|---|---|---|
+| **Image** — PNG, JPEG, WEBP, GIF (first frame), BMP, ICO | Full: scaled decode, zoom to 1:1 and beyond, pan | Skia's own codecs, already linked |
+| **Image** — SVG | Full, re-rendered at each zoom level, so it stays sharp | Skia's own SVG module — `skia-safe` is already built with `features = ["svg"]` |
+| **PDF** | Full: rendered pages, page navigation, zoom | An external rasteriser, exec'd — see below |
+| **Text and source code** | Full: monospace layout, line numbers, encoding sniff, wrap toggle. No syntax highlighting in v1 | Nothing |
+| Directory | Full: entry count, total size, a grid of child icons and image thumbnails | Nothing |
+| Lottie animation | Full, played | Skottie — already enabled and already used by otto-kit |
+| Archive — zip, uncompressed tar | Listing only: names, sizes, dates, entry count | Nothing (see below) |
+| Audio | Metadata card: title/artist/album/duration, plus embedded cover art | Tag parsing by hand; PCM decode deferred |
+| Video | Metadata card: dimensions, duration, codec, plus the container's embedded poster when present | Frame decode deferred |
+| HEIC, AVIF, camera RAW | Not previewed — shown as an unsupported card naming the type | Deferred |
+| HTML, EPUB, Office documents | Never | — |
+
+Notes on the ones that look like they need a crate and do not:
+
+- **Archive listing needs no decompression.** A zip's central directory carries
+  every entry's name, size and date in plain form at the end of the file; a tar
+  is 512-byte headers. Listing is a parse, not an extraction. A *compressed* tar
+  (`.tar.gz`, `.tar.zst`) cannot be listed without inflating and is therefore
+  shown as a plain file card in v1.
+- **Scaled image decode needs Skia's `Codec`, not `Image::from_encoded`.**
+  Sample-size decoding is the difference between previewing a 200 MP image and
+  refusing to.
+- **SVG and Lottie come from Skia, not from `resvg`.** Both modules are already
+  compiled into `skia-safe` here, so the vector types cost nothing. Quick View
+  deliberately does not become a new consumer of `resvg`/`usvg`, since whether
+  Skia's SVG can replace them outright is an open question elsewhere in the
+  project and a new caller would only make removing them harder.
+- **Skia does not help with PDF.** Its PDF support is a document *writer*; there
+  is no reader and no rasteriser. This is worth stating because "Skia already
+  does PDF" is the natural wrong assumption.
+
+### PDF, and the external rasteriser seam
+
+PDF is rendered in v1 by **exec'ing an existing rasteriser inside the decode
+worker** and reading a PNG or PPM back from its standard output, which Skia then
+decodes like any other image. No PDF library is linked into anything Otto
+builds.
+
+The worker tries, in order, and uses the first one present:
+
+| Command | From | Notes |
+|---|---|---|
+| `pdftoppm -png -r <dpi> -f N -l N` | poppler-utils | The expected path. Poppler is a de-facto universal desktop dependency — it is already installed on this machine, pulled in as a plain `poppler` package. |
+| `pdftocairo -png -r <dpi> -f N -l N` | poppler-utils | Same package; better output on some documents. |
+| `mutool draw -F png -r <dpi>` | mupdf-tools | AGPL, which constrains *linking* — exec'ing a separate program does not create a derived work, so it is available here in a way `libmupdf` is not. |
+| `gs -sDEVICE=png16m` | ghostscript | Last resort; slowest. |
+
+If none is present, PDF falls back to the metadata card, and the card says which
+package would enable page rendering rather than silently looking broken.
+
+The file is handed to the rasteriser as an already-open descriptor via
+`/dev/fd`, so the child never resolves a path of its own and cannot be
+redirected to a different file between the worker's `fstat` and the child's
+open. Page navigation re-execs for the requested page; at roughly 50–100 ms per
+page this stays inside the interaction budget, and the current page is kept
+while the next renders so paging never blanks the view.
+
+**This generalises, and is the reason to prefer it over a linked library.** The
+same seam — a table of external renderer commands, tried in order, run inside
+the existing sandbox — is how video poster frames arrive later
+(`ffmpegthumbnailer`, `gst-launch-1.0`) without GStreamer entering the default
+build, and how any future format can be supported by a distribution that ships
+the right tool. A new format becomes a table row.
+
+Rejected alternatives for PDF: `pdfium-render` bundles a large C++ blob into
+Otto's build for a preview feature; `dlopen`ing a system libpdfium avoids the
+build cost but depends on a library most distributions do not package, so it
+would degrade far more often than poppler does; pure-Rust `lopdf`/`pdf` parse
+structure but do not rasterise, so they cannot produce a page image at all.
+
+Decoders Otto genuinely lacks, with candidates and their cost:
+
+- **Video poster frames.** GStreamer is already in the workspace, but only in
+  `otto-rdp`, which pins Rust 1.96 and drags the whole GStreamer tree. Taking it
+  into the default build would raise the workspace MSRV for a preview feature.
+  **Recommendation:** an optional `preview-video` feature; without it, the
+  metadata card. FFmpeg bindings are a larger version of the same trade and are
+  not recommended.
+- **Audio playback and waveforms.** Needs a PCM decoder (`symphonia` is the
+  pure-Rust candidate, one crate per codec family) plus an output path. Deferred
+  wholesale; v1 deliberately gets most of the value from tags and cover art,
+  which need neither.
+- **Syntax highlighting.** `syntect` brings a regex engine and megabytes of
+  syntax definitions; `tree-sitter` brings a crate per language. **Recommendation
+  when this is built:** a hand-written token scanner covering strings, comments,
+  numbers, and a keyword set per language — a few hundred lines, correct enough
+  for a preview, and consistent with the project's dependency posture.
+
+### The previewer seam
+
+A previewer is three pieces, and only the first two are ever written for a new
+type:
+
+1. **A claim** — the set of MIME types it handles, with a priority. Detection is
+   `otto_kit::filetype`, defined in
+   [file-browser.md](./file-browser.md#2-file-type-detection): two calls
+   answering two questions. `mime_for_name(name)` is the type of *record*, and
+   drives the icon, the browser's Kind column, and default-application
+   association. `sniff(bytes)` is a bounded magic check over the first 4 KB.
+
+   **A previewer dispatches off `sniff`, never off the name.** A file named
+   `.png` that is not one must not reach the PNG decoder; the sandbox would
+   contain the consequences, but the correct preview is the one matching the
+   bytes. Display, conversely, follows the name — so the two calls cannot
+   disagree, because they are not answering the same question. Where the answers
+   differ and it is useful, Quick View says so on the card ("named `.png`, is
+   not one").
+
+   The type hierarchy from `subclasses` is what lets the text previewer claim
+   everything that is a `text/plain` subtype without enumerating languages.
+2. **A decoder**, running worker-side: given one read-only file descriptor and a
+   budget, produce a `PreviewPayload` or fail.
+3. Nothing else. Drawing comes from the payload.
+
+`PreviewPayload` is a **closed** set in v1, and this is the point of the design:
+
+- `Pixels` — premultiplied RGBA at a stated size, with an optional intrinsic
+  size for zoom, and an optional page count. Zoom is measured against the
+  fitted rect rather than this intrinsic size; the intrinsic size says how far
+  a decode can be zoomed before it starts inventing detail.
+- `Text` — bounded, validated UTF-8 with optional style spans.
+- `Rows` — a table (archive entries, directory listing): name, size, date, an
+  icon key.
+- `Card` — key/value metadata plus an optional `Pixels` hero image.
+- `Unavailable` — a reason to display.
+
+A new content type adds a decoder that produces one of these. It does not add a
+payload variant, an IPC message, a window mode, or a draw path. When a variant
+genuinely must be added, that is a deliberate change to `otto-kit::preview` and
+to this spec — not a routine extension.
+
+### Sandboxing
+
+Nothing in the Quick View application process ever interprets file content. For
+each file to be previewed, the application:
+
+1. Opens the path itself with `O_NONBLOCK`, `fstat`s it, and refuses anything
+   that is not a regular file or a directory — no FIFOs, devices, or sockets,
+   which can block on open or on read.
+2. Creates a `memfd` for the result and a pipe for status.
+3. Spawns `otto-quickview --decode-worker`, passing exactly three descriptors:
+   the file (read-only), the memfd (write), the status pipe (write). No other
+   descriptor, no Wayland socket, no D-Bus socket, no environment beyond a
+   minimal set.
+
+The worker, before touching a byte of the file: drops to `chdir("/")`, sets
+`PR_SET_NO_NEW_PRIVS`, unshares the network namespace (and a user namespace
+where the kernel allows it), and applies `RLIMIT_AS`, `RLIMIT_CPU`,
+`RLIMIT_NOFILE`, and `RLIMIT_FSIZE = 0`. It has no path to open anything: it
+never received one.
+
+The parent enforces a wall-clock deadline independently and kills a worker that
+overruns. A worker that crashes, overruns, or reports failure produces
+`Unavailable` with a reason, and nothing else happens.
+
+**What a malformed file cannot do:** write or grow any file anywhere; make any
+network connection; talk to the compositor, the display server, or the session
+bus; escalate privileges; consume more than its address space or CPU budget;
+survive its own preview; or take down anything other than one worker process,
+which the parent expects to lose.
+
+**What it can do:** produce a wrong or blank preview, occupy one core for the
+length of the deadline, and — this is a real gap, not a rounding error — **read
+other files the user can read**. The rlimits and the network namespace are not a
+filesystem jail, and `chdir("/")` only removes relative-path surprises. Closing
+it needs one of two things, and neither is free:
+
+- a **seccomp filter** denying `openat`, which is cheap for the in-process
+  decoders but breaks the PDF path, since an exec'd rasteriser must open its own
+  libraries;
+- a **mount namespace with `pivot_root`**, which is the correct answer and must
+  then bind in enough of `/usr` for those rasterisers to run.
+
+Until one lands, the honest containment story is: one process, one descriptor,
+hard budgets, no network, no writes — and reading is not contained. This is
+stated rather than glossed because a security property nobody measures is a
+security property nobody has.
+
+**The claim is testable.** `otto-quickview --sandbox-selftest` applies the real
+sandbox in a real child and reports what is in force, so this section can be
+checked rather than believed. Any change to the sandbox must keep that output
+matching this text.
+
+### Performance
+
+- **Window mapped within 50 ms** of the keypress, unconditionally. The first
+  frame shows the file's name, size, type icon, and a cached thumbnail if one
+  exists. It is never an empty rectangle and never a delayed one.
+- **Real content within 100 ms** for anything already in the thumbnail cache,
+  which is the common case when browsing a directory the browser has scrolled
+  through. Cold decode fills in when it lands, replacing the placeholder without
+  a resize jump.
+- **Cold process start ≤ 150 ms** to a mapped window. Repeat presses in one
+  browsing session pay it once: the service stays alive for a few seconds after
+  its last session closes, then exits. It is activatable and not a daemon, per
+  the launcher's precedent — but a five-second grace is the difference between
+  arrow-keying feeling instant and feeling like process spawns.
+- **Precomputed:** thumbnails only. There is no index, no background scan, and
+  no speculative decode of files that are merely adjacent to the selection.
+- **A 200 MP image** is never decoded at full resolution. The worker decodes at
+  the smallest sample size that still exceeds twice the window's pixel size, and
+  refuses above a fixed pixel budget when the codec cannot decode scaled, in
+  which case the file gets a metadata card. **Zooming re-decodes** rather than
+  upscaling the fit-sized decode: past roughly 1:1 the worker decodes the
+  visible region at a finer sample size, so zooming into a large photograph
+  shows detail instead of blur. The previous frame stays on screen while that
+  runs. This matters because images are a primary type — a previewer that goes
+  soft the moment you look closely has not previewed the image.
+- **The doubling is the host's, and happens once.** The size in a request is
+  already about twice the panel's pixels; a decoder renders at the size it was
+  asked for and does not double it again. Applied at both ends the factors
+  compound to four, which for a PDF meant rasterising a page at four times the
+  panel and waiting seconds for detail no panel can show.
+- **A PDF page is rasterised no wider than 2048 px**, whatever the panel asks
+  for. A page is re-rendered from vectors at whatever size is requested and the
+  cost climbs faster than the area, so this is a ceiling in its own right
+  rather than a safety valve — comfortably above a full-screen panel's own
+  pixels on a HiDPI display, and the difference between a preview that opens
+  and one that is waited for.
+- **A 2 GB video** is never read whole. The worker reads container headers and
+  the index only, under a hard cap on total bytes read, and produces a poster or
+  a card. The same cap applies to every metadata-only path.
+- **The compositor is never in the path.** Quick View is a separate process and
+  decoding is in a grandchild of it; the compositor's only involvement is
+  mapping and compositing a surface like any other client's. No decode, no file
+  I/O, and no parse ever runs on a compositor thread. Memory pressure is the one
+  channel by which a preview could hurt the session, which is what the worker's
+  `RLIMIT_AS` is for.
+
+### The shared foundations, and what Quick View does with them
+
+The thumbnail cache and file-type detection are defined once, in
+[file-browser.md](./file-browser.md#shared-foundations). They are not restated
+here. What matters on this side:
+
+**Quick View is a thumbnail producer, not only a consumer.** Its worker already
+performs a scaled decode, in a sandbox, on the file the user is most interested
+in — so it writes that result into the cache under the shared rules, and the
+browser is faster afterwards for a preview having been opened. Discarding it
+would mean the browser decoding the same file again, less safely. The one
+constraint the cache imposes on a producer: write **only** the four standard
+size buckets. An off-size image in that tree is invisible to every other
+implementation and is not a thumbnail.
+
+**The cache serves the first frame only.** It is the sub-100 ms placeholder. The
+real preview is always a fresh scaled decode at roughly twice the window's pixel
+size, in the worker. The cache therefore never holds full-resolution content and
+never needs a "decode this at an arbitrary size on someone's behalf" call —
+neither now nor later.
+
+**Every file view embeds the previewer directly.** It keeps its own selection
+and its own keyboard, calls `decode_path` off its UI thread, and draws the
+result with `otto_kit::preview::draw`. There is no interface between them beyond
+the Rust API.
+
+**The worker protocol stays private.** Hosts receive a `Preview`, never bytes
+from the file. The wire format between parent and worker is an implementation
+detail of the library and may change without any host noticing.
+
+### Where the panel sits
+
+By default the panel is centred on the **window** it was opened from, and grows
+out of the file's icon. Centring it on the **display** instead is opt-in
+(`OTTO_FILES_QV_CENTER=1`), and is a genuine trade, not a strict improvement:
+
+- The panel is a subsurface of the browser, so its position is relative to that
+  window, and a client is never told where its own window sits. It asks:
+  `request_output_frame` answers with the output's *usable* rect — the display
+  minus the dock and any exclusive zones — expressed in the coordinates the
+  client already positions in. See
+  [surface-output-placement.md](./surface-output-placement.md).
+- Because the answer comes back in window coordinates, the entrance still runs
+  from the file's icon. Anchor and resting place are in the same space, so
+  nothing has to be translated and the opening reads the same as the
+  window-centred one; only where it lands differs.
+- **The resting rect is worked out once per opening and once per closing**, not
+  every frame. A window that moves while the panel is up therefore carries the
+  panel with it, which is what a subsurface does anyway; recomputing per frame
+  instead let a stale window-relative answer walk the panel off the display.
+- **The panel is stacked above every column** with `wl_subsurface.place_above`
+  against each sibling in turn, restated while the panel is up rather than
+  assumed from creation order — a pooled column that is shown again still holds
+  its old place in the stack.
+
+## Constraints & Edge Cases
+
+- A file that changes or is deleted while previewed: the preview is re-decoded
+  on modification-time change if the window is still open, and shows a "no
+  longer available" card on deletion. It never shows stale content silently.
+- A directory passed to `Open` previews as a directory, it does not descend.
+- A symlink is followed and the target is previewed; a broken symlink and a
+  symlink loop both produce `Unavailable` rather than an error dialog.
+- A zero-byte file, and a file the user cannot read, both produce a card stating
+  which — these are the two most common "nothing appears" cases and must be
+  distinguishable.
+- A file whose name and content disagree previews as its content and is labelled
+  as its name, with the mismatch noted. A file the sniff cannot identify at all
+  previews as a plain file card, never by falling back to its extension.
+- `SetUris` may arrive purely to extend the window around a moving selection,
+  with the currently shown file unchanged. That must not re-decode anything.
+- `SetIndex` arriving faster than decodes complete must not queue decodes. The
+  session keeps at most one in-flight worker; a superseded decode is killed, not
+  awaited.
+- The preview must survive the invoking window being minimised, moved to another
+  workspace, or closed. A closed caller ends the session; the other two do not.
+- Multi-output: the preview appears on the output implied by `anchor` and stays
+  there. It does not follow the pointer.
+- Under the windowed development backend there is no layer-shell overlay
+  guarantee different from production, but the dimming behind an overlay covers
+  only the compositor's own output — acceptable, and worth stating so it is not
+  reported as a bug.
+- Two callers racing `Open`: last wins, first gets `Closed(replaced)`. There is
+  no queue, because two simultaneous previews are never what anyone wanted.
+- The service must exit cleanly if it is activated but never receives an `Open`
+  — a caller that crashes between activation and its first call must not leave a
+  process behind.
+- **`xdg_toplevel.set_parent` buys nothing here.** Otto does not read toplevel
+  parentage today — window order comes from workspace stacking alone — so a
+  toplevel-based preview cannot be kept above the application that opened it,
+  and there is no protocol-level modality to fall back on. This is why the
+  ephemeral path is a layer-shell overlay and not a parented toplevel: it needs
+  to be on top, and the overlay layer is the only way to actually be on top. The
+  non-ephemeral path is an ordinary window and wants no special stacking, which
+  is the whole reason the two paths differ. Neither path may be "improved" by
+  adding `set_parent` unless Otto first grows toplevel parent stacking, which is
+  compositor work this spec does not assume and does not require.
+- Fullscreen from an overlay surface and fullscreen from a toplevel are
+  different mechanisms; `f` must work identically in both, or be absent from the
+  overlay variant rather than working differently.
+
+## Rationale
+
+**The invocation surface was designed first, and the rest fell out of it.**
+An earlier draft made that surface a typed D-Bus interface, and got a working,
+verified implementation out of it — and it was still the wrong shape, because a
+separate process cannot be parented, cannot learn where the file is on screen,
+and has to hand-manage focus and dismissal. Choosing the embedding API instead
+deleted three problems rather than solving them: the `Navigate` hand-back, the
+surface-position prerequisite, and the overlay's lifetime.
+
+**The keyboard is handed back rather than shared.** The alternative — Quick View
+declining focus so the browser keeps its arrows — leaves nobody able to close
+the window with a key, and makes the second space press unroutable. Taking focus
+and forwarding navigation puts one component in charge of the keyboard at a
+time, which is the only arrangement that stays comprehensible when a third
+caller appears.
+
+**Decoding is in a grandchild process, not a thread.** A thread shares the
+address space, so a heap corruption in a JPEG decoder is a compromise of the
+process that holds the user's file descriptors and their Wayland connection.
+Process isolation is also what makes the timeout enforceable: a runaway thread
+cannot be killed, a runaway process can. The cost is one `fork`+`exec` and a
+memfd copy per preview, which fits inside the 100 ms budget comfortably.
+
+**Two surface types, not one.** An overlay that cannot be left open is wrong for
+`otto-quickview report.pdf`; an ordinary window that must be dismissed by hand is
+wrong for space-on-selection. Both behaviours already exist in Otto's toolkit —
+layer-shell for the launcher, xdg-toplevel for the settings app — so supporting
+both costs one branch at surface creation and nothing at draw time.
+
+**v1 ships images, PDF and text properly, and everything else honestly.** Those
+three are what people press space on; a previewer that shows a photograph but
+describes a PDF has failed at a third of its job. Everything else — audio,
+video, archives — gets a metadata card, which is better than nothing and better
+than distorting the build for a convenience feature.
+
+**PDF is exec'd, not linked, and that turned out to be the better design
+anyway.** The obvious route was a PDF library in the build, which is a large C++
+blob for one file type. But the worker is *already* a separate, sandboxed,
+rlimited process spawned per preview — so running a rasteriser that already
+exists on the system costs one more `exec` in a place that was doing an `exec`
+regardless. The dependency is a package a distribution almost certainly already
+installed, not a crate in Otto's tree, and it degrades to a card with a useful
+message rather than to a build-time choice nobody can change afterwards. It also
+sidesteps MuPDF's AGPL, which restricts linking and says nothing about running a
+program. Generalising it to a table of renderer commands is what lets video
+poster frames arrive later without GStreamer.
+
+**The payload set is closed on purpose.** An open plug-in interface would let a
+new content type invent a new drawing path, and the previews would stop looking
+like each other within a release. Forcing every type through five payload shapes
+is what keeps a PDF card and an audio card visually the same object.
+
+**The thumbnail cache is a filesystem layout, not a service.** A service means a
+process to start, a lifetime to manage, and a second failure mode for something
+whose whole job is to make things faster. The freedesktop layout already
+specifies naming and invalidation, is already populated by other applications,
+and lets Quick View and the browser cooperate without either knowing the other
+exists. Both sessions designing this reached that conclusion independently,
+which is some evidence it is the obvious one.
+
+**Display follows the name; decoding follows the content.** These look like the
+same question and are not, which is why detection is two calls rather than one
+with a precedence rule. A single answer forces a choice between an icon that
+flickers when an empty file's sniff comes back inconclusive, and a decoder fed
+by an attacker-chosen extension. Two answers make both correct, and make the
+disagreement itself displayable.
+
+**Selections are sent, directories are not.** Once navigation round-trips
+through `Navigate` → `SetIndex`, Quick View never needs the directory — and it
+must not have it, because the caller's sort order, filter and hidden-file state
+are the caller's alone. The 256-URI window exists so that selecting a very large
+number of files does not put a very large array on the bus for no benefit.
+
+## Resolved decisions
+
+Settled with the file browser/picker session; recorded so neither side reopens
+them.
+
+- Quick View is a separate binary, not a compositor feature and not a library
+  the browser embeds. The cache contract is therefore cross-process — and is a
+  filesystem layout, so that costs nothing.
+- The browser has **no inline preview pane in v1**, so no decoded payload ever
+  leaves this application and the worker protocol stays private. A pane would
+  need either a second sandboxed decoder inside the file manager — which is
+  precisely what a separate previewer process exists to avoid — or a public
+  decode call. Neither is v1.
+- Quick View writes into the shared thumbnail cache, in the four standard size
+  buckets only.
+- The cache never holds full-resolution content, and gains no arbitrary-size
+  decode call.
+- `otto_kit::filetype` is two calls: name → type of record, bytes → sniffed
+  type. Previewer dispatch uses the sniff. Display uses the name.
+- Shared MIME-info **is** consulted, contrary to this spec's first draft:
+  `globs2` and `subclasses` are line-oriented plain text, so the full database
+  costs a file read and a hash map — no XML parser, no `mime.cache` binary
+  format, no new crate. A hand-rolled table of ~30 types was the wrong call; it
+  cannot name what a portal filter or a Kind column will legitimately ask for.
+- The invocation contract in this spec is adopted verbatim by the browser,
+  including the focus model.
+- The preview is embedded by its hosts rather than run as a process of its own.
+  A subsurface's parent must belong to the same client, so parented and separate
+  are mutually exclusive, and parented wins.
+- Hosts decode off their UI thread and drop stale results by generation.
+
+## Open Questions
+
+- **Is the five-second exit grace right?** It is the whole difference between
+  arrow-key navigation feeling instant and feeling spawned, but it contradicts
+  the launcher's "no daemon, nothing to keep warm" principle. If that principle
+  is absolute here too, `SetIndex` latency needs a different answer.
+- **What is a "text document"?** Plain text and source code are fully previewed
+  in v1. If the intent includes `.odt` and `.docx`, that is a different and much
+  larger feature: both are zip containers whose text lives in compressed XML, so
+  it needs an inflate implementation and an XML parser before a single word can
+  be shown, and a faithful rendering needs layout on top of that. Extracting the
+  embedded preview image both formats already carry is a far cheaper middle
+  option and would show *something* for both. Not started either way.
+- **Where does "Open with…" get its application list?** The browser has since
+  settled that it writes `mimeapps.list` directly rather than routing
+  associations through the settings service, which makes `mimeapps.list` plus
+  `freedesktop-desktop-entry` the authoritative pair and leaves the compositor's
+  `default_apps.rs` as something else — a fallback, or a thing to fold in.
+  Quick View only needs this on the non-ephemeral path, since an ephemeral
+  session emits `Activated` and lets its caller launch. Narrower than it was,
+  but not closed.
+- **Does the compositor need any new surface role for this at all?** The design
+  assumes layer-shell overlay with exclusive keyboard is sufficient. If dimming
+  the desktop behind the card while leaving the caller repainting turns out to
+  need compositor cooperation, that is a compositor-side change this spec has
+  not budgeted for.

--- a/specs/settings-app.md
+++ b/specs/settings-app.md
@@ -1,0 +1,362 @@
+# Settings App
+
+**Status:** draft — compositor side of the settings interface implemented
+**Wire contract:** [docs/developer/settings-dbus-api.md](../docs/developer/settings-dbus-api.md)
+**Related specs:** [multi-output.md](./multi-output.md), [lock-screen.md](./lock-screen.md), [login-mode.md](./login-mode.md), [lid-power.md](./lid-power.md), [topbar.md](./topbar.md)
+
+## Summary
+
+A graphical settings application for Otto (`otto-settings`) that lets a user
+inspect and change compositor configuration without editing TOML. The
+compositor remains the sole owner of the configuration file; the app is a
+D-Bus client that reads a described schema, sets values, and observes changes.
+
+## Goals
+
+- A user can change any exposed setting from a GUI and see it take effect
+  immediately, without restarting the compositor, for every setting the
+  compositor can apply live.
+- A setting changed in the app survives a compositor restart.
+- A setting the compositor *cannot* apply live is still changeable, is clearly
+  marked as requiring a restart, and is persisted.
+- Hand-editing the configuration file continues to work, and a running app
+  reflects such an edit without being restarted.
+- Changing a setting never materialises unrelated inherited defaults into the
+  user's configuration file.
+- A user can arrange multiple displays (position, primary, resolution, refresh
+  rate) graphically.
+- The app is usable with keyboard alone, and every setting it presents is
+  reachable by search.
+
+## Non-Goals
+
+- Wallpaper selection and management. Otto exposes only `background_color` /
+  `background_image`; those two keys are in scope, and `background_image` is
+  chosen through the desktop portal's file picker
+  ([file-picker.md](./file-picker.md)) rather than by typing a path. Cropping,
+  per-output wallpapers and slideshow behaviour still belong to a separate
+  application.
+- Configuring anything Otto does not already have a configuration key for.
+  This app exposes the existing surface; it does not motivate new features.
+- Application-level settings for other Otto components (bar layout, launcher
+  behaviour) unless they are already compositor configuration keys.
+- Exposing the whole configuration surface. The app presents a curated set of
+  user-facing preferences. Session plumbing (startup commands, layer-shell
+  limits, virtual outputs, renderer flags) stays hand-edited, and there is no
+  generic catch-all pane for it.
+- Editing the system-wide configuration, or any configuration layer other than
+  the user's writable one.
+- A configuration migration or versioning system.
+
+## Behavior
+
+### Configuration ownership
+
+The compositor owns the writable configuration file. It is the only process
+that writes it. The app never reads or writes configuration files.
+
+The compositor's in-memory configuration is mutable at runtime. When a value
+changes — from any source — the compositor must, in this order:
+
+1. Validate the new value against the schema. An invalid value is rejected and
+   nothing else happens.
+2. Apply the value to the running system, as far as it can.
+3. Persist the value to the writable configuration file.
+4. Announce the change to all observers.
+
+If applying fails, the value must not be persisted and the caller must be told
+why. A value that is valid but cannot be applied live is persisted, announced,
+and reported as pending a restart.
+
+### The settings interface
+
+The compositor exposes a settings service with these operations (the exact
+method names, types and error names are fixed by the wire contract):
+
+- **Describe** — returns the schema: for every setting, its identifier, type,
+  default value, allowed range or enumeration, the section it belongs to, a
+  human-readable label and description, and whether changing it takes effect
+  immediately or requires a restart.
+- **Get all** — returns the current effective value of every setting.
+- **Set** — sets one setting to one value. Fails with a distinguishable error
+  for: unknown identifier, wrong type, value out of range, and apply failure.
+- **Reset** — removes a setting from the user's configuration, so its value
+  reverts to whatever the lower configuration layers provide. This is distinct
+  from setting it to its default value: after a reset, a later change to a
+  lower layer is again visible.
+- **Changed signal** — emitted whenever any setting's effective value changes,
+  carrying the identifiers and their new values. It is emitted for changes
+  originating anywhere: this app, another client, an in-compositor interaction
+  such as dragging the dock handle, or an external edit of a configuration
+  file.
+
+Two further read operations exist for the app's benefit: **Get**, one value,
+and **Get overridden**, the identifiers currently set in the writable file —
+what the app needs to decide which settings offer a reset.
+
+A setting identifier is a stable dotted path matching the configuration
+structure (for example `dock.size`, `input.pointer_accel_speed`). Identifiers
+are part of the contract and must not change once shipped. The path is the path
+into the configuration structure itself, so a setting is read and written
+generically rather than through per-setting code; a schema row whose identifier
+does not resolve in the configuration is a bug, and is caught by a test.
+
+The schema describes a curated set, not the whole configuration. Settings that
+are lists rather than scalars — dock bookmarks, keyboard shortcuts, display
+profiles — have no identifier and are not settable through this interface.
+
+Whether a setting applies live is a property of the compositor, not of the
+setting: today all of `dock.*` (size, position, autohide, magnification,
+magnification amount and spread, icon tint, tint colour and tint strength),
+`accent_color`, `background_image` and `background_color`, and the
+touchpad/pointer half of `input.*` (tap, tap-drag,
+drag lock, click method, disable-while-typing, natural scroll, left-handed,
+middle-click emulation, scroll speed, pointer acceleration speed and profile)
+are reconciled with a changed configuration, and every other setting — including the keyboard
+`input.xkb_*` settings — is described as requiring a restart. Marking a
+setting `live` is a promise that it takes effect, so the schema is widened
+only as apply paths are written.
+
+### Choosing a file
+
+A setting whose value is a path is presented as the path plus a **Choose…**
+button, not as a text field: a path typed by hand is a path that can be
+wrong, and the picker already knows how to browse, filter and validate.
+
+The button opens the file chooser through the **portal frontend**
+(`org.freedesktop.portal.Desktop`), the same door any other application uses,
+rather than calling Otto's backend directly. That is deliberate: it exercises
+the `portals.conf` routing that decides Otto's own picker serves the request
+at all, and a misrouted frontend is exactly the failure this would otherwise
+hide.
+
+The call blocks for as long as the dialog is up, so it runs on a thread of
+its own and wakes the main loop when it is answered — the same arrangement
+the `Changed` listener uses, and for the same reason: the draw path and input
+both run on the main thread and cannot wait on a user browsing their disk.
+
+Cancelling changes nothing. A request that fails is reported, and the setting
+keeps the value it had; the app never writes an empty path because a dialog
+went wrong.
+
+### Persistence
+
+Persisting a setting writes only that setting's key. Every other key in its
+section, and every other section, is left byte-for-byte alone, including
+comments and formatting. Resetting a setting removes exactly that key, and
+removes its containing table if that leaves the table empty.
+
+Resetting cannot know what the lower layers hold without asking them, so it
+removes the key and then re-reads the whole layered configuration, applying and
+announcing everything that moved. An unrelated edit made to a file since the
+last read is therefore picked up by a reset, which is the same reconciliation
+the file watcher will use.
+
+The rule this protects: the writable configuration file is the highest-priority
+layer. A default value written into it is indistinguishable from a deliberate
+choice, and permanently shadows the same key in every lower layer.
+
+Which file that is follows from the same rule: the writable file is the
+highest-priority layer that is actually present, so what is written is what
+takes effect. Writing into any lower layer would apply the setting live and let
+it revert on the next reload, which reads as a settings app that does not save.
+The system-wide layer is never written — it belongs to the package rather than
+to the user — and when no layer above it exists, the user's own config is
+created rather than a file in whatever directory the session started from. A
+session whose writable file is not the user's own config says so in the log,
+since from `~/.config/otto` alone that is invisible.
+
+### External edits
+
+When a configuration file changes on disk, the compositor reloads the layered
+configuration, applies every value that differs from the running state, and
+emits the changed signal for those values. A value the compositor cannot apply
+live is reported as pending a restart rather than being silently ignored.
+
+An edit made by the compositor's own persistence step must not be observed as
+an external edit.
+
+The reconciliation this needs — reload the layers, diff against the running
+configuration, apply and announce what moved — exists and is what a reset uses.
+The file watch that would trigger it does not yet.
+
+### The application
+
+`otto-settings` is a standalone windowed application. On launch it fetches the
+schema and current values, and subscribes to the changed signal. A change
+arriving over the signal updates the displayed value, whether or not this app
+caused it.
+
+The window presents a list of panes and the selected pane's contents. The panes
+are:
+
+- **General** — appearance (light/dark), accent colour, font family, background
+  colour and image, cursor theme and size, icon theme, locales.
+- **Displays** — see below.
+- **Dock** — size, position, autohide, magnification, minimise effect.
+- **Keyboard** — repeat delay and rate, then shortcuts.
+- **Trackpad & Mouse** — the pointer and touchpad settings.
+- **Sound** — enabled, theme.
+- **Power** — lid switch handling, power button action.
+- **Lock & Login** — automatic lock timeout, which locker runs the lock screen,
+  which greeter runs the login screen.
+
+Settings outside these panes are not shown. The schema may describe settings
+the app does not present; the app must ignore them rather than render them
+generically.
+
+A search field filters the presented settings by label, description, and
+identifier, and selecting a result reveals that setting in its pane.
+
+Each setting shows whether it currently differs from its inherited value, and
+offers a per-setting reset when it does.
+
+A setting the compositor reports as requiring a restart is shown with that
+status after being changed.
+
+Changes take effect on interaction. There is no apply or save step, and no
+confirmation dialog for ordinary settings.
+
+The sidebar and the titlebar are translucent materials over the compositor's
+backdrop blur; the pane's ground is opaque. The sidebar is tinted heavily
+enough to read as frost rather than as a hole in the window, and the titlebar
+only slightly, so the frost runs across the whole top of the window instead of
+stopping at the sidebar's edge. Without the surface-style protocol both are
+painted flat — a tint over an unblurred desktop is not a material.
+
+The selected pane scrolls independently of the window's chrome. The window
+surface paints the chrome — titlebar, sidebar, divider and the grounds behind
+them — and nothing else; the pane's background, content and scrollbar are
+separate surfaces the compositor crops and moves, so a frame of scrolling costs
+the app no drawing at all. The content surface is only repainted when a scroll
+approaches the edge of what has been drawn, or when something other than the
+scroll changes what a row looks like. A configure that repeats the size the
+window already has changes nothing about the pane and repaints nothing, so an
+idle window draws no frames at all. Pointer events over the pane land on
+those surfaces and are translated back into the pane's coordinates before
+hit-testing; the window's resize edges along the pane's right and bottom stay
+live.
+
+### Shortcuts
+
+The keyboard pane lists every shortcut with its action. Recording a new
+shortcut captures the next key combination pressed, including modifiers, while
+suppressing that combination from reaching the rest of the system.
+
+If a captured combination is already bound, the conflict is shown and the user
+chooses whether to reassign it. Reassigning clears the previous binding. A
+combination that cannot be bound is rejected with a reason.
+
+Shortcuts can be reset individually and as a group.
+
+### Displays
+
+The displays pane shows every connected output as a proportionally sized
+rectangle in a canvas reflecting their arrangement. Dragging a rectangle
+changes that output's position; released positions snap to edge alignment with
+neighbouring outputs and may not leave an output overlapping another or
+disconnected from the arrangement.
+
+Selecting an output exposes its resolution, refresh rate, scale, and whether it
+is primary. Resolution and refresh rate offer only modes the output actually
+advertises.
+
+Position and primary changes apply immediately. A resolution, refresh rate, or
+scale change applies immediately, and must be confirmed by the user within a
+short timeout; if it is not confirmed, the previous configuration is restored.
+This protects against a mode the display cannot in fact show.
+
+An output that disconnects while the pane is open disappears from the canvas;
+the configuration recorded for it is retained so reconnecting restores it.
+
+Per-output settings are stored against a stable identity for that display, so
+they follow the display rather than the connector it happens to occupy.
+
+## Constraints & Edge Cases
+
+- Two settings clients may set values concurrently; last write wins, and both
+  observe the result through the changed signal.
+- The app must function when the compositor is running but some settings cannot
+  be applied — for example, display settings under a windowed development
+  backend. Such settings are shown as unavailable rather than hidden, with the
+  reason.
+- The app must not require the compositor to be built with development
+  features.
+- The changed signal must be coalesced: a continuous interaction such as
+  dragging a size slider must not produce one persistence write per frame.
+  Values apply live during the drag; persistence happens when the interaction
+  settles.
+- Existing in-compositor settings interactions — dragging the dock handle to
+  resize, dock context-menu toggles — must go through the same set path, so
+  they announce and persist identically. They must not keep private shadow
+  copies of configuration state.
+- A configuration file that fails to parse must leave the running configuration
+  untouched and surface an error, not fall back to defaults.
+- Resetting a setting whose value comes from a lower layer must not write an
+  empty override.
+- Settings that are read once at startup and cannot be re-read (backend
+  selection, session-level flags) must be marked restart-required in the schema
+  rather than silently failing to apply.
+- Display mode changes on the production backend require rebuilding the output's
+  scanout surface; the arrangement must survive that rebuild, and windows must
+  be re-placed rather than lost when an output's geometry changes.
+- Removing the last enabled output must be prevented.
+- The locker and greeter are external commands, and a value that does not start
+  leaves the user unable to unlock or unable to log in. Both must be validated
+  as resolvable executables before being persisted, and offered as a choice
+  among detected candidates rather than as free text where possible. A locker
+  change takes effect at the next lock, not immediately; a greeter change takes
+  effect at the next login and is reported as such.
+
+## Rationale
+
+**The compositor owns the file, the app is a client.** The alternative — the
+app writes TOML and the compositor watches for changes — creates two writers
+for one file. The compositor already writes it when the dock is resized, so the
+race is real rather than hypothetical. Client-only writes also force every
+client to re-implement the surgical-merge discipline described under
+Persistence, and make "the setting took effect" and "the setting was saved"
+independently failable. With a single owner they cannot disagree.
+
+**Reset is distinct from set-to-default.** Otto's configuration is layered.
+Writing a default into the top layer permanently pins the value, defeating the
+layering. Users expect a reset to mean "stop overriding this".
+
+**Schema is served, not compiled into the app.** The app renders from a
+description supplied by the compositor, so labels, ranges, defaults and
+restart-required status cannot drift between the two, and a range change needs
+no new app build.
+
+**Every pane is bespoke, and the app shows less than the schema does.** A
+generic catch-all pane would guarantee nothing is unreachable, but it would put
+greeter commands and renderer flags in front of a user looking for their
+trackpad settings, and it would grow a new row every time a developer adds a
+key. Configuration that only makes sense to someone reading the source is
+better served by the TOML file. The cost is accepted deliberately: adding a
+user-facing setting means also placing it in a pane.
+
+**Display mode changes are confirmed, position changes are not.** A bad mode
+can leave a display showing nothing, and the user cannot then click to undo it.
+A bad position is always recoverable.
+
+**Wallpaper is excluded.** It needs file browsing, thumbnails, per-output
+assignment and scaling modes — a different application with a different shape.
+The two raw configuration keys are still exposed here so the setting is not
+unreachable in the meantime.
+
+## Open Questions
+
+- Should the app be able to change settings for a display that is configured
+  but not currently connected?
+- Shortcuts are a keyed collection rather than a scalar and do not fit
+  `Set(id, value)`; they are excluded from the schema for now and will need
+  their own operations. Deferred until the Keyboard pane exists — nothing else
+  in the interface depends on the answer.
+- Does the schema need to express relationships between settings (one setting
+  only meaningful when another is enabled), or is it enough for panes to
+  hard-code that?
+- Should shortcut bindings be a settings identifier like any other, or their
+  own operations on the interface, given they are a keyed collection rather
+  than a scalar?
+- Is per-output scale a display setting here, given `screen_scale` is currently
+  global?


### PR DESCRIPTION
Three applications for the desktop: a file browser, an app launcher, and a settings app — plus the file picker that other applications get when they ask the portal to open or save a file.

Stacked on #142 — merge that first.

**What you get**

- **A file browser** with columns you walk sideways, list and grid views, resizable columns, right-click menus, rename in place, and New Folder.
- **Press space to see a preview** of the selected file — images, PDFs, text, video — without opening the application that owns it. Zoom and pan an image with a pinch.
- **A file picker in every app** — GTK, Qt or anything else that goes through `xdg-desktop-portal` gets Otto's own browser as its Open dialog, instead of a mismatched GTK one.
- **An app launcher** for finding and starting applications.
- **A settings app** for appearance, dock, displays and input, where changing the wallpaper or the accent colour takes effect immediately rather than at next login.
- **Screenshot and settings portal backends**, so screenshots and colour-scheme requests are served by Otto.

**How it's built**

The browser and the picker are one crate with two shells over a shared view layer — the same directory model, the same async reads, the same preview — so the picker can't drift from the browser. The picker is reached over `org.otto.FilePicker1` and bridged into `org.freedesktop.impl.portal.FileChooser` by Otto's portal backend. Previews decode in a sandboxed worker process, so a malformed file takes down the worker and not the browser, and results land in the shared thumbnail cache other apps already read. Settings changes are applied live through the compositor's settings service where the setting supports it, falling back to restart-required only where it genuinely is.
