### PR TITLE
test: end-to-end coverage for screenshare, the RDP bridge and shell interactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: cargo test --lib --workspace
       - name: Run headless integration tests
         run: cargo test --features headless --test headless_basic
+      - name: Run shell interaction tests
+        run: cargo test --features headless --test workspace_selector --test app_switcher
       - name: Run screencast integration tests
         run: cargo test --features headless --test screenshare
       - name: Run RDP bridge integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
         run: cargo test --features headless --test headless_basic
       - name: Run screencast integration tests
         run: cargo test --features headless --test screenshare
+      - name: Run RDP bridge integration tests
+        run: cargo test --features headless --test rdp_bridge
+      - name: Run RDP bridge unit tests
+        run: cargo test -p otto-rdp
+      - name: Run portal backend tests
+        run: cargo test -p xdg-desktop-portal-otto
       - name: Run font matching tests
         run: cargo test --lib -p otto -- workspaces::utils::tests --ignored
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: cargo test --lib --workspace
       - name: Run headless integration tests
         run: cargo test --features headless --test headless_basic
+      - name: Run screencast integration tests
+        run: cargo test --features headless --test screenshare
       - name: Run font matching tests
         run: cargo test --lib -p otto -- workspaces::utils::tests --ignored
   

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ cargo run -- --winit &
 WAYLAND_DISPLAY=wayland-1 cargo run -p apps-manager
 ```
 
-**Tests:** unit tests live in the lib target — run with `cargo test --lib` (e.g. `cargo test --lib backdrop` for the backdrop rebuild-gating regression tests). There is no integration/e2e suite. Minimum supported Rust version is 1.87.0 (1.96.0 to build the whole workspace, which `otto-rdp` pins through GStreamer). CI pins 1.97.0.
+**Tests:** unit tests live in the lib target — run with `cargo test --lib` (e.g. `cargo test --lib backdrop` for the backdrop rebuild-gating regression tests). End-to-end tests live in `tests/` and drive a real compositor with real Wayland clients behind the `headless` feature — run with `cargo test --features headless --test <name>` (`headless_basic`, `workspace_selector`, `screenshare`). Minimum supported Rust version is 1.87.0 (1.96.0 to build the whole workspace, which `otto-rdp` pins through GStreamer). CI pins 1.97.0.
 
 ## Architecture Overview
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,12 @@ serial_test = "3"
 serde_json = "1"
 otto-kit = { path = "components/otto-kit", features = ["testing"] }
 wayland-client = "0.31"
+# Client bindings for the protocols otto-rdp injects input through, so the
+# end-to-end tests can act as the RDP bridge does (tests/rdp_bridge.rs).
+wayland-protocols = { version = "0.32", features = ["client"] }
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
+wayland-protocols-misc = { version = "0.3", features = ["client"] }
+xkbcommon = "0.6.0"
 
 # [profile.release]
 # opt-level = 3

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -165,7 +165,21 @@ impl TestClient {
         width: u32,
         height: u32,
     ) -> Arc<Mutex<TestToplevel>> {
-        self.create_toplevel_inner(title, width, height, false)
+        self.create_toplevel_inner(title, None, width, height, false)
+    }
+
+    /// Create a toplevel that also announces an `app_id`, the way a real
+    /// application does. The id is set before the first commit, so it is
+    /// already there when the compositor maps the window and registers it with
+    /// the foreign-toplevel protocols.
+    pub fn create_toplevel_with_app_id(
+        &mut self,
+        title: &str,
+        app_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Arc<Mutex<TestToplevel>> {
+        self.create_toplevel_inner(title, Some(app_id), width, height, false)
     }
 
     /// Create a toplevel that asks to be maximized before its first commit,
@@ -177,12 +191,13 @@ impl TestClient {
         width: u32,
         height: u32,
     ) -> Arc<Mutex<TestToplevel>> {
-        self.create_toplevel_inner(title, width, height, true)
+        self.create_toplevel_inner(title, None, width, height, true)
     }
 
     fn create_toplevel_inner(
         &mut self,
         title: &str,
+        app_id: Option<&str>,
         width: u32,
         height: u32,
         maximized: bool,
@@ -211,6 +226,9 @@ impl TestClient {
         toplevel_state.lock().unwrap().xdg_surface = Some(xdg_surface.clone());
         let toplevel = xdg_surface.get_toplevel(&self.qh, toplevel_state.clone());
         toplevel.set_title(title.to_string());
+        if let Some(app_id) = app_id {
+            toplevel.set_app_id(app_id.to_string());
+        }
         if maximized {
             toplevel.set_maximized();
         }

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -23,8 +23,8 @@ use std::{
 
 use wayland_client::{
     protocol::{
-        wl_buffer, wl_callback, wl_compositor, wl_registry, wl_seat, wl_shm, wl_shm_pool,
-        wl_surface,
+        wl_buffer, wl_callback, wl_compositor, wl_keyboard, wl_registry, wl_seat, wl_shm,
+        wl_shm_pool, wl_surface,
     },
     Connection, Dispatch, EventQueue, QueueHandle,
 };
@@ -45,6 +45,14 @@ pub struct TestClientState {
     pub otto_surface_style_manager:
         Option<otto_surface_style_manager_v1::OttoSurfaceStyleManagerV1>,
     pub shm_formats: Vec<wl_shm::Format>,
+    /// The seat's keyboard, once the compositor announces the capability.
+    pub wl_keyboard: Option<wl_keyboard::WlKeyboard>,
+    /// Keys delivered to this client, as `(evdev code, pressed)` in arrival
+    /// order — what a remote input injector's key presses look like from the
+    /// application's side.
+    pub keys: Vec<(u32, bool)>,
+    /// Whether the compositor has given this client's surface keyboard focus.
+    pub keyboard_focused: bool,
 }
 
 impl TestClientState {
@@ -56,6 +64,9 @@ impl TestClientState {
             xdg_wm_base: None,
             otto_surface_style_manager: None,
             shm_formats: Vec::new(),
+            wl_keyboard: None,
+            keys: Vec::new(),
+            keyboard_focused: false,
         }
     }
 }
@@ -515,13 +526,47 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for TestClientState {
 
 impl Dispatch<wl_seat::WlSeat, ()> for TestClientState {
     fn event(
-        _state: &mut Self,
-        _proxy: &wl_seat::WlSeat,
-        _event: wl_seat::Event,
+        state: &mut Self,
+        seat: &wl_seat::WlSeat,
+        event: wl_seat::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        // Take the keyboard as soon as the seat announces one, so tests can
+        // observe what actually reaches the application.
+        if let wl_seat::Event::Capabilities {
+            capabilities: wayland_client::WEnum::Value(caps),
+        } = event
+        {
+            if caps.contains(wl_seat::Capability::Keyboard) && state.wl_keyboard.is_none() {
+                state.wl_keyboard = Some(seat.get_keyboard(qh, ()));
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for TestClientState {
+    fn event(
+        state: &mut Self,
+        _proxy: &wl_keyboard::WlKeyboard,
+        event: wl_keyboard::Event,
         _data: &(),
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
+        match event {
+            wl_keyboard::Event::Enter { .. } => state.keyboard_focused = true,
+            wl_keyboard::Event::Leave { .. } => state.keyboard_focused = false,
+            wl_keyboard::Event::Key { key, state: s, .. } => {
+                let pressed = matches!(
+                    s,
+                    wayland_client::WEnum::Value(wl_keyboard::KeyState::Pressed)
+                );
+                state.keys.push((key, pressed));
+            }
+            _ => {}
+        }
     }
 }
 

--- a/components/otto-rdp/src/egfx.rs
+++ b/components/otto-rdp/src/egfx.rs
@@ -465,3 +465,47 @@ impl Driver {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// V8.1 opts *in* to AVC420: without the flag the client gets bitmaps.
+    #[test]
+    fn v8_1_opts_in_to_avc() {
+        assert!(cap_enables_avc(&CapabilitySet::V8_1 {
+            flags: CapabilitiesV81Flags::AVC420_ENABLED | CapabilitiesV81Flags::SMALL_CACHE,
+        }));
+        assert!(!cap_enables_avc(&CapabilitySet::V8_1 {
+            flags: CapabilitiesV81Flags::SMALL_CACHE,
+        }));
+    }
+
+    /// V10 and later opt *out*: silence means AVC is fine. Microsoft's mobile
+    /// clients set `AVC_DISABLED`, and confirming AVC to them drops the
+    /// connection — so this is the flag that decides their transport.
+    #[test]
+    fn v10_and_later_opt_out_of_avc() {
+        assert!(cap_enables_avc(&CapabilitySet::V10 {
+            flags: CapabilitiesV10Flags::SMALL_CACHE,
+        }));
+        assert!(!cap_enables_avc(&CapabilitySet::V10 {
+            flags: CapabilitiesV10Flags::AVC_DISABLED,
+        }));
+        assert!(cap_enables_avc(&CapabilitySet::V10_7 {
+            flags: CapabilitiesV107Flags::empty(),
+        }));
+        assert!(!cap_enables_avc(&CapabilitySet::V10_7 {
+            flags: CapabilitiesV107Flags::AVC_DISABLED,
+        }));
+    }
+
+    /// Versions with no AVC concept at all never take the hardware path.
+    #[test]
+    fn versions_without_avc_fall_back_to_bitmaps() {
+        assert!(!cap_enables_avc(&CapabilitySet::V8 {
+            flags: CapabilitiesV8Flags::empty(),
+        }));
+        assert!(!cap_enables_avc(&CapabilitySet::V10_1));
+    }
+}

--- a/components/otto-rdp/src/rdp.rs
+++ b/components/otto-rdp/src/rdp.rs
@@ -51,6 +51,42 @@ pub struct Updates {
     codec_rx: Option<tokio::sync::watch::Receiver<crate::egfx::Codec>>,
 }
 
+/// Lay the native picture out inside the desktop served to a client.
+///
+/// `desktop` is the client's own box verbatim (or the `--desktop` override),
+/// because clients scale a size-matched desktop to fill their view but render
+/// any other size unscaled in a corner. The native picture is aspect-fit inside
+/// it — never upscaled — and centered, leaving black bars. `input_box` stays the
+/// client's reported box: mouse coordinates arrive in that space and are mapped
+/// back through the picture rect by [`InputForwarder::map_abs`].
+///
+/// On the EGFX path the desktop is rounded down to even dimensions: H.264
+/// macroblocks (and the AVC420 encoder) cannot represent odd sizes, and the
+/// encoded picture has to match the desktop exactly.
+fn served_layout(
+    native: (u32, u32),
+    box_size: (u32, u32),
+    desktop_override: Option<(u32, u32)>,
+    egfx_mode: bool,
+) -> crate::pipewire_capture::ServedLayout {
+    let (nw, nh) = (native.0 as f64, native.1 as f64);
+    let (dw, dh) = desktop_override.unwrap_or(box_size);
+    let (dw, dh) = if egfx_mode {
+        (dw & !1, dh & !1)
+    } else {
+        (dw, dh)
+    };
+    let scale = (dw as f64 / nw).min(dh as f64 / nh).min(1.0);
+    let iw = (((nw * scale).round() as u32).max(1)).min(dw);
+    let ih = (((nh * scale).round() as u32).max(1)).min(dh);
+    crate::pipewire_capture::ServedLayout {
+        desktop: (dw, dh),
+        img_off: ((dw - iw) / 2, (dh - ih) / 2),
+        img_size: (iw, ih),
+        input_box: box_size,
+    }
+}
+
 #[async_trait::async_trait]
 impl RdpServerDisplay for VirtualOutputDisplay {
     async fn size(&mut self) -> DesktopSize {
@@ -70,8 +106,6 @@ impl RdpServerDisplay for VirtualOutputDisplay {
     /// and the bars are black. Mouse coordinates arrive in this same box
     /// space and are mapped back through the picture rect.
     async fn request_initial_size(&mut self, client_size: DesktopSize) -> DesktopSize {
-        let (nw, nh) = (self.size.0 as f64, self.size.1 as f64);
-
         // The client's box must be honored VERBATIM — clients (notably
         // mobile apps with a fixed resolution list) scale a size-matched
         // desktop to fill their screen but render any other size, even one
@@ -88,23 +122,9 @@ impl RdpServerDisplay for VirtualOutputDisplay {
         // that stretch a size-mismatched desktop to fill their view stretch
         // uniformly when the desktop's aspect matches the view's — the
         // override should therefore be the device's screen resolution.
-        let (dw, dh) = self.desktop_override.unwrap_or(box_size);
-        // The H.264 encoder (and AVC420 macroblocks) need even dimensions;
-        // round the desktop down so the encoded picture matches it exactly.
-        let (dw, dh) = if self.egfx_mode {
-            (dw & !1, dh & !1)
-        } else {
-            (dw, dh)
-        };
-        let scale = (dw as f64 / nw).min(dh as f64 / nh).min(1.0);
-        let iw = (((nw * scale).round() as u32).max(1)).min(dw);
-        let ih = (((nh * scale).round() as u32).max(1)).min(dh);
-        let layout = crate::pipewire_capture::ServedLayout {
-            desktop: (dw, dh),
-            img_off: ((dw - iw) / 2, (dh - ih) / 2),
-            img_size: (iw, ih),
-            input_box: box_size,
-        };
+        let layout = served_layout(self.size, box_size, self.desktop_override, self.egfx_mode);
+        let (dw, dh) = layout.desktop;
+        let (iw, ih) = layout.img_size;
 
         self.served = (dw, dh);
         // Always record the layout — the input path maps mouse coordinates
@@ -361,5 +381,119 @@ fn button(btn: u32, pressed: bool) -> InputCommand {
     InputCommand::Button {
         button: btn,
         pressed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipewire_capture::TargetSize;
+
+    const NATIVE: (u32, u32) = (1920, 1080);
+
+    fn forwarder(served: TargetSize) -> InputForwarder {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        InputForwarder {
+            tx,
+            native: NATIVE,
+            served,
+        }
+    }
+
+    /// A client whose box matches the output's aspect gets its box verbatim,
+    /// filled edge to edge — no bars, nothing to map around.
+    #[test]
+    fn a_matching_aspect_fills_the_desktop() {
+        let layout = served_layout(NATIVE, (1280, 720), None, false);
+        assert_eq!(layout.desktop, (1280, 720));
+        assert_eq!(layout.img_size, (1280, 720));
+        assert_eq!(layout.img_off, (0, 0));
+        assert_eq!(layout.input_box, (1280, 720));
+    }
+
+    /// A squarer box keeps the picture's aspect and centers it, leaving equal
+    /// black bars above and below.
+    #[test]
+    fn a_mismatched_aspect_is_letterboxed_and_centred() {
+        let layout = served_layout(NATIVE, (800, 800), None, false);
+        assert_eq!(layout.desktop, (800, 800));
+        assert_eq!(layout.img_size, (800, 450), "16:9 inside an 800px-wide box");
+        assert_eq!(layout.img_off, (0, 175), "bars split evenly");
+    }
+
+    /// A client bigger than the output is not served an upscaled picture — the
+    /// native image sits pillar- and letter-boxed in the middle.
+    #[test]
+    fn a_larger_client_never_upscales_the_picture() {
+        let layout = served_layout((1280, 720), (3840, 2160), None, false);
+        assert_eq!(layout.desktop, (3840, 2160));
+        assert_eq!(layout.img_size, (1280, 720));
+        assert_eq!(layout.img_off, (1280, 720));
+    }
+
+    /// H.264 cannot encode odd dimensions, so the EGFX desktop rounds down —
+    /// but mouse coordinates still arrive in the box the client reported, so
+    /// `input_box` keeps the odd size.
+    #[test]
+    fn the_egfx_desktop_is_rounded_down_to_even() {
+        let layout = served_layout(NATIVE, (1281, 721), None, true);
+        assert_eq!(layout.desktop, (1280, 720));
+        assert_eq!(layout.input_box, (1281, 721));
+
+        let bitmap = served_layout(NATIVE, (1281, 721), None, false);
+        assert_eq!(
+            bitmap.desktop,
+            (1281, 721),
+            "the bitmap path serves odd sizes as-is"
+        );
+    }
+
+    /// `--desktop` replaces the served size, but not the space mouse
+    /// coordinates arrive in.
+    #[test]
+    fn the_desktop_override_leaves_the_input_box_alone() {
+        let layout = served_layout(NATIVE, (800, 600), Some((1600, 1200)), false);
+        assert_eq!(layout.desktop, (1600, 1200));
+        assert_eq!(layout.input_box, (800, 600));
+    }
+
+    /// The remote cursor lands where the user pointed: the middle of the
+    /// client's box is the middle of the output.
+    #[test]
+    fn the_centre_of_the_client_box_is_the_centre_of_the_output() {
+        let served = TargetSize::native();
+        served.set(served_layout(NATIVE, (800, 800), None, false));
+        assert_eq!(forwarder(served).map_abs(400, 400), (960, 540));
+    }
+
+    /// A click in a black bar has no picture under it; it clamps to the
+    /// nearest edge of the picture rather than mapping off-screen.
+    #[test]
+    fn positions_in_the_bars_clamp_to_the_picture_edge() {
+        let served = TargetSize::native();
+        served.set(served_layout(NATIVE, (800, 800), None, false));
+        let forwarder = forwarder(served);
+
+        assert_eq!(forwarder.map_abs(400, 10), (960, 0), "top bar");
+        assert_eq!(forwarder.map_abs(400, 790), (960, 1078), "bottom bar");
+    }
+
+    /// Every position maps inside the output, corner included.
+    #[test]
+    fn the_far_corner_stays_inside_the_output() {
+        let served = TargetSize::native();
+        served.set(served_layout(NATIVE, (800, 800), None, false));
+        let (x, y) = forwarder(served).map_abs(799, 799);
+        assert!(x < NATIVE.0, "{x} inside {}", NATIVE.0);
+        assert!(y < NATIVE.1, "{y} inside {}", NATIVE.1);
+    }
+
+    /// Before any client has negotiated a layout, coordinates pass through
+    /// unscaled and are clamped to the output.
+    #[test]
+    fn coordinates_pass_through_until_a_client_negotiates() {
+        let forwarder = forwarder(TargetSize::native());
+        assert_eq!(forwarder.map_abs(100, 200), (100, 200));
+        assert_eq!(forwarder.map_abs(5000, 5000), (1919, 1079));
     }
 }

--- a/components/otto-rdp/src/wl_input.rs
+++ b/components/otto-rdp/src/wl_input.rs
@@ -569,3 +569,31 @@ pub fn scancode_to_evdev(code: u8, extended: bool) -> Option<u32> {
     };
     Some(key)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::scancode_to_evdev;
+
+    /// Set-1 scancodes without the 0xE0 prefix are already evdev codes.
+    #[test]
+    fn base_scancodes_pass_through() {
+        assert_eq!(scancode_to_evdev(0x1E, false), Some(30)); // KEY_A
+        assert_eq!(scancode_to_evdev(0x48, false), Some(72)); // KEY_KP8
+    }
+
+    /// The same byte means something else behind the 0xE0 prefix — keypad 8
+    /// versus the arrow key above it.
+    #[test]
+    fn extended_scancodes_are_remapped() {
+        assert_eq!(scancode_to_evdev(0x48, true), Some(103)); // KEY_UP
+        assert_eq!(scancode_to_evdev(0x1D, true), Some(97)); // KEY_RIGHTCTRL
+        assert_eq!(scancode_to_evdev(0x5B, true), Some(125)); // KEY_LEFTMETA
+    }
+
+    /// An extended scancode with no evdev equivalent is dropped rather than
+    /// injected as some unrelated key.
+    #[test]
+    fn unknown_extended_scancodes_are_dropped() {
+        assert_eq!(scancode_to_evdev(0x7F, true), None);
+    }
+}

--- a/components/xdg-desktop-portal-otto/tests/validation.rs
+++ b/components/xdg-desktop-portal-otto/tests/validation.rs
@@ -14,9 +14,19 @@ fn cursor_mode_accepts_supported_values() {
         validate_cursor_mode(CURSOR_MODE_EMBEDDED).unwrap(),
         CURSOR_MODE_EMBEDDED
     );
+}
+
+/// `AvailableCursorModes` is `HIDDEN | EMBEDDED` — metadata cursors are not
+/// implemented, so asking for one is out of contract, not a silent downgrade.
+/// See `specs/screenshare.md` (Portal implementation properties and cursor
+/// modes).
+#[test]
+fn cursor_mode_rejects_the_unadvertised_metadata_mode() {
+    let err = validate_cursor_mode(CURSOR_MODE_METADATA)
+        .expect_err("metadata cursor mode is not advertised");
     assert_eq!(
-        validate_cursor_mode(CURSOR_MODE_METADATA).unwrap(),
-        CURSOR_MODE_METADATA
+        err.name().as_str(),
+        "org.freedesktop.DBus.Error.InvalidArgs"
     );
 }
 

--- a/docs/developer/expose.md
+++ b/docs/developer/expose.md
@@ -196,6 +196,13 @@ topmost in the layer tree, rather than the one the pointer is actually over.
   than pixels; fractional scaling shifts raster output.
 - During a drag the dragged window is intentionally absent from the grid.
   Expect a gap until the drop completes or is cancelled.
+- `tests/workspace_selector.rs` covers the preview layout end to end against a
+  headless compositor: opening a window while exposé is up re-lays out the
+  grid, closing it restores the previous layout, and a workspace move updates
+  the preview counts on both workspaces. `tests/app_switcher.rs` covers
+  click-to-raise, alt-tab and the switcher's ordering. Run them with
+  `cargo test --features headless --test workspace_selector` (and
+  `--test app_switcher`).
 - **Debug lever:** `echo ActionName > /tmp/otto-action` (polled once per frame
   in the udev backend, `src/udev/init.rs`) runs a builtin shortcut action as if
   its key had been pressed — useful for driving `ExposeShowAll`,

--- a/docs/developer/rdp-virtual-output.md
+++ b/docs/developer/rdp-virtual-output.md
@@ -88,6 +88,28 @@ WAYLAND_DISPLAY=wayland-1 otto-rdp --node <N> --output virtual-1 --listen 0.0.0.
 xfreerdp /v:<host>:3389 /sec:rdp
 ```
 
