### PR TITLE
fix(shell): blur only the region a client asks for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "indextree"
-version = "4.7.4"
+version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9e21e48c85fa6643a38caca564645a3bbc9211edf506fc8ed690c7e7b4d3c7"
+checksum = "355c27a54366e073e1266ef91b1dd7910dc787294d7e8f92458e2e103bc95e33"
 dependencies = [
  "indextree-macros",
  "rayon",
@@ -3885,8 +3885,8 @@ dependencies = [
 
 [[package]]
 name = "laye-rs"
-version = "1.14.0"
-source = "git+https://github.com/nongio/layers?tag=v1.14.0#51460e5c9cbea65716ff88d5a162de0922181ebc"
+version = "1.15.0"
+source = "git+https://github.com/nongio/layers?tag=v1.15.0#a62932a5b624ac6aa1a974a2abfc22bcc68c2516"
 dependencies = [
  "bezier_easing",
  "bitflags 1.3.2",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "layers-debug-server"
 version = "0.3.0"
-source = "git+https://github.com/nongio/layers?tag=v1.14.0#51460e5c9cbea65716ff88d5a162de0922181ebc"
+source = "git+https://github.com/nongio/layers?tag=v1.15.0#a62932a5b624ac6aa1a974a2abfc22bcc68c2516"
 dependencies = [
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,7 @@ brightness = "0.8.0"
 mpris = "2.0"
 otto-kit = { path = "components/otto-kit" }
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-# Pinned to a release: v1.14.0 carries the mirror/opacity repaint fixes
-# (nongio/layers#22, #23) that Otto's follower layers and fading popups need.
-tag = "v1.14.0"
-# local development: path = "../layers"
-features = ["export-taffy"]
+laye-rs.workspace = true
 
 [dependencies.smithay-drm-extras]
 # fork: includes dmabuf-scanout + xwm focus (set_input_focus/set_active_window)
@@ -189,6 +183,21 @@ members = [
 # rendering calls that carry one through inherit the shape. Bundling them into
 # structs to satisfy a counter would hide the correspondence, not clarify it.
 too_many_arguments = "allow"
+
+# The rendering stack, declared once. Every member takes it with
+# `laye-rs.workspace = true`, so switching to a local checkout for development
+# is a one-line change here instead of an edit per component — and no member
+# can drift onto a different revision and pull a second copy into the link.
+#
+# Pinned to a release: v1.15.0 carries `Layer::set_blur_bounds`
+# (nongio/layers#24), which confines a client's ext-background-effect-v1 frost
+# to the region it asked for instead of its whole surface.
+# For local development point this at the checkout — one edit, whole workspace:
+#   laye-rs = { path = "../layers", features = ["export-taffy"] }
+[workspace.dependencies]
+laye-rs = { git = "https://github.com/nongio/layers", tag = "v1.15.0", features = [
+    "export-taffy",
+] }
 
 [workspace.package]
 version = "1.0.0-rc.2"

--- a/components/otto-auth-ui/Cargo.toml
+++ b/components/otto-auth-ui/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "The authentication panel Otto shows when it needs a password — shared by the greeter and the lock screen"
 
 [dependencies]
+laye-rs.workspace = true
 otto-kit = { path = "../otto-kit" }
 chrono = "0.4"
 taffy = "0.5"
@@ -15,17 +16,13 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 tracing = "0.1"
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.14.0"
-features = ["export-taffy"]
 
 [dependencies.skia-safe]
 version = "=0.93"
 features = ["gl", "textlayout", "svg", "skottie"]
 
 [dev-dependencies]
-laye-rs = { git = "https://github.com/nongio/layers", tag = "v1.14.0", features = ["export-taffy"] }
+laye-rs.workspace = true
 
 # Renders every panel state to PNGs, so the layout can be iterated on without
 # taking over a screen with a fullscreen overlay.

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+laye-rs.workspace = true
 otto-kit = { path = "../otto-kit" }
 otto-quickview = { path = "../otto-quickview" }
 smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
@@ -17,10 +18,6 @@ zbus = { version = "4", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.14.0"
-features = ["export-taffy"]
 
 [dependencies.skia-safe]
 version = "=0.93"

--- a/components/otto-kit/Cargo.toml
+++ b/components/otto-kit/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+laye-rs.workspace = true
 rustix = { version = "0.38", features = ["fs", "process"], optional = true }
 smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-client = "0.31"
@@ -36,11 +37,6 @@ default = []
 testing = ["rustix"]
 debugger = ["laye-rs/debugger"]
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.14.0"
-# local development: path = "../../../layers"
-features = ["export-taffy"]
 
 [dependencies.skia-safe]
 version = "=0.93"

--- a/components/otto-launcher/Cargo.toml
+++ b/components/otto-launcher/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "A keyboard-driven launcher for Otto — type to filter apps and windows, Enter to run"
 
 [dependencies]
+laye-rs.workspace = true
 otto-kit = { path = "../otto-kit" }
 taffy = "0.5"
 tracing = "0.1"
@@ -18,10 +19,6 @@ wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 freedesktop-desktop-entry = "0.7.5"
 shell-words = "1.1"
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.14.0"
-features = ["export-taffy"]
 
 [dependencies.skia-safe]
 version = "=0.93"

--- a/components/otto-quickview/Cargo.toml
+++ b/components/otto-quickview/Cargo.toml
@@ -18,6 +18,7 @@ name = "otto-quickview"
 path = "src/main.rs"
 
 [dependencies]
+laye-rs.workspace = true
 otto-kit = { path = "../otto-kit" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -26,10 +27,6 @@ smithay-client-toolkit = { version = "0.19", default-features = false, features 
 libc = "0.2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 
-[dependencies.laye-rs]
-git = "https://github.com/nongio/layers"
-tag = "v1.14.0"
-features = ["export-taffy"]
 
 [dependencies.skia-safe]
 version = "=0.93"

--- a/specs/background-effect.md
+++ b/specs/background-effect.md
@@ -19,15 +19,21 @@ ask for the pixels behind its surface to be blurred, without using Otto's own
   plane.
 - Removing the region (a `NULL` region, or destroying the effect object) takes
   the blur away again on the next commit.
+- The blur covers the region the client asked for, not the whole surface: a
+  panel that paints a transparent margin around its body keeps the frost inside
+  the body.
 - Works for toplevels, popups, subsurfaces and layer-shell surfaces alike.
 - Real clients work unmodified: foot (`blur=yes`), wezterm
   (`wayland_window_background_blur`), ghostty (`background-blur`) on builds
-  that speak this protocol.
+  that speak this protocol, and fcitx5's `classicui` candidate panel
+  (`EnableBlur=True`, with `BlurMask`/`BlurMargin` in the theme).
 
 ## Non-Goals
 
-- Honouring the region's *shape*. The region is a switch: any region with area
-  blurs the whole surface, an empty one blurs nothing. See *Rationale*.
+- Honouring a region of *arbitrary* shape. The region is reduced to one rounded
+  rectangle — its bounding box plus the corner radius it describes. A region
+  that is not a rounded rectangle (an L, a pair of disjoint islands) blurs its
+  bounding box. See *Rationale*.
 - A client-chosen blur radius, tint or vibrancy. The look is compositor policy
   and matches Otto's own chrome.
 - The legacy `org_kde_kwin_blur` protocol. Clients that still use it fall back
@@ -44,9 +50,15 @@ ask for the pixels behind its surface to be blurred, without using Otto's own
   region's rectangles are copied at request time; the `wl_region` may be
   destroyed immediately afterwards.
 - When a commit carries a region containing at least one added rectangle with
-  positive area, the surface's backdrop is blurred from that frame on. Where
-  the client's buffer is translucent, the blurred backdrop shows through; where
-  it is opaque, nothing visible changes.
+  positive area, the surface's backdrop is blurred from that frame on, over the
+  bounding box of those rectangles and rounded to the radius they describe.
+  Where the client's buffer is translucent, the blurred backdrop shows through;
+  where it is opaque, nothing visible changes. Outside the region the backdrop
+  is left alone, so content behind a transparent margin stays legible through
+  whatever the client paints there.
+- A commit that moves or resizes the region re-applies the blur at the new
+  geometry, even though the surface was already blurring.
+- Subtractive rectangles are ignored; they can only shrink the region.
 - When a commit carries a `NULL` region, or an empty one, the blur is removed
   from that frame on.
 - Destroying the effect object removes the blur on the surface's next commit,
@@ -75,11 +87,21 @@ ask for the pixels behind its surface to be blurred, without using Otto's own
 
 ## Rationale
 
-- **Region as a switch.** Otto's blur is a per-layer effect over the layer's
-  (rounded) bounds; carving it to arbitrary rectangles would need a new
-  masking path in the scene engine. Every known client asks for its whole
-  surface, so the switch gives the right result today and leaves partial
-  regions as a future refinement rather than a blocker.
+- **Region as one rounded rectangle.** Otto's blur is a per-layer effect over a
+  rounded rect, so the region is reduced to one: `Layer::set_blur_bounds`
+  overrides the layer's own bounds with what the client asked for. Reducing it
+  to a *switch* instead — blur the whole surface whenever the region has area —
+  was the original design, on the assumption that clients ask for their whole
+  surface. fcitx5's candidate panel does not: it draws its own drop shadow into
+  a transparent margin and asks for the body only. Blurring the whole surface
+  then averaged the document behind the margin away to white, and the shadow
+  landed on that smear instead of on the window below.
+- **Recovering the corner radius.** Clients hand over a rounded rectangle as a
+  stack of scanlines. Each inset row is a point on the corner arc, which pins
+  the radius: `r = row + inset + sqrt(2 * row * inset)`. Single-row estimators
+  are off by a couple of pixels once the client's rasterisation rounds, so
+  every inset row votes and the median wins. Without this the frost squares off
+  the corners of a rounded panel.
 - **Same machinery as otto-surface-style.** Reusing the blend mode that
   otto-kit windows use means the plane backdrop seeding, the material-aware
   scanout rules and the decoration blur all apply for free, and a foot window
@@ -87,5 +109,6 @@ ask for the pixels behind its surface to be blurred, without using Otto's own
 
 ## Open Questions
 
-- Should partial regions be honoured once the scene engine can mask a blur to
-  a set of rectangles?
+- Should genuinely non-rectangular regions be honoured, once the scene engine
+  can mask a blur to an arbitrary path rather than one rounded rect? No client
+  has been seen asking for one.

--- a/src/background_effect.rs
+++ b/src/background_effect.rs
@@ -33,6 +33,7 @@ use smithay::reexports::wayland_server::{
     protocol::wl_surface::WlSurface,
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
+use smithay::utils::{Logical, Rectangle};
 use smithay::wayland::compositor::{
     get_region_attributes, with_states, Cacheable, RectangleKind, RegionAttributes,
 };
@@ -62,16 +63,71 @@ impl Cacheable for BackgroundEffectCachedState {
 impl BackgroundEffectCachedState {
     /// Whether the committed region asks for any blur at all.
     ///
-    /// The protocol clips the region to the surface, but since lay-rs frosts
-    /// the whole layer, all that matters is whether the region has area: a
-    /// client that adds a rectangle and then subtracts all of it is treated
+    /// A client that adds a rectangle and then subtracts all of it is treated
     /// as asking for blur, which is a corner no real client is in.
     pub fn wants_blur(&self) -> bool {
-        self.blur_region.as_ref().is_some_and(|region| {
-            region.rects.iter().any(|(kind, rect)| {
-                matches!(kind, RectangleKind::Add) && rect.size.w > 0 && rect.size.h > 0
+        self.blur_shape().is_some()
+    }
+
+    /// The committed region as a rounded rectangle in surface-local logical
+    /// coordinates: the bounding box of its additive rectangles, plus the
+    /// corner radius they describe.
+    ///
+    /// lay-rs frosts one rounded rect per layer, so an arbitrary region cannot
+    /// be reproduced exactly — but the regions clients actually send are
+    /// rounded rectangles, handed over as a stack of scanlines. Two things
+    /// have to come back out of that stack:
+    ///
+    /// * The **bounds**, because the region is generally smaller than the
+    ///   surface. A panel that draws its own drop shadow into a transparent
+    ///   margin asks for the body only; frosting the whole surface blurs the
+    ///   content behind the margin away and the shadow then falls on the
+    ///   blurred smear instead of on the window below.
+    /// * The **radius**, because the scanlines near the top are inset and a
+    ///   square frost would show as blurred corners outside a rounded panel.
+    ///   Each inset row is a point on the corner arc, so it pins the radius:
+    ///   with the circle centred at `(r, r)` in the bounding box,
+    ///   `(inset - r)^2 + (row - r)^2 = r^2` solves to
+    ///   `r = row + inset + sqrt(2 * row * inset)`. One row is not enough —
+    ///   the client rasterised the curve to integer rows, and near the ends of
+    ///   the arc that rounding dominates — so every inset row votes and the
+    ///   median wins. A region with no inset rows is a plain rectangle and
+    ///   yields 0, which is the right answer for it.
+    ///
+    /// Subtractive rectangles are ignored: they can only carve the region
+    /// smaller, and no client has been seen sending them here.
+    pub fn blur_shape(&self) -> Option<(Rectangle<i32, Logical>, i32)> {
+        let region = self.blur_region.as_ref()?;
+        let adds = || {
+            region.rects.iter().filter_map(|(kind, rect)| {
+                (matches!(kind, RectangleKind::Add) && rect.size.w > 0 && rect.size.h > 0)
+                    .then_some(*rect)
             })
-        })
+        };
+
+        let bounds = adds().reduce(|acc, rect| acc.merge(rect))?;
+
+        let half_height = bounds.size.h as f64 / 2.0;
+        let mut votes: Vec<f64> = adds()
+            .filter_map(|rect| {
+                let row = (rect.loc.y - bounds.loc.y) as f64;
+                let inset = (rect.loc.x - bounds.loc.x) as f64;
+                // Only the top corner, and only rows the arc actually bites
+                // into: a flush row sits past the end of the curve and would
+                // vote for its own offset rather than for the radius.
+                (inset > 0.0 && row < half_height).then(|| row + inset + (2.0 * row * inset).sqrt())
+            })
+            .collect();
+
+        let radius = if votes.is_empty() {
+            0
+        } else {
+            votes.sort_by(|a, b| a.partial_cmp(b).expect("insets are finite"));
+            votes[votes.len() / 2].round() as i32
+        }
+        .clamp(0, bounds.size.w.min(bounds.size.h) / 2);
+
+        Some((bounds, radius))
     }
 }
 
@@ -248,19 +304,19 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
     /// the layer's blend mode too.
     pub(crate) fn apply_background_effect(&mut self, surface: &WlSurface) {
         let surface_id = surface.id();
-        let wants_blur = with_states(surface, |states| {
+        let shape = with_states(surface, |states| {
             states
                 .cached_state
                 .get::<BackgroundEffectCachedState>()
                 .current()
-                .wants_blur()
+                .blur_shape()
         });
-        let was_blurred = self
-            .background_effects
-            .get(&surface_id)
-            .copied()
-            .unwrap_or(false);
-        if wants_blur == was_blurred {
+        let applied = self.background_effects.get(&surface_id).copied();
+        // Compared as a shape, not as a flag: a client that moves or resizes
+        // the region it wants frosted (a candidate panel growing a row) keeps
+        // `wants_blur` true throughout, and bailing on that would leave the
+        // frost at the old geometry.
+        if shape == applied {
             return;
         }
 
@@ -270,15 +326,29 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
             return;
         };
 
-        if wants_blur {
-            self.background_effects.insert(surface_id.clone(), true);
+        if let Some((bounds, radius)) = shape {
+            self.background_effects
+                .insert(surface_id.clone(), (bounds, radius));
             layer.set_blend_mode(layers::types::BlendMode::BackgroundBlur);
             // What the frost has to show is usually the window *below* in
             // the same plane, not just the wallpaper: read the raw backdrop
             // and blur it here, as the SSD titlebar and styled windows do.
             layer.set_blur_include_content(true);
+            // The region is in surface-local logical coordinates and the layer
+            // is in physical pixels, so it scales the same way the surface's
+            // own geometry does in `configure_surface_layer`.
+            let scale = crate::config::Config::with(|c| c.screen_scale) as f32;
+            let rect = layers::skia::Rect::from_xywh(
+                bounds.loc.x as f32 * scale,
+                bounds.loc.y as f32 * scale,
+                bounds.size.w as f32 * scale,
+                bounds.size.h as f32 * scale,
+            );
+            let r = radius as f32 * scale;
+            layer.set_blur_bounds(Some(layers::skia::RRect::new_rect_xy(rect, r, r)));
         } else {
             self.background_effects.remove(&surface_id);
+            layer.set_blur_bounds(None);
             let style_blurs = self
                 .surfaces_style
                 .get(&surface_id)
@@ -298,5 +368,120 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
     /// Forget a destroyed surface's blur.
     pub(crate) fn forget_background_effect(&mut self, surface_id: &ObjectId) {
         self.background_effects.remove(surface_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::utils::Point;
+
+    fn region(rects: Vec<(RectangleKind, Rectangle<i32, Logical>)>) -> BackgroundEffectCachedState {
+        BackgroundEffectCachedState {
+            blur_region: Some(RegionAttributes { rects }),
+        }
+    }
+
+    fn rect(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, Logical> {
+        Rectangle::new(Point::from((x, y)), (w, h).into())
+    }
+
+    /// A rounded rectangle reaches clients as a stack of scanlines whose top
+    /// rows are inset. The first row flush with the left edge sits at `y =
+    /// radius`, which is what `blur_shape` reads back out.
+    fn rounded_scanlines(
+        x: i32,
+        y: i32,
+        w: i32,
+        h: i32,
+        radius: i32,
+    ) -> Vec<(RectangleKind, Rectangle<i32, Logical>)> {
+        (0..h)
+            .map(|row| {
+                let from_edge = row.min(h - 1 - row);
+                let inset = if from_edge >= radius {
+                    0
+                } else {
+                    // circular corner: horizontal inset at this row
+                    let dy = (radius - from_edge) as f64;
+                    (radius as f64 - ((radius as f64).powi(2) - dy * dy).sqrt()).round() as i32
+                };
+                (
+                    RectangleKind::Add,
+                    rect(x + inset, y + row, w - 2 * inset, 1),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn no_region_is_no_blur() {
+        let state = BackgroundEffectCachedState::default();
+        assert_eq!(state.blur_shape(), None);
+        assert!(!state.wants_blur());
+    }
+
+    #[test]
+    fn empty_region_is_no_blur() {
+        let state = region(vec![]);
+        assert_eq!(state.blur_shape(), None);
+        assert!(!state.wants_blur());
+    }
+
+    #[test]
+    fn zero_area_rectangles_are_no_blur() {
+        let state = region(vec![
+            (RectangleKind::Add, rect(0, 0, 0, 40)),
+            (RectangleKind::Add, rect(0, 0, 100, 0)),
+        ]);
+        assert_eq!(state.blur_shape(), None);
+    }
+
+    #[test]
+    fn a_plain_rectangle_keeps_square_corners() {
+        let state = region(vec![(RectangleKind::Add, rect(0, 0, 200, 40))]);
+        assert_eq!(state.blur_shape(), Some((rect(0, 0, 200, 40), 0)));
+    }
+
+    /// The reported bug: a panel that draws its own drop shadow asks for the
+    /// body only, so the frost must stop short of the surface on every side.
+    #[test]
+    fn an_inset_region_keeps_its_offset() {
+        let state = region(vec![(RectangleKind::Add, rect(6, 6, 188, 28))]);
+        let (bounds, _) = state.blur_shape().unwrap();
+        assert_eq!(bounds, rect(6, 6, 188, 28));
+    }
+
+    #[test]
+    fn scanlines_recover_the_corner_radius() {
+        for radius in [4, 8, 10, 16] {
+            let state = region(rounded_scanlines(6, 6, 200, 60, radius));
+            let (bounds, r) = state.blur_shape().unwrap();
+            assert_eq!(bounds, rect(6, 6, 200, 60), "bounds for radius {radius}");
+            assert_eq!(r, radius, "radius {radius}");
+        }
+    }
+
+    /// lay-rs draws one rounded rect, so a radius past half the shorter side
+    /// would be nonsense geometry rather than a tighter curve.
+    #[test]
+    fn radius_is_clamped_to_the_shape() {
+        let state = region(vec![
+            (RectangleKind::Add, rect(0, 30, 100, 10)),
+            (RectangleKind::Add, rect(20, 0, 60, 40)),
+        ]);
+        let (bounds, r) = state.blur_shape().unwrap();
+        assert_eq!(bounds, rect(0, 0, 100, 40));
+        assert_eq!(r, 20);
+    }
+
+    #[test]
+    fn subtractive_rectangles_do_not_grow_the_bounds() {
+        let state = region(vec![
+            (RectangleKind::Add, rect(10, 10, 50, 20)),
+            (RectangleKind::Subtract, rect(0, 0, 500, 500)),
+        ]);
+        let (bounds, _) = state.blur_shape().unwrap();
+        assert_eq!(bounds, rect(10, 10, 50, 20));
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -383,7 +383,8 @@ pub struct Otto<BackendData: Backend + 'static> {
     /// switched to `BackgroundBlur` because the client committed a blur
     /// region. Keyed by surface, present only while the blur is on — see
     /// `Otto::apply_background_effect`.
-    pub background_effects: HashMap<ObjectId, bool>,
+    pub background_effects:
+        HashMap<ObjectId, (smithay::utils::Rectangle<i32, smithay::utils::Logical>, i32)>,
     // Map from surface ID to its rendering layer in the scene graph
     pub surface_layers: HashMap<ObjectId, layers::prelude::Layer>,
     /// Tracks which parent ObjectId each surface layer was last appended to,


### PR DESCRIPTION
## The bug

`ext-background-effect-v1` lets a client hand the compositor a `wl_region` saying which part of its surface should be frosted. Otto read that region as a **switch**: `wants_blur()` asked only "does it have any area", then set `BackgroundBlur` on the whole surface layer.

That assumed clients ask for their whole surface — the module doc said so outright: *"Every client seen so far asks for the full surface anyway."*

fcitx5's candidate panel is the counter-example. It paints its own drop shadow into a transparent margin and asks for the rounded body only. Frosting the whole surface blurred the document behind that margin away to white, so the panel's shadow landed on a blurred smear instead of on the window below, and the corners squared off outside the panel's rounding.

Measured on a gedit window full of text, scanning down through the panel's bottom edge:

```
before (broken)          after
y=417  177,177,177       y=503  171,171,171   shadow ramp
y=420  189,189,189       y=506  194,194,194
y=423  210,210,210       y=509  216,216,216
y=426  228,228,227       y=512  235,235,235
y=429  255,255,255  <--  y=515  214,221,223   <-- glyph edge
y=432  255,255,255  <--  y=518   70, 64, 60   <-- glyph
```

Glyph coverage under the shadow margin, inside the panel's span vs. the untouched document beside it, is now equal (`95` vs `66`, `102` vs `59`); before it was uniformly white.

## The fix

Reduce the region to what the scene engine can draw — one rounded rectangle — and hand it to laye-rs `Layer::set_blur_bounds` (new in v1.15.0, nongio/layers#24), which overrides the layer's own bounds in both blur draw paths.

Recovering the **radius** is the only subtle part. Clients send a rounded rect as a stack of scanlines, so each inset row is a point on the corner arc:

    (inset - r)^2 + (row - r)^2 = r^2   =>   r = row + inset + sqrt(2*row*inset)

One row is not enough — the client rasterised the curve to integer rows, and near the ends of the arc that rounding dominates. Single-row estimators read `r=8` as `6`. Every inset row votes and the median wins, which is exact for an ideal rounded rect.

The applied shape is compared instead of a boolean, so a panel that grows a row re-frosts at the new geometry rather than keeping the old.

## Also here

`laye-rs` was declared in seven manifests (root plus five components, one twice). Pointing the workspace at a local checkout meant editing all of them, and missing one linked two copies and failed with duplicate symbols. It is now declared once in `[workspace.dependencies]`. `skia-safe` is deliberately left alone — its feature sets genuinely differ per component.

## Testing

Eight unit tests cover `blur_shape`: empty and zero-area regions, plain rectangles, inset regions, radius recovery across r=4/8/10/16, clamping, and subtractive rectangles.

Workspace lib tests green; `cargo clippy --locked -p otto --all-targets --features "default,headless"` clean. Verified live on hardware against fcitx5 + gedit.

Spec `specs/background-effect.md` updated: the region is no longer documented as a switch.

https://claude.ai/code/session_018GdzP2cU2w1SyKVppu4SgX