### PR TITLE
Dock badges: unread notification counts per app

### DIFF
--- a/components/otto-islands/src/dock_badges.rs
+++ b/components/otto-islands/src/dock_badges.rs
@@ -1,0 +1,196 @@
+//! Dock badges — the unread notification count on each app's dock icon.
+//!
+//! otto-islands is the session's notification daemon, so it is the only thing
+//! that knows how many notifications an app has outstanding. It publishes that
+//! count through `otto_dock_v1`: one dock item per app, its badge set to the
+//! number of notifications still waiting to be read. The count drops as the
+//! user dismisses them and the badge disappears with the last one.
+
+use std::collections::HashMap;
+
+use otto_kit::protocols::otto_dock_item_v1::OttoDockItemV1;
+use otto_kit::AppContext;
+
+use crate::activity::{Activity, ActivitySource};
+
+/// Counts above this are shown as "99+" — a dock badge is a glance, not a
+/// readout, and three digits do not fit the circle.
+const MAX_COUNT: usize = 99;
+
+#[derive(Default)]
+pub struct DockBadges {
+    /// One dock item per app, kept for the lifetime of the process: the
+    /// protocol has no destroy request, and the same app badges repeatedly.
+    items: HashMap<String, OttoDockItemV1>,
+    /// Badge text currently applied per app — the diff that keeps a redraw
+    /// storm off the compositor when nothing about the counts changed.
+    applied: HashMap<String, String>,
+}
+
+impl DockBadges {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reconcile every dock badge with `activities`.
+    ///
+    /// Cheap to call on every state change: only apps whose count actually
+    /// moved produce a request.
+    pub fn sync(&mut self, activities: &[Activity]) {
+        let wanted = badge_texts(activities);
+        let mut changed = false;
+
+        for (app_id, text) in &wanted {
+            if self.applied.get(app_id) == Some(text) {
+                continue;
+            }
+            let Some(item) = self.item(app_id) else {
+                continue;
+            };
+            item.set_badge(Some(text.clone()));
+            self.applied.insert(app_id.clone(), text.clone());
+            changed = true;
+        }
+
+        // Apps whose last notification just went away.
+        let cleared: Vec<String> = self
+            .applied
+            .keys()
+            .filter(|app_id| !wanted.contains_key(app_id.as_str()))
+            .cloned()
+            .collect();
+        for app_id in cleared {
+            if let Some(item) = self.items.get(&app_id) {
+                item.set_badge(None);
+            }
+            self.applied.remove(&app_id);
+            changed = true;
+        }
+
+        if changed {
+            tracing::debug!(badges = ?self.applied, "dock badges updated");
+            AppContext::flush();
+        }
+    }
+
+    /// The dock item for `app_id`, created on first use.
+    ///
+    /// `None` on a compositor without `otto_dock_v1` — badges are then simply
+    /// not shown, which is the right outcome for an optional decoration.
+    fn item(&mut self, app_id: &str) -> Option<&OttoDockItemV1> {
+        if !self.items.contains_key(app_id) {
+            let manager = AppContext::otto_dock_manager()?;
+            // `AppRunner` wraps the app in `DefaultApp`, so this is the queue
+            // handle the dispatch state is actually typed for.
+            let qh = AppContext::queue_handle();
+            let item = manager.get_dock_item(app_id.to_string(), qh, ());
+            self.items.insert(app_id.to_string(), item);
+        }
+        self.items.get(app_id)
+    }
+}
+
+/// The badge text each app should be showing for `activities`.
+fn badge_texts(activities: &[Activity]) -> HashMap<String, String> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for activity in activities.iter().filter(|a| badgeable(a)) {
+        *counts.entry(activity.app_id.as_str()).or_insert(0) += 1;
+    }
+
+    counts
+        .into_iter()
+        .map(|(app_id, count)| {
+            let text = if count > MAX_COUNT {
+                format!("{MAX_COUNT}+")
+            } else {
+                count.to_string()
+            };
+            (app_id.to_string(), text)
+        })
+        .collect()
+}
+
+/// Whether an activity counts towards its app's badge.
+///
+/// Only real notifications do: an internal activity (a media island, a
+/// progress readout) is not something the user has to come back to. Transient
+/// notifications opt out of persistence by definition, so they never badge.
+fn badgeable(activity: &Activity) -> bool {
+    activity.source == ActivitySource::Notification
+        && !activity.transient
+        && !activity.app_id.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activity::Priority;
+    use std::time::Instant;
+
+    fn notification(app_id: &str) -> Activity {
+        Activity {
+            id: 0,
+            app_id: app_id.to_string(),
+            title: String::new(),
+            body: String::new(),
+            icon: String::new(),
+            progress: None,
+            timeout_ms: 0,
+            priority: Priority::Normal,
+            live: false,
+            created_at: Instant::now(),
+            expired: false,
+            actions: Vec::new(),
+            default_action: None,
+            category: None,
+            image_path: None,
+            transient: false,
+            resident: false,
+            notification_id: Some(1),
+            source: ActivitySource::Notification,
+        }
+    }
+
+    #[test]
+    fn counts_notifications_per_app() {
+        let activities = vec![
+            notification("ghostty"),
+            notification("ghostty"),
+            notification("thunderbird"),
+        ];
+        let texts = badge_texts(&activities);
+        assert_eq!(texts.get("ghostty"), Some(&"2".to_string()));
+        assert_eq!(texts.get("thunderbird"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn transient_and_internal_activities_do_not_badge() {
+        let mut transient = notification("ghostty");
+        transient.transient = true;
+        let mut internal = notification("music");
+        internal.source = ActivitySource::Internal;
+
+        assert!(badge_texts(&[transient, internal]).is_empty());
+    }
+
+    #[test]
+    fn a_hundred_notifications_read_as_99_plus() {
+        let activities: Vec<Activity> = (0..100).map(|_| notification("ghostty")).collect();
+        assert_eq!(
+            badge_texts(&activities).get("ghostty"),
+            Some(&"99+".to_string())
+        );
+    }
+
+    #[test]
+    fn an_expired_notification_still_badges() {
+        // Expiring only takes the island off the row; the notification has
+        // still not been read, which is exactly what the badge counts.
+        let mut expired = notification("ghostty");
+        expired.expired = true;
+        assert_eq!(
+            badge_texts(&[expired]).get("ghostty"),
+            Some(&"1".to_string())
+        );
+    }
+}

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -829,6 +829,11 @@ impl IslandApp {
                     .or(default_action)
                     .unwrap_or_else(|| "default".to_string());
                 emit_action_invoked(nid, action_key);
+                // The notification is gone from the island either way, so the
+                // sender has to hear about it — an app that tracks its own
+                // notifications would otherwise think this one is still up.
+                // Reason 2: dismissed by the user, by acting on it.
+                emit_notification_closed(nid, 2);
             }
         }
     }

--- a/components/otto-islands/src/main.rs
+++ b/components/otto-islands/src/main.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod dbus_service;
 mod dialog;
+mod dock_badges;
 mod notifications;
 mod renderer;
 mod state;
@@ -21,6 +22,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 use crate::activity::Activity;
 use crate::dbus_service::{DialogService, IslandService, DBUS_NAME};
 use crate::dialog::{DialogHit, DialogId, DialogResponse, DialogView};
+use crate::dock_badges::DockBadges;
 use crate::renderer::{
     animate_to, apply_island_style, draw_centered, set_size_and_position, COMPACT_H, MINI_H,
 };
@@ -154,6 +156,8 @@ struct IslandApp {
     last_input_region: Option<Vec<(i32, i32, i32, i32)>>,
     /// The currently-presented Access-style dialog, if any.
     dialog: Option<DialogPanel>,
+    /// Unread-notification counts published onto the dock icons.
+    dock_badges: DockBadges,
 }
 
 impl IslandApp {
@@ -174,6 +178,7 @@ impl IslandApp {
             last_layer_size: None,
             last_input_region: None,
             dialog: None,
+            dock_badges: DockBadges::new(),
         }
     }
 
@@ -233,6 +238,10 @@ impl IslandApp {
         let state = self.state.lock().unwrap();
         let notifications: Vec<Activity> = state.activities.clone();
         drop(state);
+
+        // The dock shows what is still waiting to be read, whether or not the
+        // island for it is still on screen.
+        self.dock_badges.sync(&notifications);
 
         // Remove islands whose notification is gone.
         let mut removed_island = false;

--- a/components/otto-islands/src/notifications.rs
+++ b/components/otto-islands/src/notifications.rs
@@ -52,6 +52,8 @@ impl NotificationDaemon {
         actions: Vec<String>,
         hints: HashMap<String, Value<'_>>,
         expire_timeout: i32,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
     ) -> zbus::fdo::Result<u32> {
         // Parse hints
         let priority = parse_urgency(&hints);
@@ -61,8 +63,14 @@ impl NotificationDaemon {
         let transient = parse_bool_hint(&hints, "transient");
         let resident = parse_bool_hint(&hints, "resident");
 
-        // Determine app_id: prefer desktop-entry hint, fall back to app_name
-        let app_id = desktop_entry.unwrap_or_else(|| app_name.to_string());
+        // Determine app_id: prefer the desktop-entry hint, then app_name.
+        // A notification forwarded from a terminal escape sequence carries
+        // neither — the sending process is then the only thing that says
+        // which app this is.
+        let app_id = match desktop_entry.or_else(|| non_empty(app_name)) {
+            Some(id) => id,
+            None => sender_app_id(connection, &header).await.unwrap_or_default(),
+        };
 
         // Resolve icon: prefer app_icon param, then image-path hint, then app_id
         let icon = if !app_icon.is_empty() {
@@ -178,6 +186,37 @@ impl NotificationDaemon {
         id: u32,
         action_key: &str,
     ) -> zbus::Result<()>;
+}
+
+/// The app id of whichever process made this D-Bus call, resolved through its
+/// executable name.
+///
+/// Used only when a notification identifies itself no other way. Returns the
+/// desktop file id, so it lines up with what the dock files icons under.
+async fn sender_app_id(
+    connection: &zbus::Connection,
+    header: &zbus::message::Header<'_>,
+) -> Option<String> {
+    let sender = header.sender()?.to_owned();
+    let pid = zbus::fdo::DBusProxy::new(connection)
+        .await
+        .ok()?
+        .get_connection_unix_process_id(sender.into())
+        .await
+        .ok()?;
+
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    let comm = comm.trim();
+
+    let app_id = otto_kit::desktop_entry::lookup_app_by_binary(comm)
+        .and_then(|info| info.desktop_file_id)
+        .unwrap_or_else(|| comm.to_string());
+    tracing::debug!(pid, comm, app_id, "notification attributed to its sender");
+    Some(app_id)
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    (!s.is_empty()).then(|| s.to_string())
 }
 
 fn parse_urgency(hints: &HashMap<String, Value>) -> Priority {

--- a/components/otto-kit/src/desktop_entry.rs
+++ b/components/otto-kit/src/desktop_entry.rs
@@ -32,6 +32,11 @@ pub struct AppInfo {
 static CACHE: std::sync::LazyLock<RwLock<HashMap<String, Option<AppInfo>>>> =
     std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Separate cache for [`lookup_app_by_binary`]: its keys are program names,
+/// which must not answer a plain `app_id` lookup.
+static BINARY_CACHE: std::sync::LazyLock<RwLock<HashMap<String, Option<AppInfo>>>> =
+    std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
+
 /// Look up app info for the given `app_id`.
 ///
 /// Searches XDG desktop entry paths for a `.desktop` file whose filename
@@ -124,6 +129,78 @@ fn load_app_info(app_id: &str) -> Option<AppInfo> {
         app_id: app_id.to_string(),
         categories,
     })
+}
+
+/// Look up app info for a program name — the basename of an executable, as
+/// found in `/proc/<pid>/comm` or an `Exec=` line.
+///
+/// This is the loose cousin of [`lookup_app`], for when all that is known
+/// about an app is which binary it is: a notification that arrives with no
+/// `desktop-entry` hint, say, identified only by the process that sent it.
+/// `ghostty` finds `com.mitchellh.ghostty.desktop`, which `lookup_app` alone
+/// would miss.
+///
+/// Matching, in order: the desktop file id, its last reverse-DNS segment, then
+/// the program its `Exec=` line runs. Results are cached, `None` included.
+pub fn lookup_app_by_binary(binary: &str) -> Option<AppInfo> {
+    if binary.is_empty() {
+        return None;
+    }
+    if let Some(cached) = BINARY_CACHE.read().unwrap().get(binary) {
+        return cached.clone();
+    }
+
+    let result = lookup_app(binary).or_else(|| load_app_info_by_binary(binary));
+
+    BINARY_CACHE
+        .write()
+        .unwrap()
+        .insert(binary.to_string(), result.clone());
+    result
+}
+
+fn load_app_info_by_binary(binary: &str) -> Option<AppInfo> {
+    let mut by_exec = None;
+
+    for path in freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths()) {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        // `ghostty` naming `com.mitchellh.ghostty` — the common case, and
+        // unambiguous enough to take straight away.
+        if stem
+            .rsplit('.')
+            .next()
+            .map(|seg| seg.eq_ignore_ascii_case(binary))
+            .unwrap_or(false)
+        {
+            return lookup_app(stem);
+        }
+
+        // An Exec match is weaker — several entries can launch the same
+        // program with different arguments — so it is only used if no id
+        // matches at all.
+        if by_exec.is_none() {
+            let runs_binary = DesktopEntry::from_path(path.clone(), Some(&["en"]))
+                .ok()
+                .and_then(|entry| entry.exec().map(|s| s.to_string()))
+                .and_then(|exec| exec.split_whitespace().next().map(|s| s.to_string()))
+                .map(|program| {
+                    std::path::Path::new(&program)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .map(|name| name.eq_ignore_ascii_case(binary))
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
+            if runs_binary {
+                by_exec = Some(stem.to_string());
+            }
+        }
+    }
+
+    by_exec.as_deref().and_then(lookup_app)
 }
 
 fn find_desktop_entry(app_id: &str) -> Option<DesktopEntry> {

--- a/specs/notification-island.md
+++ b/specs/notification-island.md
@@ -106,6 +106,11 @@ notifications that have not been read.
   it keeps counting; only dismissing it (Close zone, an inline action, the
   default action, or `CloseNotification`) takes it off the badge.
 - The badge clears with the last of them.
+- A notification that identifies itself no other way — no `desktop-entry` hint
+  and no app name, as when a terminal forwards an escape sequence on an app's
+  behalf — is attributed to the process that made the D-Bus call, resolved
+  through its executable name (`ghostty` → `com.mitchellh.ghostty`). Without
+  this, everything sent that way is anonymous and badges nothing.
 - **Transient** notifications never badge: they opt out of persistence by
   definition. Neither do non-notification activities (a media island, a
   progress readout) — nothing there is waiting to be read.

--- a/specs/notification-island.md
+++ b/specs/notification-island.md
@@ -73,7 +73,9 @@ Islands sharing an `app_id` overlap into one deck, newest at the front (right-ha
 
 1. Notification arrives → island created, opens Expanded (see *Arrival*).
 2. Another notification from the same app → its own island, joining that app's deck at the front.
-3. Notification times out → island removed, with a dismiss animation.
+3. Notification times out → the island stops announcing itself and settles
+   into its deck. It is *not* removed: an unread notification stays, and keeps
+   counting towards the app's dock badge.
 4. User clicks an open island → invokes an action or closes it, and the notification is dismissed.
 5. `replaces_id` → updates the notification in place (no reorder).
 
@@ -86,6 +88,43 @@ On an Expanded island:
 - **Anywhere else (the body)** → the default action: same as above with the notification's default action id, or `"default"`.
 
 An action button always wins over the close zone; the buttons sit in the body row, clear of it.
+
+### Dock badges
+
+An island lives at the top of the screen and eventually settles into a Mini
+circle, which is a poor place to notice three unread messages from an hour ago.
+The count therefore also rides on the app's dock icon, the way a macOS dock
+badge does.
+
+otto-islands is the session's notification daemon, so it is the only thing that
+knows the counts. It publishes them through `otto_dock_v1`: one
+`otto_dock_item_v1` per app, `set_badge` carrying the number of that app's
+notifications that have not been read.
+
+- The count is the number of the app's outstanding notifications — those still
+  in the island's state. A notification that timed out has *not* been read, so
+  it keeps counting; only dismissing it (Close zone, an inline action, the
+  default action, or `CloseNotification`) takes it off the badge.
+- The badge clears with the last of them.
+- **Transient** notifications never badge: they opt out of persistence by
+  definition. Neither do non-notification activities (a media island, a
+  progress readout) — nothing there is waiting to be read.
+- Counts above 99 read as `99+`.
+- Badges are diffed against what is already applied, so a state change that
+  leaves the counts alone sends nothing.
+
+On the compositor side:
+
+- The `app_id` a notification carries is whatever the sending app put in its
+  `desktop-entry` hint — `com.mitchellh.ghostty`, `Ghostty`,
+  `ghostty.desktop` — while the dock files its icons under the desktop file
+  stem. `AppIconsManager` resolves the id to that key before applying a badge.
+- A badge for an app the dock has not drawn yet is remembered and applied when
+  its icon stack appears, so a notification that arrives before its app is
+  running is not lost.
+- The badge belongs to the client that set it: when the dock item is destroyed
+  — including a daemon that exits — the badge is cleared, rather than leaving a
+  stale count stuck on an icon.
 
 ### Focus timeout
 
@@ -142,6 +181,7 @@ The card **grows to fit**: its height is the one-line height plus a line for eac
 - `org.otto.Island1` — custom API for creating arbitrary activities.
 - `org.freedesktop.Notifications` — standard notification daemon. Each notification becomes its own island; `app_id` only decides which deck it joins.
 - `NotificationClosed` and `ActionInvoked` are emitted so senders learn what the user did.
+- `otto_dock_v1` — outbound: the unread count per app, published as a dock badge (see *Dock badges*).
 
 ## Constants
 
@@ -162,6 +202,7 @@ The card **grows to fit**: its height is the one-line height plus a line for eac
 | ACTION_ROW_H | 18 | Height of the inline action button row |
 | PEEK_STEP | 8 | Deck offset at rest |
 | FAN_STEP | 20 | Deck offset while the group is hovered |
+| MAX_COUNT | 99 | Dock badge count above which it reads `99+` |
 | MAX_STACK | 5 | Deck depth past which bubbles pile up at one offset |
 | ARRIVAL_READ_SECS | 6 | How long a new notification stays open to be read |
 | FOCUS_TIMEOUT_SECS | 4 | Inactivity before the focused island shrinks to Mini |

--- a/src/otto_dock/handlers/item.rs
+++ b/src/otto_dock/handlers/item.rs
@@ -1,4 +1,6 @@
-use smithay::reexports::wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource};
+use smithay::reexports::wayland_server::{
+    backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, Resource,
+};
 
 use crate::{
     otto_dock::protocol::{
@@ -79,5 +81,38 @@ impl<BackendData: Backend> Dispatch<OttoDockItemV1, DockItem, Otto<BackendData>>
                     .update_progress_for_app(&app_id, opt_value);
             }
         }
+    }
+
+    /// The client went away (or dropped the item). A badge is only meaningful
+    /// while the client that set it is alive — a notification daemon that
+    /// exits must not leave a stale count stuck on a dock icon.
+    fn destroyed(
+        state: &mut Otto<BackendData>,
+        _client: ClientId,
+        item: &OttoDockItemV1,
+        data: &DockItem,
+    ) {
+        let resource_id = item.id();
+        state.otto_dock.dock_items.remove(&resource_id);
+
+        let Some(app_id) = data.app_id.as_deref() else {
+            return;
+        };
+
+        // Another item may have taken over this app_id in the meantime; only
+        // the one still registered owns the badge.
+        let owns = state
+            .otto_dock
+            .app_id_to_resource
+            .get(app_id)
+            .map(|r| r.id() == resource_id)
+            .unwrap_or(false);
+        if !owns {
+            return;
+        }
+
+        state.otto_dock.app_id_to_resource.remove(app_id);
+        state.workspaces.dock.update_badge_for_app(app_id, None);
+        state.workspaces.dock.update_progress_for_app(app_id, None);
     }
 }

--- a/src/workspaces/app_icons_manager.rs
+++ b/src/workspaces/app_icons_manager.rs
@@ -13,8 +13,8 @@ use layers::{
 
 use crate::workspaces::{
     dock::{
-        draw_app_icon, draw_badge, draw_progress, setup_badge_layer, setup_progress_layer,
-        BASE_ICON_SIZE,
+        badge_size, draw_app_icon, draw_badge, draw_progress, setup_badge_layer,
+        setup_progress_layer, BASE_ICON_SIZE,
     },
     Application,
 };
@@ -166,7 +166,9 @@ impl AppIconsManager {
         if let Some(text) = pending {
             let entries = self.entries.read().unwrap();
             if let Some(entry) = entries.get(app_id) {
-                entry.badge_layer.set_draw_content(draw_badge(text));
+                entry
+                    .badge_layer
+                    .set_draw_content(draw_badge(text, badge_size(BASE_ICON_SIZE)));
                 entry.badge_layer.set_opacity(1.0_f32, None);
             }
         }
@@ -268,7 +270,9 @@ impl AppIconsManager {
         if let Some(entry) = entries.get(app_id) {
             match text {
                 Some(t) if !t.is_empty() => {
-                    entry.badge_layer.set_draw_content(draw_badge(t));
+                    entry
+                        .badge_layer
+                        .set_draw_content(draw_badge(t, badge_size(BASE_ICON_SIZE)));
                     entry
                         .badge_layer
                         .set_opacity(1.0_f32, Some(Transition::ease_in_quad(0.15)));

--- a/src/workspaces/app_icons_manager.rs
+++ b/src/workspaces/app_icons_manager.rs
@@ -39,6 +39,12 @@ pub struct AppIconsManager {
     /// `render_node_tree` can produce output for mirror followers.
     pub container: Layer,
     entries: RwLock<HashMap<String, AppIconEntry>>,
+    /// Badge text per canonical app key, kept even when no icon stack exists
+    /// yet: a notification can badge an app before the dock has built its
+    /// icon, and the badge is applied as soon as the stack appears.
+    badges: RwLock<HashMap<String, String>>,
+    /// Memoized `app_id` → canonical key resolution (see `canonical_key`).
+    key_cache: RwLock<HashMap<String, String>>,
 }
 
 impl std::fmt::Debug for AppIconsManager {
@@ -62,6 +68,8 @@ impl AppIconsManager {
             engine,
             container,
             entries: RwLock::new(HashMap::new()),
+            badges: RwLock::new(HashMap::new()),
+            key_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -136,6 +144,33 @@ impl AppIconsManager {
                 icon_id,
             },
         );
+
+        // A badge may have been set before this stack existed (a notification
+        // arriving for an app the dock had not drawn yet) — apply it now. It
+        // may also be filed under a looser id than this key, e.g. "Ghostty"
+        // for `com.mitchellh.ghostty`, since there was nothing to resolve
+        // against at the time; re-file it under the key that now exists.
+        let pending = {
+            let mut badges = self.badges.write().unwrap();
+            let loose_key = badges
+                .keys()
+                .find(|key| key.as_str() != app_id && matches_app_key(app_id, key))
+                .cloned();
+            if let Some(loose_key) = loose_key {
+                if let Some(text) = badges.remove(&loose_key) {
+                    badges.insert(app_id.to_string(), text);
+                }
+            }
+            badges.get(app_id).cloned()
+        };
+        if let Some(text) = pending {
+            let entries = self.entries.read().unwrap();
+            if let Some(entry) = entries.get(app_id) {
+                entry.badge_layer.set_draw_content(draw_badge(text));
+                entry.badge_layer.set_opacity(1.0_f32, None);
+            }
+        }
+
         stack
     }
 
@@ -160,8 +195,75 @@ impl AppIconsManager {
         }
     }
 
+    /// Resolve an arbitrary `app_id` to the key the icon stacks are filed
+    /// under (`Application::match_id`, i.e. the desktop file stem).
+    ///
+    /// A notification carries whatever the sending app put in its
+    /// `desktop-entry` hint — `com.mitchellh.ghostty`, `Ghostty`,
+    /// `ghostty.desktop` — while the dock files its icon under the desktop
+    /// file stem. Without this, badges from a notification daemon would land
+    /// on a key nothing draws.
+    pub fn canonical_key(&self, app_id: &str) -> String {
+        if let Some(cached) = self.key_cache.read().unwrap().get(app_id) {
+            return cached.clone();
+        }
+
+        let resolved = self.resolve_key(app_id);
+        // Only memoize a resolution that actually landed somewhere. Falling
+        // back to the raw id can happen simply because the app's icon stack
+        // does not exist yet, and that answer must not be cached forever.
+        if resolved != app_id {
+            self.key_cache
+                .write()
+                .unwrap()
+                .insert(app_id.to_string(), resolved.clone());
+        }
+        resolved
+    }
+
+    fn resolve_key(&self, app_id: &str) -> String {
+        {
+            let entries = self.entries.read().unwrap();
+            if entries.contains_key(app_id) {
+                return app_id.to_string();
+            }
+        }
+
+        // The dock's own resolution path: desktop entry → file stem.
+        if let Some(stem) =
+            otto_kit::desktop_entry::lookup_app(app_id).and_then(|info| info.desktop_file_id)
+        {
+            return stem;
+        }
+
+        // No desktop entry. An app_name like "Ghostty" can still name a known
+        // icon stack whose key ends in that segment (`com.mitchellh.ghostty`).
+        let entries = self.entries.read().unwrap();
+        if let Some(key) = entries.keys().find(|key| matches_app_key(key, app_id)) {
+            return key.clone();
+        }
+
+        app_id.to_string()
+    }
+
     /// Show or hide the badge on the dock/switcher icon for `app_id`.
+    ///
+    /// The text is remembered per app, so an icon stack built later still
+    /// shows it.
     pub fn update_badge(&self, app_id: &str, text: Option<String>) {
+        let app_id = &self.canonical_key(app_id);
+        match text.as_deref() {
+            Some(t) if !t.is_empty() => {
+                self.badges
+                    .write()
+                    .unwrap()
+                    .insert(app_id.clone(), t.to_string());
+            }
+            _ => {
+                self.badges.write().unwrap().remove(app_id);
+            }
+        }
+
         let entries = self.entries.read().unwrap();
         if let Some(entry) = entries.get(app_id) {
             match text {
@@ -182,6 +284,7 @@ impl AppIconsManager {
 
     /// Show or hide the progress bar on the dock/switcher icon for `app_id`.
     pub fn update_progress(&self, app_id: &str, value: Option<f64>) {
+        let app_id = &self.canonical_key(app_id);
         let entries = self.entries.read().unwrap();
         if let Some(entry) = entries.get(app_id) {
             match value {
@@ -200,5 +303,113 @@ impl AppIconsManager {
                 }
             }
         }
+    }
+}
+
+/// Whether `loose` names the app filed under `key` — the same string, or the
+/// last dotted segment of a reverse-DNS key ("Ghostty" for
+/// `com.mitchellh.ghostty`). Both comparisons ignore case and a trailing
+/// `.desktop`.
+fn matches_app_key(key: &str, loose: &str) -> bool {
+    let key = key.strip_suffix(".desktop").unwrap_or(key);
+    let loose = loose.strip_suffix(".desktop").unwrap_or(loose);
+    if key.eq_ignore_ascii_case(loose) {
+        return true;
+    }
+    key.rsplit('.')
+        .next()
+        .map(|seg| seg.eq_ignore_ascii_case(loose))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspaces::apps_info::Application;
+
+    fn manager() -> (Arc<Engine>, AppIconsManager) {
+        let engine = Engine::create(1000.0, 1000.0);
+        let icons = AppIconsManager::new(engine.clone());
+        (engine, icons)
+    }
+
+    fn settle(engine: &Arc<Engine>) {
+        for _ in 0..60 {
+            engine.update(0.016);
+        }
+    }
+
+    fn badge_opacity(icons: &AppIconsManager, app_id: &str) -> f32 {
+        icons
+            .entries
+            .read()
+            .unwrap()
+            .get(app_id)
+            .expect("icon stack")
+            .badge_layer
+            .opacity()
+    }
+
+    #[test]
+    fn badge_survives_an_icon_stack_that_does_not_exist_yet() {
+        let (engine, icons) = manager();
+
+        // The notification lands before the dock has drawn the app.
+        icons.update_badge("com.example.mail", Some("3".into()));
+        icons.get_or_create_stack(
+            "com.example.mail",
+            &Application::test_new("com.example.mail"),
+        );
+        settle(&engine);
+
+        assert_eq!(badge_opacity(&icons, "com.example.mail"), 1.0);
+    }
+
+    #[test]
+    fn clearing_a_badge_hides_it() {
+        let (engine, icons) = manager();
+        icons.get_or_create_stack(
+            "com.example.mail",
+            &Application::test_new("com.example.mail"),
+        );
+        icons.update_badge("com.example.mail", Some("3".into()));
+        settle(&engine);
+        assert_eq!(badge_opacity(&icons, "com.example.mail"), 1.0);
+
+        icons.update_badge("com.example.mail", None);
+        settle(&engine);
+        assert_eq!(badge_opacity(&icons, "com.example.mail"), 0.0);
+        assert!(icons.badges.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_loose_app_name_badges_the_stack_it_names() {
+        let (engine, icons) = manager();
+
+        // No desktop entry to resolve against, and no stack yet: the badge is
+        // parked under the name the notification used.
+        icons.update_badge("Mail", Some("1".into()));
+        icons.get_or_create_stack(
+            "com.example.mail",
+            &Application::test_new("com.example.mail"),
+        );
+        settle(&engine);
+        assert_eq!(badge_opacity(&icons, "com.example.mail"), 1.0);
+
+        // …and the next update for the same loose name finds it.
+        icons.update_badge("Mail", Some("2".into()));
+        settle(&engine);
+        assert_eq!(
+            icons.badges.read().unwrap().get("com.example.mail"),
+            Some(&"2".to_string())
+        );
+    }
+
+    #[test]
+    fn app_key_matching_ignores_case_and_desktop_suffix() {
+        assert!(matches_app_key("com.mitchellh.ghostty", "Ghostty"));
+        assert!(matches_app_key("com.mitchellh.ghostty", "ghostty.desktop"));
+        assert!(matches_app_key("ghostty", "Ghostty"));
+        assert!(!matches_app_key("com.mitchellh.ghostty", "mail"));
     }
 }

--- a/src/workspaces/dock/mod.rs
+++ b/src/workspaces/dock/mod.rs
@@ -3,7 +3,7 @@ mod model;
 mod render;
 mod view;
 pub(crate) use render::{
-    draw_app_icon, draw_badge, draw_progress, setup_badge_layer, setup_progress_layer,
+    badge_size, draw_app_icon, draw_badge, draw_progress, setup_badge_layer, setup_progress_layer,
 };
 pub use view::DockView;
 pub use view::BASE_ICON_SIZE;

--- a/src/workspaces/dock/render.rs
+++ b/src/workspaces/dock/render.rs
@@ -11,9 +11,23 @@ use crate::{
     },
 };
 
+/// The badge circle's diameter for an icon `icon_width` wide.
+pub fn badge_size(icon_width: f32) -> f32 {
+    icon_width * 0.4
+}
+
 /// Draw a badge (red circle with white text), sized to fill the layer bounds.
-pub fn draw_badge(text: String) -> ContentDrawFunction {
+///
+/// `size` is what the layer will measure once laid out. A badge whose text is
+/// set before its first layout pass is handed a zero size here, and the digit
+/// drawn into that recording would be invisible for as long as the recording
+/// is reused — leaving a red circle with nothing in it.
+pub fn draw_badge(text: String, size: f32) -> ContentDrawFunction {
     let draw_fn = move |canvas: &layers::skia::Canvas, w: f32, h: f32| -> layers::skia::Rect {
+        let (w, h) = (
+            if w > 0.0 { w } else { size },
+            if h > 0.0 { h } else { size },
+        );
         if text.is_empty() {
             return layers::skia::Rect::from_xywh(0.0, 0.0, w, h);
         }
@@ -79,7 +93,7 @@ pub fn draw_progress(value: f64) -> ContentDrawFunction {
 /// Configure a badge overlay layer (initially hidden; caller must call set_opacity to show it).
 /// The layer is positioned to float at the top-right corner of the icon content area.
 pub fn setup_badge_layer(layer: &Layer, icon_width: f32) {
-    let badge_size = icon_width * 0.4;
+    let badge_size = badge_size(icon_width);
     let tree = LayerTreeBuilder::default()
         .key("badge")
         .layout_style(taffy::Style {


### PR DESCRIPTION
An island lives at the top of the screen and settles into a 28px circle, which is a poor place to notice three unread messages from an hour ago. The count now also rides on the app's dock icon.

The `otto_dock_v1` protocol already had `get_dock_item(app_id)` + `set_badge`, and the dock already drew badges. What was missing was a producer, plus two gaps that made badges land nowhere.

## otto-islands

`dock_badges.rs` counts each app's outstanding notifications and publishes them: one dock item per app, cached for the process lifetime, diffed so unchanged counts send nothing.

- The count is what has not been read. A notification that timed out has *not* been read, so it keeps counting; only dismissing it — Close zone, an inline action, the default action, or `CloseNotification` — takes it off the badge.
- Transient notifications never badge (they opt out of persistence by definition), nor do non-notification activities like a media island or a progress readout.
- Counts above 99 read as `99+`.

## Compositor

- `AppIconsManager` remembers a badge per app instead of dropping it when no icon stack exists yet, so a notification arriving before its app is in the dock still badges once the icon appears.
- It resolves the loose `app_id` a notification carries — whatever the sender put in its `desktop-entry` hint: `com.mitchellh.ghostty`, `Ghostty`, `ghostty.desktop` — to the desktop-file-stem key the dock files icons under. Previously such badges landed on a key nothing drew. The same resolution now applies to `set_progress`.
- `otto_dock_item_v1::destroyed` clears the badge, so a daemon that exits does not strand a count on an icon.

## Testing

8 unit tests: badge resolution and pending badges in `app_icons_manager`, counting/capping/filtering in `dock_badges`.

Verified live on hardware: a notification for `com.mitchellh.ghostty` put a red 1 on the Ghostty dock icon, two more took it to 3, and clicking a notification cleared it.

Spec updated in `specs/notification-island.md`, including a correction — notifications are not removed on timeout.

https://claude.ai/code/session_01AR6ysjadsxXRcSCbwwsFCj