+## Testing
+
+The RDP wire protocol itself needs a real client (and a VA-API encoder), so it
+stays a manual check. What is covered automatically:
+
+```sh
+cargo test -p otto-rdp                            # the bridge's own logic
+cargo test --features headless --test rdp_bridge  # what it asks of Otto
+```
+
+`cargo test -p otto-rdp` covers the decisions a client's connection turns on —
+the served layout (client box verbatim, aspect-fit picture, even rounding on
+the EGFX path), the mouse mapping back through that letterbox, AVC-vs-bitmap
+transport selection from the advertised capability sets, and the RDP→evdev
+scancode table.
+
+`tests/rdp_bridge.rs` drives a headless compositor as the bridge does: it binds
+the same globals in the same versions, reads the output's logical geometry from
+`xdg-output`, and injects pointer motion, a click and keystrokes through
+`zwlr_virtual_pointer_v1` / `zwp_virtual_keyboard_v1`, asserting they land on
+the right window and reach the application.
+
 ## Current limitations
 
 - **No auth**: trusted-network only. `--tls` enables TLS security with a

--- a/docs/developer/screenshare.md
+++ b/docs/developer/screenshare.md
@@ -356,6 +356,25 @@ values. Restart it after restarting the backend.
 
 ---
 
+## Testing
+
+The two ends of the pipeline are not reachable from a test: the D-Bus service
+needs a session bus, and a stream needs a PipeWire daemon and a GPU. Everything
+between them is, and `tests/screenshare.rs` covers it against a headless
+compositor and real Wayland clients — source enumeration, window identity,
+stream sizing, the rejection paths of `RecordMonitor`/`RecordWindow`, and the
+`Captured` frame pacing a live capture forces.
+
+```sh
+cargo test --features headless --test screenshare
+```
+
+`HeadlessHandle` exposes the control plane as `screencast_*` helpers, which post
+the same `CompositorCommand`s the D-Bus thread posts. `screencast_attach_stream`
+is the one piece of scaffolding: it records a target with the PipeWire
+connection left out, so throttling, forced repaint and teardown are testable
+without a daemon.
+
 ## File map
 
 | File | Purpose |
