### PR TITLE
fix(shell): double click a titlebar to zoom the window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,9 @@ otto-kit = { path = "components/otto-kit" }
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-# Tracking main until the next lay-rs release is tagged — otto needs the
-# follower-damage and content-opacity fixes (nongio/layers#22).
-branch = "main"
+# Pinned to a release: v1.14.0 carries the mirror/opacity repaint fixes
+# (nongio/layers#22, #23) that Otto's follower layers and fading popups need.
+tag = "v1.14.0"
 # local development: path = "../layers"
 features = ["export-taffy"]
 
@@ -320,3 +320,4 @@ files = [
     ["components/xdg-desktop-portal-otto/portals.conf.example", "/usr/share/doc/otto/portals.conf.example", "644"],
     ["components/otto-lock/otto-lock.pam", "/etc/pam.d/otto-lock", "644"],
 ]
+

--- a/components/otto-auth-ui/Cargo.toml
+++ b/components/otto-auth-ui/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1"
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]
@@ -22,7 +22,7 @@ version = "=0.93"
 features = ["gl", "textlayout", "svg", "skottie"]
 
 [dev-dependencies]
-laye-rs = { git = "https://github.com/nongio/layers", branch = "main", features = ["export-taffy"] }
+laye-rs = { git = "https://github.com/nongio/layers", tag = "v1.14.0", features = ["export-taffy"] }
 
 # Renders every panel state to PNGs, so the layout can be iterated on without
 # taking over a screen with a fullscreen overlay.

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -5217,7 +5217,9 @@ impl FilesApp {
                             && view::place_at(x, y, browser.places.len()).is_none()
                         {
                             if let Some(seat) = AppContext::seat_state().seats().next() {
-                                window_for_events.start_move(&seat, serial);
+                                // A double click on the header zooms the
+                                // window instead of moving it.
+                                window_for_events.titlebar_press(&seat, serial, x, y);
                             }
                             return;
                         }

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -35,7 +35,7 @@ debugger = ["laye-rs/debugger"]
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 # local development: path = "../../../layers"
 features = ["export-taffy"]
 

--- a/components/otto-kit/src/components/window/mod.rs
+++ b/components/otto-kit/src/components/window/mod.rs
@@ -6,6 +6,7 @@ use smithay_client_toolkit::seat::pointer::PointerEvent;
 use smithay_client_toolkit::shell::xdg::window::WindowConfigure;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 use wayland_client::protocol::wl_seat;
 
 use crate::app_runner::AppContext;
@@ -23,6 +24,9 @@ fn default_layer_augmentation(layer: &otto_surface_style_v1::OttoSurfaceStyleV1)
 
 type CanvasDrawFn = Arc<Mutex<Option<Box<dyn FnMut(&skia_safe::Canvas) + Send>>>>;
 
+/// When and where the last press on the title bar landed.
+type PressMark = Arc<Mutex<Option<(Instant, (f32, f32))>>>;
+
 /// How long the material takes to fade between its frosted and opaque forms,
 /// in seconds.
 ///
@@ -31,6 +35,12 @@ type CanvasDrawFn = Arc<Mutex<Option<Box<dyn FnMut(&skia_safe::Canvas) + Send>>>
 /// follows is the tint thinning or thickening, and the toggle underneath it is
 /// always hidden by a fully opaque cover.
 const MATERIAL_FADE: f64 = 0.3;
+
+/// How long after a press on the titlebar a second one still counts as a
+/// double click, and how far it may wander in the meantime. Matches the
+/// compositor's own server-side titlebar.
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(400);
+const DOUBLE_CLICK_SLOP: f32 = 6.0;
 
 /// Window component using ToplevelSurface
 ///
@@ -70,6 +80,9 @@ pub struct Window {
     /// The application fades its own materials, and so owns the moment the
     /// frost may be switched — see [`Window::set_fades_own_material`].
     fades_own_material: Arc<AtomicBool>,
+    /// When and where the last press on the titlebar landed, for the double
+    /// click that zooms the window — see [`Window::titlebar_press`].
+    last_titlebar_press: PressMark,
 }
 
 impl Window {
@@ -106,6 +119,7 @@ impl Window {
             material: Arc::new(RwLock::new(None)),
             frosted: Arc::new(AtomicBool::new(false)),
             fades_own_material: Arc::new(AtomicBool::new(false)),
+            last_titlebar_press: Arc::new(Mutex::new(None)),
         };
         // Hand the default to the compositor too, so the background is carried
         // by the style from the first frame and a window that never calls
@@ -663,6 +677,39 @@ impl Window {
                 surface.xdg_window().move_(seat, serial);
             }
         }
+    }
+
+    /// A press that landed on the titlebar's drag area.
+    ///
+    /// Two presses in the same place zoom the window; anything else starts a
+    /// move. Applications that draw their own titlebar should call this
+    /// instead of [`Window::start_move`], so a client-decorated window
+    /// behaves like a server-decorated one.
+    ///
+    /// `x`/`y` are surface-local, as they arrive on the pointer event.
+    pub fn titlebar_press(&self, seat: &wl_seat::WlSeat, serial: u32, x: f32, y: f32) {
+        if self.take_double_click(x, y) {
+            self.toggle_maximized();
+        } else {
+            self.start_move(seat, serial);
+        }
+    }
+
+    /// Whether a press at this surface-local point closes a double click,
+    /// remembering it either way.
+    fn take_double_click(&self, x: f32, y: f32) -> bool {
+        let now = Instant::now();
+        let Ok(mut last) = self.last_titlebar_press.lock() else {
+            return false;
+        };
+        let doubled = last.is_some_and(|(at, (px, py))| {
+            now.duration_since(at) < DOUBLE_CLICK_INTERVAL
+                && (x - px).abs() <= DOUBLE_CLICK_SLOP
+                && (y - py).abs() <= DOUBLE_CLICK_SLOP
+        });
+        // A double click consumes its history, so a third press starts over.
+        *last = if doubled { None } else { Some((now, (x, y))) };
+        doubled
     }
 
     /// Whether the compositor's last configure said the window is maximized.

