### PR TITLE
feat(shell): implement ext-background-effect-v1 blur

### DIFF
--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -534,6 +534,14 @@ impl<A: App + 'static> AppRunnerWithType<A> {
 
         // Background watchers. They find their own home — an app with a plain
         // `fn main` follows the portal just like an async one does.
+        //
+        // The generation is read *before* they start: an answer that lands
+        // while `on_app_ready` runs has to reach the app as a change, not be
+        // folded into the first pass. What the app pushed to the compositor
+        // during `on_app_ready` — a window's material, say — was built from
+        // the default scheme, and only `on_theme_changed` replaces it. Seen
+        // as the settings app keeping a light frost under dark content.
+        let theme_generation_seen = crate::portal_runtime::theme_generation();
         crate::color_scheme::spawn_color_scheme_watcher();
         crate::accent::spawn_accent_watcher();
         crate::icon_theme::spawn_icon_theme_watcher();
@@ -547,6 +555,7 @@ impl<A: App + 'static> AppRunnerWithType<A> {
             conn,
             event_queue,
             app_data,
+            theme_generation_seen,
         })
     }
 
@@ -564,6 +573,9 @@ pub struct AppRunnerInitialized<A: App + 'static> {
     conn: Connection,
     event_queue: wayland_client::EventQueue<AppData<A>>,
     app_data: AppData<A>,
+    /// The theme generation last delivered to the app — taken before the
+    /// watchers were spawned, so nothing they answered during init is lost.
+    theme_generation_seen: u64,
 }
 
 impl<A: App + 'static> AppRunnerInitialized<A> {
@@ -578,9 +590,7 @@ impl<A: App + 'static> AppRunnerInitialized<A> {
 
         // Ensure wakeup pipe exists before entering the loop.
         let wake_fd = AppContext::wakeup_read_fd();