@@ -367,6 +386,7 @@ values. Restart it after restarting the backend.
 | `src/state/window_throttle.rs` | Frame pacing, including the `Captured` state |
 | `src/skia_renderer.rs` | `Blit<Dmabuf>` — the shared GPU blit |
 | `src/udev/render.rs` | Per-frame delivery, render triggers |
+| `tests/screenshare.rs` | Headless end-to-end tests for the control plane |
 | `src/winit.rs` | Starts the D-Bus service only; no frame delivery |
 | `components/xdg-desktop-portal-otto/` | Portal backend: picker, restore, session bookkeeping |
 

--- a/specs/workspaces-multi-output.md
+++ b/specs/workspaces-multi-output.md
@@ -53,6 +53,12 @@ Otto supports multiple workspaces across multiple outputs (physical monitors and
 - If the removed workspace was the last in the list and was active, the current workspace index is clamped to the new last workspace.
 - Other outputs are unaffected.
 
+**Moving a window between workspaces:**
+
+- The window is unmapped from every space that held it and mapped into the target workspace on its own output; its scene layer follows into that workspace's view.
+- Both workspaces' exposé grids are re-laid out, the one it left and the one it landed on.
+- The workspace model is rebuilt, so everything derived from it follows the move immediately: the selector previews' window counts, the app switcher's ordering, and the dock's app list. None of these may wait for an unrelated window to open or close before catching up.
+
 **Fullscreen guard:** A workspace that is in fullscreen mode and still contains windows cannot be removed.
 
 ### Navigation
@@ -100,6 +106,8 @@ Otto supports multiple workspaces across multiple outputs (physical monitors and
 - A change to the host geometry re-renders the panel immediately, whether it came from the panel moving to another output or from that output's mode or scale changing while the panel sits on it. Recording new host metrics is what triggers the re-render, so the panel is never left laid out for the screen it used to be on.
 - Only the host output pushes a switcher plane, counts the panel as a scanout occluder, and treats it as blocking fullscreen direct scanout; every other output is unaffected while the switcher is up.
 - The panel still lists windows from every output (it mirrors the global z-index app list); selecting one focuses it on the output that owns it, which may be a different output from the one showing the switcher.
+- Apps are listed front to back: the app owning the topmost window first, so the first alt-tab step lands on the app that was in use before the current one. Apps whose windows are all on a non-current workspace sort behind the apps on the workspace in front of the user. An app appears once, at the position of its frontmost window.
+- Committing a switch (releasing the modifier) focuses the selected app, which raises its window and re-sorts the list behind it, so stepping again returns to the app just left.
 - If the host output is unplugged while hosting the panel, the panel returns to the primary output rather than being left detached from the scene.
 
 ### Expose Mode (Show All Workspaces)

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -427,6 +427,103 @@ impl HeadlessHandle {
         })
     }
 
+    // ── Windows, stacking and the switchers ──────────────────────────────
+
+    /// Titles of the current workspace's windows, bottom of the stack first.
+    pub fn window_stack_titles(&self) -> Vec<String> {
+        self.query(|state| {
+            let index = state.workspaces.get_current_workspace_index();
+            let Some(workspace) = state.workspaces.get_workspace_at(index) else {
+                return Vec::new();
+            };
+            let ids = workspace.windows_list.read().unwrap().clone();
+            ids.iter()
+                .filter_map(|id| state.workspaces.windows_map.get(id))
+                .map(|w| w.xdg_title())
+                .collect()
+        })
+    }
+
+    /// Title of the topmost non-minimized window on the current workspace.
+    pub fn top_window_title(&self) -> Option<String> {
+        self.query(|state| {
+            let index = state.workspaces.get_current_workspace_index();
+            let id = state.workspaces.get_top_window_of_workspace(index)?;
+            state.workspaces.windows_map.get(&id).map(|w| w.xdg_title())
+        })
+    }
+
+    /// Move the window with this title to another workspace on its own output.
+    pub fn move_window_to_workspace(&self, title: &str, workspace_index: usize) {
+        let title = title.to_string();
+        self.with_state(move |state| {
+            let Some(window) = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == title)
+                .cloned()
+            else {
+                return;
+            };
+            state
+                .workspaces
+                .move_window_to_workspace(&window, workspace_index, (0, 0));
+        });
+    }
+
+    /// `(workspace index, window count)` behind each workspace-selector
+    /// preview, for the output the selector belongs to.
+    pub fn workspace_preview_window_counts(&self) -> Vec<(usize, usize)> {
+        self.query(|state| {
+            state
+                .workspaces
+                .output_selector(OUTPUT_NAME)
+                .map(|selector| selector.preview_window_counts())
+                .unwrap_or_default()
+        })
+    }
+
+    // ── App switcher ─────────────────────────────────────────────────────
+    //
+    // The panel's app list is rebuilt off the workspace model by a background
+    // task, so tests poll it (see `app_switcher_apps`) rather than assuming it
+    // has caught up.
+
+    /// App identifiers as the switcher lists them, left to right.
+    pub fn app_switcher_apps(&self) -> Vec<String> {
+        self.query(|state| {
+            state
+                .workspaces
+                .app_switcher
+                .view
+                .get_state()
+                .apps
+                .iter()
+                .map(|app| app.identifier.clone())
+                .collect()
+        })
+    }
+
+    /// The app the switcher's selection is on.
+    pub fn app_switcher_selection(&self) -> Option<String> {
+        self.query(|state| state.workspaces.app_switcher.get_current_app_id())
+    }
+
+    /// One alt-tab step: open the switcher if needed and advance.
+    pub fn app_switcher_next(&self) {
+        self.with_state(|state| state.handle_app_switcher_next());
+    }
+
+    /// One shift-alt-tab step.
+    pub fn app_switcher_previous(&self) {
+        self.with_state(|state| state.handle_app_switcher_prev());
+    }
+
+    /// Release the modifier: hide the panel and focus the selected app.
+    pub fn app_switcher_commit(&self) {
+        self.with_state(|state| state.dismiss_app_switcher());
+    }
+
     // ── Screencast control plane ─────────────────────────────────────────
     //
     // The D-Bus service (`org.otto.ScreenCast`) is not started headlessly —

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -393,6 +393,26 @@ impl HeadlessHandle {
         })
     }
 
+    /// Where the window with this title sits on screen, in logical pixels:
+    /// `(x, y, width, height)`. `None` if no such window is mapped.
+    pub fn window_logical_geometry(&self, title: &str) -> Option<(i32, i32, i32, i32)> {
+        let title = title.to_string();
+        self.query(move |state| {
+            let window = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == title)
+                .cloned()?;
+            let geometry = state.workspaces.element_geometry(&window)?;
+            Some((
+                geometry.loc.x,
+                geometry.loc.y,
+                geometry.size.w,
+                geometry.size.h,
+            ))
+        })
+    }
+
     /// Logical-pixel geometry of the mapped window with this title, as the
     /// space knows it. `None` if no such window is mapped.
     pub fn window_logical_size(&self, title: &str) -> Option<(i32, i32)> {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -392,6 +392,223 @@ impl HeadlessHandle {
                 .collect()
         })
     }
