### PR TITLE
fix(expose): make show desktop work, and animate its exit

### DIFF
--- a/components/otto-kit/src/components/titlebar/window_controls.rs
+++ b/components/otto-kit/src/components/titlebar/window_controls.rs
@@ -10,7 +10,7 @@ pub enum WindowControl {
     Zoom,
 }
 
-/// Traffic-light window controls: three round buttons that stay colored while
+/// Traffic-light window controls: round buttons that stay colored while
 /// the window is active, gray out when it is not, and reveal their glyph when
 /// the pointer is over the group.
 #[derive(Debug, Clone)]
@@ -34,6 +34,10 @@ pub struct WindowControls {
     /// what a group sitting at the trailing edge wants, so close stays the
     /// outermost dot whichever end the group is at.
     pub reversed: bool,
+    /// Whether the zoom dot is drawn at all. Off by default — a window is
+    /// zoomed by double-clicking its bar — and turned on by the desktop's
+    /// `show_maximize_button` setting; see [`crate::maximize_button`].
+    pub show_zoom: bool,
 }
 
 impl Default for WindowControls {
@@ -55,6 +59,7 @@ impl WindowControls {
             disabled: Vec::new(),
             dark: false,
             reversed: false,
+            show_zoom: crate::maximize_button::enabled(),
         }
     }
 
@@ -105,9 +110,19 @@ impl WindowControls {
         self
     }
 
+    /// Show or hide the zoom dot, overriding what the desktop is configured
+    /// for.
+    pub fn with_zoom(mut self, show_zoom: bool) -> Self {
+        self.show_zoom = show_zoom;
+        self
+    }
+
     /// The dots left to right.
