### PR TITLE
fix(shell): SSD titlebar under scanout, and resize borders

### DIFF
--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -294,6 +294,12 @@ vibrancy even though the content behind it lives on other planes.
   candidates that lose the plane auction, GPU-composite, and demote every
   plane below them (z-order). The demotion re-import restores the root
   surface's draw content.
+- A window Otto decorates itself carries its titlebar on a compositor
+  layer above the client, and the client's content starts one bar height
+  below the window's origin. The promoted buffer is placed at that
+  content origin, not at the window's — placing it at the window origin
+  scans the client out over its own titlebar, which is invisible to a
+  screenshot (screencopy forces a composite) and shows only on hardware.
 ### Promotion tiers
 
 A hardware plane scans out a rectangle of pixels: it cannot clip to a shape,

--- a/specs/window-decorations.md
+++ b/specs/window-decorations.md
@@ -18,6 +18,8 @@ one of them can still be decorated.
   draws nothing above it.
 - The title bar is compositor-owned: dragging it moves the window and its
   controls act on the window regardless of what the client is doing.
+- A window Otto decorates can be resized by dragging its edges, without any
+  cooperation from the client.
 - A window's layout geometry accounts for the title bar when it has one, and
   reclaims that space when it loses it.
 
@@ -63,7 +65,22 @@ appears, and discarded if the surface dies first.
   other, zoom the window instead: maximized windows are restored, others are
   maximized, and that press starts no move.
 - The window's geometry in the layout includes the strip, so mapping,
-  maximizing and tiling all account for its height.
+  maximizing and tiling all account for its height. A resize configures the
+  client with the size *under* the bar, so a window does not gain the bar's
+  height every time it is dragged.
+
+**Resize borders.** A server-decorated client has no frame of its own to grab,
+and never asks the compositor to resize it — so Otto offers the border itself:
+
+- A strip along the window's own edges, a few points wide, is hit-tested ahead
+  of both the titlebar and the client's surfaces. The corners take both of
+  their edges, so a press in a top corner resizes rather than moves.
+- The pointer over the strip shows the resize cursor for the edge it would
+  grab, and a press there starts a compositor resize grab.
+- Maximized, fullscreen and minimized windows have no border: there is no free
+  size to drag. Neither do windows too small to have an interior left.
+- Clients that draw their own decoration keep their own affordances and get no
+  border from Otto.
 
 **Activation.** A client that draws its own decoration needs to know when it
 has the focus, so every mapped toplevel's `activated` state follows the

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -36,7 +36,8 @@ use crate::{
     shell::WindowElement,
     state::{Backend, Otto},
     workspaces::{
-        AppSwitcherView, DockView, WindowDecorationView, WindowSelectorView, WorkspaceSelectorView,
+        AppSwitcherView, DockView, WindowDecorationView, WindowResizeView, WindowSelectorView,
+        WorkspaceSelectorView,
     },
 };
 
@@ -758,6 +759,15 @@ where
 
 impl<B: Backend> From<WindowDecorationView> for PointerFocusTarget<B> {
     fn from(value: WindowDecorationView) -> Self {
+        let d = InteractiveView {
+            view: Box::new(value),
+        };
+        PointerFocusTarget::View(d)
+    }
+}
+
+impl<B: Backend> From<WindowResizeView> for PointerFocusTarget<B> {
+    fn from(value: WindowResizeView) -> Self {
         let d = InteractiveView {
             view: Box::new(value),
         };

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -491,6 +491,28 @@ impl<BackendData: Backend> Otto<BackendData> {
             ));
         }
 