--- a/components/otto-launcher/Cargo.toml
+++ b/components/otto-launcher/Cargo.toml
@@ -17,7 +17,7 @@ shell-words = "1.1"
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]

--- a/components/otto-quickview/Cargo.toml
+++ b/components/otto-quickview/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 
 [dependencies.laye-rs]
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 features = ["export-taffy"]
 
 [dependencies.skia-safe]

--- a/components/otto-settings/src/main.rs
+++ b/components/otto-settings/src/main.rs
@@ -964,8 +964,10 @@ impl App for SettingsApp {
                                     needs_redraw = true;
                                 }
                                 view::TitlebarHit::Drag => {
+                                    // Dragging moves the window; a double
+                                    // click zooms it.
                                     if let Some(seat) = AppContext::seat_state().seats().next() {
-                                        redraw.start_move(&seat, *serial);
+                                        redraw.titlebar_press(&seat, *serial, x, y);
                                     }
                                 }
                             }

--- a/specs/window-decorations.md
+++ b/specs/window-decorations.md
@@ -64,6 +64,12 @@ appears, and discarded if the surface dies first.
 - Two presses on the bar away from the controls, within 400 ms and 6 px of each
   other, zoom the window instead: maximized windows are restored, others are
   maximized, and that press starts no move.
+- A maximized or tiled window is restored *into* the drag — when the pointer
+  has travelled 6 px, not when the button goes down. Restoring at the press
+  would make a bare click unmaximize the window, and would spend the first
+  press of the double click above: the client is told it is no longer
+  maximized, so the second press asks to maximize a window that already
+  looks maximized and nothing appears to happen.
 - The window's geometry in the layout includes the strip, so mapping,
   maximizing and tiling all account for its height. A resize configures the
   client with the size *under* the bar, so a window does not gain the bar's
@@ -81,6 +87,25 @@ and never asks the compositor to resize it — so Otto offers the border itself:
   size to drag. Neither do windows too small to have an interior left.
 - Clients that draw their own decoration keep their own affordances and get no
   border from Otto.
+
+**Zoom.** Maximizing and restoring animate the window's size, but the
+`maximized` state itself is sent on the *first* configure of that animation,
+not the last: a client that draws its own decoration decides from that state
+whether its own zoom control maximizes or restores, and a client that never
+hears it asks to be maximized over and over. A window that is already
+maximized ignores a further maximize request — honouring it would overwrite
+the geometry it has to restore to with the maximized one, and unmaximizing
+would then appear to do nothing. A window that asked to be maximized before it
+ever had a size of its own restores to a default rect (two thirds of the
+usable zone, centred) rather than to an empty one.
+
+**Client-drawn title bars.** A client that decorates itself owns these
+gestures too, so otto-kit offers them from `Window`: a press on the title bar's
+drag area starts a compositor move, and two such presses within 400 ms and 6 px
+of each other maximize the window, or restore it if it already is — the same
+thresholds the server-side bar uses. Otto's own applications (Files, Settings)
+go through it, so a client-decorated window answers a double click on its bar
+the way a server-decorated one does.
 
 **Activation.** A client that draws its own decoration needs to know when it
 has the focus, so every mapped toplevel's `activated` state follows the