-        // The watchers may already have answered before the first pass, and a
-        // first-run notification is wasted work: the app paints anyway.
-        let mut theme_generation_seen = crate::portal_runtime::theme_generation();
+        let mut theme_generation_seen = self.theme_generation_seen;
 
         while !self.app_data.exit {
             // 1. Drain any events already queued (no I/O).

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -24,8 +24,8 @@ use std::{
 use wayland_client::{
     protocol::{
         wl_buffer, wl_callback, wl_compositor, wl_data_device, wl_data_device_manager,
-        wl_data_offer, wl_data_source, wl_keyboard, wl_pointer, wl_registry, wl_seat, wl_shm,
-        wl_shm_pool, wl_surface,
+        wl_data_offer, wl_data_source, wl_keyboard, wl_pointer, wl_region, wl_registry, wl_seat,
+        wl_shm, wl_shm_pool, wl_surface,
     },
     Connection, Dispatch, EventQueue, QueueHandle,
 };
@@ -34,6 +34,9 @@ use wayland_protocols::xdg::shell::client::{
 };
 
 use crate::protocols::{otto_surface_style_manager_v1, otto_surface_style_v1};
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1, ext_background_effect_surface_v1,
+};
 
 /// Shared state for the test client's Wayland event dispatching.
 #[derive(Debug)]
@@ -45,6 +48,10 @@ pub struct TestClientState {
     /// The compositor-side material protocol, when the compositor advertises it.
     pub otto_surface_style_manager:
         Option<otto_surface_style_manager_v1::OttoSurfaceStyleManagerV1>,
+    pub ext_background_effect_manager:
+        Option<ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1>,
+    /// The `capabilities` bitmask the background-effect global sent on bind.
+    pub background_effect_capabilities: Option<u32>,
     pub shm_formats: Vec<wl_shm::Format>,
     /// The seat's keyboard, once the compositor announces the capability.
     pub wl_keyboard: Option<wl_keyboard::WlKeyboard>,
@@ -75,6 +82,8 @@ impl TestClientState {
             wl_seat: None,
             xdg_wm_base: None,
             otto_surface_style_manager: None,
+            ext_background_effect_manager: None,
+            background_effect_capabilities: None,
             shm_formats: Vec::new(),
             wl_keyboard: None,
             keys: Vec::new(),
@@ -166,6 +175,33 @@ impl TestClient {
         style.set_background_color(0.9, 0.9, 0.9, 0.85);
         style.set_blend_mode(otto_surface_style_v1::BlendMode::BackgroundBlur);
         Some(style)
+    }
+
+    /// Ask for the standard `ext-background-effect-v1` blur behind `surface`,
+    /// the way foot or wezterm do with a translucent background: the whole
+    /// surface as the blur region. Takes effect on the surface's next commit.
+    ///
+    /// Returns the effect object so the caller can keep it alive — dropping
+    /// it removes the blur on the next commit. Returns `None` when the
+    /// compositor does not advertise `ext_background_effect_manager_v1`.
+    pub fn request_background_blur(
+        &self,
+        surface: &wl_surface::WlSurface,
+        width: i32,
+        height: i32,
+    ) -> Option<ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1> {
+        let manager = self.state.ext_background_effect_manager.as_ref()?;
+        let effect = manager.get_background_effect(surface, &self.qh, ());
+        let region = self
+            .state
+            .wl_compositor
+            .as_ref()
+            .expect("compositor not bound")
+            .create_region(&self.qh, ());
+        region.add(0, 0, width, height);
+        effect.set_blur_region(Some(&region));
+        region.destroy();
+        Some(effect)
     }
 
     /// Ask the compositor to round the surface's corners, the way every
@@ -541,6 +577,10 @@ impl Dispatch<wl_registry::WlRegistry, ()> for TestClientState {
                     state.otto_surface_style_manager =
                         Some(registry.bind(name, version.min(2), qh, ()));
                 }
+                "ext_background_effect_manager_v1" => {
+                    state.ext_background_effect_manager =
+                        Some(registry.bind(name, version.min(1), qh, ()));
+                }
                 _ => {}
             }
         }
@@ -783,6 +823,49 @@ impl Dispatch<otto_surface_style_v1::OttoSurfaceStyleV1, ()> for TestClientState
         _state: &mut Self,
         _proxy: &otto_surface_style_v1::OttoSurfaceStyleV1,
         _event: otto_surface_style_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_region::WlRegion, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_region::WlRegion,
+        _event: wl_region::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1, ()>
+    for TestClientState
+{
+    fn event(
+        state: &mut Self,
+        _proxy: &ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1,
+        event: ext_background_effect_manager_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            state.background_effect_capabilities = Some(u32::from(flags));
+        }
+    }
+}
+
+impl Dispatch<ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1, ()>
+    for TestClientState
+{
+    fn event(
+        _state: &mut Self,
+        _proxy: &ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
+        _event: ext_background_effect_surface_v1::Event,
         _data: &(),
         _conn: &Connection,
         _qh: &QueueHandle<Self>,

--- a/docs/developer/wayland.md
+++ b/docs/developer/wayland.md
@@ -76,6 +76,7 @@ Handlers are split roughly like this:
 | `ext_session_lock_v1` | `src/state/session_lock_handler.rs`, `src/lock.rs` | |
 | `zwlr_screencopy_manager_v1` | `src/state/screencopy.rs` | |
 | foreign toplevel (both protocols) | `src/state/foreign_toplevel_list_handler.rs`, `src/state/wlr_foreign_toplevel.rs` | see [foreign-toplevel.md](foreign-toplevel.md) |
+| `ext_background_effect_manager_v1` | `src/background_effect.rs` | Standard blur-behind; maps onto the same `BackgroundBlur` layer path as `otto-surface-style`. See [specs/background-effect.md](../../specs/background-effect.md) |
 
 ## Otto's own protocols
 

--- a/specs/background-effect.md
+++ b/specs/background-effect.md
@@ -1,0 +1,91 @@
+# Background Effect (ext-background-effect-v1)
+
+**Status:** draft
+**Related specs:** [plane-scanout.md](./plane-scanout.md), [window-decorations.md](./window-decorations.md)
+
+## Summary
+
+Otto implements the standard `ext-background-effect-v1` Wayland protocol so any
+client — a terminal with a translucent background, a panel, a launcher — can
+ask for the pixels behind its surface to be blurred, without using Otto's own
+`otto_surface_style_v1`. The frost it gets is the same one otto-kit apps get.
+
+## Goals
+
+- A client that binds `ext_background_effect_manager_v1` is told the compositor
+  can blur.
+- A surface that commits a non-empty blur region is rendered over a blurred
+  backdrop, on every backend and whether or not the window is on its own KMS
+  plane.
+- Removing the region (a `NULL` region, or destroying the effect object) takes
+  the blur away again on the next commit.
+- Works for toplevels, popups, subsurfaces and layer-shell surfaces alike.
+- Real clients work unmodified: foot (`blur=yes`), wezterm
+  (`wayland_window_background_blur`), ghostty (`background-blur`) on builds
+  that speak this protocol.
+
+## Non-Goals
+
+- Honouring the region's *shape*. The region is a switch: any region with area
+  blurs the whole surface, an empty one blurs nothing. See *Rationale*.
+- A client-chosen blur radius, tint or vibrancy. The look is compositor policy
+  and matches Otto's own chrome.
+- The legacy `org_kde_kwin_blur` protocol. Clients that still use it fall back
+  to no blur; the ones that matter have moved or are moving to the standard.
+
+## Behavior
+
+- When a client binds the manager global, the compositor immediately sends
+  `capabilities` with the `blur` bit set.
+- `get_background_effect` on a surface that already has a live effect object
+  raises the `background_effect_exists` protocol error.
+- `set_blur_region` is double-buffered: it changes nothing until the surface's
+  next `wl_surface.commit` (for a synchronized subsurface, the parent's). The
+  region's rectangles are copied at request time; the `wl_region` may be
+  destroyed immediately afterwards.
+- When a commit carries a region containing at least one added rectangle with
+  positive area, the surface's backdrop is blurred from that frame on. Where
+  the client's buffer is translucent, the blurred backdrop shows through; where
+  it is opaque, nothing visible changes.
+- When a commit carries a `NULL` region, or an empty one, the blur is removed
+  from that frame on.
+- Destroying the effect object removes the blur on the surface's next commit,
+  and the surface may obtain a new effect object afterwards.
+- `set_blur_region` on an effect whose surface has been destroyed raises the
+  `surface_destroyed` protocol error.
+- A blurred window is treated as carrying compositor-drawn pixels: it is never
+  handed to a KMS plane as a raw client buffer (that would drop the blur), only
+  as a re-rendered subtree. A window that is already promoted the raw way when
+  its blur arrives is demoted that same frame.
+- A surface that also carries an `otto_surface_style_v1` `BackgroundBlur` keeps
+  blurring when its background-effect region is removed; the style owns the
+  blur too.
+
+## Constraints & Edge Cases
+
+- The blur samples what is actually behind the surface — windows below it,
+  not just the wallpaper — on both the composited and the multi-plane path.
+- A region set before the surface is first mapped is applied by the mapping
+  commit.
+- A region whose rectangles all lie outside the surface still counts as
+  non-empty; the protocol clips to the surface, and a whole-surface blur is
+  the result either way.
+- Nothing is re-applied on commits where the effective on/off state did not
+  change, so a client committing every frame pays nothing for the protocol.
+
+## Rationale
+
+- **Region as a switch.** Otto's blur is a per-layer effect over the layer's
+  (rounded) bounds; carving it to arbitrary rectangles would need a new
+  masking path in the scene engine. Every known client asks for its whole
+  surface, so the switch gives the right result today and leaves partial
+  regions as a future refinement rather than a blocker.
+- **Same machinery as otto-surface-style.** Reusing the blend mode that
+  otto-kit windows use means the plane backdrop seeding, the material-aware
+  scanout rules and the decoration blur all apply for free, and a foot window
+  looks exactly like an otto-kit popup.
+
+## Open Questions
+
+- Should partial regions be honoured once the scene engine can mask a blur to
+  a set of rectangles?

--- a/src/background_effect.rs
+++ b/src/background_effect.rs
@@ -1,0 +1,302 @@
+//! `ext-background-effect-v1`: a client asks for the pixels behind its
+//! surface to be blurred.
+//!
+//! The protocol is tiny — one global that reports what the compositor can do
+//! (blur, here), and one object per `wl_surface` carrying a double-buffered
+//! `wl_region`. The region is the part of the surface whose background the
+//! client wants frosted; `NULL` (or never set) means none. Terminals with a
+//! translucent background (foot, wezterm, ghostty) and panels are the
+//! intended users.
+//!
+//! Otto already knows how to frost a surface: `otto-surface-style`'s
+//! `BackgroundBlur` blend mode sets the surface's own scene layer to
+//! [`layers::types::BlendMode::BackgroundBlur`], and everything downstream —
+//! the plane backdrop seeding, keeping such a window off a raw scanout plane
+//! through [`WindowElement::has_material`](crate::shell::WindowElement::has_material)
+//! — keys off that. This module maps the protocol onto that same path, so a
+//! foot window blurs exactly like an otto-kit popup does.
+//!
+//! What the compositor does with the region's *shape* is its own policy. lay-rs
+//! blurs a layer's whole (rounded) bounds, so a non-empty region frosts the
+//! entire surface and an empty one nothing: the region is a switch, its
+//! rectangles are not honoured individually. Every client seen so far asks
+//! for the full surface anyway.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use smithay::reexports::wayland_protocols::ext::background_effect::v1::server::{
+    ext_background_effect_manager_v1::{self, ExtBackgroundEffectManagerV1},
+    ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
+};
+use smithay::reexports::wayland_server::{
+    backend::{GlobalId, ObjectId},
+    protocol::wl_surface::WlSurface,
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+use smithay::wayland::compositor::{
+    get_region_attributes, with_states, Cacheable, RectangleKind, RegionAttributes,
+};
+
+use crate::{state::Backend, Otto};
+
+/// The blur region a client committed, double-buffered by smithay alongside
+/// the rest of the surface state so it lands on `wl_surface.commit` — and,
+/// for a synchronized subsurface, on the parent's.
+#[derive(Debug, Default, Clone)]
+pub struct BackgroundEffectCachedState {
+    /// `None` is "no blur": never set, set to `NULL`, or the effect object
+    /// was destroyed.
+    pub blur_region: Option<RegionAttributes>,
+}
+
+impl Cacheable for BackgroundEffectCachedState {
+    fn commit(&mut self, _dh: &DisplayHandle) -> Self {
+        self.clone()
+    }
+
+    fn merge_into(self, into: &mut Self, _dh: &DisplayHandle) {
+        *into = self;
+    }
+}
+
+impl BackgroundEffectCachedState {
+    /// Whether the committed region asks for any blur at all.
+    ///
+    /// The protocol clips the region to the surface, but since lay-rs frosts
+    /// the whole layer, all that matters is whether the region has area: a
+    /// client that adds a rectangle and then subtracts all of it is treated
+    /// as asking for blur, which is a corner no real client is in.
+    pub fn wants_blur(&self) -> bool {
+        self.blur_region.as_ref().is_some_and(|region| {
+            region.rects.iter().any(|(kind, rect)| {
+                matches!(kind, RectangleKind::Add) && rect.size.w > 0 && rect.size.h > 0
+            })
+        })
+    }
+}
+
+/// Per-surface marker: the protocol allows one effect object per surface and
+/// makes a second `get_background_effect` a protocol error.
+#[derive(Debug, Default)]
+struct BackgroundEffectSurfaceMarker {
+    taken: AtomicBool,
+}
+
+/// User data of an `ext_background_effect_surface_v1`.
+#[derive(Debug)]
+pub struct BackgroundEffectSurfaceUserData {
+    /// The surface the effect belongs to. A `WlSurface` handle does not keep
+    /// the surface alive, so `is_alive` is the "inert" check the protocol
+    /// asks for once the client destroys the surface first.
+    surface: WlSurface,
+}
+
+/// The `ext_background_effect_manager_v1` global.
+#[derive(Debug, Clone)]
+pub struct BackgroundEffectState {
+    global: GlobalId,
+}
+
+impl BackgroundEffectState {
+    /// Create and advertise the global.
+    pub fn new<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<ExtBackgroundEffectManagerV1, ()>
+            + Dispatch<ExtBackgroundEffectManagerV1, ()>
+            + Dispatch<ExtBackgroundEffectSurfaceV1, BackgroundEffectSurfaceUserData>
+            + 'static,
+    {
+        let global = display.create_global::<D, ExtBackgroundEffectManagerV1, _>(1, ());
+        Self { global }
+    }
+
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+impl<BackendData: Backend + 'static> GlobalDispatch<ExtBackgroundEffectManagerV1, ()>
+    for Otto<BackendData>
+{
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ExtBackgroundEffectManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        let manager = data_init.init(resource, ());
+        // Sent on bind and whenever it changes; Otto's blur is always on.
+        manager.capabilities(ext_background_effect_manager_v1::Capability::Blur);
+    }
+}
+
+impl<BackendData: Backend + 'static> Dispatch<ExtBackgroundEffectManagerV1, ()>
+    for Otto<BackendData>
+{
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        manager: &ExtBackgroundEffectManagerV1,
+        request: ext_background_effect_manager_v1::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_background_effect_manager_v1::Request::GetBackgroundEffect { id, surface } => {
+                let already = with_states(&surface, |states| {
+                    states
+                        .data_map
+                        .insert_if_missing_threadsafe(BackgroundEffectSurfaceMarker::default);
+                    states
+                        .data_map
+                        .get::<BackgroundEffectSurfaceMarker>()
+                        .unwrap()
+                        .taken
+                        .swap(true, Ordering::AcqRel)
+                });
+                if already {
+                    manager.post_error(
+                        ext_background_effect_manager_v1::Error::BackgroundEffectExists,
+                        "the surface already has a background effect object",
+                    );
+                    return;
+                }
+                data_init.init(id, BackgroundEffectSurfaceUserData { surface });
+            }
+            ext_background_effect_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl<BackendData: Backend + 'static>
+    Dispatch<ExtBackgroundEffectSurfaceV1, BackgroundEffectSurfaceUserData> for Otto<BackendData>
+{
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        effect: &ExtBackgroundEffectSurfaceV1,
+        request: ext_background_effect_surface_v1::Request,
+        data: &BackgroundEffectSurfaceUserData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_background_effect_surface_v1::Request::SetBlurRegion { region } => {
+                if !data.surface.is_alive() {
+                    effect.post_error(
+                        ext_background_effect_surface_v1::Error::SurfaceDestroyed,
+                        "set_blur_region on an effect whose surface was destroyed",
+                    );
+                    return;
+                }
+                // Copy semantics: the client may destroy the wl_region right
+                // after this request, so take the rectangles now.
+                let attributes = region.as_ref().map(get_region_attributes);
+                with_states(&data.surface, |states| {
+                    states
+                        .cached_state
+                        .get::<BackgroundEffectCachedState>()
+                        .pending()
+                        .blur_region = attributes;
+                });
+            }
+            ext_background_effect_surface_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+
+    fn destroyed(
+        _state: &mut Self,
+        _client: smithay::reexports::wayland_server::backend::ClientId,
+        _effect: &ExtBackgroundEffectSurfaceV1,
+        data: &BackgroundEffectSurfaceUserData,
+    ) {
+        if !data.surface.is_alive() {
+            return;
+        }
+        // "The effect regions will be removed on the next commit" — clear
+        // the pending state rather than the live one, and let the surface
+        // ask again later.
+        with_states(&data.surface, |states| {
+            states
+                .cached_state
+                .get::<BackgroundEffectCachedState>()
+                .pending()
+                .blur_region = None;
+            if let Some(marker) = states.data_map.get::<BackgroundEffectSurfaceMarker>() {
+                marker.taken.store(false, Ordering::Release);
+            }
+        });
+    }
+}
+
+impl<BackendData: Backend + 'static> Otto<BackendData> {
+    /// Apply the blur region a surface just committed to its scene layer.
+    ///
+    /// Runs from `CompositorHandler::commit`, after the commit has built or
+    /// refreshed the surface's layer, so the layer is there to set. Cheap on
+    /// the common path: the last applied value is remembered per surface in
+    /// [`Otto::background_effects`] and nothing is touched when it has not
+    /// changed — `set_blend_mode` on every commit would damage the layer.
+    ///
+    /// Only turns a blur *off* that it turned on: a surface that also holds
+    /// an `otto-surface-style` `BackgroundBlur` keeps it, that style owns
+    /// the layer's blend mode too.
+    pub(crate) fn apply_background_effect(&mut self, surface: &WlSurface) {
+        let surface_id = surface.id();
+        let wants_blur = with_states(surface, |states| {
+            states
+                .cached_state
+                .get::<BackgroundEffectCachedState>()
+                .current()
+                .wants_blur()
+        });
+        let was_blurred = self
+            .background_effects
+            .get(&surface_id)
+            .copied()
+            .unwrap_or(false);
+        if wants_blur == was_blurred {
+            return;
+        }
+
+        let Some(layer) = self.surface_layers.get(&surface_id).cloned() else {
+            // No layer yet — an unmapped surface. The commit that maps it
+            // comes back through here with the same committed region.
+            return;
+        };
+
+        if wants_blur {
+            self.background_effects.insert(surface_id.clone(), true);
+            layer.set_blend_mode(layers::types::BlendMode::BackgroundBlur);
+            // What the frost has to show is usually the window *below* in
+            // the same plane, not just the wallpaper: read the raw backdrop
+            // and blur it here, as the SSD titlebar and styled windows do.
+            layer.set_blur_include_content(true);
+        } else {
+            self.background_effects.remove(&surface_id);
+            let style_blurs = self
+                .surfaces_style
+                .get(&surface_id)
+                .is_some_and(|styles| styles.iter().any(|s| s.background_blur));
+            if !style_blurs {
+                layer.set_blend_mode(layers::types::BlendMode::default());
+                layer.set_blur_include_content(false);
+            }
+        }
+
+        self.refresh_window_material(&surface_id);
+        if let Some(window) = self.workspaces.get_window_for_surface(&surface_id).cloned() {
+            self.update_window_view(&window);
+        }
+    }
+
+    /// Forget a destroyed surface's blur.
+    pub(crate) fn forget_background_effect(&mut self, surface_id: &ObjectId) {
+        self.background_effects.remove(surface_id);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 
 pub mod audio;
+pub mod background_effect;
 #[cfg(any(feature = "udev", feature = "xwayland", feature = "headless"))]
 pub mod cursor;
 pub mod debug_gesture;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -367,6 +367,9 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
                 }
             }
         }
+        // The commit above created or refreshed the surface's layer; now
+        // the blur region it carried can be applied to that layer.
+        self.apply_background_effect(surface);
         self.popups.commit(surface);
 
         // ensure_initial_configure(surface, self.space(), &mut self.popups)
@@ -378,6 +381,7 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
     fn destroyed(&mut self, surface: &WlSurface) {
         // Clean up the layer for this surface
         self.destroy_layer_for_surface(&surface.id());
+        self.forget_background_effect(&surface.id());
 
         // A decoration mode stashed for a surface that never became a toplevel
         // has nothing left to apply to.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -379,6 +379,11 @@ pub struct Otto<BackendData: Backend + 'static> {
     // Map from surface ID to list of surface styles augmenting that surface
     pub surfaces_style: HashMap<ObjectId, Vec<crate::surface_style::SurfaceStyle>>,
     pub style_transactions: HashMap<ObjectId, crate::surface_style::StyleTransaction>,
+    /// `ext-background-effect-v1`: surfaces whose scene layer this compositor
+    /// switched to `BackgroundBlur` because the client committed a blur
+    /// region. Keyed by surface, present only while the blur is on — see
+    /// `Otto::apply_background_effect`.
+    pub background_effects: HashMap<ObjectId, bool>,
     // Map from surface ID to its rendering layer in the scene graph
     pub surface_layers: HashMap<ObjectId, layers::prelude::Layer>,
     /// Tracks which parent ObjectId each surface layer was last appended to,
@@ -789,6 +794,10 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         // Create minimal sc_layer shell global
         crate::surface_style::create_style_manager_global::<BackendData>(&dh);
 
+        // ext-background-effect-v1: the standard way for a terminal or panel
+        // to ask for the frost otto-surface-style gives otto-kit apps.
+        crate::background_effect::BackgroundEffectState::new::<Self>(&dh);
+
         // Create otto_dock protocol global
         let otto_dock = crate::otto_dock::handlers::OttoDockState::new::<Self>(&dh);
 
@@ -992,6 +1001,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             // Surface style protocol
             surfaces_style: HashMap::new(),
             style_transactions: HashMap::new(),
+            background_effects: HashMap::new(),
             surface_layer_parents: HashMap::new(),
             surface_children_order: HashMap::new(),
             surface_layers: HashMap::new(),

--- a/src/surface_style/handlers/mod.rs
+++ b/src/surface_style/handlers/mod.rs
@@ -80,46 +80,53 @@ fn trigger_window_update<BackendData: Backend>(
     }
 }
 
-/// Re-derive whether the compositor draws anything for `surface_id`'s window
-/// that the client's buffer does not already contain — a background colour, a
-/// backdrop blur, a rounded clip, a border — and take the window off its
-/// scanout plane if it is on one.
-///
-/// A material lives on the window's own scene layer, and promotion picks how
-/// to make room for the plane: a plain window has that whole layer hidden, a
-/// material one only has its texture blanked so the material keeps rendering
-/// (see `Workspaces::set_scanout_windows`). A window already promoted the
-/// plain way when the material arrives has the wrong treatment and would show
-/// no frost, so it is demoted here; the next candidate pass re-promotes it
-/// with the material intact.
-///
-/// Only the window's own surface counts: a subsurface keeps rendering in the
-/// windows plane even while the root is promoted, so a material on one is not
-/// at risk.
-fn refresh_window_material<BackendData: Backend>(
-    state: &mut Otto<BackendData>,
-    surface_id: &smithay::reexports::wayland_server::backend::ObjectId,
-) {
-    let material = state
-        .surfaces_style
-        .get(surface_id)
-        .map(|styles| {
-            styles
-                .iter()
-                .any(|s| s.background_alpha > 0.0 || s.background_blur || s.rounded || s.bordered)
-        })
-        .unwrap_or(false);
+impl<BackendData: Backend> Otto<BackendData> {
+    /// Re-derive whether the compositor draws anything for `surface_id`'s
+    /// window that the client's buffer does not already contain — a
+    /// background colour, a backdrop blur, a rounded clip, a border — and
+    /// take the window off its scanout plane if it is on one.
+    ///
+    /// Two protocols feed this: `otto-surface-style` (all four kinds) and
+    /// `ext-background-effect-v1` (blur only, see
+    /// [`Otto::apply_background_effect`]).
+    ///
+    /// A material lives on the window's own scene layer, and promotion picks
+    /// how to make room for the plane: a plain window has that whole layer
+    /// hidden, a material one only has its texture blanked so the material
+    /// keeps rendering (see `Workspaces::set_scanout_windows`). A window
+    /// already promoted the plain way when the material arrives has the wrong
+    /// treatment and would show no frost, so it is demoted here; the next
+    /// candidate pass re-promotes it with the material intact.
+    ///
+    /// Only the window's own surface counts: a subsurface keeps rendering in
+    /// the windows plane even while the root is promoted, so a material on
+    /// one is not at risk.
+    pub(crate) fn refresh_window_material(
+        &mut self,
+        surface_id: &smithay::reexports::wayland_server::backend::ObjectId,
+    ) {
+        let styled = self
+            .surfaces_style
+            .get(surface_id)
+            .map(|styles| {
+                styles.iter().any(|s| {
+                    s.background_alpha > 0.0 || s.background_blur || s.rounded || s.bordered
+                })
+            })
+            .unwrap_or(false);
+        let material = styled || self.background_effects.contains_key(surface_id);
 
-    let Some(window) = state.workspaces.get_window_for_surface(surface_id).cloned() else {
-        return;
-    };
-    if window.set_has_material(material) == material {
-        return;
-    }
-    if material {
-        // It may already be on a plane: take it back this frame rather than
-        // waiting for the next candidate pass.
-        state.workspaces.remove_scanout_window(surface_id);
+        let Some(window) = self.workspaces.get_window_for_surface(surface_id).cloned() else {
+            return;
+        };
+        if window.set_has_material(material) == material {
+            return;
+        }
+        if material {
+            // It may already be on a plane: take it back this frame rather than
+            // waiting for the next candidate pass.
+            self.workspaces.remove_scanout_window(surface_id);
+        }
     }
 }
 

--- a/src/surface_style/handlers/style.rs
+++ b/src/surface_style/handlers/style.rs
@@ -7,7 +7,7 @@ use crate::{
     state::Backend,
     surface_style::handlers::{
         accumulate_change, clip_mode_enabled, find_active_transaction_for_client,
-        refresh_window_material, trigger_window_update, wl_fixed_to_f32, OttoLayerUserData,
+        trigger_window_update, wl_fixed_to_f32, OttoLayerUserData,
     },
     Otto,
 };
@@ -250,7 +250,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                         s.background_alpha = alpha;
                     }
                 }
-                refresh_window_material(state, &surface_id);
+                state.refresh_window_material(&surface_id);
             }
 
             otto_surface_style_v1::Request::SetCornerRadius { radius } => {
@@ -278,7 +278,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                         s.rounded = radius > 0.0;
                     }
                 }