+
+    /// Logical-pixel geometry of the mapped window with this title, as the
+    /// space knows it. `None` if no such window is mapped.
+    pub fn window_logical_size(&self, title: &str) -> Option<(i32, i32)> {
+        let title = title.to_string();
+        self.query(move |state| {
+            let window = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == title)?;
+            let size = smithay::desktop::space::SpaceElement::geometry(window).size;
+            Some((size.w, size.h))
+        })
+    }
+
+    // ── Screencast control plane ─────────────────────────────────────────
+    //
+    // The D-Bus service (`org.otto.ScreenCast`) is not started headlessly —
+    // it needs a session bus, and a stream needs a PipeWire daemon and a GPU.
+    // What these helpers drive is everything below that: the same
+    // `CompositorCommand`s the D-Bus thread posts, handled by the same
+    // compositor-side handler, against real client windows.
+
+    /// Run one screencast command against compositor state, as the D-Bus
+    /// thread's calloop channel would.
+    fn screencast_command(&self, cmd: crate::screenshare::CompositorCommand) {
+        self.with_state(move |state| {
+            crate::screenshare::handle_screenshare_command(state, cmd);
+        });
+    }
+
+    /// `org.otto.ScreenCast.ListOutputs` — the connectors a session may record.
+    pub fn screencast_list_outputs(&self) -> Vec<crate::screenshare::OutputInfo> {
+        self.query(|state| {
+            let (tx, mut rx) = tokio::sync::oneshot::channel();
+            crate::screenshare::handle_screenshare_command(
+                state,
+                crate::screenshare::CompositorCommand::ListOutputs { response_tx: tx },
+            );
+            rx.try_recv().expect("ListOutputs answered synchronously")
+        })
+    }
+
+    /// `org.otto.ScreenCast.ListWindows` — the capturable toplevels, each named
+    /// by its `ext-foreign-toplevel-list-v1` identifier.
+    pub fn screencast_list_windows(&self) -> Vec<crate::screenshare::WindowInfo> {
+        self.query(|state| {
+            let (tx, mut rx) = tokio::sync::oneshot::channel();
+            crate::screenshare::handle_screenshare_command(
+                state,
+                crate::screenshare::CompositorCommand::ListWindows { response_tx: tx },
+            );
+            rx.try_recv().expect("ListWindows answered synchronously")
+        })
+    }
+
+    /// `org.otto.ScreenCast.CreateSession`. `session_id` is the D-Bus object
+    /// path the service would have minted.
+    pub fn screencast_create_session(&self, session_id: &str, cursor_mode: u32) {
+        self.screencast_command(crate::screenshare::CompositorCommand::CreateSession {
+            session_id: session_id.to_string(),
+            cursor_mode,
+        });
+    }
+
+    /// `org.otto.ScreenCast.Session.Stop` / session destruction.
+    pub fn screencast_destroy_session(&self, session_id: &str) {
+        self.screencast_command(crate::screenshare::CompositorCommand::DestroySession {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    /// `RecordMonitor` / `RecordWindow`, up to and including PipeWire.
+    ///
+    /// Only the rejection paths (unknown target, unknown session, already
+    /// recording) are reachable without a PipeWire daemon — a target that
+    /// resolves goes on to open a real stream.
+    pub fn screencast_start_recording(
+        &self,
+        session_id: &str,
+        target: crate::screenshare::StreamTarget,
+    ) -> Result<u32, String> {
+        let session_id = session_id.to_string();
+        self.query(move |state| {
+            let (tx, mut rx) = tokio::sync::oneshot::channel();
+            crate::screenshare::handle_screenshare_command(
+                state,
+                crate::screenshare::CompositorCommand::StartRecording {
+                    session_id,
+                    target,
+                    cursor_mode: crate::screenshare::CURSOR_MODE_EMBEDDED,
+                    response_tx: tx,
+                },
+            );
+            rx.try_recv()
+                .expect("StartRecording answered synchronously")
+        })
+    }
+
+    /// Record a target with the PipeWire connection left out.
+    ///
+    /// Produces exactly the compositor-side state a successful
+    /// `RecordMonitor`/`RecordWindow` leaves behind — a session stream keyed by
+    /// [`crate::screenshare::StreamTarget::key`], sized as that call would size
+    /// it — but with an unstarted [`crate::screenshare::PipeWireStream`], so
+    /// everything downstream of "this target is being cast" (throttling, forced
+    /// repaint, teardown) is exercisable without a PipeWire daemon or a GPU.
+    ///
+    /// Returns the capture size the real call would have negotiated.
+    pub fn screencast_attach_stream(
+        &self,
+        session_id: &str,
+        target: crate::screenshare::StreamTarget,
+    ) -> Result<(u32, u32), String> {
+        let session_id = session_id.to_string();
+        self.query(move |state| {
+            use crate::screenshare::{ActiveStream, PipeWireStream, StreamConfig, StreamTarget};
+
+            let (width, height, refresh) = match &target {
+                StreamTarget::Output(connector) => state
+                    .workspaces
+                    .outputs()
+                    .find(|o| o.name() == *connector)
+                    .and_then(|o| o.current_mode())
+                    .map(|m| (m.size.w as u32, m.size.h as u32, m.refresh as u32))
+                    .ok_or_else(|| format!("Output not found: {connector}"))?,
+                StreamTarget::Window(id) => crate::screenshare::window_capture_size(
+                    &state.workspaces,
+                    &state.foreign_toplevels,
+                    id,
+                )?,
+            };
+
+            let session = state
+                .screenshare_sessions
+                .get_mut(&session_id)
+                .ok_or_else(|| format!("Session not found: {session_id}"))?;
+
+            session.streams.insert(
+                target.key(),
+                ActiveStream {
+                    target,
+                    pipewire_stream: PipeWireStream::new(StreamConfig {
+                        width,
+                        height,
+                        framerate_num: (refresh / 1000).min(60),
+                        framerate_denom: 1,
+                        gbm_device: None,
+                        capabilities: Default::default(),
+                    }),
+                    pending_frame: None,
+                },
+            );
+
+            Ok((width, height))
+        })
+    }
+
+    /// Stream keys (`output:<connector>` / `window:<identifier>`) currently
+    /// active in a session. `None` if the session does not exist.
+    pub fn screencast_stream_keys(&self, session_id: &str) -> Option<Vec<String>> {
+        let session_id = session_id.to_string();
+        self.query(move |state| {
+            let session = state.screenshare_sessions.get(&session_id)?;
+            let mut keys: Vec<String> = session.streams.keys().cloned().collect();
+            keys.sort();
+            Some(keys)
+        })
+    }
+
+    /// The capture size `RecordWindow` would fix a window's stream at:
+    /// `(width_px, height_px, refresh_millihz)`.
+    pub fn screencast_window_capture_size(
+        &self,
+        identifier: &str,
+    ) -> Result<(u32, u32, u32), String> {
+        let identifier = identifier.to_string();
+        self.query(move |state| {
+            crate::screenshare::window_capture_size(
+                &state.workspaces,
+                &state.foreign_toplevels,
+                &identifier,
+            )
+        })
+    }
+
+    /// Frame-callback throttle state of every mapped window, keyed by title.
+    ///
+    /// Classified exactly as the udev render loop does, screencast streams
+    /// included — a captured window is `Captured` no matter what covers it.
+    pub fn window_throttle_states(
+        &self,
+    ) -> std::collections::HashMap<String, crate::state::window_throttle::WindowThrottleState> {
+        self.query(|state| {
+            #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+            let captured_ids = crate::screenshare::screencast_window_ids(
+                &state.screenshare_sessions,
+                &state.workspaces,
+                &state.foreign_toplevels,
+            );
+            let windows: Vec<crate::shell::WindowElement> =
+                state.workspaces.spaces_elements().cloned().collect();
+            let refs: Vec<&crate::shell::WindowElement> = windows.iter().collect();
+            #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+            let states = crate::state::window_throttle::classify_windows(
+                &state.workspaces,
+                &refs,
+                &Default::default(),
+                state.workspaces.get_show_all(),
+                &captured_ids,
+            );
+            windows
+                .iter()
+                .filter_map(|w| states.get(&w.id()).map(|s| (w.xdg_title(), *s)))
+                .collect()
+        })
+    }
 }
 
 impl Otto<HeadlessData> {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -334,7 +334,10 @@ impl<BackendData: Backend> Otto<BackendData> {
         action
     }
 
-    fn dismiss_app_switcher(&mut self) {
+    /// Commit the app switcher's selection: hide the panel and focus the app
+    /// it landed on. `pub(crate)` so the headless harness can finish an
+    /// alt-tab the way releasing the modifier does.
+    pub(crate) fn dismiss_app_switcher(&mut self) {
         if self.workspaces.app_switcher.alive() {
             self.workspaces.app_switcher.hide();
             if let Some(app_id) = self.workspaces.app_switcher.get_current_app_id() {

--- a/src/screenshare/mod.rs
+++ b/src/screenshare/mod.rs
@@ -257,6 +257,42 @@ pub fn window_for_identifier(
     Some((window.clone(), output))
 }
 
+/// Capture size and pacing for a window stream: `(width_px, height_px, refresh_millihz)`.
+///
+/// Resolved once, at `RecordWindow` time: the PipeWire format is never
+/// renegotiated, so a window that later grows is cropped to this size and one
+/// that shrinks leaves the remainder black.
+///
+/// Dimensions are physical pixels rounded **down to even** — several PipeWire
+/// consumers, and every YUV encoder downstream, reject odd sizes. A window that
+/// rounds down to zero in either axis is not capturable.
+#[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+pub fn window_capture_size(
+    workspaces: &crate::workspaces::Workspaces,
+    foreign_toplevels: &HashMap<
+        smithay::reexports::wayland_server::backend::ObjectId,
+        crate::state::foreign_toplevel_shared::ForeignToplevelHandles,
+    >,
+    identifier: &str,
+) -> Result<(u32, u32, u32), String> {
+    let (window, output) = window_for_identifier(workspaces, foreign_toplevels, identifier)
+        .ok_or_else(|| format!("Window not found: {identifier}"))?;
+
+    let scale = output.current_scale().fractional_scale();
+    let size = smithay::desktop::space::SpaceElement::geometry(&window).size;
+    let w = (((size.w as f64) * scale).round() as u32) & !1;
+    let h = (((size.h as f64) * scale).round() as u32) & !1;
+    if w == 0 || h == 0 {
+        return Err(format!("Window {identifier} has zero size"));
+    }
+
+    let refresh = output
+        .current_mode()
+        .map(|m| m.refresh as u32)
+        .unwrap_or(60000);
+    Ok((w, h, refresh))
+}
+
 /// Ids of windows with an active screencast stream.
 ///
 /// Drives [`crate::state::window_throttle::WindowThrottleState::Captured`] so a
@@ -287,7 +323,10 @@ pub fn screencast_window_ids(
 }
 
 /// Handle a command from the D-Bus service.
-fn handle_screenshare_command<B: crate::state::Backend + 'static>(
+///
+/// Public so the headless test harness can drive the same control plane the
+/// D-Bus service drives, without a session bus.
+pub fn handle_screenshare_command<B: crate::state::Backend + 'static>(
     state: &mut crate::state::Otto<B>,
     cmd: CompositorCommand,
 ) {
@@ -395,25 +434,7 @@ fn handle_screenshare_command<B: crate::state::Backend + 'static>(
                         (w, h, refresh)
                     }),
                 StreamTarget::Window(id) => {
-                    window_for_identifier(&state.workspaces, &state.foreign_toplevels, id)
-                        .ok_or_else(|| format!("Window not found: {id}"))
-                        .and_then(|(window, output)| {
-                            let scale = output.current_scale().fractional_scale();
-                            let size =
-                                smithay::desktop::space::SpaceElement::geometry(&window).size;
-                            // Even dimensions: several PipeWire consumers (and
-                            // every YUV encoder downstream) reject odd sizes.
-                            let w = (((size.w as f64) * scale).round() as u32) & !1;
-                            let h = (((size.h as f64) * scale).round() as u32) & !1;
-                            if w == 0 || h == 0 {
-                                return Err(format!("Window {id} has zero size"));
-                            }
-                            let refresh = output
-                                .current_mode()
-                                .map(|m| m.refresh as u32)
-                                .unwrap_or(60000);
-                            Ok((w, h, refresh))
-                        })
+                    window_capture_size(&state.workspaces, &state.foreign_toplevels, id)
                 }
             };
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -4190,6 +4190,12 @@ impl Workspaces {
             self.expose_update_if_needed_workspace(*src);
         }
         self.expose_update_if_needed_workspace(workspace_index);
+
+        // The window changed workspace, so everything derived from the model
+        // — the selector previews' window counts, the app switcher's z-order,
+        // the dock's app list — is now stale. Without this the stale state
+        // survives until some unrelated window maps or closes.
+        self.update_workspace_model();
     }
 
     /// Per-output variant of `defer_remove_workspace_at`: remove workspace `n`

--- a/src/workspaces/workspace_selector.rs
+++ b/src/workspaces/workspace_selector.rs
@@ -255,6 +255,18 @@ impl WorkspaceSelectorView {
         self.view.update_state(&state);
     }
 
+    /// `(workspace index, window count)` for every preview, in the order they
+    /// are laid out. What the previews are currently drawn from — stale here
+    /// means a preview showing a window that has since moved or closed.
+    pub fn preview_window_counts(&self) -> Vec<(usize, usize)> {
+        self.view
+            .get_state()
+            .workspaces
+            .iter()
+            .map(|w| (w.index, w.window_count))
+            .collect()
+    }
+
     /// Set the global logical origin of the output hosting this selector, so
     /// pointer events (delivered in global logical space) can be converted to
     /// output-local coordinates for hit-testing.

