### PR TITLE
ci: run each area's checks only when it changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,103 @@ on:
   pull_request:
   workflow_dispatch:
 
+# A PR that gets pushed to twice in a minute used to run every job three times
+# over. Superseded runs on the same ref are cancelled; runs on main and on tags
+# publish artifacts, so those are never cancelled.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Which areas of the repo the diff touches. Every other job reads these
+  # outputs to decide what is worth running: a change under
+  # components/otto-rdp does not need the compositor's headless suite, and a
+  # change under src/ does not need otto-rdp's GStreamer bin rebuilt.
+  #
+  # Anything shared (the lockfile, the workspace manifest, the toolchain, the
+  # UI toolkit every component links, this file) sets *every* flag — the safe
+  # default is to run more, never less.
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      compositor: ${{ steps.filter.outputs.compositor }}
+      ui: ${{ steps.filter.outputs.ui }}
+      rdp: ${{ steps.filter.outputs.rdp }}
+      portal: ${{ steps.filter.outputs.portal }}
+      packaging: ${{ steps.filter.outputs.packaging }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # workflow_dispatch, a tag build, or a first push to a new branch has
+          # no usable base to diff against: treat everything as changed.
+          if [ -z "${BASE_SHA:-}" ] \
+             || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              echo "no diff base ($BASE_SHA); running everything"
+              FILES='__all__'
+          else
+              FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+              echo "changed files:"
+              echo "$FILES" | sed 's/^/  /'
+          fi
+
+          # Matches any path, so a missing base turns every filter on.
+          if [ "$FILES" = '__all__' ]; then FILES=$(git ls-files); fi
+
+          matches() { echo "$FILES" | grep -qE "$1"; }
+
+          # Nothing in the tree is unaffected by these.
+          SHARED='^(Cargo\.lock|Cargo\.toml|rust-toolchain\.toml)$|^\.github/workflows/ci\.yml$'
+          # The UI toolkit: linked by otto and by every component except the
+          # RDP bridge and the portal backend, which are leaf crates (verified
+          # with `cargo tree -p <crate> | grep otto-kit`).
+          KIT='^components/otto-kit/'
+          COMPOSITOR='^(src|tests|protocols|resources)/|^otto_config.*\.toml$'
+          RDP='^components/otto-rdp/'
+          PORTAL='^components/xdg-desktop-portal-otto/'
+          # Every component except the two with their own filters above.
+          UI='^components/(?!otto-rdp/|xdg-desktop-portal-otto/)|^sample-clients/'
+          PACKAGING='^PKGBUILD|^(Cargo\.toml)$|^(resources|scripts)/|^\.github/workflows/ci\.yml$'
+
+          shared=false; matches "$SHARED" && shared=true
+          kit=false; matches "$KIT" && kit=true
+
+          for name in compositor rdp portal; do
+              case $name in
+                  # otto-kit reaches the compositor and the UI components, but
+                  # not the two leaf crates below.
+                  compositor) pat=$COMPOSITOR; extra=$kit ;;
+                  rdp)        pat=$RDP;        extra=false ;;
+                  portal)     pat=$PORTAL;     extra=false ;;
+              esac
+              if $shared || $extra || matches "$pat"; then v=true; else v=false; fi
+              echo "$name=$v" >> "$GITHUB_OUTPUT"
+              eval "$name=$v"
+          done
+
+          # -P for the negative lookahead; plain -E cannot express it.
+          if $shared || $kit || echo "$FILES" | grep -qP "$UI"; then ui=true; else ui=false; fi
+          echo "ui=$ui" >> "$GITHUB_OUTPUT"
+
+          if matches "$PACKAGING"; then packaging=true; else packaging=false; fi
+          echo "packaging=$packaging" >> "$GITHUB_OUTPUT"
+
+          if $compositor || $ui || $rdp || $portal; then rust=true; else rust=false; fi
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+
+          echo "--- compositor=$compositor ui=$ui rdp=$rdp portal=$portal packaging=$packaging rust=$rust"
+
   format:
     runs-on: ubuntu-24.04
     steps:
@@ -29,7 +125,12 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
   
+  # One job rather than several: every step shares a single target directory,
+  # so splitting them apart would pay for the compositor's dependency graph
+  # once per job. Individual steps are gated instead.
   check:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
