### PR TITLE
fix: titlebar of a promoted window, and exposé preview sampling

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -844,6 +844,41 @@ impl HeadlessHandle {
         });
     }
 
+    /// Mark this window as direct-scanned-out, the way the DRM backend does
+    /// when it promotes a window's buffer to a KMS plane. The commit path
+    /// takes a different branch for a promoted window — no scene import — and
+    /// this is the only way a headless test can reach it.
+    pub fn set_window_scanned_out(&self, title: &str, scanned_out: bool) {
+        let title = title.to_string();
+        self.with_state(move |state| {
+            if let Some(window) = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == title)
+            {
+                window.set_scanned_out(scanned_out);
+            }
+        });
+    }
+
+    /// Width of the server-side titlebar as the scene has it, in logical
+    /// points — what the bar is actually drawn at, not what the window
+    /// geometry says it should be.
+    pub fn window_decoration_width(&self, title: &str) -> Option<f32> {
+        let title = title.to_string();
+        self.query(move |state| {
+            let window = state
+                .workspaces
+                .spaces_elements()
+                .find(|w| w.xdg_title() == title)
+                .cloned()?;
+            state
+                .workspaces
+                .get_window_view(&window.id())
+                .map(|view| view.decoration_state().width)
+        })
+    }
+
     /// Whether this window is currently maximized.
     pub fn window_is_maximized(&self, title: &str) -> bool {
         let title = title.to_string();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -334,7 +334,7 @@ impl<BackendData: Backend> CompositorHandler for Otto<BackendData> {
                             // shadow still renders in the windows plane — keep
                             // its geometry in sync (tile/resize) or it ghosts at
                             // the pre-change size while the content tiles.
-                            self.refresh_window_shadow_geometry(&window);
+                            self.refresh_window_chrome_geometry(&window);
                         } else {
                             self.update_window_view_for_commit(&window, Some(surface));
                         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2014,33 +2014,15 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 let decoration_height = window.decoration_height();
                 window_view.set_decorated(window.is_decorated());
                 if window.is_decorated() {
-                    window_view.update_decoration(crate::workspaces::WindowDecorationModel {
-                        width: window_geometry.size.w as f32 / scale_factor as f32,
-                        height: decoration_height as f32,
-                        title: window.xdg_title(),
-                        active: is_focused,
-                        dark: Config::with(|c| {
-                            matches!(c.theme_scheme, crate::theme::ThemeScheme::Dark)
-                        }),
-                        // Maximized and fullscreen windows sit flush
-                        // against the screen edges, so their frame — and
-                        // with it the bar — squares off.
-                        corner_radius: if window.is_maximized() || fullscreen {
-                            0.0
-                        } else {
-                            otto_kit::corners::radius(12.0)
-                        },
-                        controls_hovered: window_view.decoration_state().controls_hovered,
-                        pressed: window_view.decoration_state().pressed,
-                        sharing: crate::screenshare::is_window_screencast(
-                            &self.screenshare_sessions,
-                            &self.workspaces,
-                            &self.foreign_toplevels,
-                            &window.id(),
-                        ),
-                        fixed_size: !window.is_resizable(),
-                        scale: scale_factor as f32,
-                    });
+                    let model = self.decoration_model_for(
+                        window,
+                        &window_view,
+                        window_geometry.size.w as f32,
+                        is_focused,
+                        fullscreen,
+                        scale_factor,
+                    );
+                    window_view.update_decoration(model);
                 }
 
                 // Directly add root surface layer to content layer without using LayerTreeBuilder
@@ -2094,16 +2076,59 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
         }
     }
 
