### PR TITLE
Islands: one island per notification, growing row that pushes its neighbours

### DIFF
--- a/components/otto-islands/src/activity.rs
+++ b/components/otto-islands/src/activity.rs
@@ -54,7 +54,7 @@ pub enum PresentationMode {
     Banner,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NotificationAction {
     pub id: String,
     pub label: String,

--- a/components/otto-islands/src/dialog.rs
+++ b/components/otto-islands/src/dialog.rs
@@ -15,7 +15,7 @@ use otto_kit::SubsurfaceSurface;
 use skia_safe::{Canvas, Color, Paint, RRect, Rect};
 use tokio::sync::oneshot;
 
-use crate::renderer::BUFFER_SCALE;
+use crate::renderer::buffer_scale;
 
 pub type DialogId = u64;
 
@@ -577,7 +577,7 @@ pub fn apply_dialog_style(surface: &SubsurfaceSurface) {
             c.b() as f64 / 255.0,
             c.a() as f64 / 255.0,
         );
-        ss.set_corner_radius(PANEL_RADIUS as f64 * BUFFER_SCALE);
+        ss.set_corner_radius(PANEL_RADIUS as f64 * buffer_scale());
         ss.set_masks_to_bounds(ClipMode::Enabled);
         ss.set_shadow(0.35, 24.0, 0.0, 8.0, 0.0, 0.0, 0.0);
         ss.set_blend_mode(BlendMode::BackgroundBlur);

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -104,6 +104,10 @@ struct Island {
     last_layout: (f32, f32, f32, f32),
     /// Last drawn pill content — skip redraw when unchanged.
     last_content: Option<PillContent>,
+    /// "+N more" indicator shown below the stack when there are more
+    /// notifications than fit in the visible card list. Lazily created,
+    /// like cards.
+    more_indicator: Option<(SubsurfaceSurface, usize)>,
 }
 
 struct CardSurface {
@@ -277,6 +281,9 @@ impl IslandApp {
                 for card in island.cards.drain(..) {
                     self.defer_destroy(card.surface);
                 }
+                if let Some((surface, _)) = island.more_indicator.take() {
+                    self.defer_destroy(surface);
+                }
                 self.defer_destroy(island.surface);
                 removed_island = true;
             }
@@ -300,6 +307,7 @@ impl IslandApp {
                         peek_until: None,
                         last_layout: (0.0, 0.0, 0.0, 0.0),
                         last_content: None,
+                        more_indicator: None,
                     });
                     // Auto-focus only if no island is currently Expanded.
                     let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
@@ -356,6 +364,17 @@ impl IslandApp {
                 &card.surface,
                 renderer::CARD_W,
                 renderer::CARD_H,
+                pill_cx,
+                pill_cy,
+                0.0,
+                0.0,
+            );
+        }
+        if let Some((surface, _)) = &island.more_indicator {
+            renderer::animate_position_opacity(
+                surface,
+                renderer::CARD_W,
+                renderer::MORE_INDICATOR_H,
                 pill_cx,
                 pill_cy,
                 0.0,
@@ -634,7 +653,7 @@ impl IslandApp {
             let card_cx = pill_left_x + pill_w / 2.0;
             // Pill bottom edge in top-left coords.
             let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
-            let max_cards = 5;
+            let max_cards = renderer::MAX_VISIBLE_CARDS;
 
             for (i, notif) in notifs.iter().take(max_cards).enumerate() {
                 // Card center y.
@@ -753,6 +772,58 @@ impl IslandApp {
                     .position(|&id| id == c.activity_id)
                     .unwrap_or(usize::MAX)
             });
+
+            // "+N more" indicator below the visible cards, when the stack
+            // holds more notifications than fit (spec: MAX_VISIBLE_CARDS).
+            let hidden_count = notifs.len().saturating_sub(max_cards);
+            if hidden_count > 0 {
+                let more_h = renderer::MORE_INDICATOR_H;
+                let more_top = pill_bottom + card_gap + (max_cards as f32) * (card_h + card_gap);
+                let more_cy = more_top + more_h / 2.0;
+                let start_cy = pill_bottom + more_h / 2.0;
+
+                if island.more_indicator.as_ref().map(|(_, n)| *n) != Some(hidden_count) {
+                    if island.more_indicator.is_none() {
+                        if let Some(ref wl) = wl {
+                            if let Ok(surface) = SubsurfaceSurface::new(
+                                wl,
+                                0,
+                                0,
+                                renderer::SLOT_BUF_W,
+                                renderer::SLOT_BUF_H,
+                            ) {
+                                renderer::apply_card_style(&surface);
+                                surface.place_above(island.surface.wl_surface());
+                                if let Some(ss) = surface.base_surface().surface_style() {
+                                    ss.set_opacity(0.0);
+                                }
+                                set_size_and_position(&surface, card_w, more_h, card_cx, start_cy);
+                                card_created = true;
+                                island.more_indicator = Some((surface, 0));
+                            }
+                        }
+                    }
+                    if let Some((surface, n)) = &mut island.more_indicator {
+                        draw_centered(surface, card_w, more_h, |canvas| {
+                            renderer::draw_more_indicator(canvas, hidden_count, card_w, more_h);
+                        });
+                        *n = hidden_count;
+                    }
+                }
+                if let Some((surface, _)) = &island.more_indicator {
+                    renderer::animate_position_opacity_slow(
+                        surface,
+                        card_w,
+                        more_h,
+                        card_cx,
+                        more_cy,
+                        1.0,
+                        max_cards as f64 * 0.05,
+                    );
+                }
+            } else if let Some((surface, _)) = island.more_indicator.take() {
+                dismissed_card_surfaces.push(surface);
+            }
         }
         for s in dismissed_card_surfaces {
             self.defer_destroy(s);
@@ -781,10 +852,16 @@ impl IslandApp {
                 let card_count = island.cards.len().min(5) as f32;
                 let pill_h = COMPACT_H;
                 let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
+                let more_h = if island.more_indicator.is_some() {
+                    renderer::CARD_GAP + renderer::MORE_INDICATOR_H
+                } else {
+                    0.0
+                };
                 let stack_h = pill_bottom
                     + renderer::CARD_GAP
                     + card_count * renderer::CARD_H
-                    + (card_count - 1.0).max(0.0) * renderer::CARD_GAP;
+                    + (card_count - 1.0).max(0.0) * renderer::CARD_GAP
+                    + more_h;
                 max_h = max_h.max(stack_h + 4.0);
             }
         }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -277,18 +277,22 @@ impl IslandApp {
             }
         }
 
-        // Assign modes: focused → Compact (or stays Expanded), peeking stays
-        // Compact until it expires, everything else → Mini.
+        // Exactly one island may be Compact at a time. The pointer wins it,
+        // then whatever was last clicked, then the newest still-peeking
+        // arrival — so a burst of notifications doesn't blow the row up into
+        // a wall of pills.
+        let compact_id = self.hovered_island.or(self.focused_island).or_else(|| {
+            self.islands
+                .iter()
+                .filter(|i| i.peek_until.is_some())
+                .max_by_key(|i| i.created_at)
+                .map(|i| i.activity_id)
+        });
+
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
                 // Only user interaction (click / focus loss) closes it.
-            } else if Some(island.activity_id) == self.focused_island
-                || Some(island.activity_id) == self.hovered_island
-            {
-                // Hovering a mini bubble grows it to the peek size, so you can
-                // read what it is before deciding to open it.
-                island.mode = IslandMode::Compact;
-            } else if island.peek_until.is_some() {
+            } else if Some(island.activity_id) == compact_id {
                 island.mode = IslandMode::Compact;
             } else {
                 island.mode = IslandMode::Mini;
@@ -310,22 +314,22 @@ impl IslandApp {
     /// stands rather than pulling it to the front, so the deck never
     /// reshuffles under the pointer.
     fn group_order(&self) -> Vec<Vec<usize>> {
-        let mut groups: Vec<(std::time::Instant, String, Vec<usize>)> = Vec::new();
+        // `self.islands` is already in arrival order, so nothing is sorted
+        // here: groups appear in the order their first notification did, and
+        // members in the order they arrived. Reversing a group's members just
+        // expresses the same row front-to-back, since the newest bubble is the
+        // rightmost one and sits on top.
+        let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
         for (idx, island) in self.islands.iter().enumerate() {
-            match groups.iter_mut().find(|(_, app, _)| *app == island.app_id) {
-                Some((oldest, _, members)) => {
-                    *oldest = (*oldest).min(island.created_at);
-                    members.push(idx);
-                }
-                None => groups.push((island.created_at, island.app_id.clone(), vec![idx])),
+            match groups.iter_mut().find(|(app, _)| *app == island.app_id) {
+                Some((_, members)) => members.push(idx),
+                None => groups.push((island.app_id.clone(), vec![idx])),
             }
         }
-        groups.sort_by_key(|(oldest, _, _)| *oldest);
-
         groups
             .into_iter()
-            .map(|(_, _, mut members)| {
-                members.sort_by_key(|&i| std::cmp::Reverse(self.islands[i].created_at));
+            .map(|(_, mut members)| {
+                members.reverse();
                 members
             })
             .collect()

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -40,6 +40,9 @@ const DIALOG_TOP: f32 = BAR_HEIGHT + 14.0;
 const FOCUS_TIMEOUT_SECS: f64 = 4.0;
 /// Seconds a destroyed surface is kept alive so its exit animation can play.
 const DESTROY_DELAY_SECS: f64 = 0.8;
+/// Per-island delay added as the push travels outward from whichever island
+/// grew, so the row ripples instead of moving in lockstep.
+const CASCADE_STAGGER_SECS: f64 = 0.035;
 /// Expanded-card metrics shared between drawing and hit-testing.
 const CARD_PAD: f32 = 10.0;
 const CARD_ICON: f32 = 24.0;
@@ -129,6 +132,9 @@ struct IslandApp {
     last_stack_order: Option<Vec<u64>>,
     /// Width the last layout pass centered the island row within.
     last_content_width: f32,
+    /// The island the last push radiated from — kept so the row cascades back
+    /// in the same order when that island shrinks again.
+    last_active_island: Option<u64>,
     /// Surfaces pending destruction (kept alive for animations, destroyed next cycle).
     pending_destroy: Vec<(SubsurfaceSurface, std::time::Instant)>,
     /// Last time the user interacted (pointer event). Used for focus timeout.
@@ -153,6 +159,7 @@ impl IslandApp {
             hovered_app: None,
             last_stack_order: None,
             last_content_width: LAYER_W as f32,
+            last_active_island: None,
             pending_destroy: Vec::new(),
             last_interaction: std::time::Instant::now(),
             last_layer_size: None,
@@ -448,9 +455,35 @@ impl IslandApp {
             group_x += group_widths[gi] + GAP;
         }
 
+        // The push travels along the row rather than hitting every bubble at
+        // once: whichever island is currently grown is the source, and each
+        // island further from it starts a little later. When nothing is grown
+        // the source is whatever was grown last, so the row cascades back too.
+        let mut row: Vec<usize> = targets.iter().map(|(idx, ..)| *idx).collect();
+        row.sort_by(|&a, &b| {
+            let (ax, bx) = (self.islands[a].last_layout.2, self.islands[b].last_layout.2);
+            ax.partial_cmp(&bx).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let active = self
+            .islands
+            .iter()
+            .find(|i| i.mode == IslandMode::Expanded)
+            .or_else(|| self.islands.iter().find(|i| i.mode == IslandMode::Compact))
+            .map(|i| i.activity_id)
+            .or(self.last_active_island);
+        self.last_active_island = active;
+        let source_pos = active
+            .and_then(|id| row.iter().position(|&i| self.islands[i].activity_id == id))
+            .unwrap_or(0);
+
         // Redraw buffers whose content changed, then animate to the new layout.
         let layout_delay = if reposition_delay { 0.4 } else { 0.0 };
         for (idx, w, h, cx, cy) in targets {
+            let cascade = row
+                .iter()
+                .position(|&i| i == idx)
+                .map(|p| p.abs_diff(source_pos) as f64 * CASCADE_STAGGER_SECS)
+                .unwrap_or(0.0);
             let activity = notifications
                 .iter()
                 .find(|a| a.id == self.islands[idx].activity_id)
@@ -503,7 +536,7 @@ impl IslandApp {
                     cx,
                     cy,
                     radius,
-                    layout_delay,
+                    layout_delay + cascade,
                 );
                 self.islands[idx].last_layout = target;
             }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -75,6 +75,7 @@ struct CardContent {
     body: String,
     icon: String,
     time_label: String,
+    actions: Vec<crate::activity::NotificationAction>,
 }
 
 /// An island represents one group (notification app_id or music).
@@ -110,6 +111,9 @@ struct CardSurface {
     activity_id: u64,
     /// Last drawn card content — skip redraw when unchanged.
     last_content: Option<CardContent>,
+    /// Inline actions for this notification, cached for hit-testing without
+    /// locking state (kept in sync with the activity every layout pass).
+    actions: Vec<crate::activity::NotificationAction>,
 }
 
 /// A presented Access-style dialog panel (one subsurface, drawn as a whole).
@@ -648,6 +652,7 @@ impl IslandApp {
                         notif.icon.clone()
                     },
                     time_label: renderer::elapsed_label(notif.created_at),
+                    actions: notif.actions.clone(),
                 };
                 let existing = island.cards.iter().position(|c| c.activity_id == notif.id);
                 let is_new = existing.is_none();
@@ -679,10 +684,13 @@ impl IslandApp {
                         surface,
                         activity_id: notif.id,
                         last_content: Some(content.clone()),
+                        actions: notif.actions.clone(),
                     });
                     card_created = true;
                     island.cards.len() - 1
                 };
+
+                island.cards[cidx].actions = notif.actions.clone();
 
                 // Redraw only when the card's content actually changed.
                 if island.cards[cidx].last_content.as_ref() != Some(&content) {
@@ -904,9 +912,10 @@ impl IslandApp {
     // Hit testing
     // -----------------------------------------------------------------------
 
-    /// Returns (app_id, Option<activity_id>) for what's at (px, py).
-    /// activity_id is Some when a card is hit.
-    fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>)> {
+    /// Returns (app_id, Option<activity_id>, Option<action_id>) for what's at
+    /// (px, py). activity_id is Some when a card is hit; action_id is Some
+    /// when the hit landed on one of the card's inline action buttons.
+    fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>, Option<String>)> {
         for island in &self.islands {
             let (w, _h, cx, _cy) = island.last_layout;
             let pill_h = match island.mode {
@@ -934,14 +943,34 @@ impl IslandApp {
                         && py >= card_y
                         && py <= card_y + card_h
                     {
-                        return Some((island.app_id.clone(), Some(card.activity_id)));
+                        let action_id = if card.actions.is_empty() {
+                            None
+                        } else {
+                            let pad = 10.0;
+                            let icon_size = 24.0;
+                            let close_zone = 40.0;
+                            let text_x = pad + icon_size + 8.0;
+                            let max_w = card_w - text_x - close_zone;
+                            let local_x = px - card_x;
+                            let local_y = py - card_y;
+                            renderer::action_button_rects(&card.actions, text_x, max_w)
+                                .into_iter()
+                                .find(|(bx, by, bw, bh, _, _)| {
+                                    local_x >= *bx
+                                        && local_x <= *bx + *bw
+                                        && local_y >= *by
+                                        && local_y <= *by + *bh
+                                })
+                                .map(|(_, _, _, _, id, _)| id)
+                        };
+                        return Some((island.app_id.clone(), Some(card.activity_id), action_id));
                     }
                 }
             }
 
             // Hit test pill/circle.
             if px >= x && px <= x + pill_w && py >= y && py <= y + pill_h {
-                return Some((island.app_id.clone(), None));
+                return Some((island.app_id.clone(), None, None));
             }
         }
 
@@ -957,26 +986,29 @@ impl IslandApp {
         if self.handle_dialog_click(px, py) {
             return;
         }
-        let Some((app_id, card_id)) = self.hit_test(px, py) else {
+        let Some((app_id, card_id, action_id)) = self.hit_test(px, py) else {
             return;
         };
 
         if let Some(activity_id) = card_id {
             // Determine if the click is in the close zone (right 40px of card).
+            // An inline action button always wins over the close zone — the
+            // buttons live in the body row, well clear of it.
             let close_zone = 40.0_f32;
-            let is_close = self
-                .islands
-                .iter()
-                .find(|i| i.app_id == app_id)
-                .map(|island| {
-                    let pill_w = island.last_layout.0;
-                    let pill_cx = island.last_layout.2;
-                    let card_w = renderer::CARD_W;
-                    let pill_x = pill_cx - pill_w / 2.0;
-                    let card_x = pill_x + (pill_w - card_w) / 2.0;
-                    px - card_x > card_w - close_zone
-                })
-                .unwrap_or(false);
+            let is_close = action_id.is_none()
+                && self
+                    .islands
+                    .iter()
+                    .find(|i| i.app_id == app_id)
+                    .map(|island| {
+                        let pill_w = island.last_layout.0;
+                        let pill_cx = island.last_layout.2;
+                        let card_w = renderer::CARD_W;
+                        let pill_x = pill_cx - pill_w / 2.0;
+                        let card_x = pill_x + (pill_w - card_w) / 2.0;
+                        px - card_x > card_w - close_zone
+                    })
+                    .unwrap_or(false);
 
             // Clicked a card — animate dismiss (scale up + fade out), then remove.
             if let Some(island) = self.islands.iter().find(|i| i.app_id == app_id) {
@@ -1010,11 +1042,15 @@ impl IslandApp {
             drop(state);
 
             if !is_close {
-                // Action click — focus the app and emit ActionInvoked.
+                // Action click — focus the app and emit ActionInvoked. A hit on
+                // a specific inline action button reports that action's id;
+                // otherwise (click on the card body) it's the default action.
                 request_focus_app(app_id.clone());
 
                 if let Some(nid) = notification_id {
-                    let action_key = default_action.as_deref().unwrap_or("default").to_string();
+                    let action_key = action_id
+                        .or(default_action)
+                        .unwrap_or_else(|| "default".to_string());
                     emit_action_invoked(nid, action_key);
                 }
             }
@@ -1430,7 +1466,7 @@ impl App for IslandApp {
                 PointerEventKind::Enter { .. } | PointerEventKind::Motion { .. } => {
                     let (px, py) = event.position;
                     let hit = self.hit_test(px as f32, py as f32);
-                    let new_hovered = hit.as_ref().map(|(app_id, _)| app_id.clone());
+                    let new_hovered = hit.as_ref().map(|(app_id, _, _)| app_id.clone());
                     if new_hovered != self.hovered_app {
                         let old = &self.hovered_app;
                         // Relayout when a Mini or Compact island gains/loses hover (for grow effect).

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -423,22 +423,13 @@ impl IslandApp {
         let total_w: f32 =
             group_widths.iter().sum::<f32>() + (group_widths.len().saturating_sub(1)) as f32 * GAP;
 
-        // The row is centred on its *resting* width — every bubble mini, every
-        // deck at peek spacing — not on its current one. That pins the left
-        // edge, so growing an island pushes the islands to its right along
-        // instead of sliding the whole row back into centre under the pointer.
-        let resting_w: f32 = groups
-            .iter()
-            .map(|members| {
-                let depth = members.len().min(renderer::MAX_STACK);
-                (depth - 1) as f32 * renderer::PEEK_STEP + MINI_H
-            })
-            .sum::<f32>()
-            + (groups.len().saturating_sub(1)) as f32 * GAP;
-
-        let base_layer_w = (resting_w + 40.0).max(LAYER_W as f32);
-        let mut group_x = ((base_layer_w - resting_w) / 2.0).max(0.0);
-        self.last_content_width = base_layer_w.max(group_x + total_w + 20.0);
+        // The row stays centred on its current width, so an island growing
+        // spreads in both directions: its neighbours to the left are pushed
+        // left and those to the right are pushed right, half the growth each
+        // way. The layer itself keeps a fixed generous width so the surface
+        // origin doesn't shift underneath and cancel the effect.
+        self.last_content_width = (total_w + 40.0).max(LAYER_W as f32);
+        let mut group_x = ((self.last_content_width - total_w) / 2.0).max(0.0);
 
         let mut targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
         for (gi, placed) in placements.iter().enumerate() {

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -977,17 +977,23 @@ impl App for IslandApp {
     }
 
     fn on_configure_layer(&mut self, _ctx: &AppContext, _w: i32, _h: i32, _serial: u32) {
-        if !self.surfaces_ready {
-            // Clear the parent surface.
-            if let Some(layer) = &self.layer_surface {
-                layer.draw(|canvas| {
-                    canvas.clear(skia_safe::Color::TRANSPARENT);
-                });
-            }
-            self.surfaces_ready = true;
-            // Set empty input region so clicks pass through until islands appear.
-            self.update_input_region(false);
+        // Redraw on *every* configure, not just the first. The parent surface is
+        // fully transparent, but its buffer is what bounds the input region: a
+        // region rect outside the attached buffer is clipped away by the
+        // compositor. Without a redraw after a grow, the layer keeps its initial
+        // buffer and clicks below the old height are never delivered — a tall
+        // dialog's lower rows and its buttons go dead.
+        if let Some(layer) = &self.layer_surface {
+            layer.draw(|canvas| {
+                canvas.clear(skia_safe::Color::TRANSPARENT);
+            });
         }
+        let first = !self.surfaces_ready;
+        self.surfaces_ready = true;
+        // On the first configure this sets an empty region so clicks pass
+        // through until islands appear; later ones re-commit the region now
+        // that the buffer is large enough to carry it.
+        self.update_input_region(!first);
     }
 
     fn on_update(&mut self, _ctx: &AppContext) {

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -38,14 +38,15 @@ const GAP: f32 = 6.0;
 const DIALOG_TOP: f32 = BAR_HEIGHT + 14.0;
 /// Seconds of inactivity before the focused island shrinks to Mini.
 const FOCUS_TIMEOUT_SECS: f64 = 4.0;
+/// Seconds a newly-arrived notification stays open, long enough to be read
+/// before it settles back into its app's stack.
+const ARRIVAL_READ_SECS: u64 = 6;
 /// Seconds a destroyed surface is kept alive so its exit animation can play.
 const DESTROY_DELAY_SECS: f64 = 0.8;
 /// Per-island delay added as the push travels outward from whichever island
 /// grew, so the row ripples instead of moving in lockstep.
 const CASCADE_STAGGER_SECS: f64 = 0.035;
-/// Expanded-card metrics shared between drawing and hit-testing.
-const CARD_PAD: f32 = 10.0;
-const CARD_ICON: f32 = 24.0;
+/// Width of the card's right-hand Close zone, used to hit-test a close click.
 const CARD_CLOSE_ZONE: f32 = 40.0;
 
 // ---------------------------------------------------------------------------
@@ -87,14 +88,22 @@ struct Island {
     mode: IslandMode,
     /// When this notification arrived (newest sits at the front of its stack).
     created_at: std::time::Instant,
-    /// When set, the island temporarily shows as Compact until this instant.
+    /// When set, this is a fresh arrival announcing itself until this instant:
+    /// it opens Expanded so it can be read, then settles into its stack.
     peek_until: Option<std::time::Instant>,
+    /// Whether the user opened this island themselves. Only a user-opened
+    /// island stays Expanded indefinitely; one that opened on arrival closes
+    /// again when its window runs out.
+    opened_by_user: bool,
     /// Last layout target (w, h, x, y) — skip animation when unchanged.
     last_layout: (f32, f32, f32, f32),
     /// Last drawn content — skip redraw when unchanged.
     last_content: Option<IslandContent>,
     /// Inline actions, cached for hit-testing without locking state.
     actions: Vec<crate::activity::NotificationAction>,
+    /// Body text, cached alongside the actions: the action row sits under the
+    /// wrapped body, so hit-testing has to know how many lines it took.
+    body: String,
 }
 
 /// A presented Access-style dialog panel (one subsurface, drawn as a whole).
@@ -259,12 +268,16 @@ impl IslandApp {
                 surface,
                 mode: IslandMode::Mini,
                 created_at: activity.created_at,
-                // A new notification announces itself as Compact for a few
+                // A new notification announces itself Expanded for a few
                 // seconds, then settles back into its app's stack.
-                peek_until: Some(std::time::Instant::now() + Duration::from_secs(3)),
+                peek_until: Some(
+                    std::time::Instant::now() + Duration::from_secs(ARRIVAL_READ_SECS),
+                ),
                 last_layout: (0.0, 0.0, 0.0, 0.0),
                 last_content: None,
                 actions: activity.actions.clone(),
+                body: activity.body.clone(),
+                opened_by_user: false,
             });
             self.last_interaction = std::time::Instant::now();
         }
@@ -274,6 +287,7 @@ impl IslandApp {
             if let Some(a) = notifications.iter().find(|a| a.id == island.activity_id) {
                 island.actions = a.actions.clone();
                 island.icon = a.icon.clone();
+                island.body = a.body.clone();
             }
         }
 
@@ -284,22 +298,37 @@ impl IslandApp {
             }
         }
 
+        // The newest still-announcing arrival, which opens Expanded so it can
+        // be read on sight.
+        let arriving = self
+            .islands
+            .iter()
+            .filter(|i| i.peek_until.is_some())
+            .max_by_key(|i| i.created_at)
+            .map(|i| i.activity_id);
+
+        // An island the user opened themselves is never taken over: a new
+        // arrival must not yank away whatever is being read right now, so it
+        // announces itself Compact instead.
+        let user_expanded = self
+            .islands
+            .iter()
+            .any(|i| i.mode == IslandMode::Expanded && i.opened_by_user);
+        let expand_id = if user_expanded { None } else { arriving };
+
         // Exactly one island may be Compact at a time. The pointer wins it,
-        // then whatever was last clicked, then the newest still-peeking
-        // arrival — so a burst of notifications doesn't blow the row up into
-        // a wall of pills.
-        let compact_id = self.hovered_island.or(self.focused_island).or_else(|| {
-            self.islands
-                .iter()
-                .filter(|i| i.peek_until.is_some())
-                .max_by_key(|i| i.created_at)
-                .map(|i| i.activity_id)
-        });
+        // then whatever was last clicked, then the arrival when it could not
+        // open — so a burst of notifications doesn't blow the row up into a
+        // wall of pills.
+        let compact_id = self.hovered_island.or(self.focused_island).or(arriving);
 
         for island in &mut self.islands {
-            if island.mode == IslandMode::Expanded {
-                // Only user interaction (click / focus loss) closes it.
-            } else if Some(island.activity_id) == compact_id {
+            let id = Some(island.activity_id);
+            if island.mode == IslandMode::Expanded && island.opened_by_user {
+                // User-opened: only user interaction (click / focus loss) closes it.
+            } else if id == expand_id {
+                island.mode = IslandMode::Expanded;
+            } else if id == compact_id {
                 island.mode = IslandMode::Compact;
             } else {
                 island.mode = IslandMode::Mini;
@@ -381,7 +410,14 @@ impl IslandApp {
                 let (w, h) = match island.mode {
                     IslandMode::Mini => (MINI_H, MINI_H),
                     IslandMode::Compact => (renderer::pill_width(&title_of(island)), COMPACT_H),
-                    IslandMode::Expanded => (renderer::CARD_W, renderer::CARD_H),
+                    IslandMode::Expanded => {
+                        let h = notifications
+                            .iter()
+                            .find(|a| a.id == island.activity_id)
+                            .map(renderer::card_height)
+                            .unwrap_or(renderer::CARD_H);
+                        (renderer::CARD_W, h)
+                    }
                 };
                 sizes.push((idx, w, h));
             }
@@ -686,10 +722,8 @@ impl IslandApp {
                 // Only an expanded island draws action buttons.
                 let action_id = if island.mode == IslandMode::Expanded && !island.actions.is_empty()
                 {
-                    let text_x = CARD_PAD + CARD_ICON + 8.0;
-                    let max_w = w - text_x - CARD_CLOSE_ZONE;
                     let (local_x, local_y) = (px - x, py - y);
-                    renderer::action_button_rects(&island.actions, text_x, max_w)
+                    renderer::card_action_rects(&island.body, &island.actions, w)
                         .into_iter()
                         .find(|(bx, by, bw, bh, _, _)| {
                             local_x >= *bx
@@ -736,6 +770,7 @@ impl IslandApp {
             for island in &mut self.islands {
                 if island.mode == IslandMode::Expanded {
                     island.mode = IslandMode::Compact;
+                    island.opened_by_user = false;
                 }
             }
             let island = &mut self.islands[idx];
@@ -744,6 +779,7 @@ impl IslandApp {
                 IslandMode::Mini => IslandMode::Compact,
                 _ => IslandMode::Expanded,
             };
+            island.opened_by_user = island.mode == IslandMode::Expanded;
             tracing::info!(app_id = %island.app_id, mode = ?island.mode, "click: island opened");
             self.focused_island = Some(activity_id);
             let mut state = self.state.lock().unwrap();
@@ -1027,13 +1063,17 @@ impl App for IslandApp {
 
         let now = std::time::Instant::now();
 
-        // Peek timeout: a newly-arrived notification stops announcing itself
-        // and settles back into its app's stack.
+        // Arrival timeout: a newly-arrived notification stops announcing
+        // itself and settles back into its app's stack. The window is held
+        // open while the pointer is on that island, so it never collapses out
+        // from under someone reading it.
         let mut dirty_after_peek = false;
         for island in &mut self.islands {
             if let Some(until) = island.peek_until {
-                if now >= until {
-                    tracing::info!(app_id = %island.app_id, "peek expired → Mini");
+                if self.hovered_island == Some(island.activity_id) {
+                    island.peek_until = Some(now + Duration::from_secs(ARRIVAL_READ_SECS));
+                } else if now >= until {
+                    tracing::info!(app_id = %island.app_id, "arrival window expired → Mini");
                     island.peek_until = None;
                     dirty_after_peek = true;
                 }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1118,7 +1118,12 @@ impl IslandApp {
             state.dismiss_activity(activity_id);
             drop(state);
 
-            if !is_close {
+            if is_close {
+                // Reason 2: dismissed by the user via the Close affordance.
+                if let Some(nid) = notification_id {
+                    emit_notification_closed(nid, 2);
+                }
+            } else {
                 // Action click — focus the app and emit ActionInvoked. A hit on
                 // a specific inline action button reports that action's id;
                 // otherwise (click on the card body) it's the default action.
@@ -1619,27 +1624,66 @@ fn request_focus_app(app_id: String) {
     });
 }
 
+/// The D-Bus connection that owns the org.freedesktop.Notifications bus name.
+/// Signals must be emitted from this connection, not an anonymous one, so
+/// receivers matching on sender="org.freedesktop.Notifications" can see them.
+static NOTIFICATIONS_DBUS_CONNECTION: std::sync::OnceLock<zbus::Connection> =
+    std::sync::OnceLock::new();
+
 /// Emit the org.freedesktop.Notifications ActionInvoked signal.
 fn emit_action_invoked(notification_id: u32, action_key: String) {
+    let Some(connection) = NOTIFICATIONS_DBUS_CONNECTION.get().cloned() else {
+        tracing::warn!(
+            notification_id,
+            "ActionInvoked: notifications D-Bus connection not ready"
+        );
+        return;
+    };
     tokio::spawn(async move {
-        let connection = match zbus::Connection::session().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!("failed to connect to session bus for ActionInvoked: {e}");
-                return;
-            }
+        let Ok(ctxt) =
+            zbus::SignalContext::new(&connection, notifications::NOTIFICATIONS_DBUS_PATH)
+        else {
+            tracing::warn!(
+                notification_id,
+                "ActionInvoked: failed to build signal context"
+            );
+            return;
         };
-        let result = connection
-            .emit_signal(
-                None::<&str>,
-                "/org/freedesktop/Notifications",
-                "org.freedesktop.Notifications",
-                "ActionInvoked",
-                &(notification_id, action_key.as_str()),
-            )
-            .await;
-        if let Err(e) = result {
+        if let Err(e) =
+            notifications::NotificationDaemon::action_invoked(&ctxt, notification_id, &action_key)
+                .await
+        {
             tracing::warn!(notification_id, "ActionInvoked signal failed: {e}");
+        }
+    });
+}
+
+/// Emit the org.freedesktop.Notifications NotificationClosed signal.
+/// Reasons per spec: 1 = expired, 2 = dismissed by the user, 3 = closed via
+/// CloseNotification, 4 = undefined.
+fn emit_notification_closed(notification_id: u32, reason: u32) {
+    let Some(connection) = NOTIFICATIONS_DBUS_CONNECTION.get().cloned() else {
+        tracing::warn!(
+            notification_id,
+            "NotificationClosed: notifications D-Bus connection not ready"
+        );
+        return;
+    };
+    tokio::spawn(async move {
+        let Ok(ctxt) =
+            zbus::SignalContext::new(&connection, notifications::NOTIFICATIONS_DBUS_PATH)
+        else {
+            tracing::warn!(
+                notification_id,
+                "NotificationClosed: failed to build signal context"
+            );
+            return;
+        };
+        if let Err(e) =
+            notifications::NotificationDaemon::notification_closed(&ctxt, notification_id, reason)
+                .await
+        {
+            tracing::warn!(notification_id, "NotificationClosed signal failed: {e}");
         }
     });
 }
@@ -1731,6 +1775,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             return;
         }
 
+        let _ = NOTIFICATIONS_DBUS_CONNECTION.set(connection);
         tracing::info!(
             "Notifications daemon running on {}",
             notifications::NOTIFICATIONS_DBUS_NAME

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -379,42 +379,34 @@ impl IslandApp {
                 sizes.push((idx, w, h));
             }
 
-            // An expanded island leaves the stack and takes its own slot. The
-            // rest of the group — the train — trails off to its left, so the
-            // open notification stays at the right-hand front of its group.
-            let expanded: Vec<&(usize, f32, f32)> = sizes
-                .iter()
-                .filter(|(i, _, _)| self.islands[*i].mode == IslandMode::Expanded)
-                .collect();
-            let stacked: Vec<&(usize, f32, f32)> = sizes
-                .iter()
-                .filter(|(i, _, _)| self.islands[*i].mode != IslandMode::Expanded)
-                .collect();
-
+            // Place every member in arrival order, left to right. Each bubble
+            // covers a fixed slice of the one before it, so the step comes
+            // from the bubble's own width: growing to compact — or opening
+            // fully — pushes the newer ones along instead of expanding
+            // underneath them, and nothing ever changes places.
+            let overlap = (MINI_H - step).max(0.0);
+            let n = sizes.len();
             let mut placed: Vec<(usize, f32, f32, f32)> = Vec::new();
-            let mut cursor = 0.0_f32;
             let mut group_w = 0.0_f32;
+            let mut x = 0.0_f32;
 
-            if let Some(&&(_, front_w, _)) = stacked.first() {
-                // Depth of the visible deck; anything deeper piles up at the
-                // back so a huge group can't stretch the row.
-                let depth = stacked.len().min(renderer::MAX_STACK);
-                let back_span = (depth - 1) as f32 * step;
-                for (i, &&(idx, w, h)) in stacked.iter().enumerate() {
-                    // i == 0 is the front and sits furthest right; each older
-                    // bubble steps back to the left, behind the one before it.
-                    let steps_back = i.min(depth - 1) as f32;
-                    let offset = cursor + back_span - steps_back * step;
-                    placed.push((idx, offset, w, h));
-                    group_w = group_w.max(offset + w);
+            for (k, &(idx, w, h)) in sizes.iter().rev().enumerate() {
+                let expanded = self.islands[idx].mode == IslandMode::Expanded;
+                // An open notification is a panel, not a bubble in the deck:
+                // it stands clear of its neighbours instead of overlapping.
+                if expanded {
+                    x += GAP;
                 }
-                cursor += back_span + front_w + GAP;
-            }
+                placed.push((idx, x, w, h));
+                group_w = group_w.max(x + w);
 
-            for &&(idx, w, h) in &expanded {
-                placed.push((idx, cursor, w, h));
-                group_w = group_w.max(cursor + w);
-                cursor += w + GAP;
+                if expanded {
+                    x += w + GAP;
+                } else if n - 1 - k < renderer::MAX_STACK {
+                    // Anything deeper than MAX_STACK from the front piles up
+                    // in place, so a huge group can't stretch the row.
+                    x += (w - overlap).max(0.0);
+                }
             }
 
             group_widths.push(group_w);
@@ -517,7 +509,17 @@ impl IslandApp {
             }
         }
 
-        let restacked = self.restack(&groups);
+        // Z-order only — this never moves anything, it just decides what
+        // draws on top: an open notification, then the deck front-to-back.
+        let stacking: Vec<Vec<usize>> = groups
+            .iter()
+            .map(|members| {
+                let mut m = members.clone();
+                m.sort_by_key(|&i| self.islands[i].mode != IslandMode::Expanded);
+                m
+            })
+            .collect();
+        let restacked = self.restack(&stacking);
         let size_changed = self.update_layer_size();
         self.update_input_region(size_changed || restacked);
     }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -419,10 +419,23 @@ impl IslandApp {
 
         let total_w: f32 =
             group_widths.iter().sum::<f32>() + (group_widths.len().saturating_sub(1)) as f32 * GAP;
-        // Size the layer from the content, then centre the row inside it, so
-        // the two can't chase each other frame to frame.
-        self.last_content_width = (total_w + 40.0).max(LAYER_W as f32);
-        let mut group_x = ((self.last_content_width - total_w) / 2.0).max(0.0);
+
+        // The row is centred on its *resting* width — every bubble mini, every
+        // deck at peek spacing — not on its current one. That pins the left
+        // edge, so growing an island pushes the islands to its right along
+        // instead of sliding the whole row back into centre under the pointer.
+        let resting_w: f32 = groups
+            .iter()
+            .map(|members| {
+                let depth = members.len().min(renderer::MAX_STACK);
+                (depth - 1) as f32 * renderer::PEEK_STEP + MINI_H
+            })
+            .sum::<f32>()
+            + (groups.len().saturating_sub(1)) as f32 * GAP;
+
+        let base_layer_w = (resting_w + 40.0).max(LAYER_W as f32);
+        let mut group_x = ((base_layer_w - resting_w) / 2.0).max(0.0);
+        self.last_content_width = base_layer_w.max(group_x + total_w + 20.0);
 
         let mut targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
         for (gi, placed) in placements.iter().enumerate() {

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -22,7 +22,7 @@ use crate::activity::Activity;
 use crate::dbus_service::{DialogService, IslandService, DBUS_NAME};
 use crate::dialog::{DialogHit, DialogId, DialogResponse, DialogView};
 use crate::renderer::{
-    animate_to, apply_island_style, draw_centered, set_size_and_position, COMPACT_H, MINI_H, MINI_W,
+    animate_to, apply_island_style, draw_centered, set_size_and_position, COMPACT_H, MINI_H,
 };
 use crate::state::{IslandState, SharedState};
 
@@ -40,6 +40,10 @@ const DIALOG_TOP: f32 = BAR_HEIGHT + 14.0;
 const FOCUS_TIMEOUT_SECS: f64 = 4.0;
 /// Seconds a destroyed surface is kept alive so its exit animation can play.
 const DESTROY_DELAY_SECS: f64 = 0.8;
+/// Expanded-card metrics shared between drawing and hit-testing.
+const CARD_PAD: f32 = 10.0;
+const CARD_ICON: f32 = 24.0;
+const CARD_CLOSE_ZONE: f32 = 40.0;
 
 // ---------------------------------------------------------------------------
 // Island — one notification group or music activity
@@ -52,71 +56,41 @@ enum IslandMode {
     Expanded,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum IslandKind {
-    Notification,
-}
-
-/// Signature of what a pill buffer currently shows — redraw only on change.
+/// Signature of what an island buffer currently shows — redraw only on change.
 #[derive(Clone, PartialEq)]
-struct PillContent {
+struct IslandContent {
     mode: IslandMode,
     icon: String,
     title: String,
-    count: usize,
+    body: String,
+    time_label: String,
+    actions: Vec<crate::activity::NotificationAction>,
     w: f32,
     h: f32,
 }
 
-/// Signature of what a card buffer currently shows.
-#[derive(Clone, PartialEq)]
-struct CardContent {
-    title: String,
-    body: String,
-    icon: String,
-    time_label: String,
-    actions: Vec<crate::activity::NotificationAction>,
-}
-
-/// An island represents one group (notification app_id or music).
-/// It owns a pill/circle subsurface and optionally card subsurfaces.
+/// An island is one notification. There is no separate group header and no
+/// separate card: the island *is* the notification, and expanding it grows
+/// this same bubble into the full title/body/actions layout. Notifications
+/// from the same app are grouped visually by overlapping their islands into
+/// a peek stack, not by collapsing them into one representative.
 struct Island {
-    /// The group key (app_id for notifications, "org.otto.music" for music).
+    /// The notification this island represents.
+    activity_id: u64,
+    /// Grouping key — same-app islands overlap into one stack.
     app_id: String,
-    kind: IslandKind,
-    /// The icon for this group (resolved once, used consistently in all modes).
     icon: String,
-    /// The pill/circle subsurface.
     surface: SubsurfaceSurface,
-    /// Lazily-created card subsurfaces (only when Expanded, notifications only).
-    cards: Vec<CardSurface>,
-    /// Current mode.
     mode: IslandMode,
-    /// When this group first appeared.
+    /// When this notification arrived (newest sits at the front of its stack).
     created_at: std::time::Instant,
-    /// Last known notification count (for pulse detection).
-    last_count: usize,
-    /// Last seen activity ID (to detect new notifications even when count doesn't change).
-    last_activity_id: u64,
     /// When set, the island temporarily shows as Compact until this instant.
     peek_until: Option<std::time::Instant>,
     /// Last layout target (w, h, x, y) — skip animation when unchanged.
     last_layout: (f32, f32, f32, f32),
-    /// Last drawn pill content — skip redraw when unchanged.
-    last_content: Option<PillContent>,
-    /// "+N more" indicator shown below the stack when there are more
-    /// notifications than fit in the visible card list. Lazily created,
-    /// like cards.
-    more_indicator: Option<(SubsurfaceSurface, usize)>,
-}
-
-struct CardSurface {
-    surface: SubsurfaceSurface,
-    activity_id: u64,
-    /// Last drawn card content — skip redraw when unchanged.
-    last_content: Option<CardContent>,
-    /// Inline actions for this notification, cached for hit-testing without
-    /// locking state (kept in sync with the activity every layout pass).
+    /// Last drawn content — skip redraw when unchanged.
+    last_content: Option<IslandContent>,
+    /// Inline actions, cached for hit-testing without locking state.
     actions: Vec<crate::activity::NotificationAction>,
 }
 
@@ -144,10 +118,17 @@ struct IslandApp {
     layer_surface: Option<LayerShellSurface>,
     islands: Vec<Island>,
     surfaces_ready: bool,
-    /// Which island (by app_id) is currently focused (Compact/Expanded).
-    focused_app: Option<String>,
-    /// Which island (by app_id) the pointer is currently hovering over.
+    /// Which island (by notification id) is currently focused (Compact/Expanded).
+    focused_island: Option<u64>,
+    /// Which island the pointer is over (drives the hover grow).
+    hovered_island: Option<u64>,
+    /// Which group (by app_id) the pointer is over — that stack fans out.
     hovered_app: Option<String>,
+    /// Last applied front-to-back order, so subsurfaces are only restacked
+    /// when the order actually changes.
+    last_stack_order: Option<Vec<u64>>,
+    /// Width the last layout pass centered the island row within.
+    last_content_width: f32,
     /// Surfaces pending destruction (kept alive for animations, destroyed next cycle).
     pending_destroy: Vec<(SubsurfaceSurface, std::time::Instant)>,
     /// Last time the user interacted (pointer event). Used for focus timeout.
@@ -167,8 +148,11 @@ impl IslandApp {
             layer_surface: None,
             islands: Vec::new(),
             surfaces_ready: false,
-            focused_app: None,
+            focused_island: None,
+            hovered_island: None,
             hovered_app: None,
+            last_stack_order: None,
+            last_content_width: LAYER_W as f32,
             pending_destroy: Vec::new(),
             last_interaction: std::time::Instant::now(),
             last_layer_size: None,
@@ -177,15 +161,9 @@ impl IslandApp {
         }
     }
 
-    /// Compute the current effective layer width based on island layout.
+    /// The layer width the last layout pass centered its row within.
     fn layer_width(&self) -> f32 {
-        let total_w: f32 = self
-            .islands
-            .iter()
-            .map(|i| i.last_layout.0.max(MINI_H))
-            .sum::<f32>()
-            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
-        (total_w + 40.0).max(LAYER_W as f32)
+        self.last_content_width.max(LAYER_W as f32)
     }
 
     /// Get the parent wl_surface for creating subsurfaces.
@@ -205,7 +183,7 @@ impl IslandApp {
         // Center coordinates (anchor point is 0.5, 0.5).
         let cx = self.layer_width() / 2.0;
         let cy = BAR_HEIGHT / 2.0;
-        set_size_and_position(&surface, MINI_W, MINI_H, cx, cy);
+        set_size_and_position(&surface, MINI_H, MINI_H, cx, cy);
         surface.draw(|canvas| {
             canvas.clear(skia_safe::Color::TRANSPARENT);
         });
@@ -237,600 +215,325 @@ impl IslandApp {
 
     fn sync(&mut self) {
         let state = self.state.lock().unwrap();
-        let grouped = state.grouped_activities();
+        let notifications: Vec<Activity> = state.activities.clone();
         drop(state);
 
-        // Build the set of app_ids that should exist as islands.
-        let mut desired: Vec<(String, IslandKind, String)> = Vec::new(); // (app_id, kind, icon)
-        for (activity, _count) in &grouped {
-            let kind = IslandKind::Notification;
-            if !desired.iter().any(|(id, _, _)| id == &activity.app_id) {
-                desired.push((activity.app_id.clone(), kind, activity.icon.clone()));
-            }
-        }
-
-        // Remove islands whose app_id is no longer present.
+        // Remove islands whose notification is gone.
         let mut removed_island = false;
         let mut i = 0;
         while i < self.islands.len() {
-            if desired
+            if notifications
                 .iter()
-                .any(|(app_id, _, _)| app_id == &self.islands[i].app_id)
+                .any(|a| a.id == self.islands[i].activity_id)
             {
                 i += 1;
             } else {
-                let mut island = self.islands.remove(i);
-                tracing::info!(app_id = %island.app_id, "island removed");
-                let cx = self.layer_width() / 2.0;
-                let cy = BAR_HEIGHT / 2.0;
-                let h = COMPACT_H;
-                renderer::animate_to_with_opacity(
-                    &island.surface,
-                    0.0,
-                    h,
-                    cx,
-                    cy,
-                    h as f64 / 2.0,
-                    Some(0.0),
-                    0.3,
-                );
-                for card in &island.cards {
-                    renderer::animate_dismiss(&card.surface, 1.2);
-                }
-                // Defer destruction of all surfaces.
-                for card in island.cards.drain(..) {
-                    self.defer_destroy(card.surface);
-                }
-                if let Some((surface, _)) = island.more_indicator.take() {
-                    self.defer_destroy(surface);
-                }
+                let island = self.islands.remove(i);
+                tracing::info!(app_id = %island.app_id, id = island.activity_id, "island removed");
+                renderer::animate_dismiss(&island.surface, 1.2);
                 self.defer_destroy(island.surface);
                 removed_island = true;
             }
         }
 
-        // Add islands for new app_ids.
-        for (app_id, kind, icon) in &desired {
-            if !self.islands.iter().any(|i| i.app_id == *app_id) {
-                if let Some(surface) = self.create_pill_subsurface() {
-                    tracing::info!(%app_id, ?kind, %icon, "island created");
-                    self.islands.push(Island {
-                        app_id: app_id.clone(),
-                        kind: *kind,
-                        icon: icon.clone(),
-                        surface,
-                        cards: Vec::new(),
-                        mode: IslandMode::Mini,
-                        created_at: std::time::Instant::now(),
-                        last_count: 0,
-                        last_activity_id: 0,
-                        peek_until: None,
-                        last_layout: (0.0, 0.0, 0.0, 0.0),
-                        last_content: None,
-                        more_indicator: None,
-                    });
-                    // Auto-focus only if no island is currently Expanded.
-                    let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
-                    if !any_expanded {
-                        self.focused_app = Some(app_id.clone());
-                    }
-                    self.last_interaction = std::time::Instant::now();
-                }
+        // Add an island per new notification.
+        for activity in &notifications {
+            if self.islands.iter().any(|i| i.activity_id == activity.id) {
+                continue;
+            }
+            let Some(surface) = self.create_pill_subsurface() else {
+                continue;
+            };
+            tracing::info!(app_id = %activity.app_id, id = activity.id, "island created");
+            self.islands.push(Island {
+                activity_id: activity.id,
+                app_id: activity.app_id.clone(),
+                icon: activity.icon.clone(),
+                surface,
+                mode: IslandMode::Mini,
+                created_at: activity.created_at,
+                // A new notification announces itself as Compact for a few
+                // seconds, then settles back into its app's stack.
+                peek_until: Some(std::time::Instant::now() + Duration::from_secs(3)),
+                last_layout: (0.0, 0.0, 0.0, 0.0),
+                last_content: None,
+                actions: activity.actions.clone(),
+            });
+            self.last_interaction = std::time::Instant::now();
+        }
+
+        // Refresh cached per-notification data.
+        for island in &mut self.islands {
+            if let Some(a) = notifications.iter().find(|a| a.id == island.activity_id) {
+                island.actions = a.actions.clone();
+                island.icon = a.icon.clone();
             }
         }
 
-        // Sort islands by creation time (oldest left).
-        self.islands.sort_by_key(|i| i.created_at);
-
-        // If focused app no longer exists, clear focus.
-        if let Some(ref focused) = self.focused_app {
-            if !self.islands.iter().any(|i| i.app_id == *focused) {
-                self.focused_app = None;
+        // If the focused island is gone, clear focus.
+        if let Some(focused) = self.focused_island {
+            if !self.islands.iter().any(|i| i.activity_id == focused) {
+                self.focused_island = None;
             }
         }
 
-        // Assign modes: focused gets Compact/Expanded, peeking stays Compact, rest → Mini.
-        // Expanded islands are preserved — they coexist with Compact (peeking) islands.
+        // Assign modes: focused → Compact (or stays Expanded), peeking stays
+        // Compact until it expires, everything else → Mini.
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
-                // Expanded stays Expanded — only user interaction (click/focus loss) closes it.
-            } else if Some(&island.app_id) == self.focused_app.as_ref() {
-                if island.mode == IslandMode::Mini {
-                    island.mode = IslandMode::Compact;
-                    tracing::debug!(app_id = %island.app_id, "Mini → Compact (focused)");
-                }
+                // Only user interaction (click / focus loss) closes it.
+            } else if Some(island.activity_id) == self.focused_island {
+                island.mode = IslandMode::Compact;
             } else if island.peek_until.is_some() {
-                // Peeking — stay Compact until peek expires.
+                island.mode = IslandMode::Compact;
             } else {
-                // Non-focused, non-peeking, non-expanded → Mini.
-                if island.mode != IslandMode::Mini {
-                    tracing::debug!(app_id = %island.app_id, from = ?island.mode, "→ Mini");
-                }
                 island.mode = IslandMode::Mini;
             }
         }
 
-        self.layout(&grouped, removed_island);
-    }
-
-    /// Close the card stack — animate out but keep surfaces alive for reuse.
-    fn close_cards_for(island: &mut Island) {
-        tracing::info!(app_id = %island.app_id, cards = island.cards.len(), "stack closed");
-        // Slide up to pill center y, keep current x. Fade out.
-        let pill_cy = BAR_HEIGHT / 2.0;
-        let pill_cx = island.last_layout.2; // cx from last layout
-        for card in &island.cards {
-            renderer::animate_position_opacity(
-                &card.surface,
-                renderer::CARD_W,
-                renderer::CARD_H,
-                pill_cx,
-                pill_cy,
-                0.0,
-                0.0,
-            );
-        }
-        if let Some((surface, _)) = &island.more_indicator {
-            renderer::animate_position_opacity(
-                surface,
-                renderer::CARD_W,
-                renderer::MORE_INDICATOR_H,
-                pill_cx,
-                pill_cy,
-                0.0,
-                0.0,
-            );
-        }
+        self.layout(&notifications, removed_island);
     }
 
     // -----------------------------------------------------------------------
     // Layout: position all islands and their cards
     // -----------------------------------------------------------------------
 
-    fn layout(&mut self, grouped: &[(Activity, usize)], reposition_delay: bool) {
+    /// Islands grouped by app, front-to-back within each group.
+    ///
+    /// Groups are ordered by their oldest notification so a group keeps its
+    /// place in the row as notifications come and go. Within a group the
+    /// focused island is pulled to the front, then newest first — the front
+    /// island is the one on top of the stack and the one a click lands on.
+    fn group_order(&self) -> Vec<Vec<usize>> {
+        let mut groups: Vec<(std::time::Instant, String, Vec<usize>)> = Vec::new();
+        for (idx, island) in self.islands.iter().enumerate() {
+            match groups.iter_mut().find(|(_, app, _)| *app == island.app_id) {
+                Some((oldest, _, members)) => {
+                    *oldest = (*oldest).min(island.created_at);
+                    members.push(idx);
+                }
+                None => groups.push((island.created_at, island.app_id.clone(), vec![idx])),
+            }
+        }
+        groups.sort_by_key(|(oldest, _, _)| *oldest);
+
+        let focused = self.focused_island;
+        groups
+            .into_iter()
+            .map(|(_, _, mut members)| {
+                members.sort_by_key(|&i| {
+                    let island = &self.islands[i];
+                    let is_focused = Some(island.activity_id) == focused;
+                    // Focused first, then newest first.
+                    (!is_focused, std::cmp::Reverse(island.created_at))
+                });
+                members
+            })
+            .collect()
+    }
+
+    fn layout(&mut self, notifications: &[Activity], reposition_delay: bool) {
         if self.islands.is_empty() {
             let size_changed = self.update_layer_size();
             self.update_input_region(size_changed);
             return;
         }
 
-        // Compute element sizes for layout.
-        let island_size = |island: &Island, mode: IslandMode| -> (f32, f32) {
-            let entry = grouped.iter().find(|(a, _)| a.app_id == island.app_id);
-            let count = entry.map(|(_, c)| *c).unwrap_or(1);
-            let title = entry.map(|(a, _)| a.title.as_str()).unwrap_or("");
-            match mode {
-                IslandMode::Mini => (renderer::mini_width(count), MINI_H),
-                IslandMode::Compact => {
-                    let w = renderer::pill_width(&island.app_id, title, count);
-                    (w, COMPACT_H)
-                }
-                IslandMode::Expanded => {
-                    let w =
-                        renderer::pill_width(&island.app_id, title, count).max(renderer::CARD_W);
-                    (w, COMPACT_H)
-                }
-            }
+        let title_of = |island: &Island| -> String {
+            notifications
+                .iter()
+                .find(|a| a.id == island.activity_id)
+                .map(|a| a.title.clone())
+                .unwrap_or_default()
         };
 
-        // Compute total row width.
-        let total_w: f32 = self
-            .islands
-            .iter()
-            .map(|i| island_size(i, i.mode).0)
-            .sum::<f32>()
-            + (self.islands.len() - 1) as f32 * GAP;
+        let groups = self.group_order();
 
-        let mut x = ((self.layer_width() - total_w) / 2.0).max(0.0);
+        // Measure every island, then lay each group out as an overlapped stack.
+        // (idx, offset within group, w, h)
+        let mut placements: Vec<Vec<(usize, f32, f32, f32)>> = Vec::new();
+        let mut group_widths: Vec<f32> = Vec::new();
 
-        // Collect positions for expanded islands, pulse targets, and layout targets.
-        let mut expanded_layouts: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
-        let mut pulse_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
-        let mut layout_targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new(); // (idx, w, h, x, y)
-        let mut content_updates: Vec<(usize, PillContent)> = Vec::new();
-
-        for (idx, island) in self.islands.iter().enumerate() {
-            let count = grouped
-                .iter()
-                .find(|(a, _)| a.app_id == island.app_id)
-                .map(|(_, c)| *c)
-                .unwrap_or(0);
-            let icon = island.icon.as_str();
-
-            let (base_w, base_h) = island_size(island, island.mode);
-            let is_hovered = self.hovered_app.as_ref() == Some(&island.app_id);
-            let grow = if is_hovered
-                && (island.mode == IslandMode::Mini || island.mode == IslandMode::Compact)
-            {
-                renderer::HOVER_GROW
+        for members in &groups {
+            let app_id = &self.islands[members[0]].app_id;
+            let step = if self.hovered_app.as_deref() == Some(app_id.as_str()) {
+                renderer::FAN_STEP
             } else {
-                0.0
+                renderer::PEEK_STEP
             };
-            let w = base_w + grow;
-            let h = base_h + grow;
-            // Center coordinates for anchor_point(0.5, 0.5).
-            let cx = x + w / 2.0;
-            let cy = BAR_HEIGHT / 2.0;
 
-            // Detect new notification: count increased or representative activity changed.
-            let current_activity_id = grouped
+            // Measure every member first, then place them: the front of the
+            // stack sits at the right-hand end of the group and the older
+            // bubbles peek out to its left, behind it.
+            let mut sizes: Vec<(usize, f32, f32)> = Vec::new();
+            for &idx in members {
+                let island = &self.islands[idx];
+                let hovered = self.hovered_island == Some(island.activity_id);
+                let grow = if hovered && island.mode != IslandMode::Expanded {
+                    renderer::HOVER_GROW
+                } else {
+                    0.0
+                };
+                let (w, h) = match island.mode {
+                    IslandMode::Mini => (MINI_H + grow, MINI_H + grow),
+                    IslandMode::Compact => (
+                        renderer::pill_width(&title_of(island)) + grow,
+                        COMPACT_H + grow,
+                    ),
+                    IslandMode::Expanded => (renderer::CARD_W, renderer::CARD_H),
+                };
+                sizes.push((idx, w, h));
+            }
+
+            // An expanded island leaves the stack and takes its own slot on
+            // the left; whatever is left of the group stacks to its right.
+            let expanded: Vec<&(usize, f32, f32)> = sizes
                 .iter()
-                .find(|(a, _)| a.app_id == island.app_id)
-                .map(|(a, _)| a.id)
-                .unwrap_or(0);
-            let count_increased = count > island.last_count;
-            let activity_changed =
-                current_activity_id != island.last_activity_id && island.last_activity_id > 0;
-            // Only pulse on new notifications (count went up), not on dismissals.
-            let should_pulse = island.kind == IslandKind::Notification && count_increased;
-            if island.kind == IslandKind::Notification {
-                tracing::debug!(
-                    app_id = %island.app_id,
-                    mode = ?island.mode,
-                    count,
-                    last_count = island.last_count,
-                    current_activity_id,
-                    last_activity_id = island.last_activity_id,
-                    count_increased,
-                    activity_changed,
-                    should_pulse,
-                    "notification pulse check"
-                );
+                .filter(|(i, _, _)| self.islands[*i].mode == IslandMode::Expanded)
+                .collect();
+            let stacked: Vec<&(usize, f32, f32)> = sizes
+                .iter()
+                .filter(|(i, _, _)| self.islands[*i].mode != IslandMode::Expanded)
+                .collect();
+
+            let mut placed: Vec<(usize, f32, f32, f32)> = Vec::new();
+            let mut cursor = 0.0_f32;
+            let mut group_w = 0.0_f32;
+            for &&(idx, w, h) in &expanded {
+                placed.push((idx, cursor, w, h));
+                group_w = group_w.max(cursor + w);
+                cursor += w + GAP;
             }
 
-            match island.mode {
-                IslandMode::Mini => {
-                    let content = PillContent {
-                        mode: island.mode,
-                        icon: icon.to_string(),
-                        title: String::new(),
-                        count,
-                        w,
-                        h,
-                    };
-                    if island.last_content.as_ref() != Some(&content) {
-                        draw_centered(&island.surface, w, h, |canvas| {
-                            renderer::draw_mini(canvas, icon, count, w, h);
-                        });
-                        content_updates.push((idx, content));
-                    }
-                    if should_pulse {
-                        pulse_targets.push((idx, w, h, cx, cy));
-                    } else {
-                        layout_targets.push((idx, w, h, cx, cy));
-                    }
-                }
-                IslandMode::Compact | IslandMode::Expanded => {
-                    let title = grouped
-                        .iter()
-                        .find(|(a, _)| a.app_id == island.app_id)
-                        .map(|(a, _)| a.title.as_str())
-                        .unwrap_or("");
-                    let expanded = island.mode == IslandMode::Expanded;
-                    let content = PillContent {
-                        mode: island.mode,
-                        icon: icon.to_string(),
-                        title: title.to_string(),
-                        count,
-                        w,
-                        h,
-                    };
-                    if island.last_content.as_ref() != Some(&content) {
-                        draw_centered(&island.surface, w, h, |canvas| {
-                            renderer::draw_pill(
-                                canvas,
-                                &island.app_id,
-                                icon,
-                                title,
-                                count,
-                                expanded,
-                                w,
-                                h,
-                            );
-                        });
-                        content_updates.push((idx, content));
-                    }
-                    if should_pulse {
-                        pulse_targets.push((idx, w, h, cx, cy));
-                    } else {
-                        layout_targets.push((idx, w, h, cx, cy));
-                    }
-
-                    if island.mode == IslandMode::Expanded {
-                        // Store top-left x for card positioning.
-                        expanded_layouts.push((idx, x, cx, cy, w));
-                    }
+            if !stacked.is_empty() {
+                // Depth of the visible deck; anything deeper piles up at the
+                // back so a huge group can't stretch the row.
+                let depth = stacked.len().min(renderer::MAX_STACK);
+                let back_span = (depth - 1) as f32 * step;
+                for (i, &&(idx, w, h)) in stacked.iter().enumerate() {
+                    // i == 0 is the front and sits furthest right; each older
+                    // bubble steps back to the left, behind the one before it.
+                    let steps_back = i.min(depth - 1) as f32;
+                    let offset = cursor + back_span - steps_back * step;
+                    placed.push((idx, offset, w, h));
+                    group_w = group_w.max(offset + w);
                 }
             }
 
-            x += w + GAP;
+            group_widths.push(group_w);
+            placements.push(placed);
         }
 
-        for (idx, content) in content_updates {
-            self.islands[idx].last_content = Some(content);
+        let total_w: f32 =
+            group_widths.iter().sum::<f32>() + (group_widths.len().saturating_sub(1)) as f32 * GAP;
+        // Size the layer from the content, then centre the row inside it, so
+        // the two can't chase each other frame to frame.
+        self.last_content_width = (total_w + 40.0).max(LAYER_W as f32);
+        let mut group_x = ((self.last_content_width - total_w) / 2.0).max(0.0);
+
+        let mut targets: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
+        for (gi, placed) in placements.iter().enumerate() {
+            for &(idx, offset, w, h) in placed {
+                let x = group_x + offset;
+                let cx = x + w / 2.0;
+                let cy = match self.islands[idx].mode {
+                    // Expanded grows downward from where the pill's top edge is.
+                    IslandMode::Expanded => (BAR_HEIGHT - COMPACT_H) / 2.0 + h / 2.0,
+                    _ => BAR_HEIGHT / 2.0,
+                };
+                targets.push((idx, w, h, cx, cy));
+            }
+            group_x += group_widths[gi] + GAP;
         }
 
-        // Apply layout animations only when target changed.
+        // Redraw buffers whose content changed, then animate to the new layout.
         let layout_delay = if reposition_delay { 0.4 } else { 0.0 };
-        for (idx, w, h, x, y) in layout_targets {
-            let target = (w, h, x, y);
-            if self.islands[idx].last_layout != target {
-                let radius = h as f64 / 2.0;
-                animate_to(&self.islands[idx].surface, w, h, x, y, radius, layout_delay);
-                self.islands[idx].last_layout = target;
-            }
-        }
+        for (idx, w, h, cx, cy) in targets {
+            let activity = notifications
+                .iter()
+                .find(|a| a.id == self.islands[idx].activity_id)
+                .cloned();
+            let Some(activity) = activity else { continue };
 
-        // Apply pulse and peek as Compact for new notifications.
-        for (idx, w, h, cx, cy) in pulse_targets {
-            let current_mode = self.islands[idx].mode;
-            // If already Compact or Expanded, don't downgrade — just refresh content.
-            if current_mode == IslandMode::Expanded || current_mode == IslandMode::Compact {
-                tracing::info!(
-                    app_id = %self.islands[idx].app_id,
-                    mode = ?current_mode,
-                    "new notification while open — refresh only"
-                );
-            } else {
-                tracing::info!(
-                    app_id = %self.islands[idx].app_id,
-                    from = ?current_mode,
-                    "pulse → peek Compact for 3s"
-                );
-                renderer::animate_pulse(
+            let mode = self.islands[idx].mode;
+            let content = IslandContent {
+                mode,
+                icon: activity.icon.clone(),
+                title: activity.title.clone(),
+                body: activity.body.clone(),
+                time_label: renderer::elapsed_label(activity.created_at),
+                actions: activity.actions.clone(),
+                w,
+                h,
+            };
+            if self.islands[idx].last_content.as_ref() != Some(&content) {
+                let surface = &self.islands[idx].surface;
+                match mode {
+                    IslandMode::Mini => draw_centered(surface, w, h, |canvas| {
+                        renderer::draw_mini(canvas, &activity.icon, w, h);
+                    }),
+                    IslandMode::Compact => draw_centered(surface, w, h, |canvas| {
+                        renderer::draw_pill(canvas, &activity.icon, &activity.title, w, h);
+                    }),
+                    IslandMode::Expanded => draw_centered(surface, w, h, |canvas| {
+                        renderer::draw_card(canvas, &activity, w, h);
+                    }),
+                }
+                self.islands[idx].last_content = Some(content);
+            }
+
+            let radius = match mode {
+                IslandMode::Expanded => renderer::CARD_RADIUS as f64,
+                _ => h as f64 / 2.0,
+            };
+            let target = (w, h, cx, cy);
+            if self.islands[idx].last_layout == (0.0, 0.0, 0.0, 0.0) {
+                // First layout for a brand-new island: land it in place, then
+                // pop it open.
+                set_size_and_position(&self.islands[idx].surface, w, h, cx, cy);
+                renderer::animate_enter_pop(&self.islands[idx].surface, radius);
+                self.islands[idx].last_layout = target;
+            } else if self.islands[idx].last_layout != target {
+                animate_to(
                     &self.islands[idx].surface,
                     w,
                     h,
                     cx,
                     cy,
-                    h as f64 / 2.0,
-                    6.0,
+                    radius,
+                    layout_delay,
                 );
-                self.islands[idx].last_layout = (w, h, cx, cy);
-                self.islands[idx].peek_until =
-                    Some(std::time::Instant::now() + Duration::from_secs(3));
-                self.islands[idx].mode = IslandMode::Compact;
-            }
-            // Update tracking now so the next sync doesn't re-trigger.
-            let app_id = &self.islands[idx].app_id;
-            if let Some((a, c)) = grouped.iter().find(|(a, _)| &a.app_id == app_id) {
-                self.islands[idx].last_count = *c;
-                self.islands[idx].last_activity_id = a.id;
-            }
-            // Mark dirty so the next tick re-layouts at Compact size.
-            // Safe from loops because last_count/last_activity_id are now current.
-            let mut st = self.state.lock().unwrap();
-            st.dirty = true;
-        }
-        for island in &mut self.islands {
-            let entry = grouped.iter().find(|(a, _)| a.app_id == island.app_id);
-            island.last_count = entry.map(|(_, c)| *c).unwrap_or(0);
-            island.last_activity_id = entry.map(|(a, _)| a.id).unwrap_or(0);
-        }
-
-        // Now lay out cards for expanded islands (separate pass to avoid borrow conflict).
-        // Collect (notifs, group_icon) per app_id.
-        let state = self.state.lock().unwrap();
-        let all_notifs: std::collections::HashMap<String, (Vec<Activity>, String)> = {
-            let mut map = std::collections::HashMap::new();
-            for (idx, _, _, _, _) in &expanded_layouts {
-                let app_id = &self.islands[*idx].app_id;
-                let notifs: Vec<Activity> = state
-                    .notifications_for_app(app_id)
-                    .into_iter()
-                    .cloned()
-                    .collect();
-                // Group icon: from grouped_activities representative.
-                let group_icon = grouped
-                    .iter()
-                    .find(|(a, _)| a.app_id == *app_id)
-                    .map(|(a, _)| a.icon.clone())
-                    .unwrap_or_default();
-                map.insert(app_id.clone(), (notifs, group_icon));
-            }
-            map
-        };
-        drop(state);
-
-        let mut dismissed_card_surfaces: Vec<SubsurfaceSurface> = Vec::new();
-        // place_above on a new card only takes effect on a parent commit — force one.
-        let mut card_created = false;
-
-        // Capture wl_surface before mutable borrow of islands.
-        let wl = self.wl_surface();
-
-        for (idx, pill_left_x, _pill_cx, _pill_cy, pill_w) in expanded_layouts {
-            let island = &mut self.islands[idx];
-            let Some((notifs, group_icon)) = all_notifs.get(&island.app_id) else {
-                continue;
-            };
-            let pill_h = COMPACT_H;
-
-            let card_w = renderer::CARD_W;
-            let card_h = renderer::CARD_H;
-            let card_gap = renderer::CARD_GAP;
-            // Center x for cards (centered under pill).
-            let card_cx = pill_left_x + pill_w / 2.0;
-            // Pill bottom edge in top-left coords.
-            let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
-            let max_cards = renderer::MAX_VISIBLE_CARDS;
-
-            for (i, notif) in notifs.iter().take(max_cards).enumerate() {
-                // Card center y.
-                let card_top = pill_bottom + card_gap + (i as f32) * (card_h + card_gap);
-                let card_cy = card_top + card_h / 2.0;
-                // Start position: center of card at pill bottom.
-                let start_cy = pill_bottom + card_h / 2.0;
-
-                let content = CardContent {
-                    title: notif.title.clone(),
-                    body: notif.body.clone(),
-                    icon: if notif.icon.is_empty() {
-                        group_icon.clone()
-                    } else {
-                        notif.icon.clone()
-                    },
-                    time_label: renderer::elapsed_label(notif.created_at),
-                    actions: notif.actions.clone(),
-                };
-                let existing = island.cards.iter().position(|c| c.activity_id == notif.id);
-                let is_new = existing.is_none();
-                let cidx = if let Some(ci) = existing {
-                    ci
-                } else {
-                    let Some(ref wl) = wl else { continue };
-                    let Ok(surface) = SubsurfaceSurface::new(
-                        wl,
-                        0,
-                        0,
-                        renderer::SLOT_BUF_W,
-                        renderer::SLOT_BUF_H,
-                    ) else {
-                        continue;
-                    };
-                    renderer::apply_card_style(&surface);
-                    // Wayland subsurface stacking is parent-relative, not screen-relative.
-                    // For a top-anchored layer shell, "above" in the stack means further
-                    // from the screen edge — i.e. visually behind the pill. So place_above
-                    // makes cards render behind the title surface.
-                    surface.place_above(island.surface.wl_surface());
-                    // Pre-render content before making the surface visible.
-                    draw_centered(&surface, card_w, card_h, |canvas| {
-                        renderer::draw_card(canvas, notif, group_icon, card_w, card_h);
-                    });
-                    set_size_and_position(&surface, card_w, card_h, card_cx, start_cy);
-                    island.cards.push(CardSurface {
-                        surface,
-                        activity_id: notif.id,
-                        last_content: Some(content.clone()),
-                        actions: notif.actions.clone(),
-                    });
-                    card_created = true;
-                    island.cards.len() - 1
-                };
-
-                island.cards[cidx].actions = notif.actions.clone();
-
-                // Redraw only when the card's content actually changed.
-                if island.cards[cidx].last_content.as_ref() != Some(&content) {
-                    draw_centered(&island.cards[cidx].surface, card_w, card_h, |canvas| {
-                        renderer::draw_card(canvas, notif, group_icon, card_w, card_h);
-                    });
-                    island.cards[cidx].last_content = Some(content);
-                }
-
-                if is_new {
-                    // New card: start at pill bottom, invisible, slide down + fade in.
-                    set_size_and_position(
-                        &island.cards[cidx].surface,
-                        card_w,
-                        card_h,
-                        card_cx,
-                        start_cy,
-                    );
-                    if let Some(ss) = island.cards[cidx].surface.base_surface().surface_style() {
-                        ss.set_opacity(0.0);
-                    }
-                    renderer::animate_position_opacity_slow(
-                        &island.cards[cidx].surface,
-                        card_w,
-                        card_h,
-                        card_cx,
-                        card_cy,
-                        1.0,
-                        i as f64 * 0.05,
-                    );
-                } else {
-                    // Existing card: animate to position + ensure visible.
-                    renderer::animate_position_opacity_slow(
-                        &island.cards[cidx].surface,
-                        card_w,
-                        card_h,
-                        card_cx,
-                        card_cy,
-                        1.0,
-                        i as f64 * 0.05,
-                    );
-                }
-            }
-
-            // Remove dismissed cards and reorder to match notification order.
-            let notif_ids: Vec<u64> = notifs.iter().take(max_cards).map(|n| n.id).collect();
-            let mut i = 0;
-            while i < island.cards.len() {
-                if notif_ids.contains(&island.cards[i].activity_id) {
-                    i += 1;
-                } else {
-                    let card = island.cards.remove(i);
-                    dismissed_card_surfaces.push(card.surface);
-                }
-            }
-            // Sort cards to match layout order (same as notif_ids).
-            island.cards.sort_by_key(|c| {
-                notif_ids
-                    .iter()
-                    .position(|&id| id == c.activity_id)
-                    .unwrap_or(usize::MAX)
-            });
-
-            // "+N more" indicator below the visible cards, when the stack
-            // holds more notifications than fit (spec: MAX_VISIBLE_CARDS).
-            let hidden_count = notifs.len().saturating_sub(max_cards);
-            if hidden_count > 0 {
-                let more_h = renderer::MORE_INDICATOR_H;
-                let more_top = pill_bottom + card_gap + (max_cards as f32) * (card_h + card_gap);
-                let more_cy = more_top + more_h / 2.0;
-                let start_cy = pill_bottom + more_h / 2.0;
-
-                if island.more_indicator.as_ref().map(|(_, n)| *n) != Some(hidden_count) {
-                    if island.more_indicator.is_none() {
-                        if let Some(ref wl) = wl {
-                            if let Ok(surface) = SubsurfaceSurface::new(
-                                wl,
-                                0,
-                                0,
-                                renderer::SLOT_BUF_W,
-                                renderer::SLOT_BUF_H,
-                            ) {
-                                renderer::apply_card_style(&surface);
-                                surface.place_above(island.surface.wl_surface());
-                                if let Some(ss) = surface.base_surface().surface_style() {
-                                    ss.set_opacity(0.0);
-                                }
-                                set_size_and_position(&surface, card_w, more_h, card_cx, start_cy);
-                                card_created = true;
-                                island.more_indicator = Some((surface, 0));
-                            }
-                        }
-                    }
-                    if let Some((surface, n)) = &mut island.more_indicator {
-                        draw_centered(surface, card_w, more_h, |canvas| {
-                            renderer::draw_more_indicator(canvas, hidden_count, card_w, more_h);
-                        });
-                        *n = hidden_count;
-                    }
-                }
-                if let Some((surface, _)) = &island.more_indicator {
-                    renderer::animate_position_opacity_slow(
-                        surface,
-                        card_w,
-                        more_h,
-                        card_cx,
-                        more_cy,
-                        1.0,
-                        max_cards as f64 * 0.05,
-                    );
-                }
-            } else if let Some((surface, _)) = island.more_indicator.take() {
-                dismissed_card_surfaces.push(surface);
+                self.islands[idx].last_layout = target;
             }
         }
-        for s in dismissed_card_surfaces {
-            self.defer_destroy(s);
-        }
 
+        let restacked = self.restack(&groups);
         let size_changed = self.update_layer_size();
-        self.update_input_region(size_changed || card_created);
+        self.update_input_region(size_changed || restacked);
+    }
+
+    /// Keep the front of each stack visually on top. Wayland subsurface
+    /// stacking is parent-relative: for this top-anchored layer surface
+    /// `place_above` pushes a surface *behind*, so walking each group
+    /// front-to-back and placing each one above its predecessor puts the
+    /// front island on top. Returns true when the order actually changed.
+    fn restack(&mut self, groups: &[Vec<usize>]) -> bool {
+        let order: Vec<u64> = groups
+            .iter()
+            .flat_map(|m| m.iter().map(|&i| self.islands[i].activity_id))
+            .collect();
+        if self.last_stack_order.as_ref() == Some(&order) {
+            return false;
+        }
+        for members in groups {
+            for pair in members.windows(2) {
+                let (front, behind) = (pair[0], pair[1]);
+                let front_surface = self.islands[front].surface.wl_surface().clone();
+                self.islands[behind].surface.place_above(&front_surface);
+            }
+        }
+        self.last_stack_order = Some(order);
+        true
     }
 
     // -----------------------------------------------------------------------
@@ -844,41 +547,17 @@ impl IslandApp {
             return false;
         };
 
-        // Compute the minimum height needed for current layout.
+        // Tall enough for the deepest expanded island, plus any dialog panel.
         let mut max_h = BAR_HEIGHT;
-
         for island in &self.islands {
-            if island.mode == IslandMode::Expanded {
-                let card_count = island.cards.len().min(5) as f32;
-                let pill_h = COMPACT_H;
-                let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
-                let more_h = if island.more_indicator.is_some() {
-                    renderer::CARD_GAP + renderer::MORE_INDICATOR_H
-                } else {
-                    0.0
-                };
-                let stack_h = pill_bottom
-                    + renderer::CARD_GAP
-                    + card_count * renderer::CARD_H
-                    + (card_count - 1.0).max(0.0) * renderer::CARD_GAP
-                    + more_h;
-                max_h = max_h.max(stack_h + 4.0);
-            }
+            let (_, h, _, cy) = island.last_layout;
+            max_h = max_h.max(cy + h / 2.0 + 4.0);
         }
-
-        // A presented dialog panel drops below the bar and may extend the layer.
         if let Some(panel) = &self.dialog {
             max_h = max_h.max(DIALOG_TOP + panel.layout_h + 12.0);
         }
 
-        // Compute the minimum width needed for all islands.
-        let total_w: f32 = self
-            .islands
-            .iter()
-            .map(|i| i.last_layout.0.max(MINI_H))
-            .sum::<f32>()
-            + (self.islands.len().saturating_sub(1)) as f32 * GAP;
-        let mut needed_w = (total_w + 40.0).max(LAYER_W as f32); // padding + minimum
+        let mut needed_w = self.layer_width();
         if self.dialog.is_some() {
             needed_w = needed_w.max(dialog::DIALOG_W + 40.0);
         }
@@ -901,49 +580,15 @@ impl IslandApp {
         // Empty region = zero input area (clicks pass through).
         let mut rects: Vec<(i32, i32, i32, i32)> = Vec::new();
         if !self.islands.is_empty() {
-            // One rect per island, derived from last_layout (center coords).
+            // One rect per island, straight from its layout box. Overlapping
+            // rects in a wl_region are fine — the union is what matters.
             for island in &self.islands {
-                let (w, _h, cx, _cy) = island.last_layout;
-                let pill_h = match island.mode {
-                    IslandMode::Mini => MINI_H,
-                    IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
-                };
-                let pill_w = match island.mode {
-                    IslandMode::Expanded => w.max(renderer::CARD_W),
-                    _ => w.max(MINI_H),
-                };
-                let x = cx - pill_w / 2.0;
-                let y = (BAR_HEIGHT - pill_h) / 2.0;
+                let (w, h, cx, cy) = island.last_layout;
                 rects.push((
-                    x.max(0.0) as i32,
-                    y as i32,
-                    pill_w.ceil() as i32,
-                    pill_h.ceil() as i32,
-                ));
-            }
-
-            // Card stack region — one rect per expanded island, positioned under its pill.
-            for island in &self.islands {
-                if island.mode != IslandMode::Expanded || island.cards.is_empty() {
-                    continue;
-                }
-                let pill_w = island.last_layout.0;
-                let pill_cx = island.last_layout.2;
-                let pill_left = pill_cx - pill_w / 2.0;
-                let pill_h = COMPACT_H;
-                let pill_bottom = (BAR_HEIGHT - pill_h) / 2.0 + pill_h;
-                let card_w = renderer::CARD_W;
-                let card_h = renderer::CARD_H;
-                let card_gap = renderer::CARD_GAP;
-                let card_count = island.cards.len() as f32;
-                let stack_top = pill_bottom + card_gap;
-                let stack_h = card_count * card_h + (card_count - 1.0) * card_gap;
-                let card_region_x = pill_left + (pill_w - card_w) / 2.0;
-                rects.push((
-                    card_region_x.max(0.0) as i32,
-                    stack_top as i32,
-                    card_w.ceil() as i32,
-                    stack_h.ceil() as i32,
+                    (cx - w / 2.0).max(0.0) as i32,
+                    (cy - h / 2.0).max(0.0) as i32,
+                    w.ceil() as i32,
+                    h.ceil() as i32,
                 ));
             }
         }
@@ -989,68 +634,40 @@ impl IslandApp {
     // Hit testing
     // -----------------------------------------------------------------------
 
-    /// Returns (app_id, Option<activity_id>, Option<action_id>) for what's at
-    /// (px, py). activity_id is Some when a card is hit; action_id is Some
-    /// when the hit landed on one of the card's inline action buttons.
-    fn hit_test(&self, px: f32, py: f32) -> Option<(String, Option<u64>, Option<String>)> {
-        for island in &self.islands {
-            let (w, _h, cx, _cy) = island.last_layout;
-            let pill_h = match island.mode {
-                IslandMode::Mini => MINI_H,
-                IslandMode::Compact | IslandMode::Expanded => COMPACT_H,
-            };
-            let pill_w = match island.mode {
-                IslandMode::Expanded => w.max(renderer::CARD_W),
-                _ => w.max(MINI_H),
-            };
-            let x = cx - pill_w / 2.0;
-            let y = (BAR_HEIGHT - pill_h) / 2.0;
-
-            // Hit test cards first (they sit below the pill).
-            if island.mode == IslandMode::Expanded {
-                let card_w = renderer::CARD_W;
-                let card_h = renderer::CARD_H;
-                let card_gap = renderer::CARD_GAP;
-                let card_x = x + (pill_w - card_w) / 2.0;
-
-                for (i, card) in island.cards.iter().enumerate() {
-                    let card_y = y + pill_h + card_gap + (i as f32) * (card_h + card_gap);
-                    if px >= card_x
-                        && px <= card_x + card_w
-                        && py >= card_y
-                        && py <= card_y + card_h
-                    {
-                        let action_id = if card.actions.is_empty() {
-                            None
-                        } else {
-                            let pad = 10.0;
-                            let icon_size = 24.0;
-                            let close_zone = 40.0;
-                            let text_x = pad + icon_size + 8.0;
-                            let max_w = card_w - text_x - close_zone;
-                            let local_x = px - card_x;
-                            let local_y = py - card_y;
-                            renderer::action_button_rects(&card.actions, text_x, max_w)
-                                .into_iter()
-                                .find(|(bx, by, bw, bh, _, _)| {
-                                    local_x >= *bx
-                                        && local_x <= *bx + *bw
-                                        && local_y >= *by
-                                        && local_y <= *by + *bh
-                                })
-                                .map(|(_, _, _, _, id, _)| id)
-                        };
-                        return Some((island.app_id.clone(), Some(card.activity_id), action_id));
-                    }
+    /// What is at (px, py): the island hit, and which of its inline action
+    /// buttons if the hit landed on one. Islands are tested front-to-back
+    /// within each group so the top of an overlapped stack wins.
+    fn hit_test(&self, px: f32, py: f32) -> Option<(u64, Option<String>)> {
+        for members in self.group_order() {
+            for idx in members {
+                let island = &self.islands[idx];
+                let (w, h, cx, cy) = island.last_layout;
+                let (x, y) = (cx - w / 2.0, cy - h / 2.0);
+                if px < x || px > x + w || py < y || py > y + h {
+                    continue;
                 }
-            }
 
-            // Hit test pill/circle.
-            if px >= x && px <= x + pill_w && py >= y && py <= y + pill_h {
-                return Some((island.app_id.clone(), None, None));
+                // Only an expanded island draws action buttons.
+                let action_id = if island.mode == IslandMode::Expanded && !island.actions.is_empty()
+                {
+                    let text_x = CARD_PAD + CARD_ICON + 8.0;
+                    let max_w = w - text_x - CARD_CLOSE_ZONE;
+                    let (local_x, local_y) = (px - x, py - y);
+                    renderer::action_button_rects(&island.actions, text_x, max_w)
+                        .into_iter()
+                        .find(|(bx, by, bw, bh, _, _)| {
+                            local_x >= *bx
+                                && local_x <= *bx + *bw
+                                && local_y >= *by
+                                && local_y <= *by + *bh
+                        })
+                        .map(|(_, _, _, _, id, _)| id)
+                } else {
+                    None
+                };
+                return Some((island.activity_id, action_id));
             }
         }
-
         None
     }
 
@@ -1063,120 +680,75 @@ impl IslandApp {
         if self.handle_dialog_click(px, py) {
             return;
         }
-        let Some((app_id, card_id, action_id)) = self.hit_test(px, py) else {
+        let Some((activity_id, action_id)) = self.hit_test(px, py) else {
+            return;
+        };
+        let Some(idx) = self
+            .islands
+            .iter()
+            .position(|i| i.activity_id == activity_id)
+        else {
             return;
         };
 
-        if let Some(activity_id) = card_id {
-            // Determine if the click is in the close zone (right 40px of card).
-            // An inline action button always wins over the close zone — the
-            // buttons live in the body row, well clear of it.
-            let close_zone = 40.0_f32;
-            let is_close = action_id.is_none()
-                && self
-                    .islands
-                    .iter()
-                    .find(|i| i.app_id == app_id)
-                    .map(|island| {
-                        let pill_w = island.last_layout.0;
-                        let pill_cx = island.last_layout.2;
-                        let card_w = renderer::CARD_W;
-                        let pill_x = pill_cx - pill_w / 2.0;
-                        let card_x = pill_x + (pill_w - card_w) / 2.0;
-                        px - card_x > card_w - close_zone
-                    })
-                    .unwrap_or(false);
+        self.last_interaction = std::time::Instant::now();
 
-            // Clicked a card — animate dismiss (scale up + fade out), then remove.
-            if let Some(island) = self.islands.iter().find(|i| i.app_id == app_id) {
-                if let Some(card) = island.cards.iter().find(|c| c.activity_id == activity_id) {
-                    renderer::animate_dismiss(&card.surface, 1.2);
-                }
-            }
-
-            let mut state = self.state.lock().unwrap();
-            let notification_id = state
-                .activities
-                .iter()
-                .find(|a| a.id == activity_id)
-                .and_then(|a| a.notification_id);
-            let default_action = state
-                .activities
-                .iter()
-                .find(|a| a.id == activity_id)
-                .and_then(|a| a.default_action.clone());
-            if let Some(activity) = state.activities.iter().find(|a| a.id == activity_id) {
-                tracing::info!(
-                    activity_id,
-                    %app_id,
-                    close = is_close,
-                    action = ?activity.default_action,
-                    "card clicked"
-                );
-            }
-
-            state.dismiss_activity(activity_id);
-            drop(state);
-
-            if is_close {
-                // Reason 2: dismissed by the user via the Close affordance.
-                if let Some(nid) = notification_id {
-                    emit_notification_closed(nid, 2);
-                }
-            } else {
-                // Action click — focus the app and emit ActionInvoked. A hit on
-                // a specific inline action button reports that action's id;
-                // otherwise (click on the card body) it's the default action.
-                request_focus_app(app_id.clone());
-
-                if let Some(nid) = notification_id {
-                    let action_key = action_id
-                        .or(default_action)
-                        .unwrap_or_else(|| "default".to_string());
-                    emit_action_invoked(nid, action_key);
-                }
-            }
-        } else {
-            // Clicked a pill/circle.
-            // Close any other expanded island first — only one can be expanded at a time.
-            for island in self.islands.iter_mut().filter(|i| i.app_id != app_id) {
+        // Mini → Compact → Expanded is just growth; nothing is dismissed until
+        // the notification is actually open.
+        if self.islands[idx].mode != IslandMode::Expanded {
+            // Only one island is open at a time.
+            for island in &mut self.islands {
                 if island.mode == IslandMode::Expanded {
-                    Self::close_cards_for(island);
                     island.mode = IslandMode::Compact;
-                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
                 }
             }
-            let island = self.islands.iter_mut().find(|i| i.app_id == app_id);
-            if let Some(island) = island {
-                match island.mode {
-                    IslandMode::Mini => {
-                        tracing::info!(%app_id, "click: Mini → Compact");
-                        self.focused_app = Some(app_id.clone());
-                        self.last_interaction = std::time::Instant::now();
-                        island.mode = IslandMode::Compact;
-                        island.peek_until = None;
-                    }
-                    IslandMode::Compact => {
-                        tracing::info!(%app_id, "click: Compact → Expanded");
-                        self.focused_app = Some(app_id.clone());
-                        self.last_interaction = std::time::Instant::now();
-                        island.mode = IslandMode::Expanded;
-                        island.peek_until = None;
-                    }
-                    IslandMode::Expanded => {
-                        tracing::info!(%app_id, "click: Expanded → Compact");
-                        Self::close_cards_for(island);
-                        island.mode = IslandMode::Compact;
-                        island.last_layout = (0.0, 0.0, 0.0, 0.0);
-                        // Keep focus so timeout governs Mini transition.
-                        self.focused_app = Some(app_id.clone());
-                        self.last_interaction = std::time::Instant::now();
-                    }
-                }
-            }
-            // Mark dirty so sync() runs.
+            let island = &mut self.islands[idx];
+            island.peek_until = None;
+            island.mode = match island.mode {
+                IslandMode::Mini => IslandMode::Compact,
+                _ => IslandMode::Expanded,
+            };
+            tracing::info!(app_id = %island.app_id, mode = ?island.mode, "click: island opened");
+            self.focused_island = Some(activity_id);
             let mut state = self.state.lock().unwrap();
             state.dirty = true;
+            return;
+        }
+
+        // The island is expanded: decide between close, an inline action, and
+        // the body (default action). An action button always wins over the
+        // close zone — the buttons sit in the body row, clear of it.
+        let (w, _h, cx, _cy) = self.islands[idx].last_layout;
+        let is_close = action_id.is_none() && px - (cx - w / 2.0) > w - CARD_CLOSE_ZONE;
+
+        let mut state = self.state.lock().unwrap();
+        let activity = state.activities.iter().find(|a| a.id == activity_id);
+        let notification_id = activity.and_then(|a| a.notification_id);
+        let default_action = activity.and_then(|a| a.default_action.clone());
+        let app_id = self.islands[idx].app_id.clone();
+        tracing::info!(activity_id, %app_id, close = is_close, ?action_id, "expanded island clicked");
+
+        state.dismiss_activity(activity_id);
+        drop(state);
+
+        renderer::animate_dismiss(&self.islands[idx].surface, 1.2);
+
+        if is_close {
+            // Reason 2: dismissed by the user via the Close affordance.
+            if let Some(nid) = notification_id {
+                emit_notification_closed(nid, 2);
+            }
+        } else {
+            // Action click — focus the app and emit ActionInvoked. A hit on a
+            // specific inline action button reports that action's id; otherwise
+            // (a click on the body) it's the default action.
+            request_focus_app(app_id);
+            if let Some(nid) = notification_id {
+                let action_key = action_id
+                    .or(default_action)
+                    .unwrap_or_else(|| "default".to_string());
+                emit_action_invoked(nid, action_key);
+            }
         }
     }
 
@@ -1396,15 +968,15 @@ impl App for IslandApp {
             self.last_interaction = std::time::Instant::now();
         }
         let elapsed = self.last_interaction.elapsed().as_secs_f64();
-        if elapsed >= FOCUS_TIMEOUT_SECS && self.focused_app.is_some() {
+        if elapsed >= FOCUS_TIMEOUT_SECS && self.focused_island.is_some() {
             let any_expanded = self.islands.iter().any(|i| i.mode == IslandMode::Expanded);
             if !any_expanded {
                 tracing::info!(
-                    focused = ?self.focused_app,
+                    focused = ?self.focused_island,
                     elapsed_secs = format!("{:.1}", elapsed),
                     "focus timeout → all Mini"
                 );
-                self.focused_app = None;
+                self.focused_island = None;
                 let mut state = self.state.lock().unwrap();
                 state.dirty = true;
                 drop(state);
@@ -1413,27 +985,23 @@ impl App for IslandApp {
 
         let now = std::time::Instant::now();
 
-        // Peek timeout: revert Compact peek back to Mini.
+        // Peek timeout: a newly-arrived notification stops announcing itself
+        // and settles back into its app's stack.
+        let mut dirty_after_peek = false;
         for island in &mut self.islands {
             if let Some(until) = island.peek_until {
                 if now >= until {
                     tracing::info!(app_id = %island.app_id, "peek expired → Mini");
                     island.peek_until = None;
-                    island.mode = IslandMode::Mini;
-                    island.last_layout = (0.0, 0.0, 0.0, 0.0);
-                    // Snapshot current state so the next sync doesn't re-trigger peek.
-                    let state = self.state.lock().unwrap();
-                    let grouped = state.grouped_activities();
-                    drop(state);
-                    if let Some((a, c)) = grouped.iter().find(|(a, _)| a.app_id == island.app_id) {
-                        island.last_count = *c;
-                        island.last_activity_id = a.id;
-                    }
-                    let mut state = self.state.lock().unwrap();
-                    state.dirty = true;
-                    drop(state);
+                    dirty_after_peek = true;
                 }
             }
+        }
+
+        if dirty_after_peek {
+            let mut state = self.state.lock().unwrap();
+            state.dirty = true;
+            drop(state);
         }
 
         // Poll for withdrawn dialogs (caller aborted the request). This marks
@@ -1480,7 +1048,7 @@ impl App for IslandApp {
             deadlines.push(now + Duration::from_millis(500));
         }
         // Focus timeout only counts down when it can actually fire (see on_update).
-        if self.focused_app.is_some()
+        if self.focused_island.is_some()
             && !self.islands.iter().any(|i| i.mode == IslandMode::Expanded)
         {
             deadlines.push(self.last_interaction + Duration::from_secs_f64(FOCUS_TIMEOUT_SECS));
@@ -1523,13 +1091,11 @@ impl App for IslandApp {
         _ctx: &AppContext,
         _surface: &wayland_client::protocol::wl_surface::WlSurface,
     ) {
-        // Close expanded stack on focus loss — animate cards out first.
+        // Collapse an open notification on focus loss.
         let mut changed = false;
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
-                Self::close_cards_for(island);
                 island.mode = IslandMode::Compact;
-                island.last_layout = (0.0, 0.0, 0.0, 0.0);
                 changed = true;
             }
         }
@@ -1548,23 +1114,19 @@ impl App for IslandApp {
                 PointerEventKind::Enter { .. } | PointerEventKind::Motion { .. } => {
                     let (px, py) = event.position;
                     let hit = self.hit_test(px as f32, py as f32);
-                    let new_hovered = hit.as_ref().map(|(app_id, _, _)| app_id.clone());
-                    if new_hovered != self.hovered_app {
-                        let old = &self.hovered_app;
-                        // Relayout when a Mini or Compact island gains/loses hover (for grow effect).
-                        let has_hover_grow = |app: &Option<String>| -> bool {
-                            app.as_ref()
-                                .and_then(|a| self.islands.iter().find(|i| i.app_id == *a))
-                                .is_some_and(|i| {
-                                    i.mode == IslandMode::Mini || i.mode == IslandMode::Compact
-                                })
-                        };
-                        let needs_relayout = has_hover_grow(old) || has_hover_grow(&new_hovered);
-                        self.hovered_app = new_hovered;
-                        if needs_relayout {
-                            let mut state = self.state.lock().unwrap();
-                            state.dirty = true;
-                        }
+                    let new_island = hit.as_ref().map(|(id, _)| *id);
+                    let new_app = new_island.and_then(|id| {
+                        self.islands
+                            .iter()
+                            .find(|i| i.activity_id == id)
+                            .map(|i| i.app_id.clone())
+                    });
+                    // The hovered island grows; its whole group fans out.
+                    if new_island != self.hovered_island || new_app != self.hovered_app {
+                        self.hovered_island = new_island;
+                        self.hovered_app = new_app;
+                        let mut state = self.state.lock().unwrap();
+                        state.dirty = true;
                     }
                     if hit.is_some() {
                         AppContext::set_cursor_shape(otto_kit::CursorShape::Pointer);
@@ -1573,8 +1135,9 @@ impl App for IslandApp {
                     }
                 }
                 PointerEventKind::Leave { .. } => {
-                    if self.hovered_app.is_some() {
+                    if self.hovered_app.is_some() || self.hovered_island.is_some() {
                         self.hovered_app = None;
+                        self.hovered_island = None;
                         let mut state = self.state.lock().unwrap();
                         state.dirty = true;
                     }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1031,8 +1031,15 @@ impl IslandApp {
             let island = self.islands.iter_mut().find(|i| i.app_id == app_id);
             if let Some(island) = island {
                 match island.mode {
-                    IslandMode::Mini | IslandMode::Compact => {
-                        tracing::info!(%app_id, from = ?island.mode, "click: → Expanded");
+                    IslandMode::Mini => {
+                        tracing::info!(%app_id, "click: Mini → Compact");
+                        self.focused_app = Some(app_id.clone());
+                        self.last_interaction = std::time::Instant::now();
+                        island.mode = IslandMode::Compact;
+                        island.peek_until = None;
+                    }
+                    IslandMode::Compact => {
+                        tracing::info!(%app_id, "click: Compact → Expanded");
                         self.focused_app = Some(app_id.clone());
                         self.last_interaction = std::time::Instant::now();
                         island.mode = IslandMode::Expanded;

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -31,7 +31,7 @@ use crate::state::{IslandState, SharedState};
 // ---------------------------------------------------------------------------
 
 const LAYER_W: u32 = 800;
-const LAYER_H: u32 = 400; // Tall enough for pill + MAX_VISIBLE_CARDS cards.
+const LAYER_H: u32 = 400; // Tall enough for an open notification.
 const BAR_HEIGHT: f32 = 36.0;
 const GAP: f32 = 6.0;
 /// Top edge of a dialog panel, dropped down just below the island bar.
@@ -46,7 +46,7 @@ const CARD_ICON: f32 = 24.0;
 const CARD_CLOSE_ZONE: f32 = 40.0;
 
 // ---------------------------------------------------------------------------
-// Island — one notification group or music activity
+// Island — one notification
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,7 +120,7 @@ struct IslandApp {
     surfaces_ready: bool,
     /// Which island (by notification id) is currently focused (Compact/Expanded).
     focused_island: Option<u64>,
-    /// Which island the pointer is over (drives the hover grow).
+    /// Which island the pointer is over — it grows to the peek size.
     hovered_island: Option<u64>,
     /// Which group (by app_id) the pointer is over — that stack fans out.
     hovered_app: Option<String>,
@@ -282,7 +282,11 @@ impl IslandApp {
         for island in &mut self.islands {
             if island.mode == IslandMode::Expanded {
                 // Only user interaction (click / focus loss) closes it.
-            } else if Some(island.activity_id) == self.focused_island {
+            } else if Some(island.activity_id) == self.focused_island
+                || Some(island.activity_id) == self.hovered_island
+            {
+                // Hovering a mini bubble grows it to the peek size, so you can
+                // read what it is before deciding to open it.
                 island.mode = IslandMode::Compact;
             } else if island.peek_until.is_some() {
                 island.mode = IslandMode::Compact;
@@ -301,9 +305,10 @@ impl IslandApp {
     /// Islands grouped by app, front-to-back within each group.
     ///
     /// Groups are ordered by their oldest notification so a group keeps its
-    /// place in the row as notifications come and go. Within a group the
-    /// focused island is pulled to the front, then newest first — the front
-    /// island is the one on top of the stack and the one a click lands on.
+    /// place in the row as notifications come and go. Within a group it is
+    /// always newest-first: focusing or hovering an island grows it where it
+    /// stands rather than pulling it to the front, so the deck never
+    /// reshuffles under the pointer.
     fn group_order(&self) -> Vec<Vec<usize>> {
         let mut groups: Vec<(std::time::Instant, String, Vec<usize>)> = Vec::new();
         for (idx, island) in self.islands.iter().enumerate() {
@@ -317,16 +322,10 @@ impl IslandApp {
         }
         groups.sort_by_key(|(oldest, _, _)| *oldest);
 
-        let focused = self.focused_island;
         groups
             .into_iter()
             .map(|(_, _, mut members)| {
-                members.sort_by_key(|&i| {
-                    let island = &self.islands[i];
-                    let is_focused = Some(island.activity_id) == focused;
-                    // Focused first, then newest first.
-                    (!is_focused, std::cmp::Reverse(island.created_at))
-                });
+                members.sort_by_key(|&i| std::cmp::Reverse(self.islands[i].created_at));
                 members
             })
             .collect()
@@ -368,25 +367,17 @@ impl IslandApp {
             let mut sizes: Vec<(usize, f32, f32)> = Vec::new();
             for &idx in members {
                 let island = &self.islands[idx];
-                let hovered = self.hovered_island == Some(island.activity_id);
-                let grow = if hovered && island.mode != IslandMode::Expanded {
-                    renderer::HOVER_GROW
-                } else {
-                    0.0
-                };
                 let (w, h) = match island.mode {
-                    IslandMode::Mini => (MINI_H + grow, MINI_H + grow),
-                    IslandMode::Compact => (
-                        renderer::pill_width(&title_of(island)) + grow,
-                        COMPACT_H + grow,
-                    ),
+                    IslandMode::Mini => (MINI_H, MINI_H),
+                    IslandMode::Compact => (renderer::pill_width(&title_of(island)), COMPACT_H),
                     IslandMode::Expanded => (renderer::CARD_W, renderer::CARD_H),
                 };
                 sizes.push((idx, w, h));
             }
 
-            // An expanded island leaves the stack and takes its own slot on
-            // the left; whatever is left of the group stacks to its right.
+            // An expanded island leaves the stack and takes its own slot. The
+            // rest of the group — the train — trails off to its left, so the
+            // open notification stays at the right-hand front of its group.
             let expanded: Vec<&(usize, f32, f32)> = sizes
                 .iter()
                 .filter(|(i, _, _)| self.islands[*i].mode == IslandMode::Expanded)
@@ -399,13 +390,8 @@ impl IslandApp {
             let mut placed: Vec<(usize, f32, f32, f32)> = Vec::new();
             let mut cursor = 0.0_f32;
             let mut group_w = 0.0_f32;
-            for &&(idx, w, h) in &expanded {
-                placed.push((idx, cursor, w, h));
-                group_w = group_w.max(cursor + w);
-                cursor += w + GAP;
-            }
 
-            if !stacked.is_empty() {
+            if let Some(&&(_, front_w, _)) = stacked.first() {
                 // Depth of the visible deck; anything deeper piles up at the
                 // back so a huge group can't stretch the row.
                 let depth = stacked.len().min(renderer::MAX_STACK);
@@ -418,6 +404,13 @@ impl IslandApp {
                     placed.push((idx, offset, w, h));
                     group_w = group_w.max(offset + w);
                 }
+                cursor += back_span + front_w + GAP;
+            }
+
+            for &&(idx, w, h) in &expanded {
+                placed.push((idx, cursor, w, h));
+                group_w = group_w.max(cursor + w);
+                cursor += w + GAP;
             }
 
             group_widths.push(group_w);

--- a/components/otto-islands/src/notifications.rs
+++ b/components/otto-islands/src/notifications.rs
@@ -6,8 +6,8 @@
 
 use otto_kit::AppContext;
 use std::collections::HashMap;
-use zbus::interface;
 use zbus::zvariant::Value;
+use zbus::{interface, SignalContext};
 
 use crate::activity::{NotificationAction, Priority};
 use crate::state::SharedState;
@@ -132,14 +132,21 @@ impl NotificationDaemon {
     }
 
     /// Close a notification by ID.
-    async fn close_notification(&self, id: u32) -> zbus::fdo::Result<()> {
-        let mut state = self.state.lock().unwrap();
-        let dismissed = state.dismiss_notification(id);
-        drop(state);
+    async fn close_notification(
+        &self,
+        id: u32,
+        #[zbus(signal_context)] ctxt: SignalContext<'_>,
+    ) -> zbus::fdo::Result<()> {
+        let dismissed = {
+            let mut state = self.state.lock().unwrap();
+            state.dismiss_notification(id)
+        };
 
         if dismissed {
             AppContext::request_wakeup();
             tracing::info!(id, "notification closed");
+            // Reason 3: closed by a CloseNotification call.
+            Self::notification_closed(&ctxt, id, 3).await?;
         }
         Ok(())
     }
@@ -154,9 +161,23 @@ impl NotificationDaemon {
         )
     }
 
-    // TODO: Signals — these require zbus SignalContext
-    // NotificationClosed(id: u32, reason: u32)
-    // ActionInvoked(id: u32, action_key: String)
+    /// Emitted when a notification is closed — reasons per spec: 1 = expired,
+    /// 2 = dismissed by the user, 3 = closed via CloseNotification, 4 = undefined.
+    #[zbus(signal)]
+    pub async fn notification_closed(
+        ctxt: &SignalContext<'_>,
+        id: u32,
+        reason: u32,
+    ) -> zbus::Result<()>;
+
+    /// Emitted when the user activates one of a notification's actions (or the
+    /// default action by clicking the notification body).
+    #[zbus(signal)]
+    pub async fn action_invoked(
+        ctxt: &SignalContext<'_>,
+        id: u32,
+        action_key: &str,
+    ) -> zbus::Result<()>;
 }
 
 fn parse_urgency(hints: &HashMap<String, Value>) -> Priority {

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -335,13 +335,18 @@ fn truncate_text(text: &str, font: &skia_safe::Font, max_width: f32) -> String {
 // Surface style helpers
 // ---------------------------------------------------------------------------
 
-/// Bounce for ordinary layout moves — growing, shrinking, and getting pushed
-/// along by a neighbour. Enough overshoot that bubbles feel like they have
-/// weight rather than sliding on rails.
-const LAYOUT_BOUNCE: f64 = 0.4;
-/// Springs settle within the transaction's duration, so this is really "how
-/// long the bounce takes to die down". Short enough to stay responsive.
-const LAYOUT_DURATION: f64 = 0.55;
+/// Moving and resizing get their own springs, because they read as different
+/// kinds of motion: a bubble shoved aside by its neighbour should overshoot
+/// and rock back, while the same bubble growing should just settle.
+///
+/// Bounce for being pushed along the row — overshoots the target and comes
+/// back, enough to feel shoved rather than slid.
+const MOVE_BOUNCE: f64 = 0.45;
+const MOVE_DURATION: f64 = 0.6;
+/// Bounce for growing and shrinking — barely any, so a bubble changing size
+/// doesn't wobble while its content is being read.
+const RESIZE_BOUNCE: f64 = 0.12;
+const RESIZE_DURATION: f64 = 0.45;
 
 pub fn apply_island_style(
     surface: &otto_kit::SubsurfaceSurface,
@@ -398,24 +403,34 @@ pub fn animate_to_with_opacity(
         if let Some(scene) = AppContext::surface_style_manager() {
             let qh = AppContext::queue_handle();
 
-            let timing = scene.create_timing_function(qh, ());
-            timing.set_spring(LAYOUT_BOUNCE, 0.0);
-
-            let anim = scene.begin_transaction(qh, ());
-            anim.set_duration(LAYOUT_DURATION);
+            // Two transactions, so position and size can carry different
+            // springs: the bubble is shoved to its new spot with overshoot
+            // while it settles into its new size without wobbling.
+            let move_timing = scene.create_timing_function(qh, ());
+            move_timing.set_spring(MOVE_BOUNCE, 0.0);
+            let move_anim = scene.begin_transaction(qh, ());
+            move_anim.set_duration(MOVE_DURATION);
             if delay > 0.0 {
-                anim.set_delay(delay);
+                move_anim.set_delay(delay);
             }
-            anim.set_timing_function(&timing);
-
-            scene_surface.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
+            move_anim.set_timing_function(&move_timing);
             scene_surface.set_position(x as f64 * buffer_scale(), y as f64 * buffer_scale());
+            move_anim.commit();
+
+            let resize_timing = scene.create_timing_function(qh, ());
+            resize_timing.set_spring(RESIZE_BOUNCE, 0.0);
+            let resize_anim = scene.begin_transaction(qh, ());
+            resize_anim.set_duration(RESIZE_DURATION);
+            if delay > 0.0 {
+                resize_anim.set_delay(delay);
+            }
+            resize_anim.set_timing_function(&resize_timing);
+            scene_surface.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
             scene_surface.set_corner_radius(radius * buffer_scale());
             if let Some(o) = opacity {
                 scene_surface.set_opacity(o);
             }
-
-            anim.commit();
+            resize_anim.commit();
         }
     }
 }

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -15,7 +15,7 @@ pub const CARD_W: f32 = 300.0;
 pub const CARD_H: f32 = 68.0;
 /// Corner radius of an open notification — noticeably squarer than the fully
 /// rounded pill/circle it grew out of.
-pub const CARD_RADIUS: f32 = 8.0;
+pub const CARD_RADIUS: f32 = 12.0;
 
 /// Horizontal offset between stacked islands of the same app at rest — small,
 /// so they read as one deck with only a sliver of each one behind showing.

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -345,7 +345,7 @@ const MOVE_BOUNCE: f64 = 0.45;
 const MOVE_DURATION: f64 = 0.6;
 /// Bounce for growing and shrinking — barely any, so a bubble changing size
 /// doesn't wobble while its content is being read.
-const RESIZE_BOUNCE: f64 = 0.12;
+const RESIZE_BOUNCE: f64 = 0.04;
 const RESIZE_DURATION: f64 = 0.45;
 
 pub fn apply_island_style(
@@ -440,18 +440,18 @@ pub fn animate_to_with_opacity(
 /// The surface must already be sized and positioned at its final layout — this
 /// only drives the transform, so the content never reflows. Starts as a small,
 /// fully-rounded, transparent blob at the panel's centre (anchor is 0.5/0.5)
-/// and springs out to full size with a pronounced bounce, the corner radius
-/// relaxing to `radius` on the way.
+/// and springs out to full size, the corner radius relaxing to `radius` on
+/// the way.
 pub fn animate_enter_pop(surface: &otto_kit::SubsurfaceSurface, radius: f64) {
-    /// Scale the panel starts at. Small enough to read as "a shape opening up"
-    /// rather than "a panel that was already there, slightly smaller".
-    const FROM_SCALE: f64 = 0.32;
+    /// Scale the panel starts at. Enough to read as "a shape opening up"
+    /// without launching it across the row.
+    const FROM_SCALE: f64 = 0.62;
     /// Corner radius at rest in the start state. Once divided by FROM_SCALE it
     /// is far larger than half the collapsed box, so the blob reads as a pill.
     const FROM_RADIUS: f64 = 44.0;
-    /// Spring bounce. Higher still than ordinary layout moves — an island
-    /// arriving is the one moment it should really spring.
-    const BOUNCE: f64 = 0.55;
+    /// Spring bounce — a little more than a resize settles with, since this is
+    /// the island announcing itself, but nowhere near a pop.
+    const BOUNCE: f64 = 0.2;
 
     if let Some(scene_surface) = surface.base_surface().surface_style() {
         // Start state, applied outside any transaction so it is instant.

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -1,5 +1,4 @@
 use crate::activity::{Activity, NotificationAction};
-use otto_kit::desktop_entry::lookup_app;
 use otto_kit::icons::named_icon_sized;
 use otto_kit::protocols::otto_surface_style_v1::{BlendMode, ClipMode, ContentsGravity};
 use otto_kit::typography::TextStyle;
@@ -10,17 +9,22 @@ use skia_safe::{Canvas, Color, Paint, RRect, Rect};
 // Constants (from spec)
 // ---------------------------------------------------------------------------
 
-pub const MINI_W: f32 = 44.0;
 pub const MINI_H: f32 = 28.0;
-pub const COMPACT_W: f32 = 240.0;
 pub const COMPACT_H: f32 = 36.0;
 pub const CARD_W: f32 = 300.0;
-pub const CARD_H: f32 = 60.0;
-pub const CARD_GAP: f32 = 4.0;
-pub const CARD_RADIUS: f32 = 10.0;
+pub const CARD_H: f32 = 68.0;
+pub const CARD_RADIUS: f32 = 14.0;
 pub const HOVER_GROW: f32 = 4.0;
-pub const MAX_VISIBLE_CARDS: usize = 5;
-pub const MORE_INDICATOR_H: f32 = 24.0;
+
+/// Horizontal offset between stacked islands of the same app at rest — small,
+/// so they read as one deck with only a sliver of each one behind showing.
+pub const PEEK_STEP: f32 = 8.0;
+/// Offset between stacked islands when the group is hovered — fanned out far
+/// enough that each one can be aimed at and clicked individually.
+pub const FAN_STEP: f32 = 20.0;
+/// Islands past this depth in a group pile up at the same offset, so a huge
+/// group can't grow the row without bound.
+pub const MAX_STACK: usize = 5;
 
 pub const SLOT_BUF_W: i32 = 460;
 pub const SLOT_BUF_H: i32 = 140;
@@ -37,55 +41,23 @@ pub fn buffer_scale() -> f64 {
 // Drawing: group pill (Compact mode)
 // ---------------------------------------------------------------------------
 
-/// Resolve an app_id to a human-readable display name via XDG desktop entries.
-fn app_display_name(app_id: &str) -> String {
-    lookup_app(app_id)
-        .map(|info| info.name)
-        .unwrap_or_else(|| app_id.to_string())
-}
-
-/// Compute the width needed for a notification pill based on its content.
-/// Measures both rows (app name + title) and uses the wider one.
-pub fn pill_width(app_id: &str, title: &str, count: usize) -> f32 {
+/// Compute the width a Compact pill needs for one notification's own title.
+pub fn pill_width(title: &str) -> f32 {
     let pad = 8.0;
     let icon_size = COMPACT_H - pad * 2.0;
     let text_x = pad + icon_size + 6.0;
-    let badge_w = if count > 1 { 8.0 + 18.0 } else { 0.0 };
-
-    // Top row: app name (9px)
-    let name = app_display_name(app_id);
-    let app_font = TextStyle {
-        family: "Inter",
-        weight: 600,
-        size: 9.0,
-    }
-    .font();
-    let (name_w, _) = app_font.measure_str(&name, None);
-
-    // Bottom row: notification title (11px)
-    let display_title = if title.is_empty() { &name } else { title };
-    let title_font = TextStyle {
+    let font = TextStyle {
         family: "Inter",
         weight: 600,
         size: 11.0,
     }
     .font();
-    let (title_w, _) = title_font.measure_str(display_title, None);
-
-    let text_w = name_w.max(title_w);
-    (text_x + text_w + badge_w + pad).clamp(MINI_W, 340.0)
+    let (title_w, _) = font.measure_str(title, None);
+    (text_x + title_w + pad).clamp(MINI_H, 300.0)
 }
 
-pub fn draw_pill(
-    canvas: &Canvas,
-    app_id: &str,
-    icon: &str,
-    title: &str,
-    count: usize,
-    _expanded: bool,
-    w: f32,
-    h: f32,
-) {
+/// Compact: this notification's own icon and title on one line.
+pub fn draw_pill(canvas: &Canvas, icon: &str, title: &str, w: f32, h: f32) {
     let pad = 8.0;
     let icon_size = h - pad * 2.0;
     let icon_x = pad;
@@ -93,88 +65,31 @@ pub fn draw_pill(
     draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
 
     let text_x = icon_x + icon_size + 6.0;
-    let badge_w = if count > 1 { 8.0 + 18.0 } else { 0.0 };
-    let max_w = w - text_x - badge_w - pad;
+    let max_w = w - text_x - pad;
 
-    // Top row: app name (small, dimmer)
-    let name = app_display_name(app_id);
-    let app_font = TextStyle {
-        family: "Inter",
-        weight: 600,
-        size: 9.0,
-    }
-    .font();
-    let mut app_paint = Paint::default();
-    app_paint.set_anti_alias(true);
-    app_paint.set_color(Color::from_argb(140, 255, 255, 255));
-    let app_label = truncate_text(&name, &app_font, max_w);
-    canvas.draw_str(&app_label, (text_x, h / 2.0 - 3.0), &app_font, &app_paint);
-
-    // Bottom row: notification title (bold, white)
-    let title_font = TextStyle {
+    let font = TextStyle {
         family: "Inter",
         weight: 600,
         size: 11.0,
     }
     .font();
-    let mut title_paint = Paint::default();
-    title_paint.set_anti_alias(true);
-    title_paint.set_color(Color::WHITE);
-    let display_title = if title.is_empty() { &name } else { title };
-    let title_label = truncate_text(display_title, &title_font, max_w);
-    canvas.draw_str(
-        &title_label,
-        (text_x, h / 2.0 + 9.0),
-        &title_font,
-        &title_paint,
-    );
-
-    // Count badge
-    if count > 1 {
-        draw_count_badge(canvas, w - pad - 18.0, (h - 14.0) / 2.0, count);
-    }
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::WHITE);
+    let label = truncate_text(title, &font, max_w);
+    canvas.draw_str(&label, (text_x, h / 2.0 + 4.0), &font, &paint);
 }
 
 // ---------------------------------------------------------------------------
-// Drawing: peek pill (two-line: app name + notification title)
-// ---------------------------------------------------------------------------
-// Drawing: group circle (Mini mode)
+// Drawing: mini circle
 // ---------------------------------------------------------------------------
 
-/// Width for a mini pill: smaller when just one notification.
-pub fn mini_width(count: usize) -> f32 {
-    if count > 1 {
-        MINI_W
-    } else {
-        MINI_H // square pill (icon only)
-    }
-}
-
-pub fn draw_mini(canvas: &Canvas, icon: &str, count: usize, _w: f32, h: f32) {
+/// Mini: just this notification's icon in a circle. There is no count badge —
+/// how many bubbles are stacked behind is what conveys the count.
+pub fn draw_mini(canvas: &Canvas, icon: &str, _w: f32, h: f32) {
     let pad = 6.0;
     let icon_size = h - pad * 2.0;
-    let icon_x = pad;
-    let icon_y = (h - icon_size) / 2.0;
-    draw_app_icon(canvas, icon, icon_x, icon_y, icon_size);
-
-    if count > 1 {
-        let count_text = format!("{count}");
-        let font = TextStyle {
-            family: "Inter",
-            weight: 600,
-            size: 11.0,
-        }
-        .font();
-        let mut paint = Paint::default();
-        paint.set_anti_alias(true);
-        paint.set_color(Color::WHITE);
-        canvas.draw_str(
-            &count_text,
-            (icon_x + icon_size + 4.0, h / 2.0 + 4.0),
-            &font,
-            &paint,
-        );
-    }
+    draw_app_icon(canvas, icon, pad, (h - icon_size) / 2.0, icon_size);
 }
 
 // ---------------------------------------------------------------------------
@@ -194,18 +109,14 @@ pub fn elapsed_label(created_at: std::time::Instant) -> String {
     }
 }
 
-pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32, h: f32) {
+/// Expanded: the island itself grown into a full notification, drawn directly
+/// into the same bubble — icon, title, body (or inline actions), time, close.
+pub fn draw_card(canvas: &Canvas, activity: &Activity, w: f32, h: f32) {
     let pad = 10.0;
-
-    // Use the activity icon if available, otherwise fall back to group icon.
-    let icon = if activity.icon.is_empty() {
-        group_icon
-    } else {
-        &activity.icon
-    };
+    let icon = activity.icon.as_str();
 
     // No background rect here — the subsurface itself is the near-black
-    // bubble material (apply_card_style), same as the pill.
+    // bubble material (apply_island_style).
 
     // Icon
     let icon_size = 24.0;
@@ -312,25 +223,8 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     );
 }
 
-/// "+N more" indicator shown below the stack when there are more
-/// notifications than fit in the visible card list (spec: MAX_VISIBLE_CARDS).
-pub fn draw_more_indicator(canvas: &Canvas, count: usize, w: f32, h: f32) {
-    let font = TextStyle {
-        family: "Inter",
-        weight: 600,
-        size: 10.0,
-    }
-    .font();
-    let mut paint = Paint::default();
-    paint.set_anti_alias(true);
-    paint.set_color(Color::from_argb(160, 255, 255, 255));
-    let text = format!("+{count} more");
-    let (tw, _) = font.measure_str(&text, None);
-    canvas.draw_str(&text, ((w - tw) / 2.0, h / 2.0 + 4.0), &font, &paint);
-}
-
 // ---------------------------------------------------------------------------
-// Helpers: icons, badges, text
+// Helpers: icons, text
 // ---------------------------------------------------------------------------
 // (dialog and fingerprint rendering will be added in separate PRs)
 
@@ -378,33 +272,6 @@ fn draw_envelope(canvas: &Canvas, x: f32, y: f32, size: f32) {
     b.line_to((x + w / 2.0, oy + h * 0.55));
     b.line_to((x + w, oy));
     canvas.draw_path(&b.detach(), &paint);
-}
-
-fn draw_count_badge(canvas: &Canvas, x: f32, y: f32, count: usize) {
-    let badge_w = 18.0_f32;
-    let badge_h = 14.0_f32;
-    let badge_r = 7.0_f32;
-
-    let mut bg = Paint::default();
-    bg.set_anti_alias(true);
-    bg.set_color(Color::from_argb(80, 255, 255, 255));
-    canvas.draw_rrect(
-        RRect::new_rect_xy(Rect::from_xywh(x, y, badge_w, badge_h), badge_r, badge_r),
-        &bg,
-    );
-
-    let text = format!("{count}");
-    let font = TextStyle {
-        family: "Inter",
-        weight: 600,
-        size: 10.0,
-    }
-    .font();
-    let mut paint = Paint::default();
-    paint.set_anti_alias(true);
-    paint.set_color(Color::WHITE);
-    let (cw, _) = font.measure_str(&text, None);
-    canvas.draw_str(&text, (x + (badge_w - cw) / 2.0, y + 11.0), &font, &paint);
 }
 
 /// Lay out a row of inline action-button chips starting at `(text_x, pad + 28.0)`,
@@ -483,21 +350,6 @@ pub fn apply_island_style(
     }
 }
 
-/// Style for notification cards — same near-black bubble material as the
-/// group pill, so a card reads as a continuation of the same shape rather
-/// than a separate panel.
-pub fn apply_card_style(surface: &otto_kit::SubsurfaceSurface) {
-    if let Some(ss) = surface.base_surface().surface_style() {
-        ss.set_background_color(0.03, 0.03, 0.03, 1.0);
-        ss.set_corner_radius(CARD_RADIUS as f64 * buffer_scale());
-        ss.set_masks_to_bounds(ClipMode::Enabled);
-        ss.set_shadow(0.25, 16.0, 0.0, 1.0, 0.0, 0.0, 0.0);
-        ss.set_blend_mode(BlendMode::BackgroundBlur);
-        ss.set_contents_gravity(ContentsGravity::Center);
-        ss.set_anchor_point(0.5, 0.5);
-    }
-}
-
 pub fn set_size_and_position(
     surface: &otto_kit::SubsurfaceSurface,
     w: f32,
@@ -553,66 +405,6 @@ pub fn animate_to_with_opacity(
             if let Some(o) = opacity {
                 scene_surface.set_opacity(o);
             }
-
-            anim.commit();
-        }
-    }
-}
-
-/// Animate only position and opacity (size is set instantly, not animated).
-pub fn animate_position_opacity(
-    surface: &otto_kit::SubsurfaceSurface,
-    w: f32,
-    h: f32,
-    x: f32,
-    y: f32,
-    opacity: f64,
-    delay: f64,
-) {
-    animate_position_opacity_duration(surface, w, h, x, y, opacity, delay, 0.3);
-}
-
-pub fn animate_position_opacity_slow(
-    surface: &otto_kit::SubsurfaceSurface,
-    w: f32,
-    h: f32,
-    x: f32,
-    y: f32,
-    opacity: f64,
-    delay: f64,
-) {
-    animate_position_opacity_duration(surface, w, h, x, y, opacity, delay, 0.8);
-}
-
-fn animate_position_opacity_duration(
-    surface: &otto_kit::SubsurfaceSurface,
-    w: f32,
-    h: f32,
-    x: f32,
-    y: f32,
-    opacity: f64,
-    delay: f64,
-    duration: f64,
-) {
-    if let Some(scene_surface) = surface.base_surface().surface_style() {
-        // Set size immediately (outside any transaction).
-        scene_surface.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
-
-        if let Some(scene) = AppContext::surface_style_manager() {
-            let qh = AppContext::queue_handle();
-
-            let timing = scene.create_timing_function(qh, ());
-            timing.set_spring(0.0, 0.0);
-
-            let anim = scene.begin_transaction(qh, ());
-            anim.set_duration(duration);
-            if delay > 0.0 {
-                anim.set_delay(delay);
-            }
-            anim.set_timing_function(&timing);
-
-            scene_surface.set_position(x as f64 * buffer_scale(), y as f64 * buffer_scale());
-            scene_surface.set_opacity(opacity);
 
             anim.commit();
         }
@@ -681,24 +473,6 @@ pub fn animate_dismiss(surface: &otto_kit::SubsurfaceSurface, scale: f64) {
             anim.commit();
         }
     }
-}
-
-/// Pulse animation: instantly grow by `grow` pixels, then spring back to target size.
-/// With center anchor, position stays the same — only size changes.
-pub fn animate_pulse(
-    surface: &otto_kit::SubsurfaceSurface,
-    w: f32,
-    h: f32,
-    cx: f32,
-    cy: f32,
-    radius: f64,
-    grow: f32,
-) {
-    // Step 1: instantly set to enlarged size (center anchor keeps it centered).
-    set_size_and_position(surface, w + grow, h + grow, cx, cy);
-
-    // Step 2: spring back to target size.
-    animate_to(surface, w, h, cx, cy, radius, 0.0);
 }
 
 /// Draw content centered in the subsurface buffer.

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -13,8 +13,9 @@ pub const MINI_H: f32 = 28.0;
 pub const COMPACT_H: f32 = 36.0;
 pub const CARD_W: f32 = 300.0;
 pub const CARD_H: f32 = 68.0;
-pub const CARD_RADIUS: f32 = 14.0;
-pub const HOVER_GROW: f32 = 4.0;
+/// Corner radius of an open notification — noticeably squarer than the fully
+/// rounded pill/circle it grew out of.
+pub const CARD_RADIUS: f32 = 8.0;
 
 /// Horizontal offset between stacked islands of the same app at rest — small,
 /// so they read as one deck with only a sliver of each one behind showing.

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -193,7 +193,6 @@ pub fn elapsed_label(created_at: std::time::Instant) -> String {
 }
 
 pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32, h: f32) {
-    let theme = AppContext::current_theme();
     let pad = 10.0;
 
     // Use the activity icon if available, otherwise fall back to group icon.
@@ -203,14 +202,8 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
         &activity.icon
     };
 
-    // Background — uses theme material
-    let mut bg = Paint::default();
-    bg.set_anti_alias(true);
-    bg.set_color(theme.material_medium);
-    canvas.draw_rrect(
-        RRect::new_rect_xy(Rect::from_xywh(0.0, 0.0, w, h), CARD_RADIUS, CARD_RADIUS),
-        &bg,
-    );
+    // No background rect here — the subsurface itself is the near-black
+    // bubble material (apply_card_style), same as the pill.
 
     // Icon
     let icon_size = 24.0;
@@ -227,7 +220,7 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     .font();
     let mut title_paint = Paint::default();
     title_paint.set_anti_alias(true);
-    title_paint.set_color(theme.text_primary);
+    title_paint.set_color(Color::WHITE);
     let close_zone = 40.0;
     let text_x = icon_x + icon_size + 8.0;
     let max_w = w - text_x - close_zone;
@@ -244,7 +237,7 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
         .font();
         let mut body_paint = Paint::default();
         body_paint.set_anti_alias(true);
-        body_paint.set_color(theme.text_secondary);
+        body_paint.set_color(Color::from_argb(180, 255, 255, 255));
         let body = truncate_text(&activity.body, &body_font, max_w);
         canvas.draw_str(&body, (text_x, pad + 28.0), &body_font, &body_paint);
     }
@@ -258,7 +251,7 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     .font();
     let mut hint_paint = Paint::default();
     hint_paint.set_anti_alias(true);
-    hint_paint.set_color(theme.text_tertiary);
+    hint_paint.set_color(Color::from_argb(120, 255, 255, 255));
     let time_str = elapsed_label(activity.created_at);
     let (tw, _) = hint_font.measure_str(&time_str, None);
     canvas.draw_str(
@@ -271,7 +264,7 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     // Separator line before close zone
     let mut sep_paint = Paint::default();
     sep_paint.set_anti_alias(true);
-    sep_paint.set_color(Color::from_argb(20, 0, 0, 0));
+    sep_paint.set_color(Color::from_argb(30, 255, 255, 255));
     sep_paint.set_stroke_width(1.0);
     let sep_x = w - close_zone;
     canvas.draw_line((sep_x, 0.0), (sep_x, h), &sep_paint);
@@ -285,7 +278,7 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     .font();
     let mut close_paint = Paint::default();
     close_paint.set_anti_alias(true);
-    close_paint.set_color(theme.text_secondary);
+    close_paint.set_color(Color::from_argb(180, 255, 255, 255));
     let (cw, _) = close_font.measure_str("Close", None);
     canvas.draw_str(
         "Close",
@@ -415,17 +408,12 @@ pub fn apply_island_style(
     }
 }
 
-/// Style for notification cards — theme material background with blur.
+/// Style for notification cards — same near-black bubble material as the
+/// group pill, so a card reads as a continuation of the same shape rather
+/// than a separate panel.
 pub fn apply_card_style(surface: &otto_kit::SubsurfaceSurface) {
-    let theme = AppContext::current_theme();
-    let c = theme.material_medium;
     if let Some(ss) = surface.base_surface().surface_style() {
-        ss.set_background_color(
-            c.r() as f64 / 255.0,
-            c.g() as f64 / 255.0,
-            c.b() as f64 / 255.0,
-            c.a() as f64 / 255.0,
-        );
+        ss.set_background_color(0.03, 0.03, 0.03, 1.0);
         ss.set_corner_radius(CARD_RADIUS as f64 * buffer_scale());
         ss.set_masks_to_bounds(ClipMode::Enabled);
         ss.set_shadow(0.25, 16.0, 0.0, 1.0, 0.0, 0.0, 0.0);

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -1,4 +1,4 @@
-use crate::activity::Activity;
+use crate::activity::{Activity, NotificationAction};
 use otto_kit::desktop_entry::lookup_app;
 use otto_kit::icons::named_icon_sized;
 use otto_kit::protocols::otto_surface_style_v1::{BlendMode, ClipMode, ContentsGravity};
@@ -227,8 +227,30 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
     let title = truncate_text(&activity.title, &title_font, max_w);
     canvas.draw_str(&title, (text_x, pad + 13.0), &title_font, &title_paint);
 
-    // Body
-    if !activity.body.is_empty() {
+    // Body — or, when the notification has inline actions, a row of action
+    // buttons in the same slot (there isn't room for both in a 60px card).
+    if !activity.actions.is_empty() {
+        for (bx, by, bw, bh, _id, label) in action_button_rects(&activity.actions, text_x, max_w) {
+            let mut btn_bg = Paint::default();
+            btn_bg.set_anti_alias(true);
+            btn_bg.set_color(Color::from_argb(50, 255, 255, 255));
+            canvas.draw_rrect(
+                RRect::new_rect_xy(Rect::from_xywh(bx, by, bw, bh), bh / 2.0, bh / 2.0),
+                &btn_bg,
+            );
+
+            let btn_font = TextStyle {
+                family: "Inter",
+                weight: 600,
+                size: 10.0,
+            }
+            .font();
+            let mut btn_paint = Paint::default();
+            btn_paint.set_anti_alias(true);
+            btn_paint.set_color(Color::WHITE);
+            canvas.draw_str(&label, (bx + 8.0, by + bh - 5.0), &btn_font, &btn_paint);
+        }
+    } else if !activity.body.is_empty() {
         let body_font = TextStyle {
             family: "Inter",
             weight: 400,
@@ -364,6 +386,40 @@ fn draw_count_badge(canvas: &Canvas, x: f32, y: f32, count: usize) {
     paint.set_color(Color::WHITE);
     let (cw, _) = font.measure_str(&text, None);
     canvas.draw_str(&text, (x + (badge_w - cw) / 2.0, y + 11.0), &font, &paint);
+}
+
+/// Lay out a row of inline action-button chips starting at `(text_x, pad + 28.0)`,
+/// left to right, dropping any that don't fit within `max_w`. Returns
+/// `(x, y, w, h, action_id, label)` per button in card-local coordinates —
+/// shared by `draw_card` (drawing) and hit-testing (`main.rs`) so the two
+/// never disagree about where a button is.
+pub fn action_button_rects(
+    actions: &[NotificationAction],
+    text_x: f32,
+    max_w: f32,
+) -> Vec<(f32, f32, f32, f32, String, String)> {
+    const BTN_H: f32 = 18.0;
+    const GAP: f32 = 6.0;
+    let y = 10.0 + 28.0; // pad + 28.0, same row the body text would occupy
+    let font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 10.0,
+    }
+    .font();
+
+    let mut rects = Vec::new();
+    let mut x = text_x;
+    for action in actions {
+        let (tw, _) = font.measure_str(&action.label, None);
+        let bw = tw + 16.0;
+        if x + bw > text_x + max_w {
+            break;
+        }
+        rects.push((x, y, bw, BTN_H, action.id.clone(), action.label.clone()));
+        x += bw + GAP;
+    }
+    rects
 }
 
 fn truncate_text(text: &str, font: &skia_safe::Font, max_width: f32) -> String {

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -20,9 +20,16 @@ pub const CARD_GAP: f32 = 4.0;
 pub const CARD_RADIUS: f32 = 10.0;
 pub const HOVER_GROW: f32 = 4.0;
 
-pub const BUFFER_SCALE: f64 = 2.0;
 pub const SLOT_BUF_W: i32 = 460;
 pub const SLOT_BUF_H: i32 = 140;
+
+/// Physical-pixel scale for geometry pushed to `otto-surface-style-v1`
+/// (that protocol operates in physical pixels). Must track the real output
+/// scale, not the client's fixed 2x raster buffer scale — see
+/// `otto-bar/src/app.rs`'s `animate_right_size` for the same fix.
+pub fn buffer_scale() -> f64 {
+    AppContext::fractional_scale()
+}
 
 // ---------------------------------------------------------------------------
 // Drawing: group pill (Compact mode)
@@ -399,7 +406,7 @@ pub fn apply_island_style(
 ) {
     if let Some(ss) = surface.base_surface().surface_style() {
         ss.set_background_color(0.03, 0.03, 0.03, 1.0);
-        ss.set_corner_radius(radius * BUFFER_SCALE);
+        ss.set_corner_radius(radius * buffer_scale());
         ss.set_masks_to_bounds(ClipMode::Enabled);
         ss.set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0);
         ss.set_blend_mode(BlendMode::BackgroundBlur);
@@ -419,7 +426,7 @@ pub fn apply_card_style(surface: &otto_kit::SubsurfaceSurface) {
             c.b() as f64 / 255.0,
             c.a() as f64 / 255.0,
         );
-        ss.set_corner_radius(CARD_RADIUS as f64 * BUFFER_SCALE);
+        ss.set_corner_radius(CARD_RADIUS as f64 * buffer_scale());
         ss.set_masks_to_bounds(ClipMode::Enabled);
         ss.set_shadow(0.25, 16.0, 0.0, 1.0, 0.0, 0.0, 0.0);
         ss.set_blend_mode(BlendMode::BackgroundBlur);
@@ -436,8 +443,8 @@ pub fn set_size_and_position(
     y: f32,
 ) {
     if let Some(ss) = surface.base_surface().surface_style() {
-        ss.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
-        ss.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
+        ss.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
+        ss.set_position(x as f64 * buffer_scale(), y as f64 * buffer_scale());
     }
 }
 
@@ -477,9 +484,9 @@ pub fn animate_to_with_opacity(
             }
             anim.set_timing_function(&timing);
 
-            scene_surface.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
-            scene_surface.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
-            scene_surface.set_corner_radius(radius * BUFFER_SCALE);
+            scene_surface.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
+            scene_surface.set_position(x as f64 * buffer_scale(), y as f64 * buffer_scale());
+            scene_surface.set_corner_radius(radius * buffer_scale());
             if let Some(o) = opacity {
                 scene_surface.set_opacity(o);
             }
@@ -526,7 +533,7 @@ fn animate_position_opacity_duration(
 ) {
     if let Some(scene_surface) = surface.base_surface().surface_style() {
         // Set size immediately (outside any transaction).
-        scene_surface.set_size(w as f64 * BUFFER_SCALE, h as f64 * BUFFER_SCALE);
+        scene_surface.set_size(w as f64 * buffer_scale(), h as f64 * buffer_scale());
 
         if let Some(scene) = AppContext::surface_style_manager() {
             let qh = AppContext::queue_handle();
@@ -541,7 +548,7 @@ fn animate_position_opacity_duration(
             }
             anim.set_timing_function(&timing);
 
-            scene_surface.set_position(x as f64 * BUFFER_SCALE, y as f64 * BUFFER_SCALE);
+            scene_surface.set_position(x as f64 * buffer_scale(), y as f64 * buffer_scale());
             scene_surface.set_opacity(opacity);
 
             anim.commit();
@@ -570,7 +577,7 @@ pub fn animate_enter_pop(surface: &otto_kit::SubsurfaceSurface, radius: f64) {
     if let Some(scene_surface) = surface.base_surface().surface_style() {
         // Start state, applied outside any transaction so it is instant.
         scene_surface.set_scale(FROM_SCALE, FROM_SCALE);
-        scene_surface.set_corner_radius(FROM_RADIUS * BUFFER_SCALE);
+        scene_surface.set_corner_radius(FROM_RADIUS * buffer_scale());
         scene_surface.set_opacity(0.0);
 
         if let Some(scene) = AppContext::surface_style_manager() {
@@ -584,7 +591,7 @@ pub fn animate_enter_pop(surface: &otto_kit::SubsurfaceSurface, radius: f64) {
             anim.set_timing_function(&timing);
 
             scene_surface.set_scale(1.0, 1.0);
-            scene_surface.set_corner_radius(radius * BUFFER_SCALE);
+            scene_surface.set_corner_radius(radius * buffer_scale());
             scene_surface.set_opacity(1.0);
 
             anim.commit();

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -335,6 +335,14 @@ fn truncate_text(text: &str, font: &skia_safe::Font, max_width: f32) -> String {
 // Surface style helpers
 // ---------------------------------------------------------------------------
 
+/// Bounce for ordinary layout moves — growing, shrinking, and getting pushed
+/// along by a neighbour. Enough overshoot that bubbles feel like they have
+/// weight rather than sliding on rails.
+const LAYOUT_BOUNCE: f64 = 0.4;
+/// Springs settle within the transaction's duration, so this is really "how
+/// long the bounce takes to die down". Short enough to stay responsive.
+const LAYOUT_DURATION: f64 = 0.55;
+
 pub fn apply_island_style(
     surface: &otto_kit::SubsurfaceSurface,
     radius: f64,
@@ -391,10 +399,10 @@ pub fn animate_to_with_opacity(
             let qh = AppContext::queue_handle();
 
             let timing = scene.create_timing_function(qh, ());
-            timing.set_spring(0.15, 0.0);
+            timing.set_spring(LAYOUT_BOUNCE, 0.0);
 
             let anim = scene.begin_transaction(qh, ());
-            anim.set_duration(0.8);
+            anim.set_duration(LAYOUT_DURATION);
             if delay > 0.0 {
                 anim.set_delay(delay);
             }
@@ -426,9 +434,9 @@ pub fn animate_enter_pop(surface: &otto_kit::SubsurfaceSurface, radius: f64) {
     /// Corner radius at rest in the start state. Once divided by FROM_SCALE it
     /// is far larger than half the collapsed box, so the blob reads as a pill.
     const FROM_RADIUS: f64 = 44.0;
-    /// Spring bounce. Higher than the 0.15 used for ordinary layout moves —
-    /// this is the one moment the panel is meant to feel springy.
-    const BOUNCE: f64 = 0.42;
+    /// Spring bounce. Higher still than ordinary layout moves — an island
+    /// arriving is the one moment it should really spring.
+    const BOUNCE: f64 = 0.55;
 
     if let Some(scene_surface) = surface.base_surface().surface_style() {
         // Start state, applied outside any transaction so it is instant.

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -19,6 +19,8 @@ pub const CARD_H: f32 = 60.0;
 pub const CARD_GAP: f32 = 4.0;
 pub const CARD_RADIUS: f32 = 10.0;
 pub const HOVER_GROW: f32 = 4.0;
+pub const MAX_VISIBLE_CARDS: usize = 5;
+pub const MORE_INDICATOR_H: f32 = 24.0;
 
 pub const SLOT_BUF_W: i32 = 460;
 pub const SLOT_BUF_H: i32 = 140;
@@ -308,6 +310,23 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, group_icon: &str, w: f32,
         &close_font,
         &close_paint,
     );
+}
+
+/// "+N more" indicator shown below the stack when there are more
+/// notifications than fit in the visible card list (spec: MAX_VISIBLE_CARDS).
+pub fn draw_more_indicator(canvas: &Canvas, count: usize, w: f32, h: f32) {
+    let font = TextStyle {
+        family: "Inter",
+        weight: 600,
+        size: 10.0,
+    }
+    .font();
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::from_argb(160, 255, 255, 255));
+    let text = format!("+{count} more");
+    let (tw, _) = font.measure_str(&text, None);
+    canvas.draw_str(&text, ((w - tw) / 2.0, h / 2.0 + 4.0), &font, &paint);
 }
 
 // ---------------------------------------------------------------------------

--- a/components/otto-islands/src/renderer.rs
+++ b/components/otto-islands/src/renderer.rs
@@ -12,7 +12,20 @@ use skia_safe::{Canvas, Color, Paint, RRect, Rect};
 pub const MINI_H: f32 = 28.0;
 pub const COMPACT_H: f32 = 36.0;
 pub const CARD_W: f32 = 300.0;
+/// Height of a card whose body fits on one line and which has no actions.
+/// A longer body or an action row grows it — see [`card_height`].
 pub const CARD_H: f32 = 68.0;
+/// Baseline-to-baseline distance between wrapped body lines.
+const BODY_LINE_H: f32 = 14.0;
+/// A notification that runs longer than this is ellipsised: past three lines
+/// the island stops being a glance and wants opening in the app instead.
+const MAX_BODY_LINES: usize = 3;
+const CARD_PAD: f32 = 10.0;
+const CARD_ICON: f32 = 24.0;
+const CARD_CLOSE_ZONE: f32 = 40.0;
+/// Height of the inline action button row, and the gap above it.
+const ACTION_ROW_H: f32 = 18.0;
+const ACTION_ROW_GAP: f32 = 8.0;
 /// Corner radius of an open notification — noticeably squarer than the fully
 /// rounded pill/circle it grew out of.
 pub const CARD_RADIUS: f32 = 12.0;
@@ -141,10 +154,24 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, w: f32, h: f32) {
     let title = truncate_text(&activity.title, &title_font, max_w);
     canvas.draw_str(&title, (text_x, pad + 13.0), &title_font, &title_paint);
 
-    // Body — or, when the notification has inline actions, a row of action
-    // buttons in the same slot (there isn't room for both in a 60px card).
+    // Body, wrapped over as many lines as the card was sized for. The card
+    // grows to fit it, so the text is readable on arrival rather than cut off
+    // after a few words.
+    if !activity.body.is_empty() {
+        let body_font = body_font();
+        let mut body_paint = Paint::default();
+        body_paint.set_anti_alias(true);
+        body_paint.set_color(Color::from_argb(180, 255, 255, 255));
+        for (i, line) in card_body_lines(&activity.body, w).iter().enumerate() {
+            let y = BODY_TOP_BASELINE + i as f32 * BODY_LINE_H;
+            canvas.draw_str(line, (text_x, y), &body_font, &body_paint);
+        }
+    }
+
+    // Inline action buttons, on their own row under the body.
     if !activity.actions.is_empty() {
-        for (bx, by, bw, bh, _id, label) in action_button_rects(&activity.actions, text_x, max_w) {
+        for (bx, by, bw, bh, _id, label) in card_action_rects(&activity.body, &activity.actions, w)
+        {
             let mut btn_bg = Paint::default();
             btn_bg.set_anti_alias(true);
             btn_bg.set_color(Color::from_argb(50, 255, 255, 255));
@@ -164,18 +191,6 @@ pub fn draw_card(canvas: &Canvas, activity: &Activity, w: f32, h: f32) {
             btn_paint.set_color(Color::WHITE);
             canvas.draw_str(&label, (bx + 8.0, by + bh - 5.0), &btn_font, &btn_paint);
         }
-    } else if !activity.body.is_empty() {
-        let body_font = TextStyle {
-            family: "Inter",
-            weight: 400,
-            size: 11.0,
-        }
-        .font();
-        let mut body_paint = Paint::default();
-        body_paint.set_anti_alias(true);
-        body_paint.set_color(Color::from_argb(180, 255, 255, 255));
-        let body = truncate_text(&activity.body, &body_font, max_w);
-        canvas.draw_str(&body, (text_x, pad + 28.0), &body_font, &body_paint);
     }
 
     // Elapsed time
@@ -284,10 +299,10 @@ pub fn action_button_rects(
     actions: &[NotificationAction],
     text_x: f32,
     max_w: f32,
+    y: f32,
 ) -> Vec<(f32, f32, f32, f32, String, String)> {
-    const BTN_H: f32 = 18.0;
+    const BTN_H: f32 = ACTION_ROW_H;
     const GAP: f32 = 6.0;
-    let y = 10.0 + 28.0; // pad + 28.0, same row the body text would occupy
     let font = TextStyle {
         family: "Inter",
         weight: 600,
@@ -307,6 +322,111 @@ pub fn action_button_rects(
         x += bw + GAP;
     }
     rects
+}
+
+fn body_font() -> skia_safe::Font {
+    TextStyle {
+        family: "Inter",
+        weight: 400,
+        size: 11.0,
+    }
+    .font()
+}
+
+/// Where the text column starts, and how wide it is — shared by drawing, the
+/// wrap measurement, and hit-testing so all three agree.
+fn card_text_column(w: f32) -> (f32, f32) {
+    let text_x = CARD_PAD + CARD_ICON + 8.0;
+    (text_x, w - text_x - CARD_CLOSE_ZONE)
+}
+
+/// Break `text` into at most `max_lines` lines that each fit `max_width`.
+/// The last line is ellipsised if there is more text than fits. Words longer
+/// than the column are broken mid-word rather than overflowing.
+fn wrap_text(text: &str, font: &skia_safe::Font, max_width: f32, max_lines: usize) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut line = String::new();
+
+    for word in text.split_whitespace() {
+        let candidate = if line.is_empty() {
+            word.to_string()
+        } else {
+            format!("{line} {word}")
+        };
+        if font.measure_str(&candidate, None).0 <= max_width {
+            line = candidate;
+            continue;
+        }
+        if !line.is_empty() {
+            lines.push(std::mem::take(&mut line));
+            if lines.len() == max_lines {
+                break;
+            }
+        }
+        // The word alone doesn't fit the column: let truncate_text break it.
+        if font.measure_str(word, None).0 > max_width {
+            lines.push(truncate_text(word, font, max_width));
+            if lines.len() == max_lines {
+                break;
+            }
+        } else {
+            line = word.to_string();
+        }
+    }
+    if !line.is_empty() && lines.len() < max_lines {
+        lines.push(line);
+    }
+
+    // Anything left over means we ran out of lines — mark the last one.
+    let drawn: usize = lines.iter().map(|l| l.split_whitespace().count()).sum();
+    if drawn < text.split_whitespace().count() {
+        if let Some(last) = lines.last_mut() {
+            *last = truncate_text(&format!("{last} …"), font, max_width);
+        }
+    }
+    lines
+}
+
+/// The body lines a card will draw at width `w`.
+fn card_body_lines(body: &str, w: f32) -> Vec<String> {
+    if body.is_empty() {
+        return Vec::new();
+    }
+    let (_, max_w) = card_text_column(w);
+    wrap_text(body, &body_font(), max_w, MAX_BODY_LINES)
+}
+
+/// How tall this notification's card needs to be: the one-line card, plus a
+/// line for each extra body line, plus the action row when it has actions.
+/// Layout, drawing, and hit-testing all size the card through this.
+pub fn card_height(activity: &Activity) -> f32 {
+    let lines = card_body_lines(&activity.body, CARD_W).len().max(1);
+    let mut h = CARD_H + (lines as f32 - 1.0) * BODY_LINE_H;
+    if !activity.actions.is_empty() {
+        h += ACTION_ROW_H + ACTION_ROW_GAP;
+    }
+    h
+}
+
+/// Baseline of the first body line.
+const BODY_TOP_BASELINE: f32 = CARD_PAD + 28.0;
+
+/// Top of the inline action row, sitting below the last body line.
+fn action_row_y(body: &str, w: f32) -> f32 {
+    let lines = card_body_lines(body, w).len().max(1);
+    BODY_TOP_BASELINE + (lines as f32 - 1.0) * BODY_LINE_H + ACTION_ROW_GAP
+}
+
+/// The inline action buttons of a card of width `w`, in card-local
+/// coordinates. Drawing and hit-testing both go through this so a button is
+/// clickable exactly where it was painted.
+pub fn card_action_rects(
+    body: &str,
+    actions: &[NotificationAction],
+    w: f32,
+) -> Vec<(f32, f32, f32, f32, String, String)> {
+    let (text_x, max_w) = card_text_column(w);
+    action_button_rects(actions, text_x, max_w, action_row_y(body, w))
 }
 
 fn truncate_text(text: &str, font: &skia_safe::Font, max_width: f32) -> String {

--- a/components/otto-islands/src/state.rs
+++ b/components/otto-islands/src/state.rs
@@ -208,53 +208,6 @@ impl IslandState {
         }
     }
 
-    /// Returns activities grouped for layout purposes.
-    /// Notifications from the same app_id are grouped — only the most recent
-    /// is returned as the representative, with a count of how many are in the group.
-    /// Non-notification activities (music, D-Bus, internal) are returned as-is.
-    pub fn grouped_activities(&self) -> Vec<(Activity, usize)> {
-        use std::collections::HashMap;
-
-        let mut notification_groups: HashMap<&str, Vec<&Activity>> = HashMap::new();
-        let mut result: Vec<(Activity, usize)> = Vec::new();
-
-        // Separate notifications from other activities
-        for activity in &self.activities {
-            if activity.source == ActivitySource::Notification {
-                notification_groups
-                    .entry(&activity.app_id)
-                    .or_default()
-                    .push(activity);
-            } else {
-                result.push((activity.clone(), 1));
-            }
-        }
-
-        // For each notification group, take the most recent as representative
-        for (_app_id, mut group) in notification_groups {
-            group.sort_by_key(|a| a.created_at);
-            let count = group.len();
-            if let Some(latest) = group.last() {
-                result.push(((*latest).clone(), count));
-            }
-        }
-
-        // Sort by creation time so layout order is stable
-        result.sort_by_key(|(a, _)| a.created_at);
-        result
-    }
-
-    /// Get all notifications for a given app_id, ordered by creation time (newest first).
-    pub fn notifications_for_app(&self, app_id: &str) -> Vec<&Activity> {
-        let mut result: Vec<_> = self
-            .activities
-            .iter()
-            .filter(|a| a.source == ActivitySource::Notification && a.app_id == app_id)
-            .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        result
-    }
-
     /// Remove all activities whose timeout has expired.
     pub fn expire_timeouts(&mut self) {
         let now = Instant::now();

--- a/components/otto-kit/src/icons.rs
+++ b/components/otto-kit/src/icons.rs
@@ -61,10 +61,36 @@ pub fn named_icon_sized(icon_name: &str, size: i32) -> Option<skia::Image> {
     }
 
     let scale = crate::app_runner::context::AppContext::scale_factor().max(1);
-    let icon = find_icon(icon_name, size, scale).and_then(|p| image_from_path(&p, (size, size)));
+    let icon =
+        find_icon_any_size(icon_name, size, scale).and_then(|p| image_from_path(&p, (size, size)));
 
     ic.write().unwrap().insert(cache_key, icon.clone());
     icon
+}
+
+/// The directory sizes an XDG icon theme actually ships.
+const STANDARD_ICON_SIZES: [i32; 10] = [16, 22, 24, 32, 48, 64, 96, 128, 256, 512];
+
+/// Find `icon_name` for a request of `size`, falling back to the sizes a theme
+/// is likely to have on disk.
+///
+/// A theme directory only answers for the sizes it declares, so an in-between
+/// request misses icons that plainly exist: hicolor ships ghostty at 16 and 32,
+/// and a request for 20 resolves to nothing at all. Callers scale the result
+/// into their own rect anyway, so a neighbouring size is always better than no
+/// icon. Larger neighbours come first — downscaling beats upscaling.
+fn find_icon_any_size(icon_name: &str, size: i32, scale: i32) -> Option<String> {
+    if let Some(path) = find_icon(icon_name, size, scale) {
+        return Some(path);
+    }
+    let mut candidates: Vec<i32> = STANDARD_ICON_SIZES
+        .into_iter()
+        .filter(|&s| s != size)
+        .collect();
+    candidates.sort_by_key(|&s| (s < size, (s - size).abs()));
+    candidates
+        .into_iter()
+        .find_map(|s| find_icon(icon_name, s, scale))
 }
 
 /// Load an icon from a file path with caching.

--- a/specs/notification-island.md
+++ b/specs/notification-island.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-A notification island is a group of subsurfaces that represents all notifications from one `app_id`. Multiple islands (notification groups + music) coexist side by side as a centered horizontal row. Only one island at a time can be in **Compact** (focused) mode; the rest are **Mini** circles.
+A notification island **is** one notification. There is no separate group header and no separate card: the island is the notification, and opening it grows that same bubble into the full title/body/actions layout. Islands sit side by side in a centered horizontal row at the top of the screen. Notifications from the same app are grouped *visually*, by overlapping their islands into a deck — not by collapsing them into one representative.
 
 ## Core Concepts
 
@@ -13,104 +13,92 @@ A notification island is a group of subsurfaces that represents all notification
 
 The island follows a Core Animation-like model: each visual element is its own Wayland subsurface with independent size, position, corner radius, and spring animations via `otto-surface-style-v1`. The parent layer shell surface is just a transparent container.
 
-Elements:
-- **Group pill** — one subsurface per notification group (the tab header)
-- **Notification card** — one subsurface per notification in the stack
-- **Music pill** — one subsurface for the music activity
+There is exactly one subsurface per notification. It is never destroyed and recreated to change mode — the same bubble grows and shrinks.
 
 ### Presentation Modes
 
-Each island (group) cycles through three modes via click:
+Each island is in one of three modes:
 
 | Mode | Visual | Trigger |
 |------|--------|---------|
-| **Mini** | Small circle (~28px). App icon + count badge (when count > 1). | Default for unfocused islands. |
-| **Compact** | Pill (~240x36). App icon + app name + count badge + chevron. | Click a Mini circle. |
-| **Expanded** | Compact pill stays visible. Notification cards slide down below it as a stack. | Click the Compact pill. |
+| **Mini** | Circle (28px). This notification's app icon. No count badge — how many bubbles are stacked behind conveys the count. | Default at rest. |
+| **Compact** | Pill (36px tall, width from its own title). Icon + title on one line. | Hover, focus, or an arrival that could not open. |
+| **Expanded** | Card (300px wide, height from its content). Icon, title, wrapped body, inline actions, elapsed time, Close zone. | Arrival, or a click on a Compact pill. |
 
-Click cycles: **Mini → Compact → Expanded → Compact** (clicking the pill toggles the stack).
+Click grows: **Mini → Compact → Expanded**. Nothing is dismissed until the notification is actually open; a click on an Expanded island acts on it (see *Click targets*).
 
-Only **1** island can be Compact/Expanded at a time (configurable, default 1). When one island becomes Compact, the previously focused one shrinks to Mini.
+Exactly **one** island may be Compact at a time, and one Expanded. The Compact slot goes to the pointer first, then whatever was last clicked, then an arrival that could not open. A burst of notifications therefore never blows the row up into a wall of pills.
+
+### Arrival
+
+A new notification opens **Expanded**, so it can be read on sight rather than after a click.
+
+- It stays open for `ARRIVAL_READ_SECS` (6s), then settles back into its stack.
+- The window is held open while the pointer is on that island, so it never collapses out from under someone reading it.
+- An arrival never takes over an island the **user** opened themselves. In that case it announces itself Compact instead and the open island is left alone.
+- Only a user-opened island stays Expanded indefinitely. One that opened on arrival closes again when its window runs out.
 
 ### Hover
 
-Hover causes a subtle size increase on any island element (pill or circle) to invite interaction. No mode change on hover.
+Hovering an island grows it to Compact and fans out its app's deck so each bubble can be aimed at individually. Hover pauses the focus timeout.
 
 ## Layout
 
-All islands are arranged as a **centered horizontal row** at the top of the screen:
+Islands are arranged as a **centered horizontal row**, ordered by arrival:
 
 ```
-Layer surface (480px wide, anchored top-center):
+Layer surface (anchored top-center):
 
-    [o] [o] [===compact pill===]
-    ←────── centered as group ──────→
+    [o] [o] [==compact pill==]  [o]
+    ←──────── centered as a row ────────→
 ```
 
-- Elements are ordered left-to-right by arrival time (oldest left, newest right).
-- The focused (Compact/Expanded) island is the rightmost non-mini, or whichever was last clicked.
-- Gap between elements: 6px.
-- Vertically centered within the bar height (30px) for Mini/Compact.
+- The row is centred, so an island growing pushes its neighbours **both ways**.
+- Each bubble covers a fixed slice of the one before it, so the step comes from the bubble's own width: growing — or opening fully — pushes the newer ones along instead of expanding underneath them. Nothing ever changes places.
+- The push **cascades** outward from whichever island grew, `CASCADE_STAGGER_SECS` per island, so the row ripples rather than moving in lockstep. When that island shrinks again the row cascades back in the same order.
+- Moving and resizing get their own springs: a bubble shoved aside by its neighbour overshoots and rocks back, while the same bubble growing just settles.
 
-When a stack is open (Expanded mode), cards appear below the pill:
+### Same-app decks
 
-```
-    [o] [o] [===compact pill===]
-              [  card 1        ]
-              [  card 2        ]
-              [  card 3        ]
-```
+Islands sharing an `app_id` overlap into one deck, newest at the front (right-hand end), older ones peeking out to its left.
 
-Cards are centered under the pill.
+- At rest the offset is `PEEK_STEP` — a sliver, so the deck reads as one object.
+- While the group is hovered it is `FAN_STEP`, far enough that each bubble can be clicked individually.
+- Past `MAX_STACK` from the front, bubbles pile up at the same offset, so a huge group cannot grow the row without bound.
+- Groups are ordered by their oldest notification, so a group keeps its place in the row as notifications come and go.
 
-## Notification Group Behavior
+## Notification Behavior
 
-### One group = one `app_id`
+### Lifecycle
 
-All notifications from the same `app_id` are grouped into one island. The group pill shows the app icon, app name, and count.
+1. Notification arrives → island created, opens Expanded (see *Arrival*).
+2. Another notification from the same app → its own island, joining that app's deck at the front.
+3. Notification times out → island removed, with a dismiss animation.
+4. User clicks an open island → invokes an action or closes it, and the notification is dismissed.
+5. `replaces_id` → updates the notification in place (no reorder).
 
-### Notification lifecycle
+### Click targets
 
-1. First notification from an app → group created, island appears as Mini (or Compact if no other island is focused).
-2. More notifications from same app → count increments, pill/circle redraws.
-3. Notification times out → stays in the group (not removed). Only dismissed by user action.
-4. User clicks a card → invokes default action + dismisses that notification.
-5. All notifications dismissed → group disappears, island removed from row.
-6. `replaces_id` → updates the notification in place (no reorder).
+On an Expanded island:
 
-### Stack (Expanded mode)
+- **Close zone** (right `CARD_CLOSE_ZONE` px, behind the separator) → dismiss. Emits `NotificationClosed` with reason 2 (dismissed by the user).
+- **An inline action button** → emits `ActionInvoked` with that action's id, focuses the app, dismisses.
+- **Anywhere else (the body)** → the default action: same as above with the notification's default action id, or `"default"`.
 
-- Default max visible cards: **5** (configurable).
-- If more than max: show a "+N more" indicator at the bottom.
-- Cards are created as subsurfaces **lazily** when the stack opens.
-- Cards are destroyed when the stack closes.
+An action button always wins over the close zone; the buttons sit in the body row, clear of it.
 
-### Stack open animation
+### Focus timeout
 
-1. Each card starts at zero height, positioned at the pill bottom.
-2. Cards slide down to their final position with staggered delay (0.05s per card).
-3. Spring animation (same parameters as all other transitions).
-
-### Stack close animation
-
-1. Cards collapse height to zero, sliding up toward the pill.
-2. Card subsurfaces are destroyed after animation.
-
-### Closing the stack
-
-The stack closes when:
-- The pill is clicked again (toggle).
-- The user clicks outside the island.
-- The island loses focus (e.g., user focuses another app/window).
+After `FOCUS_TIMEOUT_SECS` of no interaction, the focused island shrinks back to Mini. The timer is paused while the pointer is over any island, and does not run while an island is Expanded.
 
 ## Subsurface Style
 
 All subsurfaces use `otto-surface-style-v1`:
 
-- `set_background_color(0.03, 0.03, 0.03, 1.0)` — near-black
-- `set_corner_radius(r)` — circle for Mini, pill radius for Compact, card radius for cards
+- `set_background_color(...)` — near-black bubble material
+- `set_corner_radius(r)` — circle for Mini, pill radius for Compact, `CARD_RADIUS` for Expanded (noticeably squarer than the pill it grew out of)
 - `set_masks_to_bounds(Enabled)` — clip content
-- `set_shadow(0.2, 2.0, 0.0, 8.0, 0.0, 0.0, 0.0)` — drop shadow
+- `set_shadow(...)` — drop shadow
 - `set_blend_mode(BackgroundBlur)` — frosted glass
 - `set_contents_gravity(Center)` — content anchored center
 
@@ -118,64 +106,66 @@ No opacity manipulation. All elements are always fully visible.
 
 ## Rendering
 
-Content is drawn with Skia into each subsurface's buffer. The buffer is larger than needed (460x100) so content can be drawn at target size before the compositor spring-animates the visual bounds.
+Content is drawn with Skia into each subsurface's buffer. The buffer (`SLOT_BUF_W` x `SLOT_BUF_H`) is larger than any card so content can be drawn at target size before the compositor spring-animates the visual bounds.
+
+Geometry pushed to `otto-surface-style-v1` is in **physical pixels** and must use the real output scale (`AppContext::fractional_scale()`), not the client's fixed 2x raster buffer scale.
 
 Rendering is fully retained-mode — the client never pushes frames continuously:
 
-- Each pill/card stores a content signature (mode, icon, title, count, size / title, body, icon, time label). A buffer is redrawn and committed only when its signature changes; all motion (springs, fades, resizes) runs compositor-side via the surface-style protocol against the retained buffer.
+- Each island stores a content signature (mode, icon, title, body, time label, actions, size). A buffer is redrawn and committed only when its signature changes; all motion (springs, resizes, moves) runs compositor-side via the surface-style protocol against the retained buffer.
 - The parent layer surface is committed only when its size, input region, or subsurface stacking actually changed.
-- The event loop sleeps until the next real deadline (peek expiry, focus timeout, deferred destroy, notification timeout) or an external wakeup (Wayland event, D-Bus via `request_wakeup`). With no pending deadlines the process is fully idle — no periodic tick, no frame callbacks.
+- The event loop sleeps until the next real deadline (arrival window, focus timeout, deferred destroy, notification timeout) or an external wakeup (Wayland event, D-Bus via `request_wakeup`). With no pending deadlines the process is fully idle — no periodic tick, no frame callbacks.
 
-### Group pill (Compact)
+### Mini
 
-- App icon (rounded, left)
-- App name text (bold, 12pt)
-- Count badge (when > 1): semi-transparent pill with white count text
-- Chevron indicator (right edge)
+- App icon centered in the circle.
 
-### Group circle (Mini)
+### Compact
 
-- App icon centered (60% of circle size)
-- Count badge overlay (bottom-right, when > 1)
+- App icon (left) + this notification's own title (bold, 11pt), truncated to the pill width.
 
-### Notification card
+### Expanded
 
-- Card background: semi-transparent white (alpha 40), rounded corners (10px)
-- App icon (24px, left)
-- Title (bold, 12pt, white)
-- Body (regular, 11pt, dimmed)
-- Elapsed time (9pt, bottom-right)
-- Card dimensions: 300x60px, gap between cards: 4px
+Drawn straight into the bubble — there is no separate card background.
 
-## Coexistence with Music
+- App icon (`CARD_ICON` px, top-left)
+- Title (bold, 12pt, white), truncated to the text column
+- Body (regular, 11pt, dimmed), **wrapped** over up to `MAX_BODY_LINES` lines at `BODY_LINE_H` spacing; the last line is ellipsised if it still doesn't fit. Words longer than the column are broken mid-word rather than overflowing.
+- Inline action buttons, on their own row under the body — not in place of it
+- Elapsed time (9pt, bottom-right of the text area)
+- Separator line and a `Close` label in the right-hand zone
 
-Music is another island in the same row. It follows the same Mini/Compact/Expanded rules:
-- When music is Compact, notification groups are Mini circles.
-- When a notification group is clicked to Compact, music shrinks to Mini.
-- Music Mini: 3-bar equalizer in a circle.
-- Music Compact: album art + title + artist + equalizer.
+The card **grows to fit**: its height is the one-line height plus a line for each extra body line, plus the action row when it has actions. Layout, drawing, and hit-testing all size the card through the same function, so a button is clickable exactly where it was painted.
 
 ## D-Bus Integration
 
 - `org.otto.Island1` — custom API for creating arbitrary activities.
-- `org.freedesktop.Notifications` — standard notification daemon. Notifications come in here and are grouped by `app_id`.
+- `org.freedesktop.Notifications` — standard notification daemon. Each notification becomes its own island; `app_id` only decides which deck it joins.
+- `NotificationClosed` and `ActionInvoked` are emitted so senders learn what the user did.
 
 ## Constants
 
 | Name | Value | Description |
 |------|-------|-------------|
-| LAYER_W | 480 | Layer surface width |
-| BAR_HEIGHT | 30 | Topbar area height |
+| LAYER_W | 800 | Layer surface width |
+| LAYER_H | 400 | Layer surface height (tall enough for an open notification) |
+| BAR_HEIGHT | 36 | Topbar area height |
 | GAP | 6 | Space between islands |
-| MINI_SIZE | 28 | Mini circle diameter |
-| COMPACT_W | 240 | Compact pill width |
-| COMPACT_H | 36 | Compact pill height |
-| CARD_W | 300 | Notification card width |
-| CARD_H | 60 | Notification card height |
-| CARD_GAP | 4 | Gap between cards |
-| CARD_RADIUS | 10 | Card corner radius |
-| MAX_VISIBLE_CARDS | 5 | Default max cards in stack |
-| MAX_FOCUSED | 1 | Max islands in Compact mode |
+| MINI_H | 28 | Mini circle diameter |
+| COMPACT_H | 36 | Compact pill height (width comes from the title) |
+| CARD_W | 300 | Expanded card width |
+| CARD_H | 68 | Expanded card height with a one-line body and no actions |
+| CARD_RADIUS | 12 | Expanded corner radius |
+| BODY_LINE_H | 14 | Baseline-to-baseline spacing of wrapped body lines |
+| MAX_BODY_LINES | 3 | Body lines before the text is ellipsised |
+| CARD_CLOSE_ZONE | 40 | Width of the right-hand Close zone |
+| ACTION_ROW_H | 18 | Height of the inline action button row |
+| PEEK_STEP | 8 | Deck offset at rest |
+| FAN_STEP | 20 | Deck offset while the group is hovered |
+| MAX_STACK | 5 | Deck depth past which bubbles pile up at one offset |
+| ARRIVAL_READ_SECS | 6 | How long a new notification stays open to be read |
+| FOCUS_TIMEOUT_SECS | 4 | Inactivity before the focused island shrinks to Mini |
+| CASCADE_STAGGER_SECS | 0.035 | Per-island delay as a push travels outward |
+| DESTROY_DELAY_SECS | 0.8 | How long a destroyed surface is kept for its exit animation |
 | SLOT_BUF_W | 460 | Subsurface buffer width |
-| SLOT_BUF_H | 100 | Subsurface buffer height |
-| BUFFER_SCALE | 2.0 | HiDPI scale factor |
+| SLOT_BUF_H | 140 | Subsurface buffer height |


### PR DESCRIPTION
Reworks how otto-islands presents notifications: instead of a fixed stack, each notification is its own island in a row that grows and pushes its neighbours.

## Presentation

- One island per notification, grouped by overlap; only one compact island is open at a time, strictly in arrival order.
- Islands open on the right; hovering grows one to peek while the deck keeps a stable order.
- The row is centred so a growing island pushes both ways, and the push cascades through neighbours.
- Move and resize run on separate springs, tuned so growth and entrance stay calm rather than bouncy.
- Notification cards use the same black bubble material as the rest of the island, with a softer corner radius when open.

## Interaction

- Mini → Compact and Compact → Expanded are now separate clicks, so a single click no longer skips a state.
- Inline notification action buttons are rendered and hit-tested.
- A "+N more" indicator appears when a stack exceeds `MAX_VISIBLE_CARDS`.
- `NotificationClosed` and `ActionInvoked` D-Bus signals are emitted, so senders learn what the user did.

## Fixes

- Use the real output scale instead of a hardcoded 2.0.
- Keep input alive on a layer surface that has grown — previously a grown island stopped accepting clicks.
- otto-kit: fall back to nearby icon sizes when an icon lacks the exact one requested.

## Arrival opens full size

A notification arrived at the mid Compact size, showing only its title, so reading it needed a click. It now opens Expanded for six seconds — held open while the pointer is on it — then settles back into its stack. An arrival never takes over an island the user opened themselves; it announces itself Compact instead.

The card grows to fit its content: the body wraps over up to three lines instead of being ellipsised after a few words, and inline actions get their own row under the body rather than replacing it.

`specs/notification-island.md` is rewritten to match the redesign — it still described the old per-app group-pill-plus-card-stack model.

## Testing

Built and run against the current nightly compositor on hardware: notifications arrive, queue in order, grow and push correctly, and clicks step through Mini → Compact → Expanded.