@@ -47,23 +148,54 @@ jobs:
           cache-on-failure: true
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libpam0g-dev hicolor-icon-theme fonts-dejavu-core
-      - name: Clippy
-        run: cargo clippy --features "default" -- -D warnings
+      # Clippy mirrors the test steps below: every crate CI compiles is
+      # linted, and each area is linted only when that area changed.
+      # `--all-targets` reaches tests, examples and benches, and the headless
+      # feature is what makes tests/*.rs more than an empty file.
+      - name: Clippy (compositor)
+        if: needs.changes.outputs.compositor == 'true'
+        run: cargo clippy -p otto --all-targets --features "default,headless" -- -D warnings
+      - name: Clippy (components)
+        # Everything with no filter of its own, sample clients included.
+        # submenu-gtk is the one exception: it needs GTK development libraries
+        # that no job here installs, and nothing in CI compiles it — the
+        # release build names its packages explicitly, and `--lib --workspace`
+        # skips it because it has no lib target.
+        if: needs.changes.outputs.ui == 'true'
+        run: cargo clippy --workspace --exclude otto --exclude otto-rdp --exclude xdg-desktop-portal-otto --exclude submenu-gtk --all-targets -- -D warnings
+      - name: Clippy (RDP bridge)
+        if: needs.changes.outputs.rdp == 'true'
+        run: cargo clippy -p otto-rdp --all-targets -- -D warnings
+      - name: Clippy (portal backend)
+        if: needs.changes.outputs.portal == 'true'
+        run: cargo clippy -p xdg-desktop-portal-otto --all-targets -- -D warnings
       - name: Run tests
+        # otto-rdp is bin-only, so this never covers it — see the RDP step.
+        if: needs.changes.outputs.compositor == 'true' || needs.changes.outputs.ui == 'true'
         run: cargo test --lib --workspace
       - name: Run headless integration tests
+        if: needs.changes.outputs.compositor == 'true'
         run: cargo test --features headless --test headless_basic
       - name: Run shell interaction tests
-        run: cargo test --features headless --test workspace_selector --test app_switcher --test tiling
+        if: needs.changes.outputs.compositor == 'true'
+        run: cargo test --features headless --test workspace_selector --test app_switcher --test tiling --test dnd_icons
       - name: Run screencast integration tests
+        if: needs.changes.outputs.compositor == 'true' || needs.changes.outputs.portal == 'true'
         run: cargo test --features headless --test screenshare
       - name: Run RDP bridge integration tests
+        # The compositor half of the bridge: the protocols otto-rdp drives.
+        if: needs.changes.outputs.compositor == 'true' || needs.changes.outputs.rdp == 'true'
         run: cargo test --features headless --test rdp_bridge
       - name: Run RDP bridge unit tests
+        # The bridge half. Expensive (GStreamer), and nothing outside
+        # components/otto-rdp can affect it, so it is gated tightly.
+        if: needs.changes.outputs.rdp == 'true'
         run: cargo test -p otto-rdp
       - name: Run portal backend tests
+        if: needs.changes.outputs.portal == 'true'
         run: cargo test -p xdg-desktop-portal-otto
       - name: Run font matching tests
+        if: needs.changes.outputs.compositor == 'true'
         run: cargo test --lib -p otto -- workspaces::utils::tests --ignored
   
   # Every packaged binary is compiled exactly once here. build-deb, build-rpm
@@ -280,6 +412,10 @@ jobs:
             To update, re-download the tarball and re-run `makepkg`.
 
   validate-pkgbuild:
+    needs: changes
+    # `release` depends on this job, so it must not be skipped on a tag build
+    # even if the diff classifier saw no packaging paths.
+    if: needs.changes.outputs.packaging == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     container:
       image: archlinux:latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,15 @@ members = [
 
 # One version for the whole repo: otto and every component crate inherit these
 # via `version.workspace = true` (see docs/developer/versioning.md).
+# Lints shared by every member (each manifest opts in with `[lints] workspace
+# = true`), so a local `cargo clippy` agrees with CI.
+[workspace.lints.clippy]
+# Protocol method signatures set their own arity: Notify from
+# org.freedesktop.Notifications takes eight arguments, and the state and
+# rendering calls that carry one through inherit the shape. Bundling them into
+# structs to satisfy a counter would hide the correspondence, not clarify it.
+too_many_arguments = "allow"
+
 [workspace.package]
 version = "1.0.0-rc.2"
 edition = "2021"
@@ -333,3 +342,6 @@ files = [
     ["components/otto-lock/otto-lock.pam", "/etc/pam.d/otto-lock", "644"],
 ]
 
+
+[lints]
+workspace = true

--- a/components/apps-manager/Cargo.toml
+++ b/components/apps-manager/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 [dependencies]
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "staging"] }
+
+[lints]
+workspace = true