--- a/src/shell/grabs.rs
+++ b/src/shell/grabs.rs
@@ -41,7 +41,20 @@ pub struct PointerMoveSurfaceGrab<B: Backend + 'static> {
     /// The snap zone currently previewed under the cursor while Ctrl is held
     /// during the drag. `None` when no zone is active. Applied on button release.
     pub active_zone: Option<crate::workspaces::TileZone>,
+    /// The window is maximized or tiled and gets restored under the cursor —
+    /// but only once the drag has actually travelled. Restoring at button-down
+    /// would make a *click* unmaximize the window, and would eat the first
+    /// press of the double click that zooms it.
+    pub pending_restore: bool,
+    /// Where the drag is measured from. The press location to begin with, and
+    /// the pointer's position at the moment a pending restore fires — after
+    /// which the window has a new origin under the cursor.
+    pub drag_origin: Point<f64, Logical>,
 }
+
+/// How far the pointer travels before a press counts as a drag, and a
+/// maximized window is restored into it.
+const DRAG_THRESHOLD: f64 = 6.0;
 
 /// Whether Ctrl is held right now, read from the keyboard itself.
 ///
@@ -89,7 +102,22 @@ impl<B: Backend> PointerGrab<Otto<B>> for PointerMoveSurfaceGrab<B> {
             return;
         };
         let scale = output.current_scale().fractional_scale();
-        let delta = event.location - self.start_data.location;
+
+        // A maximized or tiled window is restored into the drag, not at the
+        // press: until the pointer has travelled, it stays where it is.
+        if self.pending_restore {
+            let travel = event.location - self.start_data.location;
+            if travel.x.abs() < DRAG_THRESHOLD && travel.y.abs() < DRAG_THRESHOLD {
+                return;
+            }
+            self.pending_restore = false;
+            if let Some(location) = state.restore_window_for_drag(&self.window, event.location) {
+                self.initial_window_location = location;
+            }
+            self.drag_origin = event.location;
+        }
+
+        let delta = event.location - self.drag_origin;
         let new_location = self.initial_window_location.to_f64() + delta;
 
         state

--- a/src/shell/x11.rs
+++ b/src/shell/x11.rs
@@ -929,6 +929,9 @@ impl<BackendData: Backend> Otto<BackendData> {
             window: element.clone(),
             initial_window_location,
             active_zone: None,
+            // X11 windows are restored above, before the grab is installed.
+            pending_restore: false,
+            drag_origin: self.pointer.current_location(),
         };
 
         let pointer = self.pointer.clone();

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -1054,13 +1054,17 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             // browser restoring a maximized window) must not then be re-placed
             // by a heuristic meant for windows that never said where they want
             // to be.
+            // Asking twice must not cost the window its restore target: a
+            // second `maximize_request` would store the MAXIMIZED geometry as
+            // `unmaximised_rect`, and unmaximizing would then restore the
+            // window to the size it already has — looking like nothing
+            // happened at all.
+            if window.is_maximized() {
+                return;
+            }
             window.set_is_maximized(true);
             self.pending_initial_placement.remove(&id);
 
-            if let Some(mut view) = self.workspaces.get_window_view(&id) {
-                view.unmaximised_rect = current_element_geometry;
-                self.workspaces.set_window_view(&id, view);
-            }
             // Maximize onto the output the window actually lives on — the
             // space it is mapped in is authoritative, including for windows
             // on a virtual (RDP) output. Only an unmapped window falls back
@@ -1086,6 +1090,19 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             // Usable area = output minus exclusive zones minus (non-autohide) dock
             let new_geometry = self.usable_zone(&output);
 