--- a/tests/app_switcher.rs
+++ b/tests/app_switcher.rs
@@ -1,0 +1,245 @@
+//! Focus, stacking and the app switcher (headless).
+//!
+//! Covers what a user sees when they change which window is in front: clicking
+//! raises it and repaints, alt-tab lands on the app they were on before, and
+//! the switcher's order tracks the z-order — across workspaces too.
+
+#[cfg(feature = "headless")]
+mod app_switcher_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    fn start() -> HeadlessHandle {
+        HeadlessHandle::start(HeadlessConfig::default())
+    }
+
+    /// Map a window belonging to app `org.otto.<title>`.
+    fn map_window(handle: &HeadlessHandle, client: &mut TestClient, title: &str) {
+        client.create_toplevel_with_app_id(title, &app_id(title), 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(300);
+    }
+
+    fn app_id(title: &str) -> String {
+        format!("org.otto.{title}")
+    }
+
+    /// The switcher's list is rebuilt off the workspace model by a background
+    /// task, so wait for it to settle on `want` rather than reading it once.
+    fn wait_for_apps(handle: &HeadlessHandle, want: &[&str]) -> Vec<String> {
+        let want: Vec<String> = want.iter().map(|t| app_id(t)).collect();
+        let mut seen = Vec::new();
+        for _ in 0..50 {
+            seen = handle.app_switcher_apps();
+            if seen == want {
+                return seen;
+            }
+            handle.wait(Duration::from_millis(100));
+        }
+        assert_eq!(
+            seen, want,
+            "app switcher never settled on the expected order"
+        );
+        seen
+    }
+
+    /// Click the top-left corner of a window — the part a window stacked later
+    /// (offset down and right) does not cover.
+    fn click_corner_of(handle: &HeadlessHandle, title: &str) {
+        let (x, y, _, _) = handle
+            .window_logical_geometry(title)
+            .unwrap_or_else(|| panic!("window {title:?} not mapped"));
+        handle.pointer_move((x + 8) as f64, (y + 8) as f64);
+        handle.pointer_click();
+    }
+
+    // ── Focus and stacking ───────────────────────────────────────────────
+
+    /// Clicking a window behind another brings it to the front, and the change
+    /// actually repaints — a raise that damages nothing is a raise the user
+    /// never sees.
+    #[test]
+    #[serial]
+    fn clicking_a_window_raises_it_and_repaints() {
+        let handle = start();
+        let mut first = TestClient::connect(&handle.socket_name).expect("client");
+        let mut second = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut first, "First");
+        map_window(&handle, &mut second, "Second");
+        handle.settle(400);
+
+        assert_eq!(
+            handle.window_stack_titles(),
+            vec!["First".to_string(), "Second".to_string()],
+            "the window mapped last starts on top"
+        );
+        assert_eq!(handle.top_window_title().as_deref(), Some("Second"));
+        assert!(
+            !handle.scene_has_damage(),
+            "the scene should be idle before the click"
+        );
+
+        click_corner_of(&handle, "First");
+
+        assert!(
+            handle.scene_has_damage(),
+            "raising a window must damage the scene"
+        );
+        let frames = handle.settle(600);
+        assert!(
+            frames > 0,
+            "the raise should have driven at least one frame"
+        );
+
+        assert_eq!(
+            handle.window_stack_titles(),
+            vec!["Second".to_string(), "First".to_string()],
+            "the clicked window should be on top of the stack"
+        );
+        assert_eq!(handle.top_window_title().as_deref(), Some("First"));
+
+        handle.stop();
+    }
+
+    // ── App switcher ─────────────────────────────────────────────────────
+
+    /// The switcher lists apps front to back, so the app you are looking at is
+    /// first and the one you were on before is second.
+    #[test]
+    #[serial]
+    fn the_switcher_lists_apps_front_to_back() {
+        let handle = start();
+        let mut alpha = TestClient::connect(&handle.socket_name).expect("client");
+        let mut beta = TestClient::connect(&handle.socket_name).expect("client");
+        let mut gamma = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut alpha, "Alpha");
+        map_window(&handle, &mut beta, "Beta");
+        map_window(&handle, &mut gamma, "Gamma");
+
+        assert_eq!(
+            handle.window_stack_titles(),
+            vec!["Alpha".to_string(), "Beta".to_string(), "Gamma".to_string()]
+        );
+        wait_for_apps(&handle, &["Gamma", "Beta", "Alpha"]);
+
+        handle.stop();
+    }
+
+    /// One alt-tab step lands on the app used before the current one, and
+    /// releasing brings that app's window to the front.
+    #[test]
+    #[serial]
+    fn alt_tab_switches_to_the_previously_used_app() {
+        let handle = start();
+        let mut alpha = TestClient::connect(&handle.socket_name).expect("client");
+        let mut beta = TestClient::connect(&handle.socket_name).expect("client");
+        let mut gamma = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut alpha, "Alpha");
+        map_window(&handle, &mut beta, "Beta");
+        map_window(&handle, &mut gamma, "Gamma");
+        wait_for_apps(&handle, &["Gamma", "Beta", "Alpha"]);
+
+        handle.app_switcher_next();
+        handle.settle(300);
+        assert_eq!(
+            handle.app_switcher_selection().as_deref(),
+            Some(app_id("Beta").as_str()),
+            "the first step selects the app behind the current one"
+        );
+
+        handle.app_switcher_commit();
+        handle.settle(600);
+
+        assert_eq!(
+            handle.top_window_title().as_deref(),
+            Some("Beta"),
+            "committing the switch raises that app's window"
+        );
+        assert_eq!(
+            handle.window_stack_titles(),
+            vec!["Alpha".to_string(), "Gamma".to_string(), "Beta".to_string()]
+        );
+
+        // ...and the list re-sorts behind it, so the next alt-tab goes back.
+        wait_for_apps(&handle, &["Beta", "Gamma", "Alpha"]);
+
+        handle.app_switcher_next();
+        handle.settle(300);
+        assert_eq!(
+            handle.app_switcher_selection().as_deref(),
+            Some(app_id("Gamma").as_str()),
+            "stepping again offers the app that was in front before"
+        );
+
+        handle.stop();
+    }
+
+    /// Stepping backwards wraps to the end of the list.
+    #[test]
+    #[serial]
+    fn stepping_back_from_the_first_app_wraps_to_the_last() {
+        let handle = start();
+        let mut alpha = TestClient::connect(&handle.socket_name).expect("client");
+        let mut beta = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut alpha, "Alpha");
+        map_window(&handle, &mut beta, "Beta");
+        wait_for_apps(&handle, &["Beta", "Alpha"]);
+
+        handle.app_switcher_previous();
+        handle.settle(300);
+        assert_eq!(
+            handle.app_switcher_selection().as_deref(),
+            Some(app_id("Alpha").as_str())
+        );
+
+        handle.stop();
+    }
+
+    /// An app whose windows are all on another workspace sorts after the apps
+    /// on the one in front of the user — it is further away, and the switcher
+    /// order says so.
+    #[test]
+    #[serial]
+    fn apps_on_other_workspaces_sort_behind_the_current_one() {
+        let handle = start();
+        let mut alpha = TestClient::connect(&handle.socket_name).expect("client");
+        let mut beta = TestClient::connect(&handle.socket_name).expect("client");
+        let mut gamma = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut alpha, "Alpha");
+        map_window(&handle, &mut beta, "Beta");
+        map_window(&handle, &mut gamma, "Gamma");
+        wait_for_apps(&handle, &["Gamma", "Beta", "Alpha"]);
+
+        handle.with_state(|state| {
+            state.workspaces.add_workspace_to_output("headless");
+        });
+        handle.settle(300);
+
+        // Gamma was in front; sending it to the next workspace should drop it
+        // to the back of the switcher, not leave it where it was.
+        handle.move_window_to_workspace("Gamma", 1);
+        handle.settle(500);
+
+        assert_eq!(
+            handle.window_stack_titles(),
+            vec!["Alpha".to_string(), "Beta".to_string()],
+            "the moved window is off this workspace"
+        );
+        wait_for_apps(&handle, &["Beta", "Alpha", "Gamma"]);
+
+        // Following it there puts it back in front.
+        handle.set_workspace(1);
+        handle.settle(500);
+        wait_for_apps(&handle, &["Gamma", "Beta", "Alpha"]);
+
+        handle.stop();
+    }
+}