--- a/components/otto-auth-ui/Cargo.toml
+++ b/components/otto-auth-ui/Cargo.toml
@@ -32,3 +32,6 @@ laye-rs = { git = "https://github.com/nongio/layers", tag = "v1.14.0", features 
 [[example]]
 name = "preview"
 path = "examples/preview.rs"
+
+[lints]
+workspace = true

--- a/components/otto-bar/Cargo.toml
+++ b/components/otto-bar/Cargo.toml
@@ -24,3 +24,6 @@ futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
+
+[lints]
+workspace = true

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -37,3 +37,6 @@ path = "src/main.rs"
 [lib]
 name = "otto_files"
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -29,6 +29,10 @@ const BTN_RIGHT: u32 = 0x111;
 use model::{Column, Entry, Place, SortKey};
 use view::ViewMode;
 
+/// What a drag carries: the entries to draw, where the grab happened, and the
+/// bounding box they were gathered from.
+type DragItems = (Vec<view::DragItem>, (f32, f32), (f32, f32));
+
 /// How soon a second press on the same column divider must land to count as
 /// a double-click rather than the start of a fresh drag.
 const DOUBLE_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
@@ -905,9 +909,9 @@ impl Browser {
         ));
         let pan = self.pan.offset();
 
-        for depth in 0..depth_count {
+        for (depth, &count) in counts.iter().enumerate() {
             let viewport = view::pane_viewport(width, height, mode, depth, pan, miller_w);
-            let content = view::pane_content_height(width, height, mode, counts[depth]);
+            let content = view::pane_content_height(width, height, mode, count);
             // A column being re-read has no entries *yet*, and telling its
             // scroll view how long *that* is would clamp the offset to the top
             // — permanently, since the offset is not restored when the listing
@@ -2606,7 +2610,7 @@ impl Browser {
     /// the moment the drag begins, which is what lets them start where they
     /// were and gather from there. The nearest [`view::DRAG_ITEMS_MAX`] to the
     /// grab are the ones shown; the badge still counts them all.
-    fn drag_items(&self, x: f32, y: f32) -> Option<(Vec<view::DragItem>, (f32, f32), (f32, f32))> {
+    fn drag_items(&self, x: f32, y: f32) -> Option<DragItems> {
         let (depth, grabbed) = self.entry_at(x, y)?;
         let names: Vec<String> = self
             .selected_entries()
@@ -4932,13 +4936,13 @@ impl FilesApp {
                                 continue;
                             }
                         }
-                        PointerEventKind::Release { button, .. } if button != BTN_RIGHT => {
-                            if browser.footer_pressed.is_some() {
-                                browser.footer_release(hit);
-                                drop(browser);
-                                window_for_events.request_frame();
-                                continue;
-                            }
+                        PointerEventKind::Release { button, .. }
+                            if button != BTN_RIGHT && browser.footer_pressed.is_some() =>
+                        {
+                            browser.footer_release(hit);
+                            drop(browser);
+                            window_for_events.request_frame();
+                            continue;
                         }
                         _ => {}
                     }

--- a/components/otto-greeter/Cargo.toml
+++ b/components/otto-greeter/Cargo.toml
@@ -26,3 +26,6 @@ path = "examples/fake_greetd.rs"
 [dependencies.skia-safe]
 version = "=0.93"
 features = ["gl", "textlayout", "svg", "skottie"]
+
+[lints]
+workspace = true

--- a/components/otto-islands/Cargo.toml
+++ b/components/otto-islands/Cargo.toml
@@ -18,3 +18,6 @@ smithay-client-toolkit = { version = "0.19", default-features = false }
 wayland-client = "0.31"
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -67,3 +67,6 @@ name = "pane_paint"
 path = "benches/pane_paint.rs"
 harness = false
 
+
+[lints]
+workspace = true

--- a/components/otto-kit/examples/clip_children_probe.rs
+++ b/components/otto-kit/examples/clip_children_probe.rs
@@ -18,6 +18,10 @@
 //! not, they spill across the whole window (and past it) and the design needs
 //! `wp_viewport` instead.
 
+// A single-threaded probe: the Arc<Mutex<..>> state mirrors the shape a real
+// otto-kit app uses, and the lay-rs values inside it are not Send.
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::sync::{Arc, Mutex};
 
 use otto_kit::prelude::*;

--- a/components/otto-kit/examples/scroll_ab.rs
+++ b/components/otto-kit/examples/scroll_ab.rs
@@ -36,6 +36,10 @@
 //! SCROLL_AB_AUTO=1 cargo run --release -p otto-kit --example scroll_ab -- surfaces
 //! ```
 
+// A single-threaded probe: the Arc<Mutex<..>> state mirrors the shape a real
+// otto-kit app uses, and the lay-rs values inside it are not Send.
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;

--- a/components/otto-kit/examples/scroll_surfaces_probe.rs
+++ b/components/otto-kit/examples/scroll_surfaces_probe.rs
@@ -14,6 +14,10 @@
 //! the terminal prints one line per band repaint — nothing at all for the
 //! frames in between, which is the entire point.
 
+// A single-threaded probe: the Arc<Mutex<..>> state mirrors the shape a real
+// otto-kit app uses, and the lay-rs values inside it are not Send.
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::sync::{Arc, Mutex};
 
 use otto_kit::components::scroll::{ScrollSurfaces, ScrollView};

--- a/components/otto-kit/examples/simple_app.rs
+++ b/components/otto-kit/examples/simple_app.rs
@@ -42,7 +42,7 @@ impl App for MyApp {
 
         let layer = AppContext::layers_renderer(|renderer| {
             let l = renderer.engine().new_layer();
-            renderer.engine().add_layer(&l);
+            let _ = renderer.engine().add_layer(&l);
             l
         });
         self.layer = layer;
@@ -214,7 +214,7 @@ fn render_menu(state: &ContextMenuState, _view: &View<ContextMenuState>) -> Laye
         };
 
         let depth_layer = LayerTreeBuilder::default()
-            .key(&format!("menu-depth-{}", depth))
+            .key(format!("menu-depth-{}", depth))
             .position(layers::types::Point::new(x_offset, 0.0))
             .size(layers::types::Size::points(width, height))
             .opacity((

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -569,10 +569,11 @@ impl Dispatch<wl_shm::WlShm, ()> for TestClientState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        if let wl_shm::Event::Format { format } = event {
-            if let wayland_client::WEnum::Value(fmt) = format {
-                state.shm_formats.push(fmt);
-            }
+        if let wl_shm::Event::Format {
+            format: wayland_client::WEnum::Value(fmt),
+        } = event
+        {
+            state.shm_formats.push(fmt);
         }
     }
 }

--- a/components/otto-launcher/Cargo.toml
+++ b/components/otto-launcher/Cargo.toml
@@ -26,3 +26,6 @@ features = ["export-taffy"]
 [dependencies.skia-safe]
 version = "=0.93"
 features = ["gl", "textlayout", "svg", "skottie"]
+
+[lints]
+workspace = true

--- a/components/otto-lock/Cargo.toml
+++ b/components/otto-lock/Cargo.toml
@@ -26,3 +26,6 @@ features = ["gl", "textlayout", "svg", "skottie"]
 [[example]]
 name = "lock_cycle"
 path = "examples/lock_cycle.rs"
+
+[lints]
+workspace = true

--- a/components/otto-quickview/Cargo.toml
+++ b/components/otto-quickview/Cargo.toml
@@ -34,3 +34,6 @@ features = ["export-taffy"]
 [dependencies.skia-safe]
 version = "=0.93"
 features = ["gl", "textlayout", "svg", "skottie"]
+
+[lints]
+workspace = true

--- a/components/otto-quickview/src/lib.rs
+++ b/components/otto-quickview/src/lib.rs
@@ -41,6 +41,10 @@
 //! Without it the previewer would re-exec the host as a *host*, which would
 //! start a second file browser instead of decoding anything.
 
+// The doctest above spells out `fn main` deliberately: where in `main` the
+// call goes is the thing being documented.
+#![allow(clippy::needless_doctest_main)]
+
 pub mod decode;
 pub mod opening;
 pub mod payload;

--- a/components/otto-rdp/Cargo.toml
+++ b/components/otto-rdp/Cargo.toml
@@ -40,3 +40,6 @@ xkbcommon = "0.6"
 rustls = "0.23"
 tokio-rustls = "0.26"
 rcgen = "0.13"
+
+[lints]
+workspace = true

--- a/components/otto-rdp/src/egfx.rs
+++ b/components/otto-rdp/src/egfx.rs
@@ -390,7 +390,7 @@ impl Driver {
         if self
             .current
             .as_ref()
-            .map_or(true, |c| !Arc::ptr_eq(c, &handle))
+            .is_none_or(|c| !Arc::ptr_eq(c, &handle))
         {
             self.current = Some(Arc::clone(&handle));
             self.surface = None;
@@ -476,7 +476,7 @@ impl Driver {
         };
 
         Self::emit(&sender, channel_id, messages);
-        if self.sent < 3 || self.sent % 120 == 0 {
+        if self.sent < 3 || self.sent.is_multiple_of(120) {
             tracing::info!(
                 "sent AVC420 frame #{} to RDP client ({} bytes{})",
                 self.sent,

--- a/components/otto-rdp/src/pipewire_capture.rs
+++ b/components/otto-rdp/src/pipewire_capture.rs
@@ -334,7 +334,7 @@ fn run(
             let receivers = data.tx.send(frame).unwrap_or(0);
             static N: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
             let n = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            if n < 3 || n % 60 == 0 {
+            if n < 3 || n.is_multiple_of(60) {
                 tracing::info!("captured frame #{n} ({width}x{height}), {receivers} RDP subscriber(s)");
             }
         })
@@ -498,59 +498,6 @@ fn scale_rows(
     out
 }
 
-#[cfg(test)]
-mod tests {
-    use super::scale_rows;
-
-    /// 1:1 must copy exactly, honouring stride padding.
-    #[test]
-    fn identity_copy_strips_stride_padding() {
-        let (w, h) = (2u32, 2u32);
-        let stride = 12; // 2px * 4B + 4B padding
-        let mut src = vec![0u8; stride * h as usize];
-        for (i, px) in [10u8, 20, 30, 40].iter().enumerate() {
-            let (x, y) = (i % 2, i / 2);
-            let p = y * stride + x * 4;
-            src[p..p + 4].copy_from_slice(&[*px, *px, *px, 255]);
-        }
-        let out = scale_rows(&src, w, h, stride, w, h);
-        assert_eq!(out.len(), 16);
-        assert_eq!(out[0], 10);
-        assert_eq!(out[4], 20);
-        assert_eq!(out[8], 30);
-        assert_eq!(out[12], 40);
-    }
-
-    /// 2x2 -> 1x1 must average all four pixels (box filter, not nearest).
-    #[test]
-    fn downscale_averages_footprint() {
-        let stride = 8;
-        // values 0, 100, 200, 255 -> mean 138 (integer div)
-        let src = vec![
-            0, 0, 0, 255, 100, 100, 100, 255, // row 0
-            200, 200, 200, 255, 255, 255, 255, 255, // row 1
-        ];
-        let out = scale_rows(&src, 2, 2, stride, 1, 1);
-        assert_eq!(out.len(), 4);
-        let expected = (0 + 100 + 200 + 255) / 4;
-        assert_eq!(out[0] as u32, expected);
-        assert_eq!(out[3], 255, "alpha preserved");
-    }
-
-    /// Non-integer ratios must stay in bounds and fill every pixel.
-    #[test]
-    fn non_integer_ratio_is_in_bounds() {
-        let (w, h) = (2880u32, 1920u32);
-        let stride = w as usize * 4;
-        let src = vec![77u8; stride * h as usize];
-        let (dw, dh) = (736u32, 1374u32);
-        let out = scale_rows(&src, w, h, stride, dw, dh);
-        assert_eq!(out.len(), dw as usize * dh as usize * 4);
-        // Uniform source -> every output pixel is the same value, none left 0.
-        assert!(out.chunks(4).all(|p| p[0] == 77), "all pixels filled");
-    }
-}
-
 /// RAII mmap of a dmabuf fd.
 struct Mmap {
     ptr: *mut libc::c_void,
@@ -588,4 +535,57 @@ fn map_dmabuf(fd: i32, len: usize) -> Option<Mmap> {
         return None;
     }
     Some(Mmap { ptr, len })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scale_rows;
+
+    /// 1:1 must copy exactly, honouring stride padding.
+    #[test]
+    fn identity_copy_strips_stride_padding() {
+        let (w, h) = (2u32, 2u32);
+        let stride = 12; // 2px * 4B + 4B padding
+        let mut src = vec![0u8; stride * h as usize];
+        for (i, px) in [10u8, 20, 30, 40].iter().enumerate() {
+            let (x, y) = (i % 2, i / 2);
+            let p = y * stride + x * 4;
+            src[p..p + 4].copy_from_slice(&[*px, *px, *px, 255]);
+        }
+        let out = scale_rows(&src, w, h, stride, w, h);
+        assert_eq!(out.len(), 16);
+        assert_eq!(out[0], 10);
+        assert_eq!(out[4], 20);
+        assert_eq!(out[8], 30);
+        assert_eq!(out[12], 40);
+    }
+
+    /// 2x2 -> 1x1 must average all four pixels (box filter, not nearest).
+    #[test]
+    fn downscale_averages_footprint() {
+        let stride = 8;
+        // values 0, 100, 200, 255 -> mean 138 (integer div)
+        let src = vec![
+            0, 0, 0, 255, 100, 100, 100, 255, // row 0
+            200, 200, 200, 255, 255, 255, 255, 255, // row 1
+        ];
+        let out = scale_rows(&src, 2, 2, stride, 1, 1);
+        assert_eq!(out.len(), 4);
+        let expected = [0, 100, 200, 255].iter().sum::<u32>() / 4;
+        assert_eq!(out[0] as u32, expected);
+        assert_eq!(out[3], 255, "alpha preserved");
+    }
+
+    /// Non-integer ratios must stay in bounds and fill every pixel.
+    #[test]
+    fn non_integer_ratio_is_in_bounds() {
+        let (w, h) = (2880u32, 1920u32);
+        let stride = w as usize * 4;
+        let src = vec![77u8; stride * h as usize];
+        let (dw, dh) = (736u32, 1374u32);
+        let out = scale_rows(&src, w, h, stride, dw, dh);
+        assert_eq!(out.len(), dw as usize * dh as usize * 4);
+        // Uniform source -> every output pixel is the same value, none left 0.
+        assert!(out.chunks(4).all(|p| p[0] == 77), "all pixels filled");
+    }
 }

--- a/components/otto-rdp/src/rdp.rs
+++ b/components/otto-rdp/src/rdp.rs
@@ -244,7 +244,7 @@ impl RdpServerDisplayUpdates for Updates {
                     };
                     static N: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
                     let n = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    if n < 3 || n % 60 == 0 {
+                    if n < 3 || n.is_multiple_of(60) {
                         tracing::info!(
                             "sending bitmap #{n} to RDP client ({}x{})",
                             frame.width,
@@ -399,10 +399,6 @@ impl RdpServerInputHandler for InputForwarder {
                 vertical: -(y as f64) / 120.0 * 15.0,
                 horizontal: (x as f64) / 120.0 * 15.0,
             }),
-            other => {
-                tracing::debug!("unhandled mouse event: {other:?}");
-                None
-            }
         };
         if let Some(cmd) = cmd {
             let _ = self.tx.send(cmd);

--- a/components/otto-settings/Cargo.toml
+++ b/components/otto-settings/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1", features = ["derive"] }
 [dependencies.skia-safe]
 version = "=0.93"
 features = ["gl", "textlayout", "svg"]
+
+[lints]
+workspace = true

--- a/components/otto-settings/src/main.rs
+++ b/components/otto-settings/src/main.rs
@@ -1622,7 +1622,7 @@ impl App for SettingsApp {
             // A blinking caret needs the same steady clock, and for the same
             // reason: nothing else is going to ask for the next frame.
             || self.editing.lock().unwrap().is_some();
-        animating.then(|| IDLE_TICK)
+        animating.then_some(IDLE_TICK)
     }
 }
 

--- a/components/xdg-desktop-portal-otto/Cargo.toml
+++ b/components/xdg-desktop-portal-otto/Cargo.toml
@@ -15,3 +15,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "syn
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 zbus = "4"
+
+[lints]
+workspace = true

--- a/sample-clients/client-rainbow/Cargo.toml
+++ b/sample-clients/client-rainbow/Cargo.toml
@@ -15,3 +15,6 @@ libc = "0.2"
 wayland-protocols = { version = "0.32.9", default-features = false, features = ["client"] }
 wayland-scanner = "0.31.7"
 gbm = { version = "0.16", default-features = false }
+
+[lints]
+workspace = true

--- a/sample-clients/deadlock-test/Cargo.toml
+++ b/sample-clients/deadlock-test/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 
 [dependencies]
 x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
+
+[lints]
+workspace = true

--- a/sample-clients/deadlock-test/src/main.rs
+++ b/sample-clients/deadlock-test/src/main.rs
@@ -396,7 +396,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let vals: Vec<u32> = values.collect();
             eprintln!(
                 "WM_HINTS: flags=0x{:x} input={} initial_state={}",
-                vals.get(0).unwrap_or(&0),
+                vals.first().unwrap_or(&0),
                 vals.get(1).unwrap_or(&0),
                 vals.get(2).unwrap_or(&0)
             );

--- a/sample-clients/submenu-gtk/Cargo.toml
+++ b/sample-clients/submenu-gtk/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 gtk4 = { version = "0.7.3", package = "gtk4", features = ["v4_4"] }
+
+[lints]
+workspace = true

--- a/sample-clients/submenu/Cargo.toml
+++ b/sample-clients/submenu/Cargo.toml
@@ -14,3 +14,6 @@ tempfile = "3.13"
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32.9", default-features = false, features = ["client"] }
 wayland-scanner = "0.31.7"
+
+[lints]
+workspace = true

--- a/sample-clients/submenu/src/main.rs
+++ b/sample-clients/submenu/src/main.rs
@@ -191,7 +191,7 @@ impl AppState {
             .fill_rect(8, 8, SUBMENU_SIZE.0 - 16, item_height - 12, first_color);
         self.submenu_buffer.fill_rect(
             8,
-            (item_height + 4) as u32,
+            item_height + 4,
             SUBMENU_SIZE.0 - 16,
             item_height - 12,
             second_color,
@@ -326,9 +326,8 @@ impl Dispatch<XdgToplevel, ()> for AppState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        match event {
-            xdg_toplevel::Event::Close => state.running = false,
-            _ => {}
+        if let xdg_toplevel::Event::Close = event {
+            state.running = false
         }
     }
 }
@@ -372,17 +371,15 @@ impl Dispatch<WlPointer, ()> for AppState {
                 button,
                 state: btn_state,
                 ..
-            } => {
-                if button == RIGHT_BUTTON
-                    && btn_state == WEnum::Value(wl_pointer::ButtonState::Pressed)
-                {
-                    state.submenu_visible = !state.submenu_visible;
-                    if !state.submenu_visible {
-                        state.pointer_on_submenu = false;
-                        state.hover_item = None;
-                    }
-                    state.needs_redraw = true;
+            } if button == RIGHT_BUTTON
+                && btn_state == WEnum::Value(wl_pointer::ButtonState::Pressed) =>
+            {
+                state.submenu_visible = !state.submenu_visible;
+                if !state.submenu_visible {
+                    state.pointer_on_submenu = false;
+                    state.hover_item = None;
                 }
+                state.needs_redraw = true;
             }
             _ => {}
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1476,6 +1476,9 @@ mod tests {
     /// files — the local override in particular is resolved against the
     /// working directory, which is the checkout when tests run.
     struct ConfigEnv {
+        /// Held only to keep the directory alive: dropping it deletes the
+        /// tree every other field points into.
+        #[allow(dead_code)]
         dir: tempfile::TempDir,
         /// The temporary directory as the process sees it once it is the
         /// working directory, which is what the layer paths are built from.

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -92,13 +92,18 @@ impl Default for HeadlessConfig {
 
 /// Handle to a running headless compositor instance.
 ///
+/// A closure sent to the compositor thread to run against live state. Boxed
+/// because every query is a different closure, `Send` because it crosses a
+/// channel, `FnOnce` because it runs once and is dropped.
+type Query = Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>;
+
 /// The compositor runs on a background thread. Use this handle to get the
 /// Wayland socket name, run queries against compositor state, and stop it.
 pub struct HeadlessHandle {
     pub socket_name: String,
     compositor_thread: Option<JoinHandle<()>>,
     running: Arc<std::sync::atomic::AtomicBool>,
-    query_tx: Sender<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>,
+    query_tx: Sender<Query>,
     result_rx: Receiver<()>,
 }
 
@@ -108,8 +113,7 @@ impl HeadlessHandle {
     /// Returns a handle once the compositor is ready to accept Wayland clients.
     pub fn start(config: HeadlessConfig) -> Self {
         let (ready_tx, ready_rx) = mpsc::channel::<String>();
-        let (query_tx, query_rx) =
-            mpsc::channel::<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>();
+        let (query_tx, query_rx) = mpsc::channel::<Query>();
         let (result_tx, result_rx) = mpsc::channel::<()>();
 
         let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
@@ -1133,7 +1137,7 @@ impl Drop for HeadlessHandle {
 fn run_headless_loop(
     config: HeadlessConfig,
     ready_tx: Sender<String>,
-    query_rx: Receiver<Box<dyn FnOnce(&mut Otto<HeadlessData>) + Send>>,
+    query_rx: Receiver<Query>,
     result_tx: Sender<()>,
     running: Arc<std::sync::atomic::AtomicBool>,
 ) {

--- a/src/state/window_throttle.rs
+++ b/src/state/window_throttle.rs
@@ -254,8 +254,6 @@ mod tests {
         // a singleton (equal to every other null()) so for multi-window
         // tests we need distinct ids. This scaffolding synthesises ids by
         // leaking small allocations — fine for tests, never used in prod.
-        use std::time::Instant;
-
         use smithay::reexports::wayland_server::backend::ObjectId;
         // Fall back to null for now; most tests can operate with the null
         // singleton plus boolean flags. Tests that need distinct ids will

--- a/src/workspaces/window_view/effects/genie.rs
+++ b/src/workspaces/window_view/effects/genie.rs
@@ -125,19 +125,6 @@ impl GenieEffect {
         }
     }
 }
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// `GenieEffect::new` unwraps the shader compilation, so a typo in the
-    /// SkSL takes down the compositor at the first minimize.
-    #[test]
-    fn genie_shader_compiles() {
-        let effect = GenieEffect::new();
-        effect.set_direction(true, true);
-        effect.set_direction(false, false);
-    }
-}
 
 impl layers::prelude::Effect for GenieEffect {
     fn init(&self, layer: &Layer) {
@@ -173,5 +160,19 @@ impl layers::prelude::Effect for GenieEffect {
     }
     fn finish(&self, layer: &Layer) {
         layer.set_image_filter(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `GenieEffect::new` unwraps the shader compilation, so a typo in the
+    /// SkSL takes down the compositor at the first minimize.
+    #[test]
+    fn genie_shader_compiles() {
+        let effect = GenieEffect::new();
+        effect.set_direction(true, true);
+        effect.set_direction(false, false);
     }
 }


### PR DESCRIPTION
CI ran everything on every PR, and lint covered less than it looked like.

## Scoping

A `changes` job classifies the diff into `compositor` / `ui` / `rdp` /
`portal` / `packaging` (hand-rolled `git diff --name-only` + grep, no
third-party action), and each step is gated on its own area:

| step | gate |
| --- | --- |
| clippy compositor, headless_basic, shell tests, font matching | `compositor` |
| clippy components, `test --lib --workspace` | `ui` (+ `compositor`) |
| screenshare | `compositor` or `portal` |
| `--test rdp_bridge` (otto side of the bridge) | `compositor` or `rdp` |
| clippy + `cargo test -p otto-rdp` (bridge side) | `rdp` |
| clippy + `cargo test -p xdg-desktop-portal-otto` | `portal` |

Anything shared — `Cargo.lock`, the workspace manifest, `rust-toolchain.toml`,
`otto-kit`, this workflow — turns every flag on. A missing diff base (tag
build, `workflow_dispatch`) runs everything.

It stays one job on purpose: all steps share a single target directory, so
splitting them would pay for the compositor's dependency graph once per job.

Against the 12 min baseline: a docs-only PR is ~12s, otto-rdp-only ~3 min, and
a compositor-only PR drops the 116s GStreamer bin build and the portal tests.

## Lint coverage

`cargo fmt --all` already covered every member. Clippy did not — it ran only
`cargo clippy --features "default"`, i.e. the `otto` package's default-feature
targets. The 13 component crates, 4 sample clients, all tests/examples/benches,
and everything behind `--features headless` were never linted.

That hid 34 warnings, fixed in the first commit. Two were dead code:

- `components/otto-rdp/src/rdp.rs` — the `other =>` catch-all in the
  mouse-event match was unreachable, so its `unhandled mouse event` debug log
  could never fire.
- `src/state/window_throttle.rs` — an unused `use std::time::Instant` left from
  a leaking-id scheme the helper no longer implements.

The rest were style: two `mod tests` blocks with items after them,
`map_or(true, …)` → `is_none_or`, three `% n == 0` → `is_multiple_of`,
collapsible `if let`/match arms, `then(|| …)` → `then_some`, `get(0)` →
`first`, an unused `Result`, and two type aliases for `type_complexity`.

Clippy now uses `--all-targets` and covers every crate CI compiles, split along
the same area lines, with `--exclude` rather than an explicit package list so
new crates are picked up automatically.

### Two judgment calls worth a look

1. **`too_many_arguments` allowed workspace-wide**, 9 of the 34. Its root case
   is otto-islands' `notify`, whose arity is fixed by
   `org.freedesktop.Notifications`; the state and renderer calls carrying a
   notification through inherit the shape. Done via `[workspace.lints]` (each
   manifest opts in with `[lints] workspace = true`) rather than a CI `-A` flag,
   so a local `cargo clippy` agrees with CI.
2. **`arc_with_non_send_sync` allowed in three otto-kit example probes**
   (file-level, with a reason) instead of refactoring `Arc<Mutex<_>>` →
   `Rc<RefCell<_>>` — the probes deliberately mirror the state shape a real
   otto-kit app uses.

## Also

- Superseded PR runs are cancelled (three overlapping runs on one branch all
  ran to completion previously). `main` and tags are never cancelled.
- `validate-pkgbuild` gated on packaging paths, with a
  `github.event_name != 'pull_request'` escape so `release` (which `needs` it)
  is not skipped on tags.
- `tests/dnd_icons.rs` had never run in CI; it joins the shell-interaction step.

## Verification

Locally: `fmt --check` and all four clippy commands exit 0; `test --lib
--workspace` (676 tests), `-p otto-rdp`, `-p xdg-desktop-portal-otto`,
`headless_basic`, the four shell-interaction suites, `screenshare`,
`rdp_bridge` and the font-matching tests all pass.

The path classifier was extracted from the YAML and run against real and
synthetic diffs: `docs/**` → nothing, `otto-kit` → everything, `otto-rdp/src`
→ `rdp` only, `sample-clients` → `ui`, `Cargo.lock` → everything,
`PKGBUILD-git` → `packaging` only.

This PR touches `ci.yml`, which is in the shared set, so its own run should
classify as everything-on — the right smoke test for the new filters.

https://claude.ai/code/session_019udHNjRveqHryLyvjwLpwD