+            // Remember what to restore to. A client that asked to be
+            // maximized before it ever committed a buffer has no geometry
+            // yet, and an empty rect would restore to nothing at all — give
+            // it the size a fresh window gets instead.
+            if let Some(mut view) = self.workspaces.get_window_view(&id) {
+                view.unmaximised_rect = if current_element_geometry.size.is_empty() {
+                    default_restored_rect(new_geometry)
+                } else {
+                    current_element_geometry
+                };
+                self.workspaces.set_window_view(&id, view);
+            }
+
             let transition = Transition::ease_out(0.3);
             let animation = self
                 .layers_engine
@@ -1104,6 +1121,15 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             let new_width = new_client_size.w as f32;
             let new_height = new_client_size.h as f32;
 
+            // The client is told it is maximized NOW, not on the animation's
+            // last frame: a client that draws its own decoration decides from
+            // this state whether its zoom control maximizes or restores, and
+            // one that never hears it asks to be maximized over and over.
+            // Only the size is animated.
+            surface.with_pending_state(|state| {
+                state.states.set(xdg_toplevel::State::Maximized);
+            });
+
             let s = surface.clone();
             self.layers_engine.on_animation_update(
                 animation,
@@ -1112,9 +1138,6 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                     let height = current_height.interpolate(&new_height, p) as i32;
                     let size = Rectangle::new((0, 0).into(), (width, height).into());
                     s.with_pending_state(|state| {
-                        if (p - 1.0).abs() < f32::EPSILON {
-                            state.states.set(xdg_toplevel::State::Maximized);
-                        }
                         state.size = Some(size.size);
                     });
                     s.send_configure();
@@ -1134,16 +1157,33 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
     }
 
     fn unmaximize_request(&mut self, surface: ToplevelSurface) {
-        if !surface
-            .with_pending_state(|state| state.states.contains(xdg_toplevel::State::Maximized))
-        {
+        let id = surface.wl_surface().id();
+        let Some(window) = self.workspaces.get_window_for_surface(&id).cloned() else {
+            return;
+        };
+        // The window's own flag decides, not the toplevel's pending
+        // `Maximized` state: the two are set together, but the flag is the
+        // one the rest of the compositor reads, and a request that disagrees
+        // with it would restore a window that is not maximized.
+        if !window.is_maximized() {
             return;
         }
-
-        let id = surface.wl_surface().id();
-        let window = self.workspaces.get_window_for_surface(&id).unwrap().clone();
         window.set_is_maximized(false);
-        if let Some(view) = self.workspaces.get_window_view(&id) {
+
+        if let Some(mut view) = self.workspaces.get_window_view(&id) {
+            // Nothing to restore to means restoring to nothing: the window
+            // would be configured 0x0, keep the size it has, and the click
+            // would look like it did nothing at all.
+            if view.unmaximised_rect.size.is_empty() {
+                let zone = self
+                    .workspaces
+                    .output_for_window(&window)
+                    .map(|output| self.usable_zone(&output))
+                    .unwrap_or(view.unmaximised_rect);
+                view.unmaximised_rect = default_restored_rect(zone);
+                self.workspaces.set_window_view(&id, view.clone());
+            }
+
             let current_element_geometry = self
                 .workspaces
                 .element_geometry(&window)
@@ -1165,6 +1205,12 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             let new_width = new_client_size.w as f32;
             let new_height = new_client_size.h as f32;
 
+            // Dropped up front, for the same reason it is set up front in
+            // `maximize_request`.
+            surface.with_pending_state(|state| {
+                state.states.unset(xdg_toplevel::State::Maximized);
+            });
+
             let s = surface.clone();
             self.layers_engine.on_animation_update(
                 animation,
@@ -1173,9 +1219,6 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                     let height = current_height.interpolate(&new_height, p) as i32;
                     let size = Rectangle::new((0, 0).into(), (width, height).into());
                     s.with_pending_state(|state| {
-                        if (p - 1.0).abs() < f32::EPSILON {
-                            state.states.unset(xdg_toplevel::State::Maximized);
-                        }
                         state.size = Some(size.size);
                     });
                     s.send_configure();
@@ -1552,21 +1595,48 @@ impl<BackendData: Backend> Otto<BackendData> {
         let Some(pointer) = seat.get_pointer() else {
             return;
         };
-        let mut initial_window_location = self.workspaces.element_location(window).unwrap();
+        let initial_window_location = self.workspaces.element_location(window).unwrap();
 
-        // If the surface is maximized or tiled, restore it as the drag begins.
+        // A maximized or tiled window is restored INTO the drag, by the grab
+        // itself, once the pointer has actually travelled — see
+        // `PointerMoveSurfaceGrab::motion`. Doing it here instead would make a
+        // plain click on the titlebar unmaximize the window, and would eat the
+        // first press of the double click that zooms it.
         let id = surface.wl_surface().id();
-        let is_maximized = surface
-            .with_pending_state(|state| state.states.contains(xdg_toplevel::State::Maximized));
+        let is_maximized = window.is_maximized();
         let is_tiled = self
             .workspaces
             .get_window_view(&id)
             .map(|v| v.tiled_zone.is_some())
             .unwrap_or(false);
-        if is_maximized || is_tiled {
-            // Get current maximized/tiled geometry before restoring
-            let maximized_geometry = self.workspaces.element_geometry(window).unwrap();
-            let pointer_location = pointer.current_location();
+
+        let grab = PointerMoveSurfaceGrab {
+            start_data,
+            window: window.clone(),
+            initial_window_location,
+            active_zone: None,
+            pending_restore: is_maximized || is_tiled,
+            drag_origin: pointer.current_location(),
+        };
+
+        pointer.set_grab(self, grab, serial, Focus::Clear);
+    }
+
+    /// Restore a maximized or tiled window into a drag that has just started,
+    /// keeping the point the user grabbed under the cursor.
+    ///
+    /// Returns the window's new origin, for the grab to measure from.
+    pub fn restore_window_for_drag(
+        &mut self,
+        window: &crate::shell::WindowElement,
+        pointer_location: smithay::utils::Point<f64, smithay::utils::Logical>,
+    ) -> Option<smithay::utils::Point<i32, smithay::utils::Logical>> {
+        let surface = window.toplevel()?.clone();
+        let id = surface.wl_surface().id();
+        let initial_window_location;
+        {
+            // The geometry it is being restored FROM.
+            let maximized_geometry = self.workspaces.element_geometry(window)?;
 
             // Calculate grab point relative to maximized window
             let grab_offset_x = pointer_location.x - maximized_geometry.loc.x as f64;
@@ -1616,19 +1686,17 @@ impl<BackendData: Backend> Otto<BackendData> {
                 initial_window_location = (new_x as i32, new_y as i32).into();
             } else {
                 // Fallback: position window centered under cursor
-                let pos = pointer.current_location();
-                initial_window_location = (pos.x as i32, pos.y as i32).into();
+                initial_window_location =
+                    (pointer_location.x as i32, pointer_location.y as i32).into();
             }
         }
 
-        let grab = PointerMoveSurfaceGrab {
-            start_data,
-            window: window.clone(),
-            initial_window_location,
-            active_zone: None,
-        };
+        // The window is no longer maximized as far as the rest of the
+        // compositor is concerned either — the flag and the state the client
+        // was just told go together.
+        window.set_is_maximized(false);
 
-        pointer.set_grab(self, grab, serial, Focus::Clear);
+        Some(initial_window_location)
     }
 
     /// Snap `window` into the given tiling `zone` on its current output, animating
@@ -1912,4 +1980,20 @@ fn clamp_popup_to_target(
     if geo.loc.y < target.loc.y {
         geo.loc.y = target.loc.y;
     }
+}
+
+/// Where a window goes when it is unmaximized but never had a size of its own
+/// — a client that asked to be maximized before its first buffer.
+///
+/// Two thirds of the usable zone, centred in it: big enough to work in, small
+/// enough that the restore is unmistakable.
+fn default_restored_rect(
+    zone: Rectangle<i32, smithay::utils::Logical>,
+) -> Rectangle<i32, smithay::utils::Logical> {
+    let size = (zone.size.w * 2 / 3, zone.size.h * 2 / 3);
+    let loc = (
+        zone.loc.x + (zone.size.w - size.0) / 2,
+        zone.loc.y + (zone.size.h - size.1) / 2,
+    );
+    Rectangle::new(loc.into(), size.into())
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -293,6 +293,12 @@ pub struct Otto<BackendData: Backend + 'static> {
     pub pointer: PointerHandle<Otto<BackendData>>,
     /// Cached pointer location (logical) to avoid deadlock when accessing during button events
     pub last_pointer_location: (f64, f64),
+    /// When and where the last press on a server-side titlebar landed, for
+    /// double-click detection. Kept here rather than on the decoration view:
+    /// that view is rebuilt on every hit test, so anything it remembers is
+    /// gone by the next event.
+    /// `(when, titlebar-local point, window key)`.
+    pub last_titlebar_press: Option<(std::time::Instant, (f32, f32), usize)>,
     /// Cached pointer position in physical pixels, updated on every pointer move.
     /// Use `get_cursor_position()` to read. This avoids the deadlock that occurs
     /// when locking `cursor_status` from button/DnD handlers.
@@ -941,6 +947,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             seat,
             pointer,
             last_pointer_location: (0.0, 0.0),
+            last_titlebar_press: None,
             cursor_physical_position: (0.0, 0.0),
             clock,
             gamma_control_manager,

--- a/src/workspaces/window_view/decoration_view.rs
+++ b/src/workspaces/window_view/decoration_view.rs
@@ -4,13 +4,7 @@
 //! this view asks that same struct what is under the pointer, so a click can
 //! never land somewhere different from what was drawn.
 
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use otto_kit::components::titlebar::WindowControl;
 use smithay::{
@@ -32,28 +26,24 @@ const BTN_LEFT: u32 = 0x110;
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(400);
 const DOUBLE_CLICK_SLOP: f32 = 6.0;
 
-/// When and where a press on the titlebar landed.
-type PressMark = Arc<Mutex<Option<(Instant, (f32, f32))>>>;
-
 /// A window's titlebar, as an input target.
+///
+/// Carries no state of its own: a fresh one is built on every hit test (see
+/// `Otto::surface_under`), so anything it remembered would be dropped before
+/// the next event — the double-click mark lives on [`crate::Otto`] instead.
 #[derive(Clone)]
 pub struct WindowDecorationView {
     pub window: WindowElement,
-    /// A press that started on the bar (rather than on a control) — the drag
-    /// that follows moves the window.
-    press_on_bar: Arc<AtomicBool>,
-    /// When and where the last press on the bar landed, for double-click
-    /// detection.
-    last_press: PressMark,
 }
 
 impl WindowDecorationView {
     pub fn new(window: WindowElement) -> Self {
-        Self {
-            window,
-            press_on_bar: Arc::new(AtomicBool::new(false)),
-            last_press: Arc::new(Mutex::new(None)),
-        }
+        Self { window }
+    }
+
+    /// Identifies the window across the views built for it.
+    fn key(&self) -> usize {
+        self.window.base_layer().id.0.into()
     }
 
     fn control_index(control: WindowControl) -> u8 {
@@ -85,16 +75,26 @@ impl WindowDecorationView {
 
     /// Whether a press at this titlebar-local point closes a double click,
     /// remembering it either way.
-    fn take_double_click(&self, x: f32, y: f32) -> bool {
+    fn take_double_click<B: crate::state::Backend>(
+        &self,
+        data: &mut crate::Otto<B>,
+        x: f32,
+        y: f32,
+    ) -> bool {
         let now = Instant::now();
-        let mut last = self.last_press.lock().unwrap();
-        let doubled = last.is_some_and(|(at, (px, py))| {
-            now.duration_since(at) < DOUBLE_CLICK_INTERVAL
+        let key = self.key();
+        let doubled = data.last_titlebar_press.is_some_and(|(at, (px, py), k)| {
+            k == key
+                && now.duration_since(at) < DOUBLE_CLICK_INTERVAL
                 && (x - px).abs() <= DOUBLE_CLICK_SLOP
                 && (y - py).abs() <= DOUBLE_CLICK_SLOP
         });
         // A double click consumes its history, so a third press starts over.
-        *last = if doubled { None } else { Some((now, (x, y))) };
+        data.last_titlebar_press = if doubled {
+            None
+        } else {
+            Some((now, (x, y), key))
+        };
         doubled
     }
 
@@ -169,10 +169,6 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowDecorat
         data.set_cursor(&CursorImageStatus::Named(CursorIcon::default()));
     }
 
-    fn on_leave(&self, _serial: smithay::utils::Serial, _time: u32) {
-        self.press_on_bar.store(false, Ordering::SeqCst);
-    }
-
     fn on_leave_with_data(
         &self,
         data: &mut crate::Otto<Backend>,
@@ -208,9 +204,9 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowDecorat
         match event.state {
             ButtonState::Pressed => {
                 if let Some(control) = control {
-                    self.last_press.lock().unwrap().take();
+                    data.last_titlebar_press = None;
                     self.update_model(data, true, Some(Self::control_index(control)));
-                } else if self.take_double_click(x, y) {
+                } else if self.take_double_click(data, x, y) {
                     // Two clicks on the bar zoom the window instead of moving
                     // it, so no move grab is started for this press.
                     self.toggle_maximized(data);
@@ -224,7 +220,6 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowDecorat
                     // non-reentrant lock — doing it inline deadlocks the
                     // compositor. Defer to an idle callback, which runs after
                     // the dispatch has released the lock.
-                    self.press_on_bar.store(true, Ordering::SeqCst);
                     let window = self.window.clone();
                     let seat = seat.clone();
                     let serial = event.serial;
@@ -234,7 +229,6 @@ impl<Backend: crate::state::Backend> ViewInteractions<Backend> for WindowDecorat
                 }
             }
             ButtonState::Released => {
-                self.press_on_bar.store(false, Ordering::SeqCst);
                 let was_pressed = self
                     .view(data)
                     .and_then(|v| v.decoration_state().pressed)

--- a/wlcs_otto/Cargo.toml
+++ b/wlcs_otto/Cargo.toml
@@ -28,5 +28,5 @@ nix = "0.24"
 [dependencies.laye-rs]
 # path = "../layers"
 git = "https://github.com/nongio/layers"
-branch = "main"
+tag = "v1.14.0"
 features = ["export-taffy"]


### PR DESCRIPTION
Double-clicking a title bar should maximize a window and restore it again. It did neither reliably — four separate bugs sat on top of each other, so fixing any one of them alone still left the gesture broken.

### 1. The double-click mark was thrown away between clicks

`WindowDecorationView` is rebuilt on every hit test (`Otto::surface_under`), and the pointer unconditionally replaces its stored focus with that new instance on each motion. The "when and where was the last press" mark lived on the view, so *any* pointer movement between the two clicks erased it — i.e. always, with a real mouse or touchpad. It only ever fired if the pointer sat perfectly still.

Moved to `Otto::last_titlebar_press`, keyed by the window's base-layer id so a press on one title bar can't complete a double click on another. `press_on_bar` went with it: write-only dead state for the same reason.

### 2. Clients never learned they were maximized

`maximize_request` set the `Maximized` state on the animation's *last* frame. A client that draws its own decoration decides from that state whether its zoom control maximizes or restores — so otto-kit apps kept asking to be maximized, over and over. From a `WAYLAND_DEBUG` trace of Files: eight `set_maximized` in a row, not one `unset_maximized`.

The state is now sent on the first configure of the animation. Only the size animates.

### 3. A second maximize destroyed the restore target

`maximize_request` on an already-maximized window stored the *maximized* geometry as `unmaximised_rect`, so unmaximizing restored the window to the size it already had: a 300 ms animation with zero delta, which reads as "unmaximize does nothing" and as "unmaximize is not animated". It now returns early.

Relatedly, a window that asks to be maximized before it ever has a size (a browser restoring a maximized window) had an empty restore rect and was configured `0x0`. It now falls back to two thirds of the usable zone, centred.

### 4. The move grab spent the first press of the double click

`begin_pointer_move` restored a maximized window the moment the grab was installed — at button *down*. So press 1 told the client it was no longer maximized, and press 2 asked to maximize a window that still looked maximized. Nothing appeared to happen, forever. Fixing #2 made this hit *every* time rather than intermittently.

Drag-to-restore now happens **into the drag**: `PointerMoveSurfaceGrab` carries `pending_restore` and calls `restore_window_for_drag` once the pointer has travelled 6 px, re-anchoring the drag origin so the grabbed point stays under the cursor. A bare click on a maximized title bar no longer unmaximizes anything.

### Client-drawn title bars

`otto-kit` gains `Window::titlebar_press(seat, serial, x, y)` — a double click zooms, anything else starts a move, with the same 400 ms / 6 px thresholds as the server-side bar. Files and Settings call it instead of `start_move`, so a client-decorated window answers a double click the way a server-decorated one does.

### lay-rs pin

First commit moves every manifest from `branch = "main"` to `tag = "v1.14.0"` (nongio/layers#23), and drops the local `../layers` patch used while those fixes were in flight.

### Testing

Verified in a nested Otto against foot (server-side) and Files/Settings (client-side): repeated double clicks alternate `set_maximized` / `unset_maximized` cleanly, and a 60 fps capture shows both directions animating over ~270 ms. Confirmed on hardware by @nongio.

`cargo test --lib` 168 pass, `cargo clippy --features default` clean. Spec updated in `specs/window-decorations.md`.