-    /// Refresh only the window's shadow geometry (position + size), without
-    /// re-importing its surface tree.
+    /// Build the titlebar model for `window` at a given decorated width.
+    ///
+    /// `width_px` is the window's width in physical pixels; the bar itself is
+    /// described in logical points. Shared by the full commit import and the
+    /// scanout refresh below, so the bar a promoted window wears is built the
+    /// same way as everyone else's.
+    fn decoration_model_for(
+        &self,
+        window: &WindowElement,
+        window_view: &crate::workspaces::WindowView,
+        width_px: f32,
+        is_focused: bool,
+        fullscreen: bool,
+        scale_factor: f64,
+    ) -> crate::workspaces::WindowDecorationModel {
+        crate::workspaces::WindowDecorationModel {
+            width: width_px / scale_factor as f32,
+            height: window.decoration_height() as f32,
+            title: window.xdg_title(),
+            active: is_focused,
+            dark: Config::with(|c| matches!(c.theme_scheme, crate::theme::ThemeScheme::Dark)),
+            // Maximized and fullscreen windows sit flush against the screen
+            // edges, so their frame — and with it the bar — squares off.
+            corner_radius: if window.is_maximized() || fullscreen {
+                0.0
+            } else {
+                otto_kit::corners::radius(12.0)
+            },
+            controls_hovered: window_view.decoration_state().controls_hovered,
+            pressed: window_view.decoration_state().pressed,
+            sharing: crate::screenshare::is_window_screencast(
+                &self.screenshare_sessions,
+                &self.workspaces,
+                &self.foreign_toplevels,
+                &window.id(),
+            ),
+            fixed_size: !window.is_resizable(),
+            scale: scale_factor as f32,
+        }
+    }
+
+    /// Refresh the chrome Otto draws around a window — its drop shadow and its
+    /// server-side titlebar — from the window's geometry, without re-importing
+    /// its surface tree.
     ///
     /// Used for scanned-out windows: their client buffer is pushed straight to
     /// a KMS plane, so the full `update_window_view` import is skipped on every
-    /// root commit (see `shell::mod` commit handler). But the drop-shadow still
-    /// renders in the windows plane from the `WindowViewBaseModel`, so a
-    /// geometry change while promoted (tile, resize) must be reflected here or
-    /// the shadow ghosts at the pre-change size while the content tiles.
-    pub fn refresh_window_shadow_geometry(&mut self, window: &WindowElement) {
+    /// root commit (see `shell::mod` commit handler). But the shadow and the
+    /// titlebar still render in the windows plane, so a geometry change while
+    /// promoted (tile, maximize, resize) must be reflected here or the shadow
+    /// ghosts at the pre-change size and the bar keeps the width it had before
+    /// — a tiled window maximized on a plane wearing a half-screen titlebar.
+    pub fn refresh_window_chrome_geometry(&mut self, window: &WindowElement) {
         let scale_factor = Config::with(|c| c.screen_scale);
         let Some(id) = window.wl_surface().map(|s| s.id()) else {
             return;
@@ -2153,6 +2178,21 @@ impl<BackendData: Backend + 'static> Otto<BackendData> {
                 active: current.active,
             };
             window_view.view_base.update_state(&model);
+
+            // The bar is sized from the same geometry, and it is drawn in the
+            // scene even while the client's content scans out.
+            window_view.set_decorated(window.is_decorated());
+            if window.is_decorated() {
+                let decoration = self.decoration_model_for(
+                    window,
+                    &window_view,
+                    window_geometry.size.w as f32,
+                    current.active,
+                    current.fullscreen,
+                    scale_factor,
+                );
+                window_view.update_decoration(decoration);
+            }
         }
     }
     // Commented out - update_layer_surface is no longer used

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -374,6 +374,28 @@ impl PlaneCandidates {
     }
 }
 
