### PR TITLE
fix(otto-kit): titlebar material opacity and init-time theme delivery

### DIFF
--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -1,7 +1,7 @@
 # Maintainer: Riccardo Canalicchio <riccardo.canalicchio@gmail.com>
 
 pkgname=otto-git
-pkgver=1.0.0rc1.r0.geb6b00e2
+pkgver=1.0.0rc.2.r4.g81d66005
 pkgrel=1
 pkgdesc="A visually-focused desktop system designed around smooth animations, thoughtful gestures and careful attention to detail, inspired by familiar macOS interactions."
 url="https://github.com/nongio/otto"

--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -534,6 +534,14 @@ impl<A: App + 'static> AppRunnerWithType<A> {
 
         // Background watchers. They find their own home — an app with a plain
         // `fn main` follows the portal just like an async one does.
+        //
+        // The generation is read *before* they start: an answer that lands
+        // while `on_app_ready` runs has to reach the app as a change, not be
+        // folded into the first pass. What the app pushed to the compositor
+        // during `on_app_ready` — a window's material, say — was built from
+        // the default scheme, and only `on_theme_changed` replaces it. Seen
+        // as the settings app keeping a light frost under dark content.
+        let theme_generation_seen = crate::portal_runtime::theme_generation();
         crate::color_scheme::spawn_color_scheme_watcher();
         crate::accent::spawn_accent_watcher();
         crate::icon_theme::spawn_icon_theme_watcher();
@@ -547,6 +555,7 @@ impl<A: App + 'static> AppRunnerWithType<A> {
             conn,
             event_queue,
             app_data,
+            theme_generation_seen,
         })
     }
 
@@ -564,6 +573,9 @@ pub struct AppRunnerInitialized<A: App + 'static> {
     conn: Connection,
     event_queue: wayland_client::EventQueue<AppData<A>>,
     app_data: AppData<A>,
+    /// The theme generation last delivered to the app — taken before the
+    /// watchers were spawned, so nothing they answered during init is lost.
+    theme_generation_seen: u64,
 }
 
 impl<A: App + 'static> AppRunnerInitialized<A> {
@@ -578,9 +590,7 @@ impl<A: App + 'static> AppRunnerInitialized<A> {
 
         // Ensure wakeup pipe exists before entering the loop.
         let wake_fd = AppContext::wakeup_read_fd();
