### PR TITLE
fix(planes): keep a demoted window in its place in the stack

### DIFF
--- a/docs/developer/drm_plane.md
+++ b/docs/developer/drm_plane.md
@@ -7,6 +7,25 @@ GPU does not have to composite them.
 > per-buffer damage rules, blur-composite invalidation, promotion hysteresis —
 > is [`specs/plane-scanout.md`](../../specs/plane-scanout.md).
 
+## Reparenting a layer raises it
+
+`add_sublayer` on a layer that is already a child *moves it to the end* of its
+parent's children — which is exactly how `raise_window_to_front` raises a
+window. Anything that reparents a window layer therefore raises it as a side
+effect, whatever its place in the stack was.
+
+Promotion moves a window's subtree out of the workspace's `windows_layer` and
+into the output's promoted-plane container; demotion moves it back. That move
+back is a raise, so a window demoted after another one was mapped came back on
+top of it and stayed there — the workspace's `windows_list` is the stack, and
+`WorkspaceView::restack_windows` re-applies it after every demotion.
+
+The promoted plane also scans out *above* the windows plane, so anything left
+promoted while it is no longer the topmost window covers the window that is.
+Promotion waits for its candidate to settle (`PROMOTE_STABLE`) to avoid moving
+a live subtree between containers every frame; demotion must not wait, or a
+newly mapped window comes up behind the one it should be covering.
+
 ## What a plane is, and why you would want one
 
 A display controller can read from more than one buffer and blend the results

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -621,8 +621,14 @@ impl Otto<UdevData> {
                         {
                             Some(id)
                         } else {
-                            // Still settling — keep whatever is promoted now.
-                            already
+                            // Still settling. The *new* candidate waits, but
+                            // whatever is promoted now does not get to stay:
+                            // its plane scans out above the windows plane, so
+                            // a window that is no longer the top one would sit
+                            // over the one that is — which is what a newly
+                            // mapped window comes up behind. Demotion is
+                            // immediate, promotion is not.
+                            None
                         }
                     }
                 }

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -5384,7 +5384,12 @@ impl Workspaces {
                 target: "otto::planes",
                 "demote: reparent back into windows_layer failed: {e}"
             );
+            return;
         }
+        // Reparenting appends, which is a raise: without this the window comes
+        // back on top of everything mapped while it was promoted, and stays
+        // there. The workspace's own list is the stack.
+        workspace.restack_windows();
     }
 
     /// The window currently rendered into its own plane on `output_name`.

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -306,6 +306,25 @@ impl WorkspaceView {
         }
     }
 
+    /// Put every window's layer back in `windows_list` order.
+    ///
+    /// `add_sublayer` on a layer that is already a child *moves it to the end*
+    /// — which is how [`Self::raise_window_to_front`] raises one. So anything
+    /// that reparents a window back into this container raises it as a side
+    /// effect, whatever its place in the stack was. Re-appending the whole list
+    /// in order is what actually restores the stack.
+    pub fn restack_windows(&self) {
+        let order = self.windows_list.read().unwrap().clone();
+        let bases = self.window_base_layers.read().unwrap();
+        for id in &order {
+            if let Some(base) = bases.get(id) {
+                if let Err(e) = self.windows_layer.add_sublayer(base) {
+                    tracing::warn!("restack_windows: failed to reparent window layer: {e}");
+                }
+            }
+        }
+    }
+
     /// remove the window from the windows list
     /// and remove the window layer from the window selector view
     pub fn unmap_window(&self, window_id: &ObjectId) {


### PR DESCRIPTION
## The bug

A newly mapped window came up **behind** the one it should have covered, and sometimes stayed there.

Two causes, both in subtree-plane promotion.

## Demotion was not immediate

The promoted plane scans out above the windows plane, so a window left promoted while it is no longer the topmost one covers the window that is.

Promotion waits for its candidate to settle, which is right — moving a live subtree between scene containers every frame is not free. But the wait applied to demotion too, keeping the previous window promoted in the meantime. Demotion is now what the comment always claimed it was: immediate.

## Reparenting silently raised the window

`add_sublayer` on an existing child moves it to the end of the child list — which is exactly how `raise_window_to_front` raises a window. So reparenting a demoted window back into its workspace raised it above everything that had been mapped while it was promoted.

The workspace's window list is the authority on stacking order, and it is now re-applied after every demotion.

## Changes

- `src/udev/render.rs` — demote immediately instead of waiting for the settle
- `src/workspaces/workspace.rs`, `src/workspaces/mod.rs` — re-apply the stack after demotion
- `docs/developer/drm_plane.md` — document the ordering guarantee

https://claude.ai/code/session_01LpFDkjzoMyCrGpX5vCrUj9