+/// Keep the window-content sampling in step with exposé.
+///
+/// The previews ARE the windows — the same layers, scaled by an ancestor
+/// transform — and the sampling each surface is drawn with is baked into its
+/// recorded picture, which lay-rs does not re-record on a pure scale change.
+/// So flipping the flag has to be followed by forcing those pictures to be
+/// recorded again. Cheap because the flag only changes twice per exposé.
+fn apply_preview_sampling(
+    window_views: &Arc<RwLock<HashMap<ObjectId, WindowView>>>,
+    downscaled: bool,
+) {
+    if !crate::workspaces::utils::set_content_downscaled(downscaled) {
+        return;
+    }
+    let Ok(views) = window_views.read() else {
+        return;
+    };
+    for view in views.values() {
+        crate::workspaces::utils::redraw_subtree(&view.content_layer);
+    }
+}
+
 impl Workspaces {
     /// Re-draw everything that paints with `theme::accent_color()`.
     ///
@@ -1808,6 +1830,14 @@ impl Workspaces {
         // is true AND delta has landed at 0 AND no closing animation is running.
         let show_expose = !end_gesture || delta > 0.0 || transition.is_some();
 
+        // Exposé draws the windows downscaled by scaling their layers, which the
+        // per-surface sampling gate cannot see. Tell it, so the previews are
+        // resampled rather than point sampled — see
+        // [`crate::workspaces::utils::set_content_downscaled`]. The flag is
+        // lowered again by the animation's `on_finish` below, once the windows
+        // are back at 1:1.
+        apply_preview_sampling(&self.window_views, show_expose || show_all);
+
         // Check if this is the current workspace early, so we can use it for window animations
         let current_workspace_index = self.get_current_workspace_index();
         let is_current_workspace = workspace_index == current_workspace_index;
@@ -2005,6 +2035,7 @@ impl Workspaces {
             let expose_dragged_window_ref = self.expose_dragged_window.clone();
             let popup_overlay_layer = self.popup_overlay.layer.clone();
             let model_ref = self.model.clone();
+            let window_views_ref = self.window_views.clone();
 
             // Collect secondary output expose layers to sync with primary
             let secondary_expose_layers: Vec<Layer> = self
@@ -2153,6 +2184,9 @@ impl Workspaces {
                         }
 
                         show_all_ref.store(show_all, std::sync::atomic::Ordering::Relaxed);
+                        // The windows are at their final scale now: 1:1 again
+                        // when expose closed, still downscaled when it opened.
+                        apply_preview_sampling(&window_views_ref, show_all);
                     },
                     true,
                 );

--- a/src/workspaces/utils/mod.rs
+++ b/src/workspaces/utils/mod.rs
@@ -25,6 +25,47 @@ fn adaptive_sampling_enabled() -> bool {
     })
 }
 