-    fn order(&self) -> [WindowControl; 3] {
-        let mut order = Self::ORDER;
+    fn order(&self) -> Vec<WindowControl> {
+        let mut order: Vec<WindowControl> = Self::ORDER
+            .into_iter()
+            .filter(|control| self.show_zoom || *control != WindowControl::Zoom)
+            .collect();
         if self.reversed {
             order.reverse();
         }
@@ -116,7 +131,8 @@ impl WindowControls {
 
     /// Total width of the group
     pub fn width(&self) -> f32 {
-        self.size * 3.0 + self.spacing * 2.0
+        let dots = self.order().len() as f32;
+        (self.size * dots + self.spacing * (dots - 1.0)).max(0.0)
     }
 
     /// Bounding box of the group in the coordinate space it is rendered in
@@ -154,12 +170,12 @@ impl WindowControls {
             };
         }
         // Tinted from the user's accent so a focused window reads as focused:
-        // close takes a dark shade of it, the other two a light one.
+        // close and minimize take a dark shade of it, zoom a light one.
         let accent =
             crate::accent::current_accent().unwrap_or_else(|| Color::from_rgb(0x0A, 0x84, 0xFF));
         let base = match control {
-            WindowControl::Close => shade(accent, -0.28),
-            WindowControl::Minimize | WindowControl::Zoom => shade(accent, 0.58),
+            WindowControl::Close | WindowControl::Minimize => shade(accent, -0.28),
+            WindowControl::Zoom => shade(accent, 0.58),
         };
         if self.pressed == Some(control) {
             // ~20% darker while held
@@ -179,10 +195,13 @@ impl WindowControls {
         paint.set_style(PaintStyle::Stroke);
         paint.set_stroke_width((self.size * 0.09).max(1.0));
         paint.set_stroke_cap(skia_safe::PaintCap::Round);
-        // Close sits on a dark dot, so its glyph is light; the others stay dark
+        // Close and minimize sit on dark dots, so their glyphs are light; zoom
+        // sits on a light dot and stays dark
         paint.set_color(match control {
-            WindowControl::Close => Color::from_argb(0xD0, 0xFF, 0xFF, 0xFF),
-            _ => Color::from_argb(0xB0, 0x00, 0x00, 0x00),
+            WindowControl::Close | WindowControl::Minimize => {
+                Color::from_argb(0xD0, 0xFF, 0xFF, 0xFF)
+            }
+            WindowControl::Zoom => Color::from_argb(0xB0, 0x00, 0x00, 0x00),
         });
 
         // Glyphs are drawn inside ~44% of the dot so they never touch the rim
@@ -252,5 +271,55 @@ impl Renderable for WindowControls {
 
     fn intrinsic_size(&self) -> Option<(f32, f32)> {
         Some((self.width(), self.size))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two dots by default, three with the maximize button turned on — and the
+    /// group is narrower by exactly one dot and one gap without it.
+    #[test]
+    fn zoom_dot_is_optional() {
+        let with = WindowControls::new().with_zoom(true);
+        let without = WindowControls::new().with_zoom(false);
+
+        assert_eq!(with.order().len(), 3);
+        assert_eq!(
+            without.order(),
+            vec![WindowControl::Close, WindowControl::Minimize]
+        );
+        assert_eq!(with.width() - without.width(), with.size + with.spacing);
+    }
+
+    /// Hiding the dot also removes its click target: the point the zoom dot
+    /// used to sit at hits nothing.
+    #[test]
+    fn hidden_zoom_is_not_hit_testable() {
+        let controls = WindowControls::new().with_zoom(true);
+        let zoom_x = (controls.size + controls.spacing) * 2.0 + controls.size / 2.0;
+        let middle = controls.size / 2.0;
+        assert_eq!(
+            controls.control_at(zoom_x, middle),
+            Some(WindowControl::Zoom)
+        );
+        assert_eq!(
+            WindowControls::new()
+                .with_zoom(false)
+                .control_at(zoom_x, middle),
+            None
+        );
+    }
+
+    /// At the trailing edge close stays outermost whether or not the zoom dot
+    /// is there.
+    #[test]
+    fn reversed_keeps_close_outermost() {
+        let order = WindowControls::new()
+            .with_zoom(false)
+            .with_reversed(true)
+            .order();
+        assert_eq!(order, vec![WindowControl::Minimize, WindowControl::Close]);
     }
 }

--- a/components/otto-kit/src/lib.rs
+++ b/components/otto-kit/src/lib.rs
@@ -19,6 +19,7 @@ pub mod icon_theme;
 pub mod icons;
 pub mod input;
 pub mod lottie;
+pub mod maximize_button;
 mod portal_runtime;
 pub mod preview;
 pub mod protocols;

--- a/components/otto-kit/src/maximize_button.rs
+++ b/components/otto-kit/src/maximize_button.rs
@@ -1,0 +1,47 @@
+//! Whether the titlebar shows the zoom (maximize) dot.
+//!
+//! Otto ships with two traffic lights — close and minimize — because a window
+//! is zoomed by double-clicking its bar. A desktop that wants the third dot
+//! turns it on in the configuration, and the answer travels the way corner
+//! rounding and the controls' side do (see [`crate::corners`]): the compositor
+//! reads the file and publishes it in the environment, and everything that
+//! draws a titlebar reads it back from here.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// The variable the compositor publishes. `1` shows the dot; anything else, or
+/// nothing at all, hides it.
+pub const ENV: &str = "OTTO_SHOW_MAXIMIZE_BUTTON";
+
+/// 0 = not resolved yet, 1 = hidden, 2 = shown.
+static SHOWN: AtomicU8 = AtomicU8::new(0);
+
+/// Whether a titlebar should draw the zoom dot.
+pub fn enabled() -> bool {
+    match SHOWN.load(Ordering::Relaxed) {
+        0 => {
+            let value = match std::env::var(ENV) {
+                Ok(text) => matches!(text.trim(), "1" | "true" | "yes" | "on"),
+                Err(_) => false,
+            };
+            store(value);
+            value
+        }
+        2 => true,
+        _ => false,
+    }
+}
+
+fn store(value: bool) {
+    SHOWN.store(if value { 2 } else { 1 }, Ordering::Relaxed);
+}
+
+/// Publish `value` to this process and everything it starts, and return the
+/// assignment for the session's activation environments. See
+/// [`crate::corners::export`].
+pub fn export(value: bool) -> String {
+    store(value);
+    let text = if value { "1" } else { "0" };
+    std::env::set_var(ENV, text);
+    format!("{ENV}={text}")
+}

--- a/components/otto-settings/src/panes/general.rs
+++ b/components/otto-settings/src/panes/general.rs
@@ -35,6 +35,12 @@ pub fn build() -> Pane {
                     )
                     .detail(otto_kit::t!("settings-rounded-corners-detail"))
                     .id("window_controls_side"),
+                    Row::new(
+                        otto_kit::t!("settings-maximize-button"),
+                        Control::Toggle(false),
+                    )
+                    .detail(otto_kit::t!("settings-maximize-button-detail"))
+                    .id("show_maximize_button"),
                     Row::new(otto_kit::t!("settings-font"), Control::Text("Inter".into()))
                         .id("font_family"),
                     // Applies to GTK clients rather than to Otto's own

--- a/docs/developer/expose.md
+++ b/docs/developer/expose.md
@@ -251,6 +251,22 @@ topmost in the layer tree, rather than the one the pointer is actually over.
 | Force a relayout while open | `expose_update_if_needed` / `expose_update_if_needed_workspace` |
 | Show desktop (push windows away) | `expose_show_desktop(delta, end_gesture)` |
 
+Show desktop reuses the exposé machinery: it hides `workspaces_layer`, shows
+`expose_layer`, and animates the same mirror layers off the screen edges. The
+render paths must therefore drop the real windows plane for it too — they gate
+on `Workspaces::mirrors_active()` (exposé, its transition, show desktop, or its
+transition), not on `get_show_all()` alone. Testing only the exposé flags left
+the untouched windows compositing on top of the mirrors sliding away, so the
+gesture rendered as a no-op.
+
+Its completion hook — the one that hides the mirrors and hands the screen back
+to the real windows — rides the first mirror's own position animation. Hanging
+it off a no-op property change instead (setting a layer to the opacity it
+already has) finished on the spot, so dismissing show desktop restored the
+windows in a single frame while the mirrors were still flying back. Anything
+that dismisses it (clicking a window, `ExposeShowDesktop`, a three-finger
+swipe) goes through `expose_show_desktop(-2.0, true)` and gets that animation.
+
 ## Keyboard focus
 
 Opening exposé clears keyboard focus (`Otto::enter_expose_focus`, called

--- a/docs/developer/expose.md
+++ b/docs/developer/expose.md
@@ -267,6 +267,14 @@ windows in a single frame while the mirrors were still flying back. Anything
 that dismisses it (clicking a window, `ExposeShowDesktop`, a three-finger
 swipe) goes through `expose_show_desktop(-2.0, true)` and gets that animation.
 
+Hiding the scene layer is not enough on its own: plane subtrees ignore ancestor
+visibility, so the render paths keep their own test. `show_desktop_animating`
+— the show-desktop twin of `expose_animating`, and for the same reason — holds
+`is_show_desktop_transitioning` (and through it `mirrors_active`) true for the
+whole flight, because the gesture accumulator commits to its final 0/1000 the
+moment the spring is *scheduled*. Without it the windows plane returns on the
+click frame and the windows snap home under the mirrors still flying back.
+
 ## Keyboard focus
 
 Opening exposé clears keyboard focus (`Otto::enter_expose_focus`, called

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -28,6 +28,11 @@ rounded_corners = true
 # outermost one. Also read at startup.
 window_controls_side = "left"
 
+# Show the third traffic light, the zoom (maximize) dot, in a window's
+# titlebar. Off by default: a double click on the titlebar zooms a window
+# either way. Also read at startup.
+show_maximize_button = false
+
 # Accent color for workspace and window selector borders.
 # Either a palette name, which follows the light and dark color schemes:
 #   red, orange, yellow, green, mint, teal, cyan, blue, indigo, purple, pink,

--- a/resources/locales/de.ftl
+++ b/resources/locales/de.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Akzentfarbe
 settings-rounded-corners = Abgerundete Ecken
 settings-rounded-corners-detail = Gilt nach einem Neustart
 settings-window-controls = Fenstersteuerelemente
+settings-maximize-button = Maximieren-Knopf
+settings-maximize-button-detail = Zeigt den Zoom-Punkt; ein Doppelklick auf die Titelleiste maximiert ohnehin
 settings-font = Systemschriftart
 settings-gtk-theme = GTK-Thema
 
@@ -487,6 +489,8 @@ schema-rounded-corners-label = Abgerundete Ecken
 schema-rounded-corners-description = Dock, obere Leiste, Fensterdekorationen und die Panels des Desktops.
 schema-window-controls-side-label = Fenstersteuerelemente
 schema-window-controls-side-description = An welchem Ende der Titelleiste die Knöpfe zum Schließen, Minimieren und Zoomen sitzen.
+schema-show-maximize-button-label = Maximieren-Knopf
+schema-show-maximize-button-description = Zeigt das Zoom-Steuerelement in der Titelleiste eines Fensters. Standardmäßig aus: Ein Doppelklick auf die Titelleiste maximiert das Fenster ohnehin.
 schema-font-family-label = Oberflächenschrift
 schema-font-family-description = Schriftfamilie für Ottos eigene Oberfläche.
 schema-background-color-label = Hintergrundfarbe

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Accent colour
 settings-rounded-corners = Rounded corners
 settings-rounded-corners-detail = Applies after a restart
 settings-window-controls = Window controls
+settings-maximize-button = Maximize button
+settings-maximize-button-detail = Show the zoom dot; a double click on the titlebar zooms either way
 settings-font = System font
 settings-gtk-theme = GTK theme
 
@@ -488,6 +490,8 @@ schema-rounded-corners-label = Rounded corners
 schema-rounded-corners-description = The dock, the top bar, window decorations and the desktop's own panels.
 schema-window-controls-side-label = Window controls
 schema-window-controls-side-description = Which end of a window's titlebar the close, minimize and zoom controls sit at.
+schema-show-maximize-button-label = Maximize button
+schema-show-maximize-button-description = Show the zoom control in a window's titlebar. Off by default: a double click on the titlebar zooms a window either way.
 schema-font-family-label = Interface font
 schema-font-family-description = Font family used by Otto's own interface.
 schema-background-color-label = Background colour

--- a/resources/locales/es.ftl
+++ b/resources/locales/es.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Color de acento
 settings-rounded-corners = Esquinas redondeadas
 settings-rounded-corners-detail = Se aplica tras reiniciar
 settings-window-controls = Controles de ventana
+settings-maximize-button = Botón de maximizar
+settings-maximize-button-detail = Muestra el punto de ampliar; un doble clic en la barra de título también amplía
 settings-font = Tipo de letra del sistema
 settings-gtk-theme = Tema GTK
 
@@ -490,6 +492,8 @@ schema-rounded-corners-label = Esquinas redondeadas
 schema-rounded-corners-description = El Dock, la barra superior, las decoraciones de ventana y los paneles del escritorio.
 schema-window-controls-side-label = Controles de ventana
 schema-window-controls-side-description = En qué extremo de la barra de título están los controles de cerrar, minimizar y ampliar.
+schema-show-maximize-button-label = Botón de maximizar
+schema-show-maximize-button-description = Muestra el control de ampliar en la barra de título de una ventana. Desactivado por defecto: un doble clic en la barra de título amplía la ventana igualmente.
 schema-font-family-label = Tipo de letra de la interfaz
 schema-font-family-description = Familia tipográfica usada por la propia interfaz de Otto.
 schema-background-color-label = Color de fondo

--- a/resources/locales/fr.ftl
+++ b/resources/locales/fr.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Couleur d’accentuation
 settings-rounded-corners = Coins arrondis
 settings-rounded-corners-detail = Applicable après un redémarrage
 settings-window-controls = Boutons de fenêtre
+settings-maximize-button = Bouton d’agrandissement
+settings-maximize-button-detail = Affiche la pastille d’agrandissement ; un double-clic sur la barre de titre agrandit de toute façon
 settings-font = Police système
 settings-gtk-theme = Thème GTK
 
@@ -491,6 +493,8 @@ schema-rounded-corners-label = Coins arrondis
 schema-rounded-corners-description = Le Dock, la barre supérieure, les décorations de fenêtre et les panneaux du bureau.
 schema-window-controls-side-label = Boutons de fenêtre
 schema-window-controls-side-description = À quelle extrémité de la barre de titre se trouvent les boutons de fermeture, de réduction et d’agrandissement.
+schema-show-maximize-button-label = Bouton d’agrandissement
+schema-show-maximize-button-description = Affiche le bouton d’agrandissement dans la barre de titre d’une fenêtre. Désactivé par défaut : un double-clic sur la barre de titre agrandit la fenêtre de toute façon.
 schema-font-family-label = Police de l’interface
 schema-font-family-description = Famille de police utilisée par l’interface propre d’Otto.
 schema-background-color-label = Couleur d’arrière-plan

--- a/resources/locales/it.ftl
+++ b/resources/locales/it.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Accento
 settings-rounded-corners = Angoli arrotondati
 settings-rounded-corners-detail = Si applica dopo il riavvio
 settings-window-controls = Comandi della finestra
+settings-maximize-button = Pulsante Ingrandisci
+settings-maximize-button-detail = Mostra il pallino di ingrandimento; un doppio clic sulla barra del titolo ingrandisce comunque
 settings-font = Font di sistema
 settings-gtk-theme = Tema GTK
 
@@ -490,6 +492,8 @@ schema-rounded-corners-label = Angoli arrotondati
 schema-rounded-corners-description = Dock, barra superiore, decorazioni delle finestre e pannelli della scrivania.
 schema-window-controls-side-label = Comandi della finestra
 schema-window-controls-side-description = A quale estremità della barra del titolo si trovano i comandi chiudi, riduci a icona e zoom.
+schema-show-maximize-button-label = Pulsante Ingrandisci
+schema-show-maximize-button-description = Mostra il comando di ingrandimento nella barra del titolo di una finestra. Disattivato per impostazione predefinita: un doppio clic sulla barra del titolo ingrandisce comunque la finestra.
 schema-font-family-label = Carattere dell'interfaccia
 schema-font-family-description = Famiglia di caratteri usata dall'interfaccia di Otto.
 schema-background-color-label = Colore di sfondo

--- a/resources/locales/pl.ftl
+++ b/resources/locales/pl.ftl
@@ -78,6 +78,8 @@ settings-accent-colour = Kolor akcentu
 settings-rounded-corners = Zaokrąglone rogi
 settings-rounded-corners-detail = Zacznie obowiązywać po ponownym uruchomieniu
 settings-window-controls = Przyciski okna
+settings-maximize-button = Przycisk maksymalizacji
+settings-maximize-button-detail = Pokazuje kropkę powiększania; dwukrotne kliknięcie paska tytułu i tak maksymalizuje
 settings-font = Czcionka systemowa
 settings-gtk-theme = Motyw GTK
 
@@ -500,6 +502,8 @@ schema-rounded-corners-label = Zaokrąglone rogi
 schema-rounded-corners-description = Dock, górny pasek, dekoracje okien i panele środowiska.
 schema-window-controls-side-label = Przyciski okna
 schema-window-controls-side-description = Przy którym końcu paska tytułu znajdują się przyciski zamykania, minimalizowania i powiększania.
+schema-show-maximize-button-label = Przycisk maksymalizacji
+schema-show-maximize-button-description = Pokazuje przycisk powiększania na pasku tytułu okna. Domyślnie wyłączone: dwukrotne kliknięcie paska tytułu i tak maksymalizuje okno.
 schema-font-family-label = Czcionka interfejsu
 schema-font-family-description = Rodzina czcionek używana przez własny interfejs Otto.
 schema-background-color-label = Kolor tła

--- a/resources/locales/pt-BR.ftl
+++ b/resources/locales/pt-BR.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Cor de destaque
 settings-rounded-corners = Cantos arredondados
 settings-rounded-corners-detail = Aplicado após reiniciar
 settings-window-controls = Controles da janela
+settings-maximize-button = Botão de maximizar
+settings-maximize-button-detail = Mostra o ponto de ampliar; um clique duplo na barra de título amplia de qualquer forma
 settings-font = Fonte do sistema
 settings-gtk-theme = Tema do GTK
 
@@ -491,6 +493,8 @@ schema-rounded-corners-label = Cantos arredondados
 schema-rounded-corners-description = O Dock, a barra superior, as decorações de janela e os painéis da área de trabalho.
 schema-window-controls-side-label = Controles da janela
 schema-window-controls-side-description = Em que extremidade da barra de título ficam os controles de fechar, minimizar e ampliar.
+schema-show-maximize-button-label = Botão de maximizar
+schema-show-maximize-button-description = Mostra o controle de ampliar na barra de título de uma janela. Desativado por padrão: um clique duplo na barra de título amplia a janela de qualquer forma.
 schema-font-family-label = Fonte da interface
 schema-font-family-description = Família de fonte usada pela própria interface do Otto.
 schema-background-color-label = Cor do plano de fundo

--- a/resources/locales/ru.ftl
+++ b/resources/locales/ru.ftl
@@ -78,6 +78,8 @@ settings-accent-colour = Цвет акцента
 settings-rounded-corners = Скруглённые углы
 settings-rounded-corners-detail = Применяется после перезапуска
 settings-window-controls = Кнопки окна
+settings-maximize-button = Кнопка развёртывания
+settings-maximize-button-detail = Показывает кружок масштабирования; двойной щелчок по заголовку и так развернёт окно
 settings-font = Системный шрифт
 settings-gtk-theme = Тема GTK
 
@@ -493,6 +495,8 @@ schema-rounded-corners-label = Скруглённые углы
 schema-rounded-corners-description = Dock, верхняя панель, оформление окон и панели рабочего стола.
 schema-window-controls-side-label = Кнопки окна
 schema-window-controls-side-description = У какого края заголовка окна расположены кнопки закрытия, сворачивания и масштабирования.
+schema-show-maximize-button-label = Кнопка развёртывания
+schema-show-maximize-button-description = Показывать кнопку масштабирования в заголовке окна. По умолчанию выключено: двойной щелчок по заголовку и так разворачивает окно.
 schema-font-family-label = Шрифт интерфейса
 schema-font-family-description = Семейство шрифтов, используемое собственным интерфейсом Otto.
 schema-background-color-label = Цвет фона

--- a/resources/locales/uk.ftl
+++ b/resources/locales/uk.ftl
@@ -79,6 +79,8 @@ settings-accent-colour = Колір акценту
 settings-rounded-corners = Заокруглені кути
 settings-rounded-corners-detail = Застосовується після перезапуску
 settings-window-controls = Кнопки вікна
+settings-maximize-button = Кнопка розгортання
+settings-maximize-button-detail = Показує кружечок масштабування; подвійне клацання на заголовку однаково розгортає вікно
 settings-font = Системний шрифт
 settings-gtk-theme = Тема GTK
 
@@ -494,6 +496,8 @@ schema-rounded-corners-label = Заокруглені кути
 schema-rounded-corners-description = Dock, верхня панель, оформлення вікон і панелі стільниці.
 schema-window-controls-side-label = Кнопки вікна
 schema-window-controls-side-description = Біля якого краю смуги заголовка розташовані кнопки закриття, згортання та масштабування.
+schema-show-maximize-button-label = Кнопка розгортання
+schema-show-maximize-button-description = Показувати кнопку масштабування в заголовку вікна. Типово вимкнено: подвійне клацання на заголовку однаково розгортає вікно.
 schema-font-family-label = Шрифт інтерфейсу
 schema-font-family-description = Гарнітура шрифту, яку використовує власний інтерфейс Otto.
 schema-background-color-label = Колір тла

--- a/specs/window-decorations.md
+++ b/specs/window-decorations.md
@@ -57,10 +57,16 @@ appears, and discarded if the surface dies first.
 **The title bar.** When a window is server-decorated:
 
 - It carries a title bar strip above the client surface, showing the window
-  title and the close, minimize and maximize controls.
+  title and the close and minimize controls. The third control, zoom, is drawn
+  only where `show_maximize_button` is on — it is off by default, because a
+  double click on the bar zooms the window either way. With it off the group is
+  narrower by one dot and one gap, and the point the dot used to occupy hits
+  nothing. The setting travels the same way `window_controls_side` does, so it
+  applies to a client-drawn otto-kit title bar as well, and changing it takes a
+  restart.
 - The controls sit at the leading end of the bar by default. The
-  `window_controls_side` setting moves them to the trailing end, and the three
-  swap order when it does, so close stays the outermost one. The screencast
+  `window_controls_side` setting moves them to the trailing end, and they swap
+  order when it does, so close stays the outermost one. The screencast
   badge always takes the other end. The setting is read at startup and
   published to the components in the environment, so it applies to a
   client-drawn otto-kit title bar as well as to a server-drawn one, and

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -69,6 +69,14 @@ pub struct Config {
     /// `otto_kit::controls_side`), so changing it takes a restart.
     #[serde(default = "default_window_controls_side")]
     pub window_controls_side: String,
+    /// Whether a window's titlebar shows the third traffic light, the zoom
+    /// (maximize) dot. Off by default: Otto zooms a window on a double click
+    /// of its titlebar, so the dot is redundant unless you want it.
+    ///
+    /// Published to the components the same way `window_controls_side` is (see
+    /// `otto_kit::maximize_button`), so changing it takes a restart.
+    #[serde(default)]
+    pub show_maximize_button: bool,
     #[serde(default = "shortcuts::default_shortcut_map")]
     pub keyboard_shortcuts: ShortcutMap,
     #[serde(default)]
@@ -140,6 +148,7 @@ impl Default for Config {
             accent_color: default_accent_color(),
             rounded_corners: default_rounded_corners(),
             window_controls_side: default_window_controls_side(),
+            show_maximize_button: false,
             keyboard_shortcuts: shortcuts::default_shortcut_map(),
             shortcut_bindings: Vec::new(),
             virtual_outputs: Vec::new(),

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -532,23 +532,27 @@ impl HeadlessHandle {
         });
     }
 
-    /// Click, and report whether the real workspace content is still hidden
-    /// the instant the click has been handled — sampled inside the same state
+    /// Click, and report `(workspace content hidden, mirrors_active)` the
+    /// instant the click has been handled — sampled inside the same state
     /// callback, so no frame can run in between.
     ///
     /// Clicking a window dismisses show desktop, and the mirrors fly back
-    /// before the real windows take over again. Seeing `false` here means the
-    /// swap happened in the same frame as the click: the windows reappear at
-    /// their old places instantly and the exit animation is never seen.
-    pub fn click_and_sample_workspaces_hidden(&self) -> bool {
+    /// before the real windows take over again. Both must still hold here.
+    /// `hidden` false means the scene swapped on the click frame; and since
+    /// plane subtrees ignore ancestor visibility, `mirrors_active` false means
+    /// the render paths push the real windows plane back regardless of what
+    /// the scene says. Either way the windows snap home and the exit animation
+    /// is never seen.
+    pub fn click_and_sample_show_desktop_exit(&self) -> (bool, bool) {
         self.query(|state| {
             state.synthetic_pointer_button(true);
             state.synthetic_pointer_button(false);
-            state
+            let hidden = state
                 .workspaces
                 .output_workspaces
                 .values()
-                .all(|ows| ows.workspaces_layer.hidden())
+                .all(|ows| ows.workspaces_layer.hidden());
+            (hidden, state.workspaces.mirrors_active())
         })
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -532,6 +532,26 @@ impl HeadlessHandle {
         });
     }
 
+    /// Click, and report whether the real workspace content is still hidden
+    /// the instant the click has been handled — sampled inside the same state
+    /// callback, so no frame can run in between.
+    ///
+    /// Clicking a window dismisses show desktop, and the mirrors fly back
+    /// before the real windows take over again. Seeing `false` here means the
+    /// swap happened in the same frame as the click: the windows reappear at
+    /// their old places instantly and the exit animation is never seen.
+    pub fn click_and_sample_workspaces_hidden(&self) -> bool {
+        self.query(|state| {
+            state.synthetic_pointer_button(true);
+            state.synthetic_pointer_button(false);
+            state
+                .workspaces
+                .output_workspaces
+                .values()
+                .all(|ows| ows.workspaces_layer.hidden())
+        })
+    }
+
     /// Click, and report whether expose still counts as transitioning the
     /// instant the click has been handled — sampled inside the same state
     /// callback, so no frame can be processed in between.

--- a/src/input/gestures.rs
+++ b/src/input/gestures.rs
@@ -21,10 +21,16 @@ impl crate::Otto<crate::udev::UdevData> {
         let serial = SCOUNTER.next_serial();
         let pointer = self.pointer.clone();
 
-        // 3-finger swipe: start detecting direction (but not if show desktop is active)
+        // 3-finger swipe: start detecting direction. Show desktop takes the
+        // gesture instead — swiping with the windows pushed aside brings them
+        // back, animated, rather than silently doing nothing.
         let is_show_desktop_active = self.workspaces.get_show_desktop();
-        if evt.fingers() == 3 && !self.is_pinching && !is_show_desktop_active {
-            self.gesture_swipe_begin_3finger();
+        if evt.fingers() == 3 && !self.is_pinching {
+            if is_show_desktop_active {
+                self.workspaces.expose_show_desktop(-2.0, true);
+            } else {
+                self.gesture_swipe_begin_3finger();
+            }
         }
 
         pointer.gesture_swipe_begin(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,12 @@ pub fn export_window_controls_side() -> String {
     otto_kit::controls_side::export(side)
 }
 
+/// Publish `show_maximize_button` the same way: the zoom dot is drawn by every
+/// process that draws a titlebar, and only the compositor reads the file.
+pub fn export_maximize_button() -> String {
+    otto_kit::maximize_button::export(config::Config::with(|c| c.show_maximize_button))
+}
+
 /// Publish `theme_scheme` the same way.
 ///
 /// otto-kit apps normally learn light-versus-dark from the freedesktop

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ async fn main() {
     // processes, and none of them reads Otto's configuration.
     otto::export_rounded_corners();
     otto::export_window_controls_side();
+    otto::export_maximize_button();
     otto::export_color_scheme();
 
     #[cfg(feature = "profile-with-tracy")]

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -302,6 +302,14 @@ pub static SETTINGS: &[SettingSpec] = &[
         ],
     ),
     spec(
+        "show_maximize_button",
+        Bool,
+        "Maximize button",
+        "Show the zoom control in a window's titlebar. Off by default: a \
+         double click on the titlebar zooms a window either way.",
+        Restart,
+    ),
+    spec(
         "font_family",
         Str,
         "Interface font",

--- a/src/shell/grabs.rs
+++ b/src/shell/grabs.rs
@@ -205,6 +205,13 @@ impl<B: Backend> PointerGrab<Otto<B>> for PointerMoveSurfaceGrab<B> {
                 // every popup the window owns, and a drag is many events.
                 data.reposition_popups_for_window(&self.window);
             }
+            // An X11 client places its own menus from the root coordinates the
+            // server reports for its window, so a drag that never sends a
+            // ConfigureNotify leaves it opening them at the pre-drag position.
+            // Runs for the tiled branch too — `apply_tile` configures the
+            // window, but a tile that was refused leaves the drag position.
+            #[cfg(feature = "xwayland")]
+            data.sync_x11_window_position(&self.window);
         }
     }
 
@@ -332,6 +339,10 @@ impl<BackendData: Backend> TouchGrab<Otto<BackendData>> for TouchMoveSurfaceGrab
 
         handle.up(data, event, seq);
         handle.unset_grab(self, data);
+        // Tell an X11 client where the drag left its window — see
+        // `Otto::sync_x11_window_position`.
+        #[cfg(feature = "xwayland")]
+        data.sync_x11_window_position(&self.window);
     }
 
     fn motion(

--- a/src/shell/x11.rs
+++ b/src/shell/x11.rs
@@ -186,44 +186,7 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
     }
 
     fn unmaximize_request(&mut self, _xwm: XwmId, window: X11Surface) {
-        let Some(elem) = self
-            .workspaces
-            .windows_map
-            .values()
-            .find(|e| matches!(e.underlying_surface(), WindowSurface::X11(x) if x == &window))
-            .cloned()
-        else {
-            return;
-        };
-
-        window.set_maximized(false).unwrap();
-
-        // Unmaximizing is the inverse of maximizing: a window that was tiled
-        // when it got maximized lands back on its tile, not on the floating
-        // rect two steps back.
-        if let Some(zone) = self
-            .workspaces
-            .get_window_view(&elem.id())
-            .and_then(|view| view.tiled_zone)
-        {
-            self.apply_tile(&elem, zone);
-            return;
-        }
-
-        if let Some(old_geo) = window
-            .user_data()
-            .get::<OldGeometry>()
-            .and_then(|data| data.restore())
-        {
-            tracing::debug!(
-                "x11::unmaximize_request: restoring to old_geo={:?} title={:?}",
-                old_geo,
-                window.title()
-            );
-            window.configure(old_geo).unwrap();
-            self.workspaces
-                .map_window(&elem, old_geo.loc, false, Some(Transition::ease_out(0.3)));
-        }
+        self.unmaximize_request_x11(&window);
     }
 
     fn fullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -542,6 +505,28 @@ impl<BackendData: Backend> XwmHandler for Otto<BackendData> {
 }
 
 impl<BackendData: Backend> Otto<BackendData> {
+    /// Tell an X11 client where its window ended up.
+    ///
+    /// X11 clients place their own menus and tooltips from the root
+    /// coordinates the server reports for their window, so a window Otto moved
+    /// on its own — a drag, above all — keeps opening popups at the position it
+    /// had before the move until a ConfigureNotify says otherwise. A no-op for
+    /// Wayland windows.
+    pub fn sync_x11_window_position(&mut self, elem: &crate::shell::WindowElement) {
+        let WindowSurface::X11(x11) = elem.underlying_surface() else {
+            return;
+        };
+        // Override-redirect windows own their geometry; never configure them.
+        if x11.is_override_redirect() {
+            return;
+        }
+        let Some(location) = self.workspaces.element_location(elem) else {
+            return;
+        };
+        let size = elem.geometry().size;
+        let _ = x11.configure(Rectangle::new(location, size));
+    }
+
     /// Run the X11 fullscreen transition for an already-mapped element.
     ///
     /// Split out of `XwmHandler::fullscreen_request` so `surface_associated` can
@@ -681,7 +666,14 @@ impl<BackendData: Backend> Otto<BackendData> {
             .or_else(|| outputs_for_window.first().cloned())
             .or_else(|| self.workspaces.outputs().next().cloned())
             .expect("No outputs found");
-        let geometry = self.workspaces.output_geometry(&output).unwrap();
+        // Refresh the exclusive zones before reading them, as the xdg path
+        // does: a layer surface may have changed its reservation since the
+        // last recalculation.
+        self.recalculate_exclusive_zones(&output);
+        // Usable area = output minus exclusive zones (otto-bar) minus the
+        // dock. Maximizing to the raw output rect puts the window under the
+        // bar.
+        let geometry = self.usable_zone(&output);
 
         tracing::debug!(
             "x11::maximize_request: title={:?} old_geo={:?} new_geometry={:?}",
@@ -690,12 +682,21 @@ impl<BackendData: Backend> Otto<BackendData> {
             geometry
         );
 
+        let was_maximized = window.is_maximized();
+
         window.set_maximized(true).unwrap();
+        elem.set_is_maximized(true);
         window.configure(geometry).unwrap();
         // A tiled window keeps the rect it had before it was tiled — saving
         // here would overwrite the floating rect with the tile, and untiling
         // later would restore the half-screen the window already has.
-        if !self.is_tiled(&elem) {
+        //
+        // An already-maximized window keeps it too: `remaximize_maximized_windows`
+        // re-runs this whenever the usable zone changes (the dock autohiding, a
+        // layer surface resizing), and saving there would overwrite the restore
+        // rect with the maximized one — unmaximize would then restore to the
+        // full screen, looking like it did nothing at all.
+        if !self.is_tiled(&elem) && !was_maximized {
             window.user_data().insert_if_missing(OldGeometry::default);
             window
                 .user_data()
@@ -760,6 +761,7 @@ impl<BackendData: Backend> Otto<BackendData> {
         }
 
         let _ = window.set_maximized(maximize);
+        elem.set_is_maximized(maximize);
         let _ = window.configure(target);
         // `target` belongs to `output`: pin it, or center-based routing would
         // send a still-full-width window onto the neighbouring output.
@@ -784,6 +786,20 @@ impl<BackendData: Backend> Otto<BackendData> {
         };
 
         window.set_maximized(false).unwrap();
+        elem.set_is_maximized(false);
+
+        // Unmaximizing is the inverse of maximizing: a window that was tiled
+        // when it got maximized lands back on its tile, not on the floating
+        // rect two steps back.
+        if let Some(zone) = self
+            .workspaces
+            .get_window_view(&elem.id())
+            .and_then(|view| view.tiled_zone)
+        {
+            self.apply_tile(&elem, zone);
+            return;
+        }
+
         if let Some(old_geo) = window
             .user_data()
             .get::<OldGeometry>()

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -671,6 +671,7 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 assignments.extend(crate::locale_env::published().iter().cloned());
                 assignments.push(crate::export_rounded_corners());
                 assignments.push(crate::export_window_controls_side());
+                assignments.push(crate::export_maximize_button());
                 assignments.push(crate::export_color_scheme());
                 let args: Vec<&str> = assignments.iter().map(String::as_str).collect();
 

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -863,8 +863,7 @@ impl Otto<UdevData> {
         // pick a per-window frame-callback throttle. `occluded_ids` is empty
         // for v1 — we rely on the fullscreen detection inside the classifier
         // for the main "background app behind a maximized window" case.
-        let expose_active =
-            self.workspaces.is_expose_transitioning() || self.workspaces.get_show_all();
+        let expose_active = self.workspaces.mirrors_active();
         tracing::debug!(
             target: "otto::planes",
             "expose inputs: transitioning={} show_all={} gesture={} animating={}",
@@ -1139,8 +1138,7 @@ impl Otto<UdevData> {
             let transient_active = self.dnd_icon.is_some()
                 || self.workspaces.osd.is_visible()
                 || self.workspaces.tiling_overlay.is_visible()
-                || self.workspaces.is_expose_transitioning()
-                || self.workspaces.get_show_all()
+                || self.workspaces.mirrors_active()
                 || self
                     .workspaces
                     .is_animating
@@ -1936,8 +1934,7 @@ impl Otto<UdevData> {
             // Top→bottom, matching the physical push order in
             // `render_output_frame`; the windows subtree is dropped while
             // expose is up, exactly like the windows plane.
-            let expose_active =
-                self.workspaces.is_expose_transitioning() || self.workspaces.get_show_all();
+            let expose_active = self.workspaces.mirrors_active();
             let scene_stack: Vec<crate::render_elements::scene_element::SceneElement> = self
                 .workspaces
                 .output_workspaces

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -585,8 +585,7 @@ pub fn run_winit() {
                     // `render_virtual_outputs` in `udev/render.rs`. Outside
                     // exposé the tree render stands: it is the cheaper path —
                     // plane subtrees deliberately skip occlusion culling.
-                    let expose_active = state.workspaces.is_expose_transitioning()
-                        || state.workspaces.get_show_all();
+                    let expose_active = state.workspaces.mirrors_active();
                     let ows = state.workspaces.output_workspaces.get(&output.name());
                     let scene_stack: Vec<crate::render_elements::scene_element::SceneElement> =
                         match ows {
@@ -704,8 +703,7 @@ pub fn run_winit() {
                         #[allow(clippy::mutable_key_type)]
                         // ObjectId as key — see window_throttle.rs
                         {
-                            let expose_active = state.workspaces.is_expose_transitioning()
-                                || state.workspaces.get_show_all();
+                            let expose_active = state.workspaces.mirrors_active();
                             let interacting_ids = crate::state::window_throttle::interacting_ids(
                                 &state.pointer_interaction,
                             );

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1141,6 +1141,18 @@ impl Workspaces {
             || (is_animating && gesture_value != 0 && gesture_value != 1000)
     }
 
+    /// True while the windows on screen are represented by their expose
+    /// mirror layers rather than the real windows plane — exposé proper, the
+    /// show-desktop gesture, or either transition. Render paths use this to
+    /// drop the windows plane; testing only `get_show_all` left show-desktop
+    /// drawing the untouched windows on top of the mirrors sliding away.
+    pub fn mirrors_active(&self) -> bool {
+        self.is_expose_transitioning()
+            || self.get_show_all()
+            || self.get_show_desktop()
+            || self.is_show_desktop_transitioning()
+    }
+
     /// Set the window selection mode
     #[allow(dead_code)]
     fn set_show_all(&self, show_all: bool) {
@@ -2319,6 +2331,13 @@ impl Workspaces {
         // Similar to expose_show_all: show_desktop_active when delta > 0
         let show_desktop_active = delta > 0.0 || transition.is_some();
 
+        // The transaction the completion hook rides on: the FIRST mirror that
+        // actually animates. Hanging it off a no-op change (setting the
+        // workspaces layer to the opacity it already has) finished on the spot,
+        // so closing show desktop restored the real windows in a single frame
+        // while the mirrors were still flying back — the exit looked instant.
+        let mut mirror_transaction: Option<layers::engine::TransactionRef> = None;
+
         // Show/hide expose_layer (master container) when showing desktop
         // This matches the pattern in expose_show_all_apply
         let expose_layer = self.expose_layer.clone();
@@ -2330,6 +2349,19 @@ impl Workspaces {
             if ows.expose_layer != expose_layer {
                 ows.expose_layer.set_hidden(!show_desktop_active);
             }
+        }
+
+        // Hide the real workspace content while the desktop is being revealed:
+        // the windows are shown through their mirror layers inside the expose
+        // layer, exactly as in expose. Without this the untouched windows keep
+        // rendering on top and the gesture looks like it does nothing.
+        let workspaces_layers: Vec<Layer> = self
+            .output_workspaces
+            .values()
+            .map(|ows| ows.workspaces_layer.clone())
+            .collect();
+        for layer in workspaces_layers.iter() {
+            layer.set_hidden(show_desktop_active);
         }
 
         // Show mirror windows layer when showing desktop, hide when not
@@ -2392,13 +2424,16 @@ impl Workspaces {
             let y = window_y.interpolate(&to_y, delta);
 
             // Animate the mirror layer, not the actual window
-            window
+            let tr = window
                 .mirror_layer()
                 .set_position(layers::types::Point { x, y }, transition.clone());
+            if mirror_transaction.is_none() {
+                mirror_transaction = Some(tr);
+            }
         }
 
         // If there's a transition, set up a callback to finalize visibility after animation
-        if let Some(trans) = transition {
+        if transition.is_some() {
             // Mark as animating when we have a transition
             tracing::debug!(target: "otto::popups", "is_animating(true) site=show-desktop");
             self.is_animating
@@ -2411,15 +2446,31 @@ impl Workspaces {
                 .clone();
             let is_animating_ref = self.is_animating.clone();
 
-            // Create a simple animation transaction to hook the on_finish callback
-            let wl = self.primary_workspaces_layer().cloned();
-            if let Some(ref wl) = wl {
-                let transaction = wl.set_opacity(1.0_f32, Some(trans));
+            // Ride the mirrors' own animation. With no window to animate there
+            // is nothing to wait for, so apply the end state right away.
+            let Some(transaction) = mirror_transaction else {
+                let is_active = show_desktop_ref.load(std::sync::atomic::Ordering::Relaxed);
+                expose_layer.set_hidden(!is_active);
+                workspace
+                    .window_selector_view
+                    .window_selector_windows_container
+                    .set_hidden(!is_active);
+                for layer in workspaces_layers.iter() {
+                    layer.set_hidden(is_active);
+                }
+                self.is_animating
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                return;
+            };
+            {
                 transaction.on_finish(
                     move |_: &Layer, _: f32| {
                         let is_active = show_desktop_ref.load(std::sync::atomic::Ordering::Relaxed);
                         expose_layer_ref.set_hidden(!is_active);
                         window_selector_layer.set_hidden(!is_active);
+                        for layer in workspaces_layers.iter() {
+                            layer.set_hidden(is_active);
+                        }
                         // Clear animating flag when animation completes
                         is_animating_ref.store(false, std::sync::atomic::Ordering::Relaxed);
                     },

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -229,6 +229,13 @@ pub struct Workspaces {
     /// duration of the animation — which is what `is_expose_transitioning`
     /// needs, or scanout promotion resumes while the previews are still flying.
     expose_animating: Arc<AtomicBool>,
+    /// The show-desktop counterpart of `expose_animating`: set while the
+    /// mirrors are flying out or back, cleared when they land. The gesture
+    /// accumulator commits to its final 0/1000 the moment the spring is
+    /// *scheduled*, so without this every frame of the exit animation reads as
+    /// "show desktop is over" and the render paths push the real windows plane
+    /// back at once — the windows snap home while the mirrors are still moving.
+    show_desktop_animating: Arc<AtomicBool>,
     /// Windows currently flagged for direct scanout (their `content_layer` is
     /// hidden; the client buffer is pushed as a `ScanoutCandidate` element).
     /// The render call-site diffs against this to re-import departing windows
@@ -559,6 +566,7 @@ impl Workspaces {
             show_desktop_gesture: Arc::new(AtomicI32::new(0)),
             is_animating: Arc::new(AtomicBool::new(false)),
             expose_animating: Arc::new(AtomicBool::new(false)),
+            show_desktop_animating: Arc::new(AtomicBool::new(false)),
             scanout_windows: Arc::new(RwLock::new(HashSet::new())),
             scanout_windows_per_output: Arc::new(RwLock::new(HashMap::new())),
             promoted_windows: Arc::new(RwLock::new(HashMap::new())),
@@ -1135,9 +1143,13 @@ impl Workspaces {
         let is_animating = self.is_animating.load(std::sync::atomic::Ordering::Relaxed);
 
         // We're transitioning if:
-        // 1. Gesture value is between 0 and 1000 (not fully closed or fully open), OR
-        // 2. Animation is in progress AND we're not at a stable state (0 or 1000)
-        (gesture_value > 0 && gesture_value < 1000)
+        // 1. A mirror animation is in flight (see `show_desktop_animating` —
+        //    the only clause that covers a click- or keyboard-driven exit), OR
+        // 2. Gesture value is between 0 and 1000 (not fully closed or fully open), OR
+        // 3. Animation is in progress AND we're not at a stable state (0 or 1000)
+        self.show_desktop_animating
+            .load(std::sync::atomic::Ordering::Relaxed)
+            || (gesture_value > 0 && gesture_value < 1000)
             || (is_animating && gesture_value != 0 && gesture_value != 1000)
     }
 
@@ -2438,6 +2450,8 @@ impl Workspaces {
             tracing::debug!(target: "otto::popups", "is_animating(true) site=show-desktop");
             self.is_animating
                 .store(true, std::sync::atomic::Ordering::Relaxed);
+            self.show_desktop_animating
+                .store(true, std::sync::atomic::Ordering::Relaxed);
 
             let expose_layer_ref = expose_layer.clone();
             let window_selector_layer = workspace
@@ -2445,6 +2459,7 @@ impl Workspaces {
                 .window_selector_windows_container
                 .clone();
             let is_animating_ref = self.is_animating.clone();
+            let show_desktop_animating_ref = self.show_desktop_animating.clone();
 
             // Ride the mirrors' own animation. With no window to animate there
             // is nothing to wait for, so apply the end state right away.
@@ -2460,6 +2475,8 @@ impl Workspaces {
                 }
                 self.is_animating
                     .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.show_desktop_animating
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 return;
             };
             {
@@ -2471,8 +2488,10 @@ impl Workspaces {
                         for layer in workspaces_layers.iter() {
                             layer.set_hidden(is_active);
                         }
-                        // Clear animating flag when animation completes
+                        // Clear animating flags when animation completes
                         is_animating_ref.store(false, std::sync::atomic::Ordering::Relaxed);
+                        show_desktop_animating_ref
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
                     },
                     true,
                 );

--- a/src/workspaces/window_view/decoration_view.rs
+++ b/src/workspaces/window_view/decoration_view.rs
@@ -112,21 +112,42 @@ impl WindowDecorationView {
     /// Deferred to an idle callback: callers run with the pointer's inner
     /// lock held, and (un)maximizing moves the focus, which takes it again.
     fn toggle_maximized<B: crate::state::Backend>(&self, data: &mut crate::Otto<B>) {
-        let Some(toplevel) = self.window.toplevel().cloned() else {
-            return;
-        };
         let maximized = self.window.is_maximized();
         // Nothing to restore to, and nothing to zoom into.
         if !maximized && self.zoom_disabled(data) {
             return;
         }
-        data.handle.insert_idle(move |state| {
-            if maximized {
-                smithay::wayland::shell::xdg::XdgShellHandler::unmaximize_request(state, toplevel);
-            } else {
-                smithay::wayland::shell::xdg::XdgShellHandler::maximize_request(state, toplevel);
+        match self.window.underlying_surface() {
+            smithay::desktop::WindowSurface::Wayland(_) => {
+                let Some(toplevel) = self.window.toplevel().cloned() else {
+                    return;
+                };
+                data.handle.insert_idle(move |state| {
+                    if maximized {
+                        smithay::wayland::shell::xdg::XdgShellHandler::unmaximize_request(
+                            state, toplevel,
+                        );
+                    } else {
+                        smithay::wayland::shell::xdg::XdgShellHandler::maximize_request(
+                            state, toplevel,
+                        );
+                    }
+                });
             }
-        });
+            // X11 windows have no toplevel: they go through the X11 requests,
+            // which track the maximized state on the X11Surface itself.
+            #[cfg(feature = "xwayland")]
+            smithay::desktop::WindowSurface::X11(surface) => {
+                let surface = surface.clone();
+                data.handle.insert_idle(move |state| {
+                    if surface.is_maximized() {
+                        state.unmaximize_request_x11(&surface);
+                    } else {
+                        state.maximize_request_x11(&surface);
+                    }
+                });
+            }
+        }
     }
 
     /// Mutate the decoration model in place, repainting only on a real change.

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -180,16 +180,69 @@ mod headless_tests {
     #[serial]
     fn pinch_show_desktop() {
         let handle = start_compositor();
+        let mut client = connect_client(&handle);
+        let _toplevel = client.create_toplevel("show-desktop-window", 400, 300);
+        handle.wait(Duration::from_millis(200));
+        let _ = client.roundtrip();
+        handle.settle(200);
 
         assert!(!handle.is_show_desktop_active());
 
         // 4-finger pinch out (spread) to show desktop
         handle.pinch_begin();
-        handle.pinch_update(1.5); // scale > 1.0 = spread
+        for scale in [1.1f64, 1.3, 1.6, 2.0, 2.5] {
+            handle.pinch_update(scale); // scale > 1.0 = spread
+            handle.settle(5);
+        }
         handle.pinch_end();
+        handle.settle(600);
 
-        // May be transitioning
-        handle.settle(300);
+        assert!(
+            handle.is_show_desktop_active(),
+            "pinch out should activate show desktop"
+        );
+
+        // The windows are shown through their expose mirrors while the desktop
+        // is revealed, so the real workspace content must be hidden — otherwise
+        // the untouched windows keep drawing on top of the mirrors sliding away
+        // and the gesture looks like it does nothing.
+        let snapshot = handle.scene_snapshot();
+        fn find<'a>(
+            node: &'a layers::engine::scene::SceneNodeSnapshot,
+            key: &str,
+        ) -> Option<&'a layers::engine::scene::SceneNodeSnapshot> {
+            if node.key == key {
+                return Some(node);
+            }
+            node.children.iter().find_map(|child| find(child, key))
+        }
+        let workspaces = snapshot
+            .nodes
+            .iter()
+            .find_map(|node| find(node, "workspaces_headless"))
+            .expect("no workspaces layer in the scene");
+        assert!(
+            workspaces.hidden,
+            "real workspace content still visible during show desktop"
+        );
+
+        // Clicking a window dismisses show desktop, and the mirrors animate
+        // back to their places first. The real windows may only take over once
+        // that animation ends — swapping them in on the click frame makes the
+        // windows snap back with no animation at all.
+        handle.pointer_move(760.0, 400.0);
+        handle.settle(5);
+        let hidden_on_click = handle.click_and_sample_workspaces_hidden();
+        assert!(
+            hidden_on_click,
+            "real windows swapped back in on the click frame — the exit animation is skipped"
+        );
+
+        handle.settle(600);
+        assert!(
+            !handle.is_show_desktop_active(),
+            "clicking a window should dismiss show desktop"
+        );
 
         handle.stop();
     }

--- a/tests/headless_basic.rs
+++ b/tests/headless_basic.rs
@@ -232,10 +232,14 @@ mod headless_tests {
         // windows snap back with no animation at all.
         handle.pointer_move(760.0, 400.0);
         handle.settle(5);
-        let hidden_on_click = handle.click_and_sample_workspaces_hidden();
+        let (hidden_on_click, mirrors_on_click) = handle.click_and_sample_show_desktop_exit();
         assert!(
             hidden_on_click,
-            "real windows swapped back in on the click frame — the exit animation is skipped"
+            "scene swapped the real windows back in on the click frame — the exit animation is skipped"
+        );
+        assert!(
+            mirrors_on_click,
+            "render paths drop the mirrors on the click frame — the windows plane snaps back under the flying mirrors"
         );
 
         handle.settle(600);


### PR DESCRIPTION
Show desktop (four-finger pinch out, or `ExposeShowDesktop`) had stopped doing anything on screen, and dismissing it snapped the windows back with no animation.

## The gesture rendered as a no-op

Show desktop reuses the exposé machinery: it slides each window's *mirror* layer off the screen edges. But it never hid the real workspace content, and every render path decided "the windows are represented by mirrors, drop the windows plane" from `get_show_all()` / `is_expose_transitioning()` alone. Show desktop is neither, so the untouched real windows kept compositing on top of the mirrors sliding away. The state flipped correctly; the pixels never moved.

- `expose_show_desktop` now hides `workspaces_layer` while the desktop is revealed and restores it when the animation ends, as exposé does.
- New `Workspaces::mirrors_active()` (exposé | its transition | show desktop | its transition) replaces the `get_show_all()` tests in the plane composition, the virtual-output/screencast stack, window throttling, and the backdrop rebuild gate.

## The exit was not animated

The hook that hides the mirrors and hands the screen back to the real windows rode a no-op property change — setting the workspaces layer to the opacity it already had — which finished on the spot. Clicking a window restored the real windows in the click frame while the mirrors were still flying home. It now rides the first mirror's own position animation.

A three-finger swipe with the desktop shown was swallowed entirely; it now dismisses show desktop through the same animated path.

## Tests

`pinch_show_desktop` asserted nothing after the pinch, which is how the regression stayed green. It now maps a real window and checks that the gesture activates, that the real workspace content is hidden while the desktop is shown, and — via the new `click_and_sample_workspaces_hidden` helper, sampled in the same state callback as the click so no frame can slip in — that the real windows are not swapped back in on the click frame. It fails on both old behaviours.

`cargo test --features headless --test headless_basic`: 26 passed. Not yet driven on hardware.