### PR TITLE
fix(packaging): keep user config across Arch upgrades

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,6 +13,10 @@ depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbu
 optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
 source=("https://github.com/nongio/otto/releases/download/v$pkgver/otto-$pkgver-x86_64.tar.gz")
 sha256sums=("SKIP")
+# Files pacman must never clobber: a modified config becomes .pacnew on
+# upgrade and .pacsave on removal, instead of being silently overwritten or
+# deleted when swapping between the otto-bin/otto-git/otto-nightly-bin variants.
+backup=("etc/otto/config.toml" "etc/pam.d/otto-lock")
 
 package() {
     cd "$srcdir/otto-$pkgver"


### PR DESCRIPTION
The release `PKGBUILD` never declared a `backup=` array, so pacman treated `/etc/otto/config.toml` as an ordinary owned file — overwritten on upgrade, and **deleted outright on removal**, leaving no `.pacnew` and no `.pacsave`.

Swapping `otto-bin` for `otto-nightly-bin` therefore discarded the admin's config silently. Observed on a real machine: pacman removed `otto-bin`, deleted the customised config, and installed the stock example one second later.

`PKGBUILD-git` and `PKGBUILD-nightly-bin` already declared it; this brings the release package in line.

### Why not just stop shipping the file

Considered and rejected. `default_shortcut_map()` (`src/config/shortcuts.rs:372`) returns an empty `ShortcutMap`, so the shipped `/etc/otto/config.toml` is what defines *every* default keyboard binding. Dropping it would leave a fresh install with no app switcher, no volume keys, and no `Ctrl+Esc` — a compositor with no way to quit.

### Verification

- `makepkg --printsrcinfo` passes for all three PKGBUILDs
- srcinfo now reports `backup = etc/otto/config.toml` and `backup = etc/pam.d/otto-lock`
- deb (`cargo-deb` auto-conffiles) and rpm (`config = true`) already had equivalent protection