+/// True while window content is being drawn downscaled (minification).
+///
+/// Nothing to do with minimize — this is the sampling sense of the word: the
+/// texture is drawn smaller than 1:1.
+///
+/// Exposé scales whole window subtrees with a layer transform and leaves the
+/// surfaces themselves untouched, which is exactly what [`surface_filter`]
+/// cannot see: every surface still maps 1:1 onto its own layer, so the cheap
+/// `Nearest` branch wins and the ~0.3x downscale is point sampled — dropped
+/// rows and columns of source pixels, which is what makes the previews crawl
+/// as they animate. While this is set the draw closure records bicubic
+/// instead.
+///
+/// It has to be a flag rather than something the closure works out for itself,
+/// because the closure never sees the canvas transform: these layers are
+/// `picture_cached`, the sampling is baked into the recorded shader, and
+/// lay-rs deliberately does NOT re-record on a pure scale change. Flipping the
+/// flag is therefore only half the job — see [`redraw_subtree`].
+static CONTENT_DOWNSCALED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Set the downscaled-content flag, returning `true` if the value CHANGED.
+///
+/// On a change the caller must [`redraw_subtree`] every affected window layer:
+/// the pictures already recorded still hold the old sampling.
+pub fn set_content_downscaled(downscaled: bool) -> bool {
+    CONTENT_DOWNSCALED.swap(downscaled, std::sync::atomic::Ordering::Relaxed) != downscaled
+}
+
+fn content_downscaled() -> bool {
+    CONTENT_DOWNSCALED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Force `layer` and every descendant to re-record their picture.
+pub fn redraw_subtree(layer: &Layer) {
+    layer.redraw();
+    for child in layer.children() {
+        redraw_subtree(&child);
+    }
+}
+
 #[allow(unused)]
 pub struct FontCache {
     pub font_collection: layers::skia::textlayout::FontCollection,
@@ -605,7 +646,10 @@ pub fn configure_surface_layer(
             Transform::Flipped270 => {}
         }
 
-        let sampling = if adaptive_sampling_enabled() {
+        // `content_downscaled` short-circuits the gate for exposé: the scale
+        // lives on an ancestor layer, so nothing `surface_filter` looks at
+        // knows the texture is about to be minified onto the framebuffer.
+        let sampling = if adaptive_sampling_enabled() && !content_downscaled() {
             surface_filter(
                 matches!(draw_wvs.transform, Transform::Normal),
                 (scale_x, scale_y),
@@ -637,6 +681,19 @@ pub fn configure_surface_layer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Flipping the flag has to report the change: the pictures already
+    /// recorded still carry the old sampling, and only a change is worth the
+    /// forced re-record of every window subtree.
+    #[test]
+    fn the_downscaled_flag_reports_only_real_changes() {
+        assert!(set_content_downscaled(true), "off -> on is a change");
+        assert!(content_downscaled());
+        assert!(!set_content_downscaled(true), "on -> on is not");
+        assert!(set_content_downscaled(false), "on -> off is a change");
+        assert!(!content_downscaled());
+        assert!(!set_content_downscaled(false), "off -> off is not");
+    }
 
     /// The initial placement of a window is chosen in logical integers, so on
     /// a fractional scale it lands mid-pixel and drags its whole subtree off

--- a/tests/ssd_maximize.rs
+++ b/tests/ssd_maximize.rs
@@ -1,0 +1,152 @@
+//! Server-side decoration sizing across tiling and maximize.
+//!
+//! Unlike `tests/tiling.rs`, the client here RESIZES: it attaches a buffer of
+//! the size it was last configured with, the way a real application does. The
+//! titlebar Otto draws is sized from the window's geometry, so a client that
+//! never resizes can never show the bar getting out of sync with it.
+
+#[cfg(feature = "headless")]
+mod ssd_maximize_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle, TileZone};
+    use otto_kit::testing::{ShmBuffer, TestClient, TestToplevel};
+    use serial_test::serial;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    const TITLE: &str = "ssd-window";
+
+    /// Attach a buffer of the size the compositor last configured, so the
+    /// window's geometry follows the configure the way a real client's does.
+    fn resize_to_configured(
+        client: &mut TestClient,
+        toplevel: &Arc<Mutex<TestToplevel>>,
+        keep: &mut Vec<ShmBuffer>,
+    ) {
+        let _ = client.roundtrip();
+        let (w, h, surface) = {
+            let tl = toplevel.lock().unwrap();
+            (tl.width, tl.height, tl.surface.clone())
+        };
+        if w <= 0 || h <= 0 {
+            return;
+        }
+        let buffer = ShmBuffer::new(
+            client.state.wl_shm.as_ref().expect("wl_shm"),
+            &client.qh,
+            w as u32,
+            h as u32,
+        );
+        surface.attach(Some(buffer.buffer()), 0, 0);
+        surface.damage(0, 0, w, h);
+        surface.commit();
+        keep.push(buffer);
+        let _ = client.roundtrip();
+    }
+
+    #[test]
+    #[serial]
+    fn maximizing_a_tiled_window_resizes_the_titlebar() {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut client =
+            TestClient::connect(&handle.socket_name).expect("Failed to connect to compositor");
+        let mut buffers = Vec::new();
+
+        let toplevel = client.create_toplevel(TITLE, 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(300);
+        handle.decorate_window(TITLE);
+        handle.settle(200);
+        handle.focus_window(TITLE);
+
+        let (zx, _zy, zw, _zh) = handle.usable_zone();
+        eprintln!("usable zone x={zx} w={zw}");
+
+        // ── Tile left ────────────────────────────────────────────────────
+        handle.tile_focused(TileZone::LeftHalf);
+        handle.settle(600);
+        resize_to_configured(&mut client, &toplevel, &mut buffers);
+        handle.settle(300);
+
+        let tiled_geo = handle.window_logical_geometry(TITLE).expect("mapped");
+        let tiled_bar = handle.window_decoration_width(TITLE).expect("decorated");
+        eprintln!("tiled geometry={tiled_geo:?} bar={tiled_bar}");
+        assert_eq!(
+            tiled_geo.2,
+            zw / 2,
+            "a left tile fills half the usable width"
+        );
+        assert_eq!(
+            tiled_bar, tiled_geo.2 as f32,
+            "the titlebar spans the tiled window"
+        );
+
+        // ── Maximize on top of the tile ──────────────────────────────────
+        handle.toggle_maximize_focused();
+        handle.settle(600);
+        resize_to_configured(&mut client, &toplevel, &mut buffers);
+        handle.settle(300);
+
+        let max_geo = handle.window_logical_geometry(TITLE).expect("mapped");
+        let max_bar = handle.window_decoration_width(TITLE).expect("decorated");
+        eprintln!("maximized geometry={max_geo:?} bar={max_bar}");
+        assert!(
+            handle.window_is_maximized(TITLE),
+            "the window should be maximized"
+        );
+        assert_eq!(max_geo.2, zw, "a maximized window fills the usable width");
+        assert_eq!(
+            max_bar, max_geo.2 as f32,
+            "the titlebar follows the window when it is maximized out of a tile"
+        );
+
+        handle.stop();
+    }
+
+    /// Same sequence, with the window promoted to a KMS plane — the state a
+    /// maximized window is normally in on the DRM backend. The commit path
+    /// skips the scene import for a promoted window, so the titlebar has to be
+    /// resized by the chrome refresh that runs instead.
+    #[test]
+    #[serial]
+    fn maximizing_a_scanned_out_tiled_window_resizes_the_titlebar() {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut client =
+            TestClient::connect(&handle.socket_name).expect("Failed to connect to compositor");
+        let mut buffers = Vec::new();
+
+        let toplevel = client.create_toplevel(TITLE, 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(300);
+        handle.decorate_window(TITLE);
+        handle.settle(200);
+        handle.focus_window(TITLE);
+
+        let (_zx, _zy, zw, _zh) = handle.usable_zone();
+
+        handle.tile_focused(TileZone::LeftHalf);
+        handle.settle(600);
+        resize_to_configured(&mut client, &toplevel, &mut buffers);
+        handle.settle(300);
+
+        // Promoted only now: a window is promoted once it is stable at a size,
+        // which is where the user finds it before reaching for maximize.
+        handle.set_window_scanned_out(TITLE, true);
+
+        handle.toggle_maximize_focused();
+        handle.settle(600);
+        resize_to_configured(&mut client, &toplevel, &mut buffers);
+        handle.settle(300);
+
+        let geo = handle.window_logical_geometry(TITLE).expect("mapped");
+        let bar = handle.window_decoration_width(TITLE).expect("decorated");
+        assert_eq!(geo.2, zw, "a maximized window fills the usable width");
+        assert_eq!(
+            bar, geo.2 as f32,
+            "the titlebar of a promoted window follows it out of the tile"
+        );
+
+        handle.stop();
+    }
+}


### PR DESCRIPTION
Two independent rendering fixes.

## Titlebar of a promoted window

A commit on a window whose buffer is direct-scanned-out to a KMS plane skips the scene import and previously refreshed only the drop shadow. The server-side titlebar renders in the scene, not on the plane, so it kept whatever width it had when the window was promoted: tile a window left, maximize it, and the bar stays half a screen wide. DRM backend only, which is why nothing headless caught it.

`refresh_window_shadow_geometry` becomes `refresh_window_chrome_geometry` and now rebuilds the titlebar model (width and corner radius) alongside the shadow, from the shared `decoration_model_for` the full commit path uses.

Covered by `tests/ssd_maximize.rs`, whose client actually resizes on configure — the existing tiling tests never resize, so the bar could never drift from the window there. The promoted test fails without the fix (bar 582 vs window 1164) and passes with it; the non-promoted path was already correct. Two new headless probes back it: `window_decoration_width` and `set_window_scanned_out`.

## Exposé preview sampling

Exposé shrinks windows with an ancestor layer transform, which the per-surface sampling gate cannot see — every surface still maps 1:1 onto its own layer, so the cheap `Nearest` branch won and the ~0.3x downscale was point sampled, making the previews crawl as they animate. A `CONTENT_DOWNSCALED` flag now forces bicubic while exposé is up, with a forced re-record of the affected subtrees (lay-rs does not re-record a `picture_cached` layer on a pure scale change). Cleared in the animation's `on_finish`.

Not yet verified on hardware.

https://claude.ai/code/session_016ddxLccDzQ8KN7PUUYVMM5