--- a/tests/rdp_bridge.rs
+++ b/tests/rdp_bridge.rs
@@ -1,0 +1,475 @@
+//! The compositor-side contract the RDP bridge runs on (headless).
+//!
+//! `otto-rdp` is a separate process: it captures an output through
+//! `org.otto.ScreenCast` and injects the remote client's input back through
+//! `zwlr_virtual_pointer_v1` and `zwp_virtual_keyboard_v1`, sizing its picture
+//! from `xdg-output`'s logical geometry. The RDP wire protocol itself needs a
+//! real client (and a VA-API encoder) and is out of reach here, but everything
+//! the bridge asks of Otto is not: these tests bind the same globals it binds,
+//! in the same versions, and drive the same requests.
+//!
+//! See `specs/rdp-bridge.md` and `components/otto-rdp/src/wl_input.rs`.
+
+#[cfg(feature = "headless")]
+mod rdp_bridge_tests {
+    use std::io::Write;
+    use std::os::fd::AsFd;
+    use std::time::Duration;
+
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use wayland_client::{
+        delegate_noop,
+        protocol::{wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat},
+        Connection, Dispatch, EventQueue, QueueHandle, WEnum,
+    };
+    use wayland_protocols::xdg::xdg_output::zv1::client::{zxdg_output_manager_v1, zxdg_output_v1};
+    use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
+        zwp_virtual_keyboard_manager_v1, zwp_virtual_keyboard_v1,
+    };
+    use wayland_protocols_wlr::virtual_pointer::v1::client::{
+        zwlr_virtual_pointer_manager_v1, zwlr_virtual_pointer_v1,
+    };
+
+    /// BTN_LEFT, as `otto-rdp` sends it.
+    const BTN_LEFT: u32 = 0x110;
+    /// evdev KEY_A.
+    const KEY_A: u32 = 30;
+
+    // ── A stand-in for otto-rdp's injection client ───────────────────────
+
+    #[derive(Default)]
+    struct InjectorState {
+        seat: Option<wl_seat::WlSeat>,
+        pointer_manager: Option<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1>,
+        pointer_manager_version: u32,
+        keyboard_manager: Option<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1>,
+        output_manager: Option<zxdg_output_manager_v1::ZxdgOutputManagerV1>,
+        output_manager_version: u32,
+        output: Option<wl_output::WlOutput>,
+        /// Mode reported by `wl_output`, in physical pixels.
+        mode: Option<(i32, i32)>,
+        /// Logical geometry reported by `xdg-output` — the space the bridge
+        /// maps remote pointer coordinates into.
+        logical_size: Option<(i32, i32)>,
+        logical_position: Option<(i32, i32)>,
+    }
+
+    impl Dispatch<wl_registry::WlRegistry, ()> for InjectorState {
+        fn event(
+            state: &mut Self,
+            registry: &wl_registry::WlRegistry,
+            event: wl_registry::Event,
+            _: &(),
+            _: &Connection,
+            qh: &QueueHandle<Self>,
+        ) {
+            let wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } = event
+            else {
+                return;
+            };
+            // Exactly what `otto-rdp`'s wl_input thread binds.
+            match interface.as_str() {
+                "wl_seat" => state.seat = Some(registry.bind(name, version.min(5), qh, ())),
+                "zwlr_virtual_pointer_manager_v1" => {
+                    state.pointer_manager_version = version;
+                    state.pointer_manager = Some(registry.bind(name, version.min(2), qh, ()));
+                }
+                "zwp_virtual_keyboard_manager_v1" => {
+                    state.keyboard_manager = Some(registry.bind(name, 1, qh, ()));
+                }
+                "zxdg_output_manager_v1" => {
+                    state.output_manager_version = version;
+                    state.output_manager = Some(registry.bind(name, version.min(3), qh, ()));
+                }
+                "wl_output" => {
+                    state.output = Some(registry.bind(name, version.min(4), qh, ()));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    impl Dispatch<wl_output::WlOutput, ()> for InjectorState {
+        fn event(
+            state: &mut Self,
+            _: &wl_output::WlOutput,
+            event: wl_output::Event,
+            _: &(),
+            _: &Connection,
+            _: &QueueHandle<Self>,
+        ) {
+            if let wl_output::Event::Mode {
+                flags,
+                width,
+                height,
+                ..
+            } = event
+            {
+                if matches!(flags, WEnum::Value(f) if f.contains(wl_output::Mode::Current)) {
+                    state.mode = Some((width, height));
+                }
+            }
+        }
+    }
+
+    impl Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for InjectorState {
+        fn event(
+            state: &mut Self,
+            _: &zxdg_output_v1::ZxdgOutputV1,
+            event: zxdg_output_v1::Event,
+            _: &(),
+            _: &Connection,
+            _: &QueueHandle<Self>,
+        ) {
+            match event {
+                zxdg_output_v1::Event::LogicalSize { width, height } => {
+                    state.logical_size = Some((width, height));
+                }
+                zxdg_output_v1::Event::LogicalPosition { x, y } => {
+                    state.logical_position = Some((x, y));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    delegate_noop!(InjectorState: ignore wl_seat::WlSeat);
+    delegate_noop!(InjectorState: zxdg_output_manager_v1::ZxdgOutputManagerV1);
+    delegate_noop!(InjectorState: zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1);
+    delegate_noop!(InjectorState: zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1);
+    delegate_noop!(InjectorState: zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1);
+    delegate_noop!(InjectorState: zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1);
+
+    struct Injector {
+        conn: Connection,
+        queue: EventQueue<InjectorState>,
+        qh: QueueHandle<InjectorState>,
+        state: InjectorState,
+    }
+
+    impl Injector {
+        /// Connect and bind the bridge's globals.
+        fn connect(handle: &HeadlessHandle) -> Self {
+            let path = format!(
+                "{}/{}",
+                std::env::var("XDG_RUNTIME_DIR").expect("XDG_RUNTIME_DIR"),
+                handle.socket_name
+            );
+            let stream = std::os::unix::net::UnixStream::connect(path).expect("connect");
+            let conn = Connection::from_socket(stream).expect("wayland connection");
+            let mut queue = conn.new_event_queue();
+            let qh = queue.handle();
+            conn.display().get_registry(&qh, ());
+
+            let mut state = InjectorState::default();
+            queue.roundtrip(&mut state).expect("bind globals");
+
+            Self {
+                conn,
+                queue,
+                qh,
+                state,
+            }
+        }
+
+        fn roundtrip(&mut self) {
+            self.queue.roundtrip(&mut self.state).expect("roundtrip");
+        }
+
+        /// `xdg-output` for the bound output — the bridge reads its logical
+        /// size to size the picture it serves.
+        fn fetch_xdg_output(&mut self) {
+            let manager = self
+                .state
+                .output_manager
+                .clone()
+                .expect("zxdg_output_manager_v1 missing");
+            let output = self.state.output.clone().expect("wl_output missing");
+            manager.get_xdg_output(&output, &self.qh, ());
+            self.roundtrip();
+            self.roundtrip();
+        }
+
+        /// A virtual pointer bound to the output, as the bridge creates it.
+        fn pointer(&mut self) -> zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1 {
+            let manager = self
+                .state
+                .pointer_manager
+                .clone()
+                .expect("zwlr_virtual_pointer_manager_v1 missing");
+            let seat = self.state.seat.clone();
+            let output = self.state.output.clone();
+            manager.create_virtual_pointer_with_output(seat.as_ref(), output.as_ref(), &self.qh, ())
+        }
+
+        /// A virtual keyboard with the US keymap the bridge uploads.
+        fn keyboard(&mut self) -> zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1 {
+            let manager = self
+                .state
+                .keyboard_manager
+                .clone()
+                .expect("zwp_virtual_keyboard_manager_v1 missing");
+            let seat = self.state.seat.clone().expect("wl_seat missing");
+            let keyboard = manager.create_virtual_keyboard(&seat, &self.qh, ());
+
+            use xkbcommon::xkb;
+            let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+            let keymap = xkb::Keymap::new_from_names(
+                &context,
+                "",
+                "",
+                "us",
+                "",
+                None,
+                xkb::COMPILE_NO_FLAGS,
+            )
+            .expect("compile us keymap");
+            let text = keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1);
+
+            let mut file = tempfile::tempfile().expect("keymap file");
+            file.write_all(text.as_bytes()).expect("write keymap");
+            file.write_all(&[0]).expect("write NUL"); // keymaps are NUL-terminated
+            file.flush().expect("flush keymap");
+
+            keyboard.keymap(
+                wl_keyboard::KeymapFormat::XkbV1 as u32,
+                file.as_fd(),
+                text.len() as u32 + 1,
+            );
+            self.roundtrip();
+            keyboard
+        }
+
+        /// Flush the injected requests and let the compositor act on them.
+        fn settle(&mut self, handle: &HeadlessHandle) {
+            self.conn.flush().expect("flush");
+            handle.wait(Duration::from_millis(120));
+            self.roundtrip();
+            handle.settle(200);
+        }
+    }
+
+    fn start() -> HeadlessHandle {
+        HeadlessHandle::start(HeadlessConfig::default())
+    }
+
+    fn map_window(handle: &HeadlessHandle, client: &mut TestClient, title: &str) {
+        client.create_toplevel_with_app_id(title, &format!("org.otto.{title}"), 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(200);
+    }
+
+    // ── Globals and geometry ─────────────────────────────────────────────
+
+    /// The bridge cannot start at all unless the compositor advertises these
+    /// four globals, at versions high enough for the requests it makes:
+    /// `create_virtual_pointer_with_output` needs virtual-pointer v2.
+    #[test]
+    #[serial]
+    fn the_globals_the_bridge_binds_are_advertised() {
+        let handle = start();
+        let injector = Injector::connect(&handle);
+
+        assert!(injector.state.seat.is_some(), "wl_seat");
+        assert!(injector.state.output.is_some(), "wl_output");
+        assert!(
+            injector.state.pointer_manager.is_some(),
+            "zwlr_virtual_pointer_manager_v1"
+        );
+        assert!(
+            injector.state.pointer_manager_version >= 2,
+            "virtual pointer v2 is required for create_virtual_pointer_with_output, got v{}",
+            injector.state.pointer_manager_version
+        );
+        assert!(
+            injector.state.keyboard_manager.is_some(),
+            "zwp_virtual_keyboard_manager_v1"
+        );
+        assert!(
+            injector.state.output_manager.is_some(),
+            "zxdg_output_manager_v1"
+        );
+        assert!(
+            injector.state.output_manager_version >= 3,
+            "xdg-output v3, got v{}",
+            injector.state.output_manager_version
+        );
+
+        drop(injector);
+        handle.stop();
+    }
+
+    /// `xdg-output` reports the output in *logical* pixels — physical mode
+    /// divided by the output scale. The bridge maps remote pointer coordinates
+    /// into this space, so a mix-up here puts the remote cursor at the wrong
+    /// place on a scaled output.
+    #[test]
+    #[serial]
+    fn xdg_output_reports_logical_geometry() {
+        let handle = start();
+        let mut injector = Injector::connect(&handle);
+        injector.fetch_xdg_output();
+
+        let scale = handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale())
+                .unwrap_or(1.0)
+        });
+
+        let mode = injector.state.mode.expect("wl_output mode");
+        let logical = injector
+            .state
+            .logical_size
+            .expect("xdg-output logical size");
+        assert_eq!(mode, (1920, 1080), "physical mode");
+        assert_eq!(
+            logical,
+            (
+                (mode.0 as f64 / scale).round() as i32,
+                (mode.1 as f64 / scale).round() as i32
+            ),
+            "logical size must be the mode divided by the output scale ({scale})"
+        );
+        assert_eq!(injector.state.logical_position, Some((0, 0)));
+
+        drop(injector);
+        handle.stop();
+    }
+
+    // ── Remote input ─────────────────────────────────────────────────────
+
+    /// An absolute motion from the remote client lands where its normalized
+    /// coordinates say, in the output's logical space.
+    #[test]
+    #[serial]
+    fn remote_pointer_motion_moves_the_compositor_pointer() {
+        let handle = start();
+        let mut injector = Injector::connect(&handle);
+        injector.fetch_xdg_output();
+        let pointer = injector.pointer();
+
+        let (logical_w, logical_h) = injector.state.logical_size.expect("logical size");
+
+        // A quarter across, three quarters down — extents are the remote
+        // client's own resolution, not the output's.
+        pointer.motion_absolute(0, 500, 1500, 2000, 2000);
+        pointer.frame();
+        injector.settle(&handle);
+
+        let (x, y) = handle.query(|state| state.last_pointer_location);
+        assert_eq!(x, logical_w as f64 * 0.25);
+        assert_eq!(y, logical_h as f64 * 0.75);
+
+        drop(injector);
+        handle.stop();
+    }
+
+    /// A remote click focuses the window under the pointer — the same
+    /// click-to-focus a physical mouse gets — and the application it belongs to
+    /// is told it has keyboard focus.
+    #[test]
+    #[serial]
+    fn remote_click_focuses_the_window_under_the_pointer() {
+        let handle = start();
+        let mut background = TestClient::connect(&handle.socket_name).expect("client");
+        let mut foreground = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut background, "Background");
+        map_window(&handle, &mut foreground, "Foreground");
+        let _ = background.roundtrip();
+        let _ = foreground.roundtrip();
+        assert!(
+            foreground.state.keyboard_focused,
+            "the window mapped last starts focused"
+        );
+
+        // Click a corner of the background window that the foreground one does
+        // not cover.
+        let (bx, by, bw, bh) = handle
+            .window_logical_geometry("Background")
+            .expect("background window mapped");
+        let (fx, fy, _, _) = handle
+            .window_logical_geometry("Foreground")
+            .expect("foreground window mapped");
+        let (target_x, target_y) = (bx + 8, by + 8);
+        assert!(
+            target_x < fx || target_y < fy,
+            "expected the background window ({bx},{by} {bw}x{bh}) to peek out from under \
+             the foreground one at ({fx},{fy})"
+        );
+
+        let mut injector = Injector::connect(&handle);
+        injector.fetch_xdg_output();
+        let pointer = injector.pointer();
+        let (logical_w, logical_h) = injector.state.logical_size.expect("logical size");
+
+        pointer.motion_absolute(
+            0,
+            target_x as u32,
+            target_y as u32,
+            logical_w as u32,
+            logical_h as u32,
+        );
+        pointer.frame();
+        injector.settle(&handle);
+
+        pointer.button(1, BTN_LEFT, wl_pointer::ButtonState::Pressed);
+        pointer.frame();
+        pointer.button(2, BTN_LEFT, wl_pointer::ButtonState::Released);
+        pointer.frame();
+        injector.settle(&handle);
+
+        let _ = background.roundtrip();
+        let _ = foreground.roundtrip();
+        assert!(
+            background.state.keyboard_focused,
+            "the clicked window should have taken keyboard focus"
+        );
+        assert!(
+            !foreground.state.keyboard_focused,
+            "the previously focused window should have lost it"
+        );
+
+        drop(injector);
+        handle.stop();
+    }
+
+    /// A remote keystroke reaches the focused application, carrying the evdev
+    /// code the bridge translated the RDP scancode into.
+    #[test]
+    #[serial]
+    fn remote_keystrokes_reach_the_focused_application() {
+        let handle = start();
+        let mut client = TestClient::connect(&handle.socket_name).expect("client");
+        map_window(&handle, &mut client, "Remote");
+        let _ = client.roundtrip();
+        assert!(client.state.keyboard_focused, "window should be focused");
+
+        let mut injector = Injector::connect(&handle);
+        let keyboard = injector.keyboard();
+
+        keyboard.key(0, KEY_A, 1);
+        keyboard.key(10, KEY_A, 0);
+        injector.settle(&handle);
+
+        let _ = client.roundtrip();
+        assert_eq!(
+            client.state.keys,
+            vec![(KEY_A, true), (KEY_A, false)],
+            "the application should have seen the press and the release"
+        );
+
+        drop(injector);
+        handle.stop();
+    }
+}

--- a/tests/screenshare.rs
+++ b/tests/screenshare.rs
@@ -338,6 +338,89 @@ mod screenshare_tests {
         handle.stop();
     }
 
+    /// Switching to another workspace does not interrupt a window's capture:
+    /// the identifier still resolves, the stream keeps its size, and the window
+    /// stays at full frame rate while it is off screen.
+    #[test]
+    #[serial]
+    fn a_cast_window_survives_a_workspace_switch() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Shared", "org.otto.Shared");
+        let id = identifier_of(&handle, "Shared");
+
+        handle.screencast_create_session(SESSION, 2);
+        let (width, height) = handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id.clone()))
+            .expect("window stream should attach");
+
+        handle.with_state(|state| {
+            state.workspaces.add_workspace_to_output(OUTPUT);
+        });
+        handle.settle(300);
+        handle.set_workspace(1);
+        handle.settle(300);
+
+        assert_eq!(
+            handle
+                .screencast_window_capture_size(&id)
+                .map(|(w, h, _)| (w, h)),
+            Ok((width, height)),
+            "the stream keeps the size it negotiated"
+        );
+        assert_eq!(
+            handle.window_throttle_states().get("Shared"),
+            Some(&WindowThrottleState::Captured),
+            "a window off the current workspace is still being watched remotely"
+        );
+
+        handle.stop();
+    }
+
+    /// A minimized window should stay capturable — the spec asks for full frame
+    /// rate "even when occluded, on an inactive workspace, or minimized".
+    ///
+    /// Ignored: minimizing unmaps the window from every space, and both
+    /// `ListWindows` and `window_for_identifier` walk `spaces_elements()`, so
+    /// today a minimized window disappears from the picker and its stream stops
+    /// resolving. See `specs/screenshare.md` (Window capture).
+    #[test]
+    #[serial]
+    #[ignore = "known gap: minimizing unmaps the window, so its capture stops resolving"]
+    fn a_minimized_window_stays_capturable() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Shared", "org.otto.Shared");
+        let id = identifier_of(&handle, "Shared");
+
+        handle.screencast_create_session(SESSION, 2);
+        handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id.clone()))
+            .expect("window stream should attach");
+
+        handle.with_state(|state| {
+            let window = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == "Shared")
+                .cloned()
+                .expect("window mapped");
+            state.workspaces.minimize_window(&window);
+        });
+        handle.settle(400);
+
+        assert!(
+            handle.screencast_window_capture_size(&id).is_ok(),
+            "a minimized window must still resolve for its stream"
+        );
+        assert_eq!(
+            handle.window_throttle_states().get("Shared"),
+            Some(&WindowThrottleState::Captured),
+        );
+
+        handle.stop();
+    }
+
     /// Destroying the session drops its streams, and the window it was casting
     /// goes back to being throttled like any other background window.
     #[test]