-                refresh_window_material(state, &surface_id);
+                state.refresh_window_material(&surface_id);
             }
 
             otto_surface_style_v1::Request::SetBorder {
@@ -321,7 +321,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                         s.bordered = width > 0.0 && alpha > 0.0;
                     }
                 }
-                refresh_window_material(state, &surface_id);
+                state.refresh_window_material(&surface_id);
             }
 
             otto_surface_style_v1::Request::SetShadow {
@@ -463,7 +463,7 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                         s.background_blur = blend_mode == LayrsBlendMode::BackgroundBlur;
                     }
                 }
-                refresh_window_material(state, &surface_id);
+                state.refresh_window_material(&surface_id);
             }
 
             otto_surface_style_v1::Request::SetZOrder { z_order } => {

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -973,6 +973,91 @@ mod headless_tests {
         handle.stop();
     }
 
+    // ── ext-background-effect-v1 ─────────────────────────────────────────
+
+    /// A client that commits a blur region through the standard protocol
+    /// gets the same frost an otto-kit popup gets: its surface layer flips to
+    /// `BackgroundBlur` and the window counts as carrying a compositor-drawn
+    /// material (so it stays off a raw scanout plane). Destroying the effect
+    /// object takes both back on the next commit.
+    #[test]
+    #[serial]
+    fn background_effect_blur_follows_commits() {
+        use layers::types::BlendMode;
+
+        let handle = start_compositor();
+        let mut client = connect_client(&handle);
+
+        let toplevel = client.create_toplevel("blur-me", 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+
+        assert_eq!(
+            client.state.background_effect_capabilities,
+            Some(1),
+            "the global must advertise the blur capability on bind"
+        );
+
+        fn material_and_blend(handle: &HeadlessHandle, title: &'static str) -> (bool, BlendMode) {
+            handle.query(move |state| {
+                let window = state
+                    .workspaces
+                    .spaces_elements()
+                    .find(|w| w.xdg_title() == title)
+                    .expect("window mapped");
+                let blend = state
+                    .surface_layers
+                    .get(&window.id())
+                    .expect("surface layer")
+                    .render_layer()
+                    .blend_mode;
+                (window.has_material(), blend)
+            })
+        }
+
+        assert_eq!(
+            material_and_blend(&handle, "blur-me"),
+            (false, BlendMode::Normal),
+            "a plain window starts without a material"
+        );
+
+        // Pending until the surface commits: the region alone changes nothing.
+        let surface = toplevel.lock().unwrap().surface.clone();
+        let effect = client
+            .request_background_blur(&surface, 640, 480)
+            .expect("ext_background_effect_manager_v1 advertised");
+        let _ = client.roundtrip();
+        handle.wait(Duration::from_millis(50));
+        assert_eq!(
+            material_and_blend(&handle, "blur-me"),
+            (false, BlendMode::Normal),
+            "set_blur_region is double-buffered"
+        );
+
+        toplevel.lock().unwrap().commit_frame();
+        let _ = client.roundtrip();
+        handle.wait(Duration::from_millis(100));
+        assert_eq!(
+            material_and_blend(&handle, "blur-me"),
+            (true, BlendMode::BackgroundBlur),
+            "the commit applies the blur to the surface layer"
+        );
+
+        // Destroying the effect removes the blur on the next commit.
+        effect.destroy();
+        let _ = client.roundtrip();
+        toplevel.lock().unwrap().commit_frame();
+        let _ = client.roundtrip();
+        handle.wait(Duration::from_millis(100));
+        assert_eq!(
+            material_and_blend(&handle, "blur-me"),
+            (false, BlendMode::Normal),
+            "destroying the effect object takes the blur back"
+        );
+
+        handle.stop();
+    }
+
     // ── Expose: moving a window to another workspace ─────────────────────
 
     /// Pick a preview up in expose and drop it on another workspace's


### PR DESCRIPTION
## Summary

Implements the standard [`ext-background-effect-v1`](https://wayland.app/protocols/ext-background-effect-v1) protocol, so any client — a terminal with a translucent background, a panel — can ask for the pixels behind its surface to be blurred without using `otto-surface-style`.

- New `src/background_effect.rs`: the manager global (advertises `capabilities = blur` on bind), one effect object per surface (`background_effect_exists` / `surface_destroyed` errors), and the blur region as smithay double-buffered `Cacheable` state so it lands on `wl_surface.commit` (the parent's for a sync subsurface).
- The commit path switches the surface's own scene layer to `BackgroundBlur` + `blur_include_content` — the same path `otto-surface-style`'s `BackgroundBlur` uses, so plane backdrop seeding, layer-shell, popups and subsurfaces come for free. Only on/off transitions touch the layer; a client committing every frame pays nothing.
- `refresh_window_material` (now an `Otto` method) counts a protocol blur as a compositor-drawn material, so a blurred window is never scanned out as a raw client buffer; it goes through the subtree plane instead.

### Also: otto-kit windows kept a light frost under dark content

Found while testing on the dark theme: the settings app's sidebar went near-white when focused. `AppRunner` snapshotted the theme generation *after* `on_app_ready`, so a colour-scheme answer that landed during init never reached `on_theme_changed` — the material pushed to the compositor in `on_app_ready` (built from the default light scheme) was never replaced, while the pane repainted dark from the atomic. The snapshot is now taken before the watchers start. Second commit, otto-kit only.

### Policy / limitation

The region is treated as a switch: any region with area frosts the whole surface. lay-rs blurs a layer's full bounds, and every known client (foot, wezterm, ghostty) asks for the full surface. Recorded in `specs/background-effect.md` as an open question.

## Test plan

- [x] `cargo test --features headless --test headless_basic background_effect` — capabilities on bind, pending-until-commit, blur on + `has_material`, destroy → back to plain
- [x] `cargo fmt --check`, `cargo clippy --features default -D warnings`
- [x] On hardware (`--tty-udev`, Framework 13): foot 1.27 with `colors.blur=yes`, `alpha=0.55` — binds the global, gets `capabilities(1)`, frosts over the wallpaper *and* over the window beneath it; open/close/drag cycles clean, scanout promotion/demotion clean
- [x] Nested winit: same

https://claude.ai/code/session_014ERdGTKoWuokwZDVU7vYQa