-        // The watchers may already have answered before the first pass, and a
-        // first-run notification is wasted work: the app paints anyway.
-        let mut theme_generation_seen = crate::portal_runtime::theme_generation();
+        let mut theme_generation_seen = self.theme_generation_seen;
 
         while !self.app_data.exit {
             // 1. Drain any events already queued (no I/O).

--- a/components/otto-kit/src/components/titlebar/titlebar.rs
+++ b/components/otto-kit/src/components/titlebar/titlebar.rs
@@ -107,7 +107,7 @@ impl TitlebarMaterial {
     /// Light material for the focused window
     pub fn light_active() -> Self {
         Self {
-            tint: Color::from_argb(0xBF, 0xEC, 0xEC, 0xEE),
+            tint: Color::from_argb(0xE4, 0xEC, 0xEC, 0xEE),
             backdrop_blur: 0.0,
             gradient: 0.5,
             top_highlight: Some(Color::from_argb(0x99, 0xFF, 0xFF, 0xFF)),
@@ -119,7 +119,7 @@ impl TitlebarMaterial {
     /// the depth cue that says "not this one".
     pub fn light_inactive() -> Self {
         Self {
-            tint: Color::from_argb(0xB3, 0xF4, 0xF4, 0xF6),
+            tint: Color::from_argb(0xDC, 0xF4, 0xF4, 0xF6),
             gradient: 0.2,
             top_highlight: Some(Color::from_argb(0x55, 0xFF, 0xFF, 0xFF)),
             bottom_shade: Some(Color::from_argb(0x14, 0x00, 0x00, 0x00)),
@@ -129,7 +129,7 @@ impl TitlebarMaterial {
 
     pub fn dark_active() -> Self {
         Self {
-            tint: Color::from_argb(0xC4, 0x32, 0x34, 0x3A),
+            tint: Color::from_argb(0xE6, 0x32, 0x34, 0x3A),
             backdrop_blur: 0.0,
             gradient: 0.5,
             top_highlight: Some(Color::from_argb(0x40, 0xFF, 0xFF, 0xFF)),
@@ -139,7 +139,7 @@ impl TitlebarMaterial {
 
     pub fn dark_inactive() -> Self {
         Self {
-            tint: Color::from_argb(0xB8, 0x2A, 0x2C, 0x31),
+            tint: Color::from_argb(0xDE, 0x2A, 0x2C, 0x31),
             gradient: 0.2,
             top_highlight: Some(Color::from_argb(0x22, 0xFF, 0xFF, 0xFF)),
             bottom_shade: Some(Color::from_argb(0x4D, 0x00, 0x00, 0x00)),

--- a/components/otto-kit/src/theme.rs
+++ b/components/otto-kit/src/theme.rs
@@ -87,7 +87,7 @@ impl Theme {
             text_secondary: Color::from_argb(0x80, 0x00, 0x00, 0x00),
             text_tertiary: Color::from_argb(0x40, 0x00, 0x00, 0x00),
 
-            material_titlebar: Color::from_argb(0xCC, 0xEA, 0xEA, 0xEA),
+            material_titlebar: Color::from_argb(0xE4, 0xEA, 0xEA, 0xEA),
             // Sidebars sit over compositor blur, but they are a window's own
             // ground and carry small text: at 0x8C the backdrop read straight
             // through and the wallpaper competed with the rows. Keep enough
@@ -120,7 +120,7 @@ impl Theme {
             text_tertiary: Color::from_argb(0x40, 0xFF, 0xFF, 0xFF),
 
             // Dark translucent surfaces
-            material_titlebar: Color::from_argb(0xBF, 0x28, 0x28, 0x28),
+            material_titlebar: Color::from_argb(0xE6, 0x28, 0x28, 0x28),
             material_sidebar: Color::from_argb(0xF0, 0x1E, 0x1E, 0x1E),
             material_medium: Color::from_argb(0x83, 0x28, 0x28, 0x28),
             material_popup: Color::from_argb(0xD8, 0x28, 0x28, 0x28),

--- a/components/otto-launcher/src/main.rs
+++ b/components/otto-launcher/src/main.rs
@@ -510,15 +510,11 @@ fn at_least_opaque(colour: skia_safe::Color, min_alpha: u8) -> skia_safe::Color 
     )
 }
 
-/// Ask the compositor for the card's material: the frost, and the shape it is
-/// cut to.
-///
-/// None of this can be drawn client-side. A blur needs the pixels behind the
-/// surface, and the only process that has them is the compositor — so the card
-/// declares what it wants to look like and paints its text on top of the
-/// result. `material_medium` is the same token the bar's menus use, so the
-/// launcher reads as the same kind of surface as the rest of the desktop.
-fn apply_card_material(card: &SubsurfaceSurface) {
+/// The card's frost colour, which is the one part of the material that follows
+/// the colour scheme. Split out of `apply_card_material` so a theme that lands
+/// after the card exists can be applied without also rewinding the entrance
+/// state that function sets.
+fn apply_card_colour(card: &SubsurfaceSurface) {
     let Some(style) = card.base_surface().surface_style() else {
         tracing::warn!("no otto-surface-style; the card will not be frosted");
         return;
@@ -538,6 +534,21 @@ fn apply_card_material(card: &SubsurfaceSurface) {
         colour.b as f64,
         colour.a as f64,
     );
+}
+
+/// Ask the compositor for the card's material: the frost, and the shape it is
+/// cut to.
+///
+/// None of this can be drawn client-side. A blur needs the pixels behind the
+/// surface, and the only process that has them is the compositor — so the card
+/// declares what it wants to look like and paints its text on top of the
+/// result. `material_medium` is the same token the bar's menus use, so the
+/// launcher reads as the same kind of surface as the rest of the desktop.
+fn apply_card_material(card: &SubsurfaceSurface) {
+    apply_card_colour(card);
+    let Some(style) = card.base_surface().surface_style() else {
+        return;
+    };
     style.set_blend_mode(BlendMode::BackgroundBlur);
     style.set_corner_radius(RADIUS as f64 * AppContext::fractional_scale());
     style.set_masks_to_bounds(ClipMode::Enabled);
@@ -624,6 +635,21 @@ impl App for Launcher {
             palette.set_size(width as f32, height as f32);
         }
         self.sized = true;
+        self.dirty = true;
+    }
+
+    /// The portal answers the colour scheme asynchronously, so the launcher is
+    /// usually already up — and drawn in the default light — by the time the
+    /// answer arrives. Recolour everything that was built from it.
+    fn on_theme_changed(&mut self, _ctx: &AppContext) {
+        let dark = dark();
+        self.input.style = field_style(dark);
+        if let Some(palette) = self.palette.as_mut() {
+            palette.set_dark(dark);
+        }
+        if let Some(card) = self.card.as_ref() {
+            apply_card_colour(card);
+        }
         self.dirty = true;
     }
 

--- a/components/otto-launcher/src/view.rs
+++ b/components/otto-launcher/src/view.rs
@@ -150,6 +150,18 @@ impl Palette {
         palette
     }
 
+    /// Switch the colour scheme. The portal answers after the palette is
+    /// built, so this is the normal path into dark, not an edge case. Only the
+    /// two layer colours are set here — the row text reads `dark` on every
+    /// `update`, and the caller marks itself dirty.
+    pub fn set_dark(&mut self, dark: bool) {
+        if self.dark == dark {
+            return;
+        }
+        self.dark = dark;
+        self.style();
+    }
+
     /// The card's scene root, for a host that needs to draw it directly — the
     /// preview example renders this subtree into a raster surface.
     pub fn card_layer(&self) -> &Layer {

--- a/specs/launcher.md
+++ b/specs/launcher.md
@@ -109,6 +109,13 @@ the list, keeping the selection on the same item where that item still exists.
   only where it is drawn: the compositor still hit-tests the pointer against the
   subsurface's own position and reports coordinates relative to it, so hover
   lands on the wrong row. Both must be set.
+- **The colour scheme arrives after the card does.** The scheme comes from the
+  settings portal, which answers asynchronously — normally after the launcher
+  has built its surfaces and drawn its first frame from the default (light)
+  scheme. Everything that was coloured from it — row text, field text, the
+  divider and highlight, and the card's frost colour — must be rebuilt when the
+  answer lands, or the launcher shows dark-theme text on a dark card. Rebuilding
+  the frost must not also rewind the card's entrance state.
 - **The query field must be laid out before it is drawn.** A field with no width
   scrolls its own text out of its clip, and the launcher then looks like it is
   ignoring the keyboard while the list filters correctly.


### PR DESCRIPTION
Two otto-kit fixes:

- **Titlebar material opacity** — make the titlebar material more opaque.
- **Init-time theme delivery** — a theme answered while the app runner is still initializing was dropped; it is now delivered once init completes. (Cherry-picked from #157.)

https://claude.ai/code/session_01ARWAFxjFZqwUfUfEQduz6J