+        // Resize borders. A server-decorated client draws no frame of its
+        // own, so it never offers a resize edge: the strip along the window's
+        // own border is Otto's, and it is hit-tested ahead of both the
+        // titlebar and the client's surfaces (a press in the top corners
+        // resizes rather than moves).
+        if under.is_none() {
+            if let Some((window, loc)) = self.workspaces.element_under(pos) {
+                if window.is_decorated()
+                    && !window.is_minimised()
+                    && !window.is_maximized()
+                    && !window.is_fullscreen()
+                {
+                    let local = pos - loc.to_f64();
+                    let size = smithay::desktop::space::SpaceElement::geometry(window).size;
+                    if let Some(edges) = crate::workspaces::resize_edges_at(local, size) {
+                        let view = crate::workspaces::WindowResizeView::new(window.clone(), edges);
+                        return Some((view.into(), loc.to_f64()));
+                    }
+                }
+            }
+        }
+
         // Server-side titlebars. The strip belongs to the compositor, not to
         // the client, so it is checked before the window's surface tree — the
         // client's surfaces start below it anyway.

--- a/src/shell/grabs.rs
+++ b/src/shell/grabs.rs
@@ -515,7 +515,12 @@ impl<B: Backend> PointerGrab<Otto<B>> for PointerResizeSurfaceGrab<B> {
             WindowSurface::Wayland(xdg) => {
                 xdg.with_pending_state(|state| {
                     state.states.set(xdg_toplevel::State::Resizing);
-                    state.size = Some(self.last_window_size);
+                    // The drag is measured on the window rect, titlebar
+                    // included; the client only ever owns what is under the
+                    // bar. Configuring it with the full rect makes a
+                    // server-decorated window gain the bar's height on every
+                    // resize (see `WindowElement::client_size`).
+                    state.size = Some(self.window.client_size(self.last_window_size));
                 });
                 xdg.send_pending_configure();
 
@@ -596,7 +601,7 @@ impl<B: Backend> PointerGrab<Otto<B>> for PointerResizeSurfaceGrab<B> {
                 WindowSurface::Wayland(xdg) => {
                     xdg.with_pending_state(|state| {
                         state.states.unset(xdg_toplevel::State::Resizing);
-                        state.size = Some(self.last_window_size);
+                        state.size = Some(self.window.client_size(self.last_window_size));
                     });
                     xdg.send_pending_configure();
 
@@ -777,7 +782,7 @@ impl<BackendData: Backend> TouchGrab<Otto<BackendData>> for TouchResizeSurfaceGr
             WindowSurface::Wayland(xdg) => {
                 xdg.with_pending_state(|state| {
                     state.states.unset(xdg_toplevel::State::Resizing);
-                    state.size = Some(self.last_window_size);
+                    state.size = Some(self.window.client_size(self.last_window_size));
                 });
                 xdg.send_pending_configure();
 
@@ -899,7 +904,12 @@ impl<BackendData: Backend> TouchGrab<Otto<BackendData>> for TouchResizeSurfaceGr
             WindowSurface::Wayland(xdg) => {
                 xdg.with_pending_state(|state| {
                     state.states.set(xdg_toplevel::State::Resizing);
-                    state.size = Some(self.last_window_size);
+                    // The drag is measured on the window rect, titlebar
+                    // included; the client only ever owns what is under the
+                    // bar. Configuring it with the full rect makes a
+                    // server-decorated window gain the bar's height on every
+                    // resize (see `WindowElement::client_size`).
+                    state.size = Some(self.window.client_size(self.last_window_size));
                 });
                 xdg.send_pending_configure();
 

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -35,8 +35,8 @@ use crate::{
 
 use super::{
     fullscreen_output_geometry, FullscreenSurface, PointerMoveSurfaceGrab,
-    PointerResizeSurfaceGrab, ResizeData, ResizeState, SurfaceData, TouchMoveSurfaceGrab,
-    WindowElement,
+    PointerResizeSurfaceGrab, ResizeData, ResizeEdge, ResizeState, SurfaceData,
+    TouchMoveSurfaceGrab, WindowElement,
 };
 
 impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
@@ -1476,6 +1476,67 @@ impl<BackendData: Backend> Otto<BackendData> {
             return;
         };
         self.begin_pointer_move(window, &surface, seat, start_data, serial);
+    }
+
+    /// Start a pointer resize grab for a window Otto itself decorated.
+    ///
+    /// A server-decorated client has no frame of its own to grab, so it never
+    /// sends `resize_request`; the press landed on Otto's own border strip
+    /// (see [`crate::workspaces::WindowResizeView`]) and the grab's focus is
+    /// that view rather than the client.
+    ///
+    /// Must not be called from inside a pointer dispatch — see the note at the
+    /// call site in `WindowResizeView::on_button`.
+    pub fn resize_request_ssd(
+        &mut self,
+        window: &crate::shell::WindowElement,
+        seat: &Seat<Self>,
+        serial: Serial,
+        edges: ResizeEdge,
+    ) {
+        let Some(pointer) = seat.get_pointer() else {
+            return;
+        };
+        if !pointer.has_grab(serial) {
+            return;
+        }
+        let Some(start_data) = pointer.grab_start_data() else {
+            return;
+        };
+        let Some(toplevel) = window.toplevel().cloned() else {
+            return;
+        };
+        // A maximized or fullscreen window has no free size to drag.
+        if window.is_maximized() || window.is_fullscreen() {
+            return;
+        }
+        let Some(initial_window_location) = self.workspaces.element_location(window) else {
+            return;
+        };
+        let initial_window_size = window.geometry().size;
+
+        with_states(toplevel.wl_surface(), move |states| {
+            states
+                .data_map
+                .get::<RefCell<SurfaceData>>()
+                .unwrap()
+                .borrow_mut()
+                .resize_state = ResizeState::Resizing(ResizeData {
+                edges,
+                initial_window_location,
+                initial_window_size,
+            });
+        });
+
+        let grab = PointerResizeSurfaceGrab {
+            start_data,
+            window: window.clone(),
+            edges,
+            initial_window_location,
+            initial_window_size,
+            last_window_size: initial_window_size,
+        };
+        pointer.set_grab(self, grab, serial, Focus::Clear);
     }
 
     /// Install the move grab: restore a maximized/tiled window under the

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -2514,6 +2514,12 @@ pub(super) fn render_output_frame<'a>(
                 };
                 let pos = win.base_layer().render_position();
                 let geo_loc = win.geometry().loc.to_f64().to_physical(scale);
+                // The window layer's origin is the top of the SSD titlebar;
+                // the client's own content starts one bar below it (the scene
+                // offsets `content_layer` by the same amount). Without this
+                // the client buffer is folded in — and scanned out — a bar too
+                // high, painting over the titlebar Otto drew.
+                let deco_y = win.decoration_height() as f64 * scale.y;
                 let entry = smithay::wayland::compositor::with_states(&wl_surface, |states| {
                     let data = states.data_map.get::<RendererSurfaceStateUserData>()?;
                     let guard = data.lock().unwrap();
@@ -2529,7 +2535,7 @@ pub(super) fn render_output_frame<'a>(
                         dmabuf,
                         layers::skia::Rect::from_xywh(
                             (pos.x as f64 - geo_loc.x + off.x) as f32,
-                            (pos.y as f64 - geo_loc.y + off.y) as f32,
+                            (pos.y as f64 + deco_y - geo_loc.y + off.y) as f32,
                             size.w as f32,
                             size.h as f32,
                         ),
@@ -2642,8 +2648,13 @@ pub(super) fn render_output_frame<'a>(
                             // back by geometry.loc.
                             let pos = win.base_layer().render_position();
                             let geo_loc = win.geometry().loc.to_f64().to_physical(scale);
+                            // Server-side decorated windows keep their titlebar
+                            // in the windows plane while the client buffer goes
+                            // to its own plane: the buffer belongs BELOW the bar,
+                            // exactly where `content_layer` sits in the scene.
                             let buf_x = pos.x as f64 - geo_loc.x;
-                            let buf_y = pos.y as f64 - geo_loc.y;
+                            let buf_y =
+                                pos.y as f64 + win.decoration_height() as f64 * scale.y - geo_loc.y;
                             let elem =
                                 smithay::wayland::compositor::with_states(&wl_surface, |states| {
                                     // Same location math as the tree walk in

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -49,7 +49,8 @@ mod workspace_selector;
 pub use background::BackgroundView;
 pub use window_selector::{WindowSelectorView, WindowSelectorWindow};
 pub use window_view::{
-    WindowDecorationModel, WindowDecorationView, WindowView, WindowViewBaseModel, WindowViewSurface,
+    resize_edges_at, WindowDecorationModel, WindowDecorationView, WindowResizeView, WindowView,
+    WindowViewBaseModel, WindowViewSurface,
 };
 
 pub use app_icons_manager::AppIconsManager;

--- a/src/workspaces/window_view/mod.rs
+++ b/src/workspaces/window_view/mod.rs
@@ -2,12 +2,14 @@ mod decoration_view;
 mod effects;
 mod model;
 pub(crate) mod render;
+mod resize_view;
 mod view;
 
 pub use decoration_view::WindowDecorationView;
 pub use model::WindowDecorationModel;
 pub use model::WindowViewBaseModel;
 pub use model::WindowViewSurface;
+pub use resize_view::{resize_edges_at, WindowResizeView};
 pub use view::WindowView;
 
 #[cfg(test)]

--- a/src/workspaces/window_view/resize_view.rs
+++ b/src/workspaces/window_view/resize_view.rs
@@ -1,0 +1,211 @@
+//! Resize borders for server-side decorated windows.
+//!
+//! A client that draws its own decoration owns its resize affordances (see
+//! otto-kit's `components::window::resize`); a client Otto decorates has none —
+//! it never asks for a resize, because from its point of view it has no frame
+//! to grab. The compositor has to offer the border itself, which is what this
+//! view is: a strip along the window's own edges that is hit-tested ahead of
+//! the client's surfaces and starts a resize grab on press.
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use smithay::{
+    backend::input::ButtonState,
+    input::pointer::{CursorIcon, CursorImageStatus},
+    utils::{IsAlive, Point, Size},
+};
+
+use crate::{
+    interactive_view::ViewInteractions,
+    shell::{ResizeEdge, WindowElement},
+};
+
+const BTN_LEFT: u32 = 0x110;
+
+/// How far inside a window edge a press still starts a resize, in logical
+/// points. Wide enough to hit without aiming, narrow enough that it does not
+/// eat the client's own edge controls (scrollbars sit further in).
+const RESIZE_MARGIN: f64 = 6.0;
+
+/// Which edges a window-local point grabs, if any. `size` is the window rect
+/// including the titlebar — the same space `element_under` reports positions
+/// in.
+pub fn resize_edges_at(
+    local: Point<f64, smithay::utils::Logical>,
+    size: Size<i32, smithay::utils::Logical>,
+) -> Option<ResizeEdge> {
+    // A window narrower than two margins has no interior left; resizing it
+    // from both sides at once is not a thing, so leave it to the titlebar.
+    let (w, h) = (size.w as f64, size.h as f64);
+    if w <= RESIZE_MARGIN * 2.0 || h <= RESIZE_MARGIN * 2.0 {
+        return None;
+    }
+    let mut edges = ResizeEdge::NONE;
+    if local.x < RESIZE_MARGIN {
+        edges |= ResizeEdge::LEFT;
+    } else if local.x >= w - RESIZE_MARGIN {
+        edges |= ResizeEdge::RIGHT;
+    }
+    if local.y < RESIZE_MARGIN {
+        edges |= ResizeEdge::TOP;
+    } else if local.y >= h - RESIZE_MARGIN {
+        edges |= ResizeEdge::BOTTOM;
+    }
+    (edges != ResizeEdge::NONE).then_some(edges)
+}
+
+/// The cursor that names what a border grab would do.
+fn cursor_for(edges: ResizeEdge) -> CursorIcon {
+    match edges {
+        ResizeEdge::TOP => CursorIcon::NResize,
+        ResizeEdge::BOTTOM => CursorIcon::SResize,
+        ResizeEdge::LEFT => CursorIcon::WResize,
+        ResizeEdge::RIGHT => CursorIcon::EResize,
+        ResizeEdge::TOP_LEFT => CursorIcon::NwResize,
+        ResizeEdge::TOP_RIGHT => CursorIcon::NeResize,
+        ResizeEdge::BOTTOM_LEFT => CursorIcon::SwResize,
+        ResizeEdge::BOTTOM_RIGHT => CursorIcon::SeResize,
+        _ => CursorIcon::default(),
+    }
+}
+
+/// One window's resize border, as an input target.
+#[derive(Clone)]
+pub struct WindowResizeView {
+    pub window: WindowElement,
+    pub edges: ResizeEdge,
+    /// Set while a press that started on the border is still held, so the
+    /// cursor is not reset out from under the grab.
+    pressed: Arc<AtomicBool>,
+}
+
+impl WindowResizeView {
+    pub fn new(window: WindowElement, edges: ResizeEdge) -> Self {
+        Self {
+            window,
+            edges,
+            pressed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl PartialEq for WindowResizeView {
+    fn eq(&self, other: &Self) -> bool {
+        self.window == other.window && self.edges == other.edges
+    }
+}
+
+impl std::fmt::Debug for WindowResizeView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WindowResizeView")
+            .field("window", &self.window.id())
+            .field("edges", &self.edges)
+            .finish()
+    }
+}
+
+impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowResizeView {
+    fn id(&self) -> Option<usize> {
+        // The edges are part of the identity: crossing from one border to the
+        // next has to look like a new target, or the cursor would keep the
+        // shape it entered with.
+        let base: usize = self.window.base_layer().id.0.into();
+        Some(base.rotate_left(32) ^ self.edges.bits() as usize)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.window.alive()
+    }
+
+    fn on_enter(&self, _event: &smithay::input::pointer::MotionEvent) {}
+
+    fn on_motion(
+        &self,
+        _seat: &smithay::input::Seat<crate::Otto<Backend>>,
+        data: &mut crate::Otto<Backend>,
+        _event: &smithay::input::pointer::MotionEvent,
+    ) {
+        data.set_cursor(&CursorImageStatus::Named(cursor_for(self.edges)));
+    }
+
+    fn on_leave_with_data(
+        &self,
+        data: &mut crate::Otto<Backend>,
+        _serial: smithay::utils::Serial,
+        _time: u32,
+    ) {
+        if !self.pressed.load(Ordering::SeqCst) {
+            data.set_cursor(&CursorImageStatus::Named(CursorIcon::default()));
+        }
+    }
+
+    fn on_button(
+        &self,
+        seat: &smithay::input::Seat<crate::Otto<Backend>>,
+        data: &mut crate::Otto<Backend>,
+        event: &smithay::input::pointer::ButtonEvent,
+    ) {
+        if event.button != BTN_LEFT {
+            return;
+        }
+        match event.state {
+            ButtonState::Pressed => {
+                self.pressed.store(true, Ordering::SeqCst);
+                // Deferred for the same reason as the titlebar's move grab:
+                // this runs inside `PointerHandle::button`, which holds the
+                // pointer's inner lock, and installing a grab takes it again.
+                let window = self.window.clone();
+                let seat = seat.clone();
+                let serial = event.serial;
+                let edges = self.edges;
+                data.handle.insert_idle(move |state| {
+                    state.resize_request_ssd(&window, &seat, serial, edges);
+                });
+            }
+            ButtonState::Released => {
+                self.pressed.store(false, Ordering::SeqCst);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edges_at(x: f64, y: f64) -> Option<ResizeEdge> {
+        resize_edges_at((x, y).into(), (200, 100).into())
+    }
+
+    #[test]
+    fn interior_grabs_nothing() {
+        assert_eq!(edges_at(100.0, 50.0), None);
+        // Just inside the margin on every side.
+        assert_eq!(edges_at(RESIZE_MARGIN, RESIZE_MARGIN), None);
+        assert_eq!(edges_at(200.0 - RESIZE_MARGIN - 1.0, 50.0), None);
+    }
+
+    #[test]
+    fn borders_grab_their_own_edge() {
+        assert_eq!(edges_at(0.0, 50.0), Some(ResizeEdge::LEFT));
+        assert_eq!(edges_at(199.0, 50.0), Some(ResizeEdge::RIGHT));
+        assert_eq!(edges_at(100.0, 0.0), Some(ResizeEdge::TOP));
+        assert_eq!(edges_at(100.0, 99.0), Some(ResizeEdge::BOTTOM));
+    }
+
+    #[test]
+    fn corners_grab_both() {
+        assert_eq!(edges_at(0.0, 0.0), Some(ResizeEdge::TOP_LEFT));
+        assert_eq!(edges_at(199.0, 0.0), Some(ResizeEdge::TOP_RIGHT));
+        assert_eq!(edges_at(0.0, 99.0), Some(ResizeEdge::BOTTOM_LEFT));
+        assert_eq!(edges_at(199.0, 99.0), Some(ResizeEdge::BOTTOM_RIGHT));
+    }
+
+    #[test]
+    fn a_window_too_small_for_two_margins_has_no_border() {
+        assert_eq!(resize_edges_at((1.0, 1.0).into(), (8, 8).into()), None);
+    }
+}


### PR DESCRIPTION
Three fixes for server-side decorated windows, found chasing "can't resize ghostty" and "the titlebar disappears".

### The titlebar vanished under direct scanout (udev only)

`src/udev/render.rs` placed a promoted window's client buffer at `win.base_layer().render_position()` — the window layer's origin, which is the **top of the titlebar**. The scene puts the client's `content_layer` at `+decoration_height * scale`, so the scanned-out buffer sat one bar too high and painted over the titlebar Otto had drawn in the windows plane.

This is invisible everywhere except real hardware: winit has no planes, and grim/screencopy forces a full composite. Both places doing that placement math — the scanout push and the backdrop fold-in of promoted buffers — now add the decoration offset.

### Server-decorated windows could not be resized at all

Otto had no compositor-side resize code: the only entry points were the client-initiated `resize_request` handlers. A window Otto decorates has no frame of its own to grab, so it never asks — nothing could resize it.

Adds `WindowResizeView` (`src/workspaces/window_view/resize_view.rs`): a 6pt strip along the window's own edges, hit-tested ahead of the titlebar (so the top corners resize instead of moving), showing the resize cursor for the edge under the pointer and starting a new `resize_request_ssd` grab on press. Skipped for maximized, fullscreen and minimized windows, and for clients that draw their own decoration.

### Resizing grew the window by the titlebar's height

The resize grabs configured the client with the *decorated* window size, so an SSD window gained the bar's height on every drag. They now send `window.client_size(...)`, like the maximize and tile paths already did.

### Notes

- Specs updated: `window-decorations.md` (resize borders), `plane-scanout.md` (promoted buffer origin).
- 4 unit tests for the border hit-test; `cargo test --lib` green (164 passed).
- Verified to build standalone against upstream lay-rs v1.13.0 — no companion `layers` PR is needed.
- Live-checked on the udev session: titlebar stays put and ghostty resizes.

https://claude.ai/code/session_014X6Noe8gCAcs7TYrmZ78xQ