--- a/tests/screenshare.rs
+++ b/tests/screenshare.rs
@@ -1,0 +1,377 @@
+//! Screencast control-plane tests (headless).
+//!
+//! The D-Bus service and the PipeWire stream are the two halves screen sharing
+//! cannot have here: one needs a session bus, the other a daemon and a GPU.
+//! Everything between them is exercised against a real compositor and real
+//! Wayland clients — enumerating capturable sources, naming a window by its
+//! `ext-foreign-toplevel-list-v1` identifier, sizing its stream, rejecting a
+//! source that no longer exists, and the frame-callback throttling a live
+//! capture forces.
+//!
+//! See `specs/screenshare.md` (Window identity, Window capture).
+
+#[cfg(feature = "headless")]
+mod screenshare_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto::screenshare::StreamTarget;
+    use otto::state::window_throttle::WindowThrottleState;
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    /// The object path the D-Bus service would have minted for a session.
+    const SESSION: &str = "/org/otto/ScreenCast/session/1";
+    const OUTPUT: &str = "headless";
+
+    fn start() -> HeadlessHandle {
+        HeadlessHandle::start(HeadlessConfig::default())
+    }
+
+    fn connect(handle: &HeadlessHandle) -> TestClient {
+        TestClient::connect(&handle.socket_name).expect("client failed to connect")
+    }
+
+    /// Map a toplevel and let the compositor settle so it is mapped, placed and
+    /// registered with the foreign-toplevel protocols.
+    fn map_window(handle: &HeadlessHandle, client: &mut TestClient, title: &str, app_id: &str) {
+        client.create_toplevel_with_app_id(title, app_id, 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(200);
+    }
+
+    /// The `ext-foreign-toplevel-list-v1` identifier the portal would pass back
+    /// to `RecordWindow` for the window with this title.
+    fn identifier_of(handle: &HeadlessHandle, title: &str) -> String {
+        handle
+            .screencast_list_windows()
+            .into_iter()
+            .find(|w| w.title == title)
+            .unwrap_or_else(|| panic!("window {title:?} not listed as capturable"))
+            .id
+    }
+
+    fn output_scale(handle: &HeadlessHandle) -> f64 {
+        handle.query(|state| {
+            state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().fractional_scale())
+                .unwrap_or(1.0)
+        })
+    }
+
+    /// The window's geometry in logical pixels, straight from the space.
+    fn logical_geometry(handle: &HeadlessHandle, title: &str) -> (i32, i32) {
+        handle
+            .window_logical_size(title)
+            .unwrap_or_else(|| panic!("window {title:?} not mapped"))
+    }
+
+    // ── Source enumeration ───────────────────────────────────────────────
+
+    /// `ListOutputs` answers with the connector name a session records by, and
+    /// the mode that paces its stream.
+    #[test]
+    #[serial]
+    fn list_outputs_reports_the_headless_output() {
+        let handle = start();
+
+        let outputs = handle.screencast_list_outputs();
+        assert_eq!(outputs.len(), 1, "expected exactly one output");
+        let output = &outputs[0];
+        assert_eq!(output.connector, OUTPUT);
+        assert_eq!((output.width, output.height), (1920, 1080));
+        assert_eq!(output.refresh_rate, 60_000);
+
+        handle.stop();
+    }
+
+    /// Every mapped toplevel is capturable, named by an identifier that is
+    /// opaque, non-empty and unique — never a title or a surface id — and
+    /// carries the app_id and title the picker shows.
+    #[test]
+    #[serial]
+    fn list_windows_names_every_mapped_toplevel() {
+        let handle = start();
+        let mut client = connect(&handle);
+
+        map_window(&handle, &mut client, "First", "org.otto.First");
+        map_window(&handle, &mut client, "Second", "org.otto.Second");
+
+        let windows = handle.screencast_list_windows();
+        assert_eq!(windows.len(), 2, "both toplevels should be capturable");
+
+        let first = windows.iter().find(|w| w.title == "First").unwrap();
+        let second = windows.iter().find(|w| w.title == "Second").unwrap();
+        assert_eq!(first.app_id, "org.otto.First");
+        assert_eq!(second.app_id, "org.otto.Second");
+        assert!(!first.id.is_empty(), "identifier must not be empty");
+        assert_ne!(first.id, second.id, "identifiers must be unique per window");
+        assert_ne!(first.id, first.title, "identifier is not the title");
+
+        // Sizes are reported in physical pixels — logical geometry × the
+        // output's scale, not the logical size itself.
+        let scale = output_scale(&handle);
+        let (logical_w, logical_h) = logical_geometry(&handle, "First");
+        assert_eq!(first.width, ((logical_w as f64) * scale).round() as u32);
+        assert_eq!(first.height, ((logical_h as f64) * scale).round() as u32);
+
+        handle.stop();
+    }
+
+    /// A window whose client disconnected is no longer offered, and the
+    /// identifier the picker handed out for it stops resolving — the portal may
+    /// still be holding it when the user finally answers the dialog.
+    #[test]
+    #[serial]
+    fn list_windows_forgets_a_window_whose_client_went_away() {
+        let handle = start();
+        let mut keeper = connect(&handle);
+        let mut leaver = connect(&handle);
+
+        map_window(&handle, &mut keeper, "Keeper", "org.otto.Keeper");
+        map_window(&handle, &mut leaver, "Leaver", "org.otto.Leaver");
+        let stale = identifier_of(&handle, "Leaver");
+
+        drop(leaver);
+        handle.wait(Duration::from_millis(200));
+        handle.settle(200);
+
+        let titles: Vec<String> = handle
+            .screencast_list_windows()
+            .into_iter()
+            .map(|w| w.title)
+            .collect();
+        assert_eq!(titles, vec!["Keeper".to_string()]);
+
+        handle.screencast_create_session(SESSION, 2);
+        let err = handle
+            .screencast_start_recording(SESSION, StreamTarget::Window(stale.clone()))
+            .expect_err("a closed window must not be recordable");
+        assert_eq!(err, format!("Window not found: {stale}"));
+
+        handle.stop();
+    }
+
+    // ── Recording rejections ─────────────────────────────────────────────
+
+    /// An identifier this compositor never issued fails outright, rather than
+    /// falling back to some other window.
+    #[test]
+    #[serial]
+    fn record_window_rejects_an_unknown_identifier() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Only", "org.otto.Only");
+        handle.screencast_create_session(SESSION, 2);
+
+        let err = handle
+            .screencast_start_recording(SESSION, StreamTarget::Window("not-a-window".into()))
+            .expect_err("unknown identifier must fail");
+        assert_eq!(err, "Window not found: not-a-window");
+        assert_eq!(handle.screencast_stream_keys(SESSION), Some(vec![]));
+
+        handle.stop();
+    }
+
+    /// Same for a connector that is not plugged in.
+    #[test]
+    #[serial]
+    fn record_monitor_rejects_an_unknown_connector() {
+        let handle = start();
+        handle.screencast_create_session(SESSION, 2);
+
+        let err = handle
+            .screencast_start_recording(SESSION, StreamTarget::Output("HDMI-A-9".into()))
+            .expect_err("unknown connector must fail");
+        assert_eq!(err, "Output not found: HDMI-A-9");
+
+        handle.stop();
+    }
+
+    /// A stream can only be opened inside a session the compositor knows about
+    /// — a resolvable target is not enough.
+    #[test]
+    #[serial]
+    fn record_rejects_an_unknown_session() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Only", "org.otto.Only");
+        let id = identifier_of(&handle, "Only");
+
+        let err = handle
+            .screencast_start_recording("/org/otto/ScreenCast/session/99", StreamTarget::Window(id))
+            .expect_err("unknown session must fail");
+        assert_eq!(err, "Session not found: /org/otto/ScreenCast/session/99");
+
+        handle.stop();
+    }
+
+    /// The same source cannot be opened twice in one session.
+    #[test]
+    #[serial]
+    fn record_rejects_a_source_already_being_recorded() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Shared", "org.otto.Shared");
+        let id = identifier_of(&handle, "Shared");
+
+        handle.screencast_create_session(SESSION, 2);
+        handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id.clone()))
+            .expect("window stream should attach");
+
+        let err = handle
+            .screencast_start_recording(SESSION, StreamTarget::Window(id.clone()))
+            .expect_err("recording the same window twice must fail");
+        assert_eq!(err, format!("Already recording: window:{id}"));
+
+        handle.stop();
+    }
+
+    // ── Stream sizing and bookkeeping ────────────────────────────────────
+
+    /// A window stream is fixed at the window's physical size, rounded down to
+    /// even — odd dimensions are rejected by PipeWire consumers downstream.
+    #[test]
+    #[serial]
+    fn window_capture_size_is_even_and_in_physical_pixels() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Sized", "org.otto.Sized");
+        let id = identifier_of(&handle, "Sized");
+
+        let scale = output_scale(&handle);
+        let (logical_w, logical_h) = logical_geometry(&handle, "Sized");
+        let (width, height, refresh) = handle
+            .screencast_window_capture_size(&id)
+            .expect("window should be sizable");
+
+        assert_eq!(width % 2, 0, "width must be even");
+        assert_eq!(height % 2, 0, "height must be even");
+        assert_eq!(width, ((logical_w as f64) * scale).round() as u32 & !1);
+        assert_eq!(height, ((logical_h as f64) * scale).round() as u32 & !1);
+        assert_eq!(
+            refresh, 60_000,
+            "the stream is paced by the output hosting the window"
+        );
+
+        handle.stop();
+    }
+
+    /// An output stream and a window stream live in the same session under
+    /// namespaced keys, so a window can never be mistaken for a connector.
+    #[test]
+    #[serial]
+    fn a_session_holds_an_output_and_a_window_stream_at_once() {
+        let handle = start();
+        let mut client = connect(&handle);
+        map_window(&handle, &mut client, "Shared", "org.otto.Shared");
+        let id = identifier_of(&handle, "Shared");
+
+        handle.screencast_create_session(SESSION, 2);
+        let (window_w, window_h) = handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id.clone()))
+            .expect("window stream should attach");
+        let (output_w, output_h) = handle
+            .screencast_attach_stream(SESSION, StreamTarget::Output(OUTPUT.into()))
+            .expect("output stream should attach");
+
+        assert_eq!((output_w, output_h), (1920, 1080));
+        assert!(
+            window_w < output_w && window_h < output_h,
+            "a window stream is sized to the window ({window_w}x{window_h}), not the output"
+        );
+        assert_eq!(
+            handle.screencast_stream_keys(SESSION),
+            Some(vec![format!("output:{OUTPUT}"), format!("window:{id}"),])
+        );
+
+        handle.stop();
+    }
+
+    // ── What a live capture changes ──────────────────────────────────────
+
+    /// A window being cast keeps receiving frame callbacks at full rate even
+    /// with another window on top of it — the remote viewer is looking at it
+    /// when the local user is not — but it is not reported as activated.
+    #[test]
+    #[serial]
+    fn a_cast_window_keeps_full_frame_rate_behind_another() {
+        let handle = start();
+        let mut client = connect(&handle);
+
+        map_window(&handle, &mut client, "Behind", "org.otto.Behind");
+        map_window(&handle, &mut client, "InFront", "org.otto.InFront");
+
+        // Before anything is cast, the window that is not on top is throttled.
+        let before = handle.window_throttle_states();
+        assert_eq!(before.get("InFront"), Some(&WindowThrottleState::Focused));
+        assert_eq!(before.get("Behind"), Some(&WindowThrottleState::Secondary));
+
+        let id = identifier_of(&handle, "Behind");
+        handle.screencast_create_session(SESSION, 2);
+        handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id))
+            .expect("window stream should attach");
+
+        let during = handle.window_throttle_states();
+        let behind = during.get("Behind").copied().expect("Behind still mapped");
+        assert_eq!(behind, WindowThrottleState::Captured);
+        assert_eq!(
+            behind.throttle(),
+            Duration::ZERO,
+            "a cast window must not be frame-throttled"
+        );
+        assert!(
+            !behind.is_activated(),
+            "capture does not give the window keyboard focus"
+        );
+        assert_eq!(
+            during.get("InFront"),
+            Some(&WindowThrottleState::Focused),
+            "casting one window must not change the others"
+        );
+
+        handle.stop();
+    }
+
+    /// Destroying the session drops its streams, and the window it was casting
+    /// goes back to being throttled like any other background window.
+    #[test]
+    #[serial]
+    fn destroying_a_session_ends_its_capture() {
+        let handle = start();
+        let mut client = connect(&handle);
+
+        map_window(&handle, &mut client, "Behind", "org.otto.Behind");
+        map_window(&handle, &mut client, "InFront", "org.otto.InFront");
+        let id = identifier_of(&handle, "Behind");
+
+        handle.screencast_create_session(SESSION, 2);
+        handle
+            .screencast_attach_stream(SESSION, StreamTarget::Window(id.clone()))
+            .expect("window stream should attach");
+        assert_eq!(
+            handle.screencast_stream_keys(SESSION),
+            Some(vec![format!("window:{id}")])
+        );
+
+        handle.screencast_destroy_session(SESSION);
+
+        assert_eq!(
+            handle.screencast_stream_keys(SESSION),
+            None,
+            "the session should be gone"
+        );
+        assert_eq!(
+            handle.window_throttle_states().get("Behind"),
+            Some(&WindowThrottleState::Secondary),
+            "the window should be throttled again once nothing casts it"
+        );
+
+        handle.stop();
+    }
+}

--- a/tests/workspace_selector.rs
+++ b/tests/workspace_selector.rs
@@ -3,7 +3,9 @@
 #[cfg(feature = "headless")]
 mod workspace_selector_tests {
     use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
     use serial_test::serial;
+    use std::time::Duration;
 
     fn find<'a>(
         nodes: &'a [layers::engine::scene::SceneNodeSnapshot],
@@ -129,6 +131,146 @@ mod workspace_selector_tests {
             opacity < 0.1,
             "remove button should hide once the pointer leaves, got {opacity}"
         );
+
+        handle.stop();
+    }
+
+    // ── Preview layout ───────────────────────────────────────────────────
+
+    fn map_window(handle: &HeadlessHandle, client: &mut TestClient, title: &str) {
+        client.create_toplevel_with_app_id(title, &format!("org.otto.{title}"), 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(300);
+    }
+
+    /// The expose previews, as `(title, x, y, w, h)`, sorted by title so the
+    /// assertions do not depend on layout order.
+    fn previews(handle: &HeadlessHandle) -> Vec<(String, f32, f32, f32, f32)> {
+        let mut rects = handle.expose_window_rects();
+        rects.sort_by(|a, b| a.0.cmp(&b.0));
+        rects
+    }
+
+    fn preview_titles(handle: &HeadlessHandle) -> Vec<String> {
+        previews(handle).into_iter().map(|r| r.0).collect()
+    }
+
+    fn overlap(a: &(String, f32, f32, f32, f32), b: &(String, f32, f32, f32, f32)) -> bool {
+        a.1 < b.1 + b.3 && b.1 < a.1 + a.3 && a.2 < b.2 + b.4 && b.2 < a.2 + a.4
+    }
+
+    /// Opening a window while the selector is up re-lays out the previews
+    /// there and then — the new window gets a preview, the existing one makes
+    /// room — and closing it puts the layout back.
+    #[test]
+    #[serial]
+    fn the_preview_layout_follows_windows_opening_and_closing() {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut first = TestClient::connect(&handle.socket_name).expect("client");
+        let mut second = TestClient::connect(&handle.socket_name).expect("client");
+
+        map_window(&handle, &mut first, "First");
+        let before_expose = handle
+            .window_logical_geometry("First")
+            .expect("window mapped");
+
+        handle.toggle_expose();
+        handle.settle(400);
+        let alone = previews(&handle);
+        assert_eq!(preview_titles(&handle), vec!["First".to_string()]);
+        assert_eq!(
+            handle.workspace_preview_window_counts().first(),
+            Some(&(1, 1))
+        );
+
+        // A window opening while expose is up must join the grid, not wait for
+        // the next time expose is opened.
+        map_window(&handle, &mut second, "Second");
+        handle.settle(400);
+        let together = previews(&handle);
+        assert_eq!(
+            preview_titles(&handle),
+            vec!["First".to_string(), "Second".to_string()]
+        );
+        assert_ne!(
+            together[0], alone[0],
+            "the existing preview should have been re-laid out to make room"
+        );
+        assert!(
+            !overlap(&together[0], &together[1]),
+            "previews must not overlap: {together:?}"
+        );
+        assert_eq!(
+            handle.workspace_preview_window_counts().first(),
+            Some(&(1, 2))
+        );
+
+        // And closing one gives the space back.
+        drop(second);
+        handle.wait(Duration::from_millis(200));
+        handle.settle(400);
+        assert_eq!(preview_titles(&handle), vec!["First".to_string()]);
+        assert_eq!(
+            previews(&handle),
+            alone,
+            "the last preview should be back to the layout it had on its own"
+        );
+        assert_eq!(
+            handle.workspace_preview_window_counts().first(),
+            Some(&(1, 1))
+        );
+
+        // Closing the selector leaves the real window untouched.
+        handle.toggle_expose();
+        handle.settle(400);
+        assert!(!handle.is_expose_active());
+        assert_eq!(handle.window_logical_geometry("First"), Some(before_expose));
+
+        handle.stop();
+    }
+
+    /// Moving a window to another workspace updates both previews — the one it
+    /// left and the one it landed on — while the selector is open.
+    #[test]
+    #[serial]
+    fn moving_a_window_between_workspaces_updates_both_previews() {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut client = TestClient::connect(&handle.socket_name).expect("client");
+        map_window(&handle, &mut client, "Wanderer");
+        handle.with_state(|state| {
+            state.workspaces.add_workspace_to_output("headless");
+        });
+        handle.settle(300);
+
+        handle.toggle_expose();
+        handle.settle(400);
+        // Expose keeps a spare empty workspace at the end, so there may be
+        // more than the two that exist here.
+        let counts = handle.workspace_preview_window_counts();
+        assert!(counts.len() >= 2, "expected two workspaces: {counts:?}");
+        assert_eq!(counts[0].1, 1, "the window starts on the first workspace");
+        assert_eq!(counts[1].1, 0);
+
+        handle.move_window_to_workspace("Wanderer", 1);
+        handle.settle(500);
+
+        let counts = handle.workspace_preview_window_counts();
+        assert_eq!(
+            (counts[0].1, counts[1].1),
+            (0, 1),
+            "both previews should have followed the move: {counts:?}"
+        );
+        assert!(
+            preview_titles(&handle).is_empty(),
+            "the workspace it left has nothing to preview"
+        );
+
+        // Following it to the other workspace, expose lays it out there.
+        handle.set_workspace(1);
+        handle.settle(500);
+        assert_eq!(preview_titles(&handle), vec!["Wanderer".to_string()]);
+        assert_eq!(handle.window_stack_titles(), vec!["Wanderer".to_string()]);
 
         handle.stop();
     }


### PR DESCRIPTION
Headless end-to-end tests for the areas the recent merged PRs touched — screen sharing (#121, #123, #125), the RDP bridge (#112) — plus the workspace selector and app switcher. Writing them turned up one real bug and one gap; both are described below.

## What's covered

**`tests/screenshare.rs` (12 tests, 1 ignored)** — the screencast control plane. The D-Bus service needs a session bus and a stream needs a PipeWire daemon and a GPU, so those stay manual; everything between them runs against a real compositor with real Wayland clients:

- `ListOutputs` / `ListWindows`: every mapped toplevel is capturable by its `ext-foreign-toplevel-list-v1` identifier, sizes reported in physical pixels, a window whose client disconnected stops being offered and stops resolving
- `RecordMonitor` / `RecordWindow` rejections: unknown identifier, unknown connector, unknown session, already recording
- window stream sizing: physical geometry rounded down to even, paced by the hosting output
- a cast window is `Captured` by the frame-callback throttler (zero throttle, not `activated`) while another window covers it and across a workspace switch, and goes back to `Secondary` when the session is destroyed

**`tests/rdp_bridge.rs` (5 tests)** — the compositor-side contract `otto-rdp` runs on. The test binds the same globals the bridge binds, in the same versions, and drives the same requests: the four globals exist (virtual-pointer **v2** for `create_virtual_pointer_with_output`, xdg-output v3), `xdg-output` reports logical geometry, absolute motion lands where the remote client's coordinates say, a remote click focuses the window under it, and a remote keystroke reaches the focused application with the right evdev code.

**`cargo test -p otto-rdp` (13 new tests)** — the bridge's own decisions, where an RDP client isn't needed: served layout (client box verbatim, aspect-fit, never upscale, even rounding on the EGFX path while `input_box` keeps the odd size), mouse mapping back through the letterbox, AVC-vs-bitmap selection from advertised capability sets, and the RDP→evdev scancode table. `served_layout` was extracted out of `request_initial_size` to make it reachable.

**`tests/workspace_selector.rs` (2 new)** — the preview layout: opening a window while the selector is up re-lays out the grid and closing it restores the previous layout; moving a window between workspaces updates the previews on both.

**`tests/app_switcher.rs` (5 tests)** — clicking a window raises it and damages the scene; one alt-tab step lands on the previously used app and committing raises its window; the switcher lists apps front to back, with apps on other workspaces behind the current one.

## Fix included

`move_window_to_workspace_on_output_with_activate` updated the spaces, the scene views and both exposé grids, but never rebuilt the workspace model. Everything derived from it stayed stale until an unrelated window happened to map or close: selector previews kept the old window counts, and the app switcher kept ordering the moved app as if it were still on the current workspace. One `update_workspace_model()` call at the end of the move fixes previews, switcher and dock list together. Verified by reverting it — the two workspace-move tests fail without it.

## Known gap, not fixed

`a_minimized_window_stays_capturable` is `#[ignore]`d. `specs/screenshare.md` says a cast window keeps full frame rate "even when occluded, on an inactive workspace, or minimized", but minimizing unmaps the window from every space, and both `ListWindows` and `window_for_identifier` walk `spaces_elements()` — so a minimized window disappears from the picker and its stream stops resolving. Left as a documented failing case rather than a drive-by behaviour change.

## CI

Three test targets were never running: `workspace_selector`, `otto-rdp` (bin-only crates are skipped by `cargo test --lib --workspace`, so its 3 existing tests were dormant) and `xdg-desktop-portal-otto`'s integration targets — one of which was **failing**: it asserted `validate_cursor_mode(METADATA)` succeeds, but `METADATA` was dropped from `AvailableCursorModes`. The test is fixed to match the spec and all of these now run in CI.

## Harness additions

`HeadlessHandle` gains `screencast_*` helpers (which post the same `CompositorCommand`s the D-Bus thread posts), window/stacking queries, and `app_switcher_*` helpers that go through the real `dismiss_app_switcher` path. `otto-kit`'s `TestClient` gains an app_id variant and keyboard-event capture. `screencast_attach_stream` is the one piece of scaffolding: it records a target with the PipeWire connection left out, so throttling and teardown are testable without a daemon.

## Docs

Testing sections added to `docs/developer/screenshare.md`, `docs/developer/rdp-virtual-output.md` and `docs/developer/expose.md`; `specs/workspaces-multi-output.md` gains a "Moving a window between workspaces" block and the app switcher's ordering rules, which weren't written down. Fixed the stale "There is no integration/e2e suite" line in CLAUDE.md.

## Verification

`cargo fmt --all --check` clean, clippy clean (no new warnings), and every suite green: headless_basic 24, workspace_selector 4, app_switcher 5, screenshare 12 (+1 ignored), rdp_bridge 5, otto-rdp 18, portal 15, lib 289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AVfpoNAEuKYq8vLkqD5zy

---
_Generated by [Claude Code](https://claude.ai/code/session_012AVfpoNAEuKYq8vLkqD5zy)_