### PR TITLE
feat(files): go to a path with Ctrl+L, and Alt navigation

### DIFF
--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -351,6 +351,10 @@ struct Browser {
     /// column's snapshot yet when `new_folder` returns — the pane and the name
     /// are held here until the re-read lands.
     pending_rename: Option<(usize, String)>,
+    /// The path entry, open on Ctrl+L. While it is up the header's title is
+    /// replaced by the field, and every key belongs to it — it is where you
+    /// are, made editable, rather than a dialog asking where to go.
+    path_entry: Option<TextInput>,
     /// The type-ahead buffer and when it was last appended to: typing
     /// printable characters walks the cursor to the entry that starts with
     /// them, without filtering the view or showing anything. Distinct from
@@ -550,6 +554,7 @@ impl Browser {
             last_boundary_click: None,
             rename: None,
             pending_rename: None,
+            path_entry: None,
             typeahead: None,
             pending_restore: false,
             pending_pick: None,
@@ -2254,6 +2259,151 @@ impl Browser {
         self.dirty = true;
     }
 
+    /// Open the path entry on the directory being shown, with the whole path
+    /// selected — typing replaces it, End keeps it and appends. The trailing
+    /// separator is there so the first Tab completes a child rather than
+    /// re-completing the folder the user is already in.
+    fn open_path_entry(&mut self) {
+        let mut path = self.current_directory().to_string_lossy().into_owned();
+        if !path.ends_with('/') {
+            path.push('/');
+        }
+        self.path_entry = Some(TextInput::editing(
+            path,
+            view::path_field_style(AppContext::current_theme()),
+        ));
+        self.dirty = true;
+    }
+
+    /// Put the title back. The location is unchanged — an abandoned path is
+    /// not a navigation.
+    fn cancel_path_entry(&mut self) {
+        self.path_entry = None;
+        self.dirty = true;
+    }
+
+    /// The directory the path entry resolves against, and the one Ctrl+L
+    /// starts on: the active Miller pane in column view, the single listing
+    /// everywhere else.
+    fn current_directory(&self) -> PathBuf {
+        if self.mode == ViewMode::Columns {
+            self.columns[self.active].path.clone()
+        } else {
+            self.current_path()
+        }
+    }
+
+    /// Resolve what has been typed: `~` for home, a bare name against the
+    /// directory on screen, anything else as given.
+    fn resolve_typed_path(&self, typed: &str) -> Option<PathBuf> {
+        let typed = typed.trim();
+        if typed.is_empty() {
+            return None;
+        }
+        let expanded = if typed == "~" {
+            model::home_dir()?
+        } else if let Some(rest) = typed.strip_prefix("~/") {
+            model::home_dir()?.join(rest)
+        } else if typed.starts_with('/') {
+            PathBuf::from(typed)
+        } else {
+            self.current_directory().join(typed)
+        };
+        Some(expanded)
+    }
+
+    /// Go where the field says. A directory is opened; a file opens its
+    /// parent with the file selected, which is what a path pasted out of a
+    /// terminal usually means. A path that is not there leaves the field up
+    /// with the reason under it — retyping one character is cheaper than
+    /// typing the whole thing again.
+    fn commit_path_entry(&mut self) {
+        let typed = self
+            .path_entry
+            .as_ref()
+            .map(|input| input.value().to_string())
+            .unwrap_or_default();
+        let Some(path) = self.resolve_typed_path(&typed) else {
+            self.cancel_path_entry();
+            return;
+        };
+        if path.is_dir() {
+            self.path_entry = None;
+            self.navigate_to(&path);
+            return;
+        }
+        if path.is_file() {
+            let name = path.file_name().map(|n| n.to_string_lossy().into_owned());
+            if let Some(parent) = path.parent() {
+                self.path_entry = None;
+                self.navigate_to(parent);
+                // The parent's listing is read off-thread, so the row to land
+                // on does not exist yet — see `pending_pick`.
+                self.pending_pick = Some((0, name));
+                return;
+            }
+        }
+        self.status = Some(otto_kit::t_owned!(
+            "files-no-such-folder",
+            path = typed.trim()
+        ));
+        self.dirty = true;
+    }
+
+    /// Tab: extend what has been typed as far as the directory allows —
+    /// to the one match, or to the longest prefix every match shares. A
+    /// completed directory gains its separator, so Tab walks down a tree
+    /// without the user reaching for `/` between levels.
+    ///
+    /// The read is synchronous, unlike a listing's: it is one directory, on
+    /// a keystroke the user is waiting on, and its result is thrown away.
+    fn complete_path_entry(&mut self) {
+        let Some(input) = self.path_entry.as_ref() else {
+            return;
+        };
+        let typed = input.value().to_string();
+        let (head, prefix) = match typed.rfind('/') {
+            Some(cut) => (&typed[..=cut], &typed[cut + 1..]),
+            None => ("", typed.as_str()),
+        };
+        let Some(dir) = self.resolve_typed_path(if head.is_empty() { "." } else { head }) else {
+            return;
+        };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return;
+        };
+        // A dotfile is only a candidate once the user has typed the dot, the
+        // way a shell does it — otherwise every completion in a home
+        // directory offers a hundred configuration folders first.
+        let mut names: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(prefix))
+            .filter(|name| prefix.starts_with('.') || !name.starts_with('.'))
+            .collect();
+        if names.is_empty() {
+            return;
+        }
+        names.sort();
+        let completed = common_prefix(&names);
+        if completed.len() < prefix.len() {
+            return;
+        }
+        let mut value = format!("{head}{completed}");
+        if names.len() == 1 && dir.join(&completed).is_dir() && !value.ends_with('/') {
+            value.push('/');
+        }
+        if value == typed {
+            return;
+        }
+        let caret = value.chars().count();
+        if let Some(input) = self.path_entry.as_mut() {
+            input.set_value(value);
+            input.state.set_caret(caret, false);
+        }
+        self.dirty = true;
+    }
+
     /// How far one Up/Down press moves. In the grid that is a whole row of
     /// cells — the arrows walk the grid in two dimensions, so vertical motion
     /// crosses a row and Left/Right steps one cell — and one entry everywhere
@@ -3728,6 +3878,7 @@ impl Browser {
             thumbs: Some(&self.thumbs),
             drop_target: self.drop_target.as_ref().map(DropTarget::highlight),
             marquee: self.marquee_band(),
+            path_entry: self.path_entry.is_some(),
         }
     }
 }
@@ -3746,6 +3897,25 @@ const PREVIEW_PANE: otto_kit::focus::FocusId = otto_kit::focus::FocusId::from_ra
 
 /// The preview panel's, when one is open.
 const QUICKVIEW: otto_kit::focus::FocusId = otto_kit::focus::FocusId::from_raw(0xF11E_5002);
+
+/// The longest prefix `names` all share, in whole characters. Empty when
+/// they diverge at the first one — which the caller reads as "nothing more
+/// to add", not as an error.
+fn common_prefix(names: &[String]) -> String {
+    let Some((first, rest)) = names.split_first() else {
+        return String::new();
+    };
+    let mut prefix = String::new();
+    for (index, ch) in first.char_indices() {
+        let candidate = &first[..index + ch.len_utf8()];
+        if rest.iter().all(|name| name.starts_with(candidate)) {
+            prefix = candidate.to_string();
+        } else {
+            break;
+        }
+    }
+    prefix
+}
 
 /// One listing row's, by its position in the visible order.
 fn row_focus(index: usize) -> otto_kit::focus::FocusId {
@@ -3944,6 +4114,18 @@ impl App for FilesApp {
                 canvas.save();
                 canvas.translate((rect.left, rect.top));
                 session.input.render_at(canvas, rect.width(), rect.height());
+                canvas.restore();
+            }
+
+            // The path entry's value, over the box the header drew for it —
+            // the same two-step as the rename and save fields.
+            if browser.path_entry.is_some() {
+                let rect = view::path_field_rect(browser.size.0);
+                let input = browser.path_entry.as_mut().unwrap();
+                input.set_size(rect.width(), rect.height());
+                canvas.save();
+                canvas.translate((rect.left, rect.top));
+                input.render_at(canvas, rect.width(), rect.height());
                 canvas.restore();
             }
 
@@ -4486,6 +4668,73 @@ impl App for FilesApp {
                 return;
             }
 
+            // The path entry owns the keyboard the same way a rename does,
+            // with two keys of its own: Tab completes against the directory
+            // being typed, and Return goes there.
+            if browser.path_entry.is_some() {
+                let key = match event.keysym {
+                    Keysym::Return | Keysym::KP_Enter => {
+                        browser.commit_path_entry();
+                        drop(browser);
+                        self.render();
+                        return;
+                    }
+                    Keysym::Escape => {
+                        browser.cancel_path_entry();
+                        drop(browser);
+                        self.render();
+                        return;
+                    }
+                    Keysym::Tab | Keysym::ISO_Left_Tab => {
+                        browser.complete_path_entry();
+                        drop(browser);
+                        self.render();
+                        return;
+                    }
+                    // A second Ctrl+L closes it, the way the chord that opens
+                    // Get Info closes it again.
+                    Keysym::l if ctrl => {
+                        browser.cancel_path_entry();
+                        drop(browser);
+                        self.render();
+                        return;
+                    }
+                    Keysym::Left => Some(TextInputKey::Left),
+                    Keysym::Right => Some(TextInputKey::Right),
+                    Keysym::Home => Some(TextInputKey::Home),
+                    Keysym::End => Some(TextInputKey::End),
+                    Keysym::BackSpace => Some(TextInputKey::Backspace),
+                    Keysym::Delete => Some(TextInputKey::Delete),
+                    Keysym::a if ctrl => Some(TextInputKey::SelectAll),
+                    Keysym::c if ctrl => Some(TextInputKey::Copy),
+                    Keysym::x if ctrl => Some(TextInputKey::Cut),
+                    Keysym::v if ctrl => clipboard::text().map(TextInputKey::Paste),
+                    _ => event
+                        .utf8
+                        .as_ref()
+                        .and_then(|s| s.chars().next())
+                        .map(TextInputKey::Char),
+                };
+                if let Some(key) = key {
+                    let mods = KeyMods { shift, ctrl };
+                    let response = browser
+                        .path_entry
+                        .as_mut()
+                        .map(|input| input.on_key(key, mods));
+                    match response {
+                        Some(TextInputResponse::Clipboard(text)) => {
+                            clipboard::set_text(&text, serial);
+                            browser.dirty = true;
+                        }
+                        Some(_) => browser.dirty = true,
+                        None => {}
+                    }
+                }
+                drop(browser);
+                self.render();
+                return;
+            }
+
             // In Save mode the name field holds the keyboard focus: what the
             // user is doing is naming a file, so printable keys are the name
             // rather than type-ahead, and Backspace edits it rather than
@@ -4554,6 +4803,17 @@ impl App for FilesApp {
             let mut typing = false;
 
             match event.keysym {
+                // History and hierarchy, on the chords every file manager
+                // binds them to. These come first: unmodified, the same keys
+                // move the cursor.
+                Keysym::Left if mods.alt => browser.go_back(),
+                Keysym::Right if mods.alt => browser.go_forward(),
+                Keysym::Up if mods.alt => browser.go_up(),
+                Keysym::Home if mods.alt => {
+                    if let Some(home) = model::home_dir() {
+                        browser.navigate_to(&home);
+                    }
+                }
                 Keysym::Down => {
                     let step = browser.row_step();
                     browser.move_cursor(step, shift)
@@ -4672,6 +4932,9 @@ impl App for FilesApp {
                     browser.dirty = true;
                 }
                 Keysym::n if ctrl => browser.open_new_window(),
+                // The location, made editable — Ctrl+L everywhere but the
+                // picker, whose header is a toolbar with no title to replace.
+                Keysym::l if ctrl && browser.picker.is_none() => browser.open_path_entry(),
                 // What a double-click does, from the keyboard: descend into a
                 // directory, or activate a file. Return is not free for this —
                 // it renames, the way it does on the desktop this follows — so
@@ -5421,6 +5684,25 @@ impl FilesApp {
                     drop(browser);
                     window_for_events.request_frame();
                     continue;
+                }
+
+                // A click in the path entry places the caret; a click
+                // anywhere else puts the title back, the way clicking away
+                // from a location bar dismisses it.
+                if browser.path_entry.is_some()
+                    && matches!(event.kind, PointerEventKind::Press { button, .. } if button != BTN_RIGHT)
+                {
+                    let field = view::path_field_rect(width);
+                    if field.contains(skia_safe::Point::new(x, y)) {
+                        if let Some(input) = browser.path_entry.as_mut() {
+                            input.on_pointer_down(x - field.left, 1, shift);
+                        }
+                        browser.dirty = true;
+                        drop(browser);
+                        window_for_events.request_frame();
+                        continue;
+                    }
+                    browser.cancel_path_entry();
                 }
 
                 // A click in the name field places the caret in it. The field
@@ -7511,5 +7793,268 @@ mod delete_tests {
 
         assert_eq!(browser.active, 0, "the parent has the keyboard");
         assert_eq!(selected(&browser), vec!["sub".to_string()]);
+    }
+}
+
+/// The path entry: Ctrl+L, tab completion, and where Return lands.
+#[cfg(test)]
+mod path_entry_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A real directory, swept up when the test ends. The listing is read off
+    /// a worker thread and completion reads the filesystem directly, so both
+    /// need something actually on disk.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn holding(files: &[&str], dirs: &[&str]) -> Self {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+            let path = std::env::temp_dir().join(format!(
+                "otto-files-path-entry-{}-{}",
+                std::process::id(),
+                COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).expect("temp dir");
+            for name in files {
+                std::fs::write(path.join(name), b"").expect("temp file");
+            }
+            for name in dirs {
+                std::fs::create_dir_all(path.join(name)).expect("temp subdir");
+            }
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A browser over the directory, with the first listing already in.
+    fn browser_over(files: &[&str], dirs: &[&str]) -> (Browser, TempDir) {
+        let dir = TempDir::holding(files, dirs);
+        let mut browser = Browser::new(dir.0.clone());
+        for _ in 0..500 {
+            if browser.columns[0].poll() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert!(!browser.columns[0].loading(), "listing never arrived");
+        (browser, dir)
+    }
+
+    /// What Ctrl+L does: the field opens on where you already are, whole
+    /// value selected so typing replaces it, and with the separator already
+    /// there so the first Tab completes a child.
+    #[test]
+    fn the_field_opens_on_the_current_directory() {
+        let (mut browser, dir) = browser_over(&["a.txt"], &[]);
+        browser.open_path_entry();
+
+        let input = browser.path_entry.as_ref().expect("field never opened");
+        assert_eq!(input.value(), format!("{}/", dir.0.display()));
+        assert_eq!(input.state.selection(), 0..input.value().chars().count());
+    }
+
+    /// Escape puts the title back and leaves the location alone — an
+    /// abandoned path is not a navigation.
+    #[test]
+    fn escape_leaves_the_location_alone() {
+        let (mut browser, dir) = browser_over(&["a.txt"], &["sub"]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(dir.0.join("sub").to_string_lossy().into_owned());
+        browser.cancel_path_entry();
+
+        assert!(browser.path_entry.is_none());
+        assert_eq!(browser.current_path(), dir.0);
+    }
+
+    /// A directory is opened, and the field goes away with it.
+    #[test]
+    fn a_typed_directory_is_opened() {
+        let (mut browser, dir) = browser_over(&[], &["sub"]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(dir.0.join("sub").to_string_lossy().into_owned());
+        browser.commit_path_entry();
+
+        assert!(browser.path_entry.is_none(), "the field stayed up");
+        assert_eq!(browser.columns[0].path, dir.0.join("sub"));
+    }
+
+    /// A path to a *file* — what pasting one out of a terminal usually gives
+    /// you — opens the folder holding it with the file selected. The listing
+    /// arrives later, so the row is handed to `pending_pick` rather than
+    /// looked up in a snapshot that does not exist yet.
+    #[test]
+    fn a_typed_file_opens_its_parent_with_the_file_selected() {
+        let (mut browser, dir) = browser_over(&["report.txt"], &["sub"]);
+        browser.navigate_to(&dir.0.join("sub"));
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(dir.0.join("report.txt").to_string_lossy().into_owned());
+        browser.commit_path_entry();
+
+        assert_eq!(browser.columns[0].path, dir.0);
+        // The frame loop polls, then settles the pick — a test has to do
+        // both, in that order, or the listing arrives with nobody to place
+        // the selection in it.
+        for _ in 0..500 {
+            browser.poll();
+            browser.settle_pick();
+            if browser.pending_pick.is_none() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert!(
+            browser.columns[0].selection.contains("report.txt"),
+            "the file the path named was never selected"
+        );
+    }
+
+    /// A path that is not there keeps the field up: retyping one character is
+    /// cheaper than typing the whole path again.
+    #[test]
+    fn a_missing_path_keeps_the_field_open() {
+        let (mut browser, dir) = browser_over(&[], &[]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(dir.0.join("nowhere").to_string_lossy().into_owned());
+        browser.commit_path_entry();
+
+        assert!(browser.path_entry.is_some(), "the field was dismissed");
+        assert!(browser.status.is_some(), "nothing said why");
+        assert_eq!(browser.current_path(), dir.0);
+    }
+
+    /// Tab against one match completes it whole.
+    #[test]
+    fn tab_completes_the_only_match() {
+        let (mut browser, dir) = browser_over(&["alpha.txt", "beta.txt"], &[]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(format!("{}/al", dir.0.display()));
+        browser.complete_path_entry();
+
+        let input = browser.path_entry.as_ref().unwrap();
+        assert_eq!(input.value(), format!("{}/alpha.txt", dir.0.display()));
+        assert_eq!(input.state.caret(), input.value().chars().count());
+    }
+
+    /// Tab against several stops at the prefix they share — the shell's
+    /// behaviour, and the reason completion is worth having at all.
+    #[test]
+    fn tab_stops_at_the_prefix_the_matches_share() {
+        let (mut browser, dir) = browser_over(&["report-a.txt", "report-b.txt"], &[]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(format!("{}/re", dir.0.display()));
+        browser.complete_path_entry();
+
+        assert_eq!(
+            browser.path_entry.as_ref().unwrap().value(),
+            format!("{}/report-", dir.0.display())
+        );
+    }
+
+    /// A completed directory gains its separator, so Tab walks down a tree
+    /// without the user reaching for `/` between levels.
+    #[test]
+    fn a_completed_directory_gains_its_separator() {
+        let (mut browser, dir) = browser_over(&[], &["projects"]);
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(format!("{}/pro", dir.0.display()));
+        browser.complete_path_entry();
+
+        assert_eq!(
+            browser.path_entry.as_ref().unwrap().value(),
+            format!("{}/projects/", dir.0.display())
+        );
+    }
+
+    /// A dotfile is only a candidate once the dot has been typed. Otherwise
+    /// completion in a home directory offers configuration folders first.
+    #[test]
+    fn dotfiles_complete_only_once_the_dot_is_typed() {
+        let (mut browser, dir) = browser_over(&[".hidden", "visible"], &[]);
+        browser.open_path_entry();
+
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(format!("{}/", dir.0.display()));
+        browser.complete_path_entry();
+        assert_eq!(
+            browser.path_entry.as_ref().unwrap().value(),
+            format!("{}/visible", dir.0.display()),
+            "the dotfile was offered unasked"
+        );
+
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(format!("{}/.h", dir.0.display()));
+        browser.complete_path_entry();
+        assert_eq!(
+            browser.path_entry.as_ref().unwrap().value(),
+            format!("{}/.hidden", dir.0.display())
+        );
+    }
+
+    /// A bare name resolves against the directory on screen, and `~` against
+    /// home — the two shorthands anyone typing a path expects to work.
+    #[test]
+    fn a_bare_name_resolves_against_the_open_directory() {
+        let (browser, dir) = browser_over(&[], &["sub"]);
+        assert_eq!(browser.resolve_typed_path("sub"), Some(dir.0.join("sub")));
+        assert_eq!(browser.resolve_typed_path("  "), None);
+        if let Some(home) = model::home_dir() {
+            assert_eq!(browser.resolve_typed_path("~"), Some(home.clone()));
+            assert_eq!(
+                browser.resolve_typed_path("~/Music"),
+                Some(home.join("Music"))
+            );
+        }
+    }
+
+    #[test]
+    fn the_shared_prefix_of_nothing_is_nothing() {
+        assert_eq!(common_prefix(&[]), "");
+        assert_eq!(common_prefix(&["one".into()]), "one");
+        assert_eq!(common_prefix(&["ab".into(), "ac".into()]), "a");
+        assert_eq!(common_prefix(&["ab".into(), "zz".into()]), "");
+        // Whole characters, never half of one.
+        assert_eq!(common_prefix(&["éa".into(), "éb".into()]), "é");
     }
 }

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3654,6 +3654,18 @@ impl Browser {
             return false;
         };
         self.select(depth, index);
+        // Sorting can put "untitled folder" anywhere, including past the fold
+        // of a long directory. `resync_cursors` deliberately does not scroll —
+        // a change somebody else made must not move the view — but this one is
+        // the user's own action, and a rename field they cannot see is worse
+        // than useless: the next keystroke would go into it unseen.
+        //
+        // The metrics have to be refreshed first. They are otherwise a frame
+        // old — from before this listing landed, when the column was one row
+        // shorter — and the scroll view would clamp the reveal short of a
+        // folder that sorted to the very bottom.
+        self.sync_scroll_metrics();
+        self.reveal_cursor();
         self.start_rename();
         true
     }
@@ -6608,6 +6620,60 @@ mod typeahead_tests {
             .to_string();
         assert!(browser.columns[browser.active].selection.contains(&name));
         assert_eq!(session.input.value(), name);
+    }
+
+    /// A folder that sorts past the fold has to be scrolled to, or the rename
+    /// field opens off screen and the user types into something they cannot
+    /// see. "untitled folder" sorts last among a pile of folders named `aaa*`,
+    /// which is exactly the case that hides it.
+    #[test]
+    fn new_folder_scrolls_the_view_to_it() {
+        let dir = TempDir::holding(&[]);
+        for i in 0..200 {
+            std::fs::create_dir_all(dir.0.join(format!("aaa{i:03}"))).expect("temp subdir");
+        }
+        let mut browser = Browser::new(dir.0.clone());
+        for _ in 0..500 {
+            if browser.columns[0].poll() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        browser.mode = ViewMode::List;
+        browser.size = (900.0, 400.0);
+        assert_eq!(browser.columns[0].scroll.offset(), 0.0, "starts at the top");
+
+        browser.new_folder();
+        for _ in 0..500 {
+            if browser.poll() && browser.rename.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert!(browser.rename.is_some(), "rename field never opened");
+
+        let depth = browser.active;
+        let index = browser.columns[depth]
+            .cursor
+            .expect("cursor on the new folder");
+        assert!(index > 0, "the folder sorted past the top");
+        let offset = browser.columns[depth].scroll.offset();
+        assert!(offset > 0.0, "view never scrolled: offset {offset}");
+        let (top, item_h) =
+            view::item_span(browser.size.0, browser.content_h(), browser.mode, index);
+        let viewport = view::pane_viewport(
+            browser.size.0,
+            browser.content_h(),
+            browser.mode,
+            depth,
+            browser.pan.offset(),
+            browser.miller_w,
+        );
+        assert!(
+            top >= offset && top + item_h <= offset + viewport.height(),
+            "row {top}..{} outside the viewport at {offset}",
+            top + item_h
+        );
     }
 
     /// Ctrl+O is bound to the same call a double-click makes, so on a folder

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -7977,11 +7977,12 @@ mod path_entry_tests {
         browser.commit_path_entry();
 
         assert_eq!(browser.columns[0].path, dir.0);
-        // The frame loop polls, then settles the pick — a test has to do
-        // both, in that order, or the listing arrives with nobody to place
-        // the selection in it.
+        // The frame loop polls, re-fits the scroll views, then settles the
+        // pick — a test has to do all three, in that order, or the listing
+        // arrives with nobody to place the selection in it.
         for _ in 0..500 {
             browser.poll();
+            browser.sync_scroll_metrics();
             browser.settle_pick();
             if browser.pending_pick.is_none() {
                 break;
@@ -8112,6 +8113,64 @@ mod path_entry_tests {
                 Some(home.join("Music"))
             );
         }
+    }
+
+    /// The row a path lands on has to be *visible*, not merely selected.
+    ///
+    /// The scroll views take their viewport and content length during
+    /// render, so anything reached from `poll` is working with metrics from
+    /// before the listing landed — a reveal against those clamps short of a
+    /// row that sorted to the bottom. The frame loop re-fits them between
+    /// the poll and the settle for exactly this reason; this pins that
+    /// order, since a Ctrl+L onto a file deep in a long directory is the
+    /// case that shows it.
+    #[test]
+    fn a_typed_file_is_scrolled_into_view() {
+        let names: Vec<String> = (0..200).map(|i| format!("aaa{i:03}.txt")).collect();
+        let mut files: Vec<&str> = names.iter().map(String::as_str).collect();
+        files.push("zzz-last.txt");
+        let (mut browser, dir) = browser_over(&files, &["sub"]);
+        browser.mode = ViewMode::List;
+        browser.size = (900.0, 400.0);
+        browser.navigate_to(&dir.0.join("sub"));
+
+        browser.open_path_entry();
+        browser
+            .path_entry
+            .as_mut()
+            .unwrap()
+            .set_value(dir.0.join("zzz-last.txt").to_string_lossy().into_owned());
+        browser.commit_path_entry();
+
+        for _ in 0..500 {
+            browser.poll();
+            browser.sync_scroll_metrics();
+            browser.settle_pick();
+            if browser.pending_pick.is_none() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let depth = browser.active;
+        let index = browser.columns[depth].cursor.expect("cursor on the file");
+        let offset = browser.columns[depth].scroll.offset();
+        assert!(offset > 0.0, "view never scrolled: offset {offset}");
+        let (top, item_h) =
+            view::item_span(browser.size.0, browser.content_h(), browser.mode, index);
+        let viewport = view::pane_viewport(
+            browser.size.0,
+            browser.content_h(),
+            browser.mode,
+            depth,
+            browser.pan.offset(),
+            browser.miller_w,
+        );
+        assert!(
+            top >= offset && top + item_h <= offset + viewport.height(),
+            "row {top}..{} outside the viewport at {offset}",
+            top + item_h
+        );
     }
 
     #[test]

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -345,6 +345,12 @@ struct Browser {
     nav_pressed: Option<view::NavButton>,
     /// An in-place rename in progress. List view only, for now.
     rename: Option<RenameSession>,
+    /// A folder just created, waiting to be selected and put into rename.
+    ///
+    /// The listing is read off-thread, so the new directory is not in the
+    /// column's snapshot yet when `new_folder` returns — the pane and the name
+    /// are held here until the re-read lands.
+    pending_rename: Option<(usize, String)>,
     /// The type-ahead buffer and when it was last appended to: typing
     /// printable characters walks the cursor to the entry that starts with
     /// them, without filtering the view or showing anything. Distinct from
@@ -543,6 +549,7 @@ impl Browser {
             opening: None,
             last_boundary_click: None,
             rename: None,
+            pending_rename: None,
             typeahead: None,
             pending_restore: false,
             pending_pick: None,
@@ -3130,11 +3137,10 @@ impl Browser {
                     vec![model::Change::Created { path: path.clone() }],
                 );
                 self.reload_all();
-                let depth = self.active;
-                if let Some(index) = self.visible(depth).iter().position(|e| e.name == name) {
-                    self.select(depth, index);
-                    self.start_rename();
-                }
+                // The re-read is off-thread: the folder is not in the column's
+                // listing yet, so the selection and the rename field wait for
+                // it in `poll`.
+                self.pending_rename = Some((self.active, name.clone()));
                 self.status = Some(otto_kit::t_owned!(
                     "files-new-folder-created",
                     name = name.as_str()
@@ -3470,12 +3476,36 @@ impl Browser {
         }
         if refreshed {
             self.resync_cursors();
+            if self.take_pending_rename() {
+                changed = true;
+            }
         }
         if let Some(depth) = vanished {
             self.follow_vanished(depth);
             changed = true;
         }
         changed
+    }
+
+    /// Select the folder `new_folder` just created and open its rename field,
+    /// now that the listing holding it has arrived.
+    ///
+    /// One shot: the request is dropped on the first refresh either way, so a
+    /// folder that was renamed or removed before the read came back does not
+    /// leave a rename armed for the next unrelated re-read.
+    fn take_pending_rename(&mut self) -> bool {
+        let Some((depth, name)) = self.pending_rename.take() else {
+            return false;
+        };
+        if depth >= self.columns.len() {
+            return false;
+        }
+        let Some(index) = self.visible(depth).iter().position(|e| e.name == name) else {
+            return false;
+        };
+        self.select(depth, index);
+        self.start_rename();
+        true
     }
 
     /// Put every cursor back on what is selected, after a listing was replaced
@@ -6264,6 +6294,38 @@ mod typeahead_tests {
         }
         assert!(!browser.columns[0].loading(), "listing never arrived");
         (browser, dir)
+    }
+
+    /// New Folder creates the directory, then selects it with its name ready
+    /// to be typed over. The listing it has to find the folder in is read off
+    /// the main thread, so the selection cannot happen in the same call — it
+    /// waits for the re-read, which is exactly what this pins.
+    #[test]
+    fn new_folder_lands_in_rename_mode() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.mode = ViewMode::List;
+        browser.new_folder();
+        assert!(
+            browser.rename.is_none(),
+            "nothing to rename before the re-read"
+        );
+
+        for _ in 0..500 {
+            if browser.poll() && browser.rename.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let session = browser.rename.as_ref().expect("rename field never opened");
+        let name = session
+            .original
+            .file_name()
+            .expect("named folder")
+            .to_string_lossy()
+            .to_string();
+        assert!(browser.columns[browser.active].selection.contains(&name));
+        assert_eq!(session.input.value(), name);
     }
 
     /// Ctrl+O is bound to the same call a double-click makes, so on a folder

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -991,6 +991,7 @@ mod tests {
             quickview_close_hovered: false,
             drop_target: None,
             marquee: None,
+            path_entry: false,
             thumbs: Some(&store),
         };
 

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -150,6 +150,11 @@ const GRID_LABEL_LINE: f32 = 16.0;
 /// Padding above and below the caption inside its selection pill. The pill is
 /// built out from the line centres, so the text sits optically centred in it.
 const GRID_LABEL_INSET: f32 = 10.0;
+/// The caption's type. One point larger than a callout, matching the name in
+/// a list row: the grid caption is the file's name, the same as that one, and
+/// a smaller one read as a footnote against it. Shared with the drag image,
+/// which is a copy of the cell and has to stay one.
+const GRID_LABEL_STYLE: TextStyle = styles::BODY_EMPHASIZED;
 /// How far the icon's selection rectangle stands off the icon itself. Small,
 /// so the highlight reads as belonging to the icon rather than to the cell.
 const GRID_ICON_INSET: f32 = 6.0;
@@ -942,7 +947,7 @@ fn draw_drag_entry(
             // The caption on its pill, the way a selected cell wears it.
             let center_y = icon_top + GRID_ICON + GRID_LABEL_GAP;
             let (first, second) = split_label(&entry.name, 13);
-            let caption = styles::CALLOUT_EMPHASIZED.font();
+            let caption = GRID_LABEL_STYLE.font();
             let text_w = caption
                 .measure_str(&first, None)
                 .0
@@ -972,7 +977,7 @@ fn draw_drag_entry(
                     continue;
                 }
                 Label::new(line)
-                    .with_style(styles::CALLOUT_EMPHASIZED)
+                    .with_style(GRID_LABEL_STYLE)
                     .with_color(Color::WHITE)
                     .centered_at(cell.center_x(), center_y + offset)
                     .render(canvas);
@@ -2732,7 +2737,7 @@ pub fn draw_grid_cell(
     };
 
     if selected && !renaming {
-        let font = styles::CALLOUT_EMPHASIZED.font();
+        let font = GRID_LABEL_STYLE.font();
         let text_w = font
             .measure_str(&first, None)
             .0
@@ -2766,7 +2771,7 @@ pub fn draw_grid_cell(
             continue;
         }
         Label::new(line)
-            .with_style(styles::CALLOUT_EMPHASIZED)
+            .with_style(GRID_LABEL_STYLE)
             .with_color(text_color)
             .centered_at(cell.center_x(), label_center_y + offset)
             .render(canvas);

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -83,6 +83,25 @@ pub fn location_rect(width: f32) -> Rect {
         TOOLBAR_CY + 15.0,
     )
 }
+/// The path entry's field, in place of the header title.
+///
+/// It starts where the title's text does and runs to the view switcher, so
+/// the field reads as the title line turned editable rather than as a box
+/// dropped on top of it — which is the whole point of Ctrl+L: you are
+/// editing where you are, not answering a question about it.
+pub fn path_field_rect(width: f32) -> Rect {
+    let left = TITLE_X - 8.0;
+    Rect::from_ltrb(
+        left,
+        TITLE_CY - PATH_FIELD_H / 2.0,
+        (switcher_rect(width).left - 16.0).max(left + 80.0),
+        TITLE_CY + PATH_FIELD_H / 2.0,
+    )
+}
+
+/// Tall enough for the title-sized text the field replaces.
+const PATH_FIELD_H: f32 = 32.0;
+
 /// One Miller pane's default width. Every pane shares one width — a column
 /// whose width changes as you descend is disorienting, and this is what makes
 /// the view scannable — but that shared width is user-resizable.
@@ -1770,6 +1789,12 @@ pub struct Frame<'a> {
     /// over one. `None` when there is no drag, or it is over nothing that
     /// takes files.
     pub drop_target: Option<DropHighlight>,
+    /// The path entry is open, so the header draws its field in place of the
+    /// title. The text is not here — the [`TextInput`] paints itself over
+    /// the rect afterwards, the way an in-place rename does.
+    ///
+    /// [`TextInput`]: otto_kit::components::text_input::TextInput
+    pub path_entry: bool,
     /// The rubber band being dragged out over the icon grid, in window
     /// coordinates. Grid view only: rows span their pane's whole width, so a
     /// band over a list or a Miller column could only ever say what dragging
@@ -2364,6 +2389,11 @@ fn draw_header(canvas: &Canvas, f: &Frame) {
         // they are and how to get elsewhere — the same things the macOS open
         // panel puts on its single toolbar row.
         draw_location_button(canvas, f);
+    } else if f.path_entry {
+        // The title line, editable. The subtitle stays put underneath: it
+        // says what is in the folder, which is still true while a new one is
+        // being typed, and losing it would make the header jump.
+        draw_path_field(canvas, f);
     } else {
         // Both drop a step down the text scale while the window is in the
         // background — the title reads as a label rather than as the thing
@@ -2398,6 +2428,20 @@ fn draw_header(canvas: &Canvas, f: &Frame) {
         Point::new(f.width, HEADER_H),
         &paint,
     );
+}
+
+/// The path entry's ground: paper with a hairline, the same box the picker's
+/// name field draws. The value, caret and selection are the input's own.
+fn draw_path_field(canvas: &Canvas, f: &Frame) {
+    let field = path_field_rect(f.width);
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(content_ground());
+    canvas.draw_rrect(RRect::new_rect_xy(field, 6.0, 6.0), &paint);
+    paint.set_style(skia_safe::paint::Style::Stroke);
+    paint.set_stroke_width(1.0);
+    paint.set_color(accent(f.theme));
+    canvas.draw_rrect(RRect::new_rect_xy(field, 6.0, 6.0), &paint);
 }
 
 /// The picker's location control: a folder icon and the current directory's
@@ -3148,6 +3192,14 @@ pub fn rename_field_style(theme: Theme) -> TextInputStyle {
 /// top of each other, one of them a hair off, is exactly the sort of seam a
 /// dialog gets judged on.
 pub fn save_field_style(theme: Theme) -> TextInputStyle {
+    let mut style = TextInputStyle::with_theme(theme);
+    style.background = Color::TRANSPARENT;
+    style
+}
+
+/// The path entry's field. Like the save field, the box is drawn by the
+/// header underneath, so the input paints no ground of its own.
+pub fn path_field_style(theme: Theme) -> TextInputStyle {
     let mut style = TextInputStyle::with_theme(theme);
     style.background = Color::TRANSPARENT;
     style
@@ -4894,6 +4946,7 @@ mod geometry_tests {
             quickview_close_hovered: false,
             drop_target: None,
             marquee: None,
+            path_entry: false,
             width: 1100.0,
             height,
             theme: &theme,

--- a/components/otto-kit/src/app_runner/context.rs
+++ b/components/otto-kit/src/app_runner/context.rs
@@ -1543,6 +1543,19 @@ impl<'a> AppContext<'a> {
         });
     }
 
+    /// Whether `surface_id` is one of this application's toplevel windows.
+    ///
+    /// Layer surfaces and popups are not registered here, which is what makes
+    /// this the test for "is the keyboard on something Cmd+W should close".
+    pub fn is_toplevel_surface(surface_id: &ObjectId) -> bool {
+        WINDOWS.with(|windows| {
+            windows
+                .borrow()
+                .iter()
+                .any(|window| window.surface_id().as_ref() == Some(surface_id))
+        })
+    }
+
     pub fn update_windows() {
         WINDOWS.with(|windows| {
             let mut windows = windows.borrow_mut();

--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -1071,6 +1071,47 @@ fn move_focus_for_key(event: &KeyEvent) -> bool {
     true
 }
 
+/// Whether a key press is the close-window shortcut.
+///
+/// Cmd reaches a client as `logo`, or as `ctrl` where the session remaps the
+/// Cmd keys (`altwin:ctrl_win`, Otto's default) — a client cannot tell that
+/// apart from the real Ctrl key, and does not need to.
+fn is_close_window_key(keysym: Keysym, modifiers: Modifiers) -> bool {
+    keysym == Keysym::w && (modifiers.ctrl || modifiers.logo) && !modifiers.alt && !modifiers.shift
+}
+
+impl<A: App + 'static> AppData<A> {
+    /// Cmd+W closes the focused window, as it does across the rest of the
+    /// desktop.
+    ///
+    /// Cmd reaches a client as `logo`, or as `ctrl` when the session remaps
+    /// the Cmd keys (`altwin:ctrl_win`, Otto's default), so either counts.
+    /// Only a toplevel window takes it: a layer surface — a bar, an island —
+    /// has no close, and quitting it on Cmd+W would be a surprise.
+    ///
+    /// The close runs through the same path as a compositor close request, so
+    /// a window with its own close handler keeps it, and an application that
+    /// refuses `on_close` keeps its veto.
+    fn close_focused_window_for_key(&mut self, event: &KeyEvent) -> bool {
+        if !is_close_window_key(event.keysym, AppContext::current_modifiers()) {
+            return false;
+        }
+        let Some(surface) = AppContext::keyboard_focus() else {
+            return false;
+        };
+        if !AppContext::is_toplevel_surface(&surface) {
+            return false;
+        }
+        if AppContext::dispatch_close_request(&surface) {
+            return true;
+        }
+        if self.app.on_close() {
+            self.exit = true;
+        }
+        true
+    }
+}
+
 impl<A: App + 'static> KeyboardHandler for AppData<A> {
     fn enter(
         &mut self,
@@ -1118,6 +1159,10 @@ impl<A: App + 'static> KeyboardHandler for AppData<A> {
         // application sees the key — but only in a window that declared any,
         // so an application that handles Tab itself is unaffected.
         if move_focus_for_key(&event) {
+            return;
+        }
+
+        if self.close_focused_window_for_key(&event) {
             return;
         }
 
@@ -1793,5 +1838,58 @@ impl<A: App + 'static> Dispatch<ZwpPointerGestureHoldV1, ()> for AppData<A> {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_close_window_key, Keysym, Modifiers};
+
+    #[test]
+    fn cmd_w_closes_however_cmd_reaches_the_client() {
+        // Remapped Cmd keys arrive as Control...
+        let ctrl = Modifiers {
+            ctrl: true,
+            ..Default::default()
+        };
+        assert!(is_close_window_key(Keysym::w, ctrl));
+
+        // ...and a stock layout raises logo instead.
+        let logo = Modifiers {
+            logo: true,
+            ..Default::default()
+        };
+        assert!(is_close_window_key(Keysym::w, logo));
+    }
+
+    #[test]
+    fn a_bare_w_is_text() {
+        assert!(!is_close_window_key(Keysym::w, Modifiers::default()));
+    }
+
+    #[test]
+    fn another_modifier_is_another_shortcut() {
+        let ctrl_shift = Modifiers {
+            ctrl: true,
+            shift: true,
+            ..Default::default()
+        };
+        assert!(!is_close_window_key(Keysym::w, ctrl_shift));
+
+        let ctrl_alt = Modifiers {
+            ctrl: true,
+            alt: true,
+            ..Default::default()
+        };
+        assert!(!is_close_window_key(Keysym::w, ctrl_alt));
+    }
+
+    #[test]
+    fn only_w() {
+        let ctrl = Modifiers {
+            ctrl: true,
+            ..Default::default()
+        };
+        assert!(!is_close_window_key(Keysym::q, ctrl));
     }
 }

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -33,7 +33,7 @@ versions: useful day to day, still filling in.
 
 | Page | What it covers |
 |------|----------------|
-| [Files](files.md) | Browsing, thumbnails, file operations, quick view, the file picker |
+| [Files](files.md) | Browsing, typing a path, thumbnails, file operations, quick view, the file picker |
 | [Settings](settings.md) | Editing the configuration live, display arrangement, shortcuts |
 | [Launcher](launcher.md) | Starting applications and switching windows from the keyboard |
 

--- a/docs/user/files.md
+++ b/docs/user/files.md
@@ -33,20 +33,38 @@ itself are not reused elsewhere.
 
 ## Getting around
 
-- **Double-click** or `Ctrl+O` opens the entry at the cursor — descend into a
-  folder, or open a file in its default application.
-- **Backspace** goes up a directory, as do `Alt+Up` and the back arrow's
-  neighbour in the header. The arrow keys move the cursor; `Right` descends.
-- **`Alt+Left` and `Alt+Right`** step back and forward through where you have
-  been, the same as the arrows in the header. `Alt+Home` goes home.
-- **`Ctrl+L` types a path.** The title turns into a field holding the folder
-  you are in; type or paste a path and press `Return` to go there. `Tab`
-  completes against the folder being typed — to the one match, or as far as
-  every match agrees — and adds the `/` for you, so you can walk down a tree
-  without reaching for it. `~` means your home directory, and a bare name is
-  taken relative to the folder on screen. A path to a *file* opens the folder
-  holding it with the file selected, which is what pasting one out of a
-  terminal usually means. `Escape` puts the title back.
+| Key | Where it goes |
+|-----|---------------|
+| `Backspace` or `Alt+↑` | Up one folder |
+| `Alt+←` / `Alt+→` | Back and forward, through where you have been |
+| `Alt+Home` | Your home folder |
+| `Ctrl+L` | Type a path (see below) |
+| `Ctrl+O`, or double-click | Open the entry at the cursor |
+| `←` `→` `↑` `↓` | Move the cursor; `Right` descends into a folder |
+
+Back and forward are also the two arrows in the header, and each half dims
+when there is nowhere for it to go.
+
+### Typing a path
+
+`Ctrl+L` turns the title into a text field holding the folder you are in.
+Type or paste a path and press `Return` to go there; `Escape`, or a second
+`Ctrl+L`, puts the title back and leaves you where you were.
+
+- `Tab` **completes** against the folder being typed — to the one match, or as
+  far as every match agrees — and adds the `/` for you, so you can walk down a
+  tree without reaching for it. Hidden files are only offered once you have
+  typed the leading dot.
+- `~` is your home folder, a path starting with `/` is taken as it reads, and
+  anything else is relative to the folder on screen — so a bare folder name is
+  enough.
+- A path to a **file** opens the folder holding it with the file selected,
+  which is what pasting one out of a terminal usually means.
+- A path that is not there leaves the field up, with the reason under it, so
+  you can correct it rather than type the whole thing again.
+
+### Type-ahead and the sidebar
+
 - **Type a few letters** to jump to the first entry whose name starts with
   them. This selects, it does not filter — the whole folder stays on screen.
   The typed text expires after about a second, and repeating one letter cycles

--- a/docs/user/files.md
+++ b/docs/user/files.md
@@ -35,8 +35,18 @@ itself are not reused elsewhere.
 
 - **Double-click** or `Ctrl+O` opens the entry at the cursor — descend into a
   folder, or open a file in its default application.
-- **Backspace** goes up a directory. The arrow keys move the cursor; `Right`
-  descends.
+- **Backspace** goes up a directory, as do `Alt+Up` and the back arrow's
+  neighbour in the header. The arrow keys move the cursor; `Right` descends.
+- **`Alt+Left` and `Alt+Right`** step back and forward through where you have
+  been, the same as the arrows in the header. `Alt+Home` goes home.
+- **`Ctrl+L` types a path.** The title turns into a field holding the folder
+  you are in; type or paste a path and press `Return` to go there. `Tab`
+  completes against the folder being typed — to the one match, or as far as
+  every match agrees — and adds the `/` for you, so you can walk down a tree
+  without reaching for it. `~` means your home directory, and a bare name is
+  taken relative to the folder on screen. A path to a *file* opens the folder
+  holding it with the file selected, which is what pasting one out of a
+  terminal usually means. `Escape` puts the title back.
 - **Type a few letters** to jump to the first entry whose name starts with
   them. This selects, it does not filter — the whole folder stays on screen.
   The typed text expires after about a second, and repeating one letter cycles

--- a/resources/locales/de.ftl
+++ b/resources/locales/de.ftl
@@ -332,6 +332,7 @@ files-undo-rename = Umbenennen
 files-renamed-to = In „{ $name }“ umbenannt
 files-new-folder-created = Neuer Ordner „{ $name }“
 files-gone = „{ $name }“ ist nicht mehr vorhanden
+files-no-such-folder = „{ $path }“ gibt es nicht
 files-rename-failed = Umbenennen nicht möglich: { $error }
 files-new-folder-failed = Ordner konnte nicht erstellt werden: { $error }
 files-open-failed = Datei konnte nicht geöffnet werden: { $error }

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -332,6 +332,7 @@ files-undo-rename = Rename
 files-renamed-to = Renamed to “{ $name }”
 files-new-folder-created = New folder “{ $name }”
 files-gone = “{ $name }” is no longer there
+files-no-such-folder = There is no “{ $path }”
 files-rename-failed = Couldn’t rename: { $error }
 files-new-folder-failed = Couldn’t create folder: { $error }
 files-open-failed = Couldn’t open that file: { $error }

--- a/resources/locales/es.ftl
+++ b/resources/locales/es.ftl
@@ -335,6 +335,7 @@ files-undo-rename = Cambiar nombre
 files-renamed-to = Nombre cambiado a «{ $name }»
 files-new-folder-created = Nueva carpeta «{ $name }»
 files-gone = «{ $name }» ya no está ahí
+files-no-such-folder = «{ $path }» no existe
 files-rename-failed = No se pudo cambiar el nombre: { $error }
 files-new-folder-failed = No se pudo crear la carpeta: { $error }
 files-open-failed = No se pudo abrir ese archivo: { $error }

--- a/resources/locales/fr.ftl
+++ b/resources/locales/fr.ftl
@@ -335,6 +335,7 @@ files-undo-rename = Renommer
 files-renamed-to = Renommé en « { $name } »
 files-new-folder-created = Nouveau dossier « { $name } »
 files-gone = « { $name } » n’existe plus
+files-no-such-folder = « { $path } » n’existe pas
 files-rename-failed = Impossible de renommer : { $error }
 files-new-folder-failed = Impossible de créer le dossier : { $error }
 files-open-failed = Impossible d’ouvrir ce fichier : { $error }

--- a/resources/locales/it.ftl
+++ b/resources/locales/it.ftl
@@ -335,6 +335,7 @@ files-undo-rename = Ridenominazione
 files-renamed-to = Rinominato in “{ $name }”
 files-new-folder-created = Nuova cartella “{ $name }”
 files-gone = “{ $name }” non è più presente
+files-no-such-folder = “{ $path }” non esiste
 files-rename-failed = Impossibile rinominare: { $error }
 files-new-folder-failed = Impossibile creare la cartella: { $error }
 files-open-failed = Impossibile aprire il file: { $error }

--- a/resources/locales/pl.ftl
+++ b/resources/locales/pl.ftl
@@ -337,6 +337,7 @@ files-undo-rename = Zmianę nazwy
 files-renamed-to = Zmieniono nazwę na „{ $name }”
 files-new-folder-created = Nowy folder „{ $name }”
 files-gone = „{ $name }” już tam nie ma
+files-no-such-folder = Nie ma „{ $path }”
 files-rename-failed = Nie można zmienić nazwy: { $error }
 files-new-folder-failed = Nie można utworzyć folderu: { $error }
 files-open-failed = Nie można otworzyć tego pliku: { $error }

--- a/resources/locales/pt-BR.ftl
+++ b/resources/locales/pt-BR.ftl
@@ -335,6 +335,7 @@ files-undo-rename = Renomear
 files-renamed-to = Renomeado para “{ $name }”
 files-new-folder-created = Nova pasta “{ $name }”
 files-gone = “{ $name }” não está mais lá
+files-no-such-folder = “{ $path }” não existe
 files-rename-failed = Não foi possível renomear: { $error }
 files-new-folder-failed = Não foi possível criar a pasta: { $error }
 files-open-failed = Não foi possível abrir o arquivo: { $error }

--- a/resources/locales/ru.ftl
+++ b/resources/locales/ru.ftl
@@ -337,6 +337,7 @@ files-undo-rename = Переименование
 files-renamed-to = Переименовано в «{ $name }»
 files-new-folder-created = Новая папка «{ $name }»
 files-gone = «{ $name }» больше не существует
+files-no-such-folder = «{ $path }» не существует
 files-rename-failed = Не удалось переименовать: { $error }
 files-new-folder-failed = Не удалось создать папку: { $error }
 files-open-failed = Не удалось открыть файл: { $error }

--- a/resources/locales/uk.ftl
+++ b/resources/locales/uk.ftl
@@ -338,6 +338,7 @@ files-undo-rename = перейменування
 files-renamed-to = Перейменовано на «{ $name }»
 files-new-folder-created = Нова папка «{ $name }»
 files-gone = «{ $name }» більше немає
+files-no-such-folder = «{ $path }» не існує
 files-rename-failed = Не вдалося перейменувати: { $error }
 files-new-folder-failed = Не вдалося створити папку: { $error }
 files-open-failed = Не вдалося відкрити файл: { $error }

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -341,6 +341,11 @@ Every navigation that moves the window somewhere else — descending into a
 directory, going up, clicking a place — first records where it was; navigating
 anew drops any Forward history, the rule a web browser follows.
 
+From the keyboard, history and hierarchy are on the chords every file manager
+binds them to: **Alt+Left** and **Alt+Right** for back and forward, **Alt+Up**
+for the parent, **Alt+Home** for the home directory. They are the same calls
+the split button makes, so a dimmed half means the chord does nothing too.
+
 A recorded location is the **whole column stack**, not just the deepest path,
 and for each pane both its selection and its cursor. Going back therefore
 restores every pane that was open *and* the entry that was selected in each,
@@ -353,6 +358,59 @@ The "Loading" placeholder belongs to a *first* read only. An in-place re-read �
 after a delete, a paste, or a watcher notification — leaves the listing that is
 already on screen up until the new one lands, because the alternative is the
 whole pane blinking through an empty placeholder and back for every operation.
+
+### The path entry
+
+**Ctrl+L turns the title into a field.** Not a dialog and not a sheet: the
+header's title line is replaced in place by a text field holding the path of
+the folder on screen, with the whole value selected and a trailing separator
+already typed. This is the Linux convention — Nautilus and Dolphin both swap
+their breadcrumb for an editable field on the same chord — and it is what
+makes the gesture read as *editing where you are* rather than as answering a
+question about it. The subtitle stays put underneath: it says what is in the
+folder, which is still true while a new one is being typed, and dropping it
+would make the header jump.
+
+The field owns the keyboard whole, the way an inline rename does. Its own keys:
+
+| Key | Effect |
+| --- | --- |
+| Return | go where the field says |
+| Tab | complete against the directory being typed |
+| Escape, or a second Ctrl+L | put the title back, leaving the location alone — an abandoned path is not a navigation |
+| a click outside the field | the same as Escape, the way clicking away from a location bar dismisses it |
+
+What a typed path may say:
+
+- `~` is the home directory, and `~/` a path under it.
+- A path starting with `/` is taken as given.
+- Anything else is **relative to the folder on screen**, so a bare child name
+  is enough.
+
+Where Return lands:
+
+- A **directory** is opened, replacing the column stack the way clicking a
+  place does, and the field goes away with it.
+- A **file** opens the folder holding it, with the file selected. This is what
+  a path pasted out of a terminal usually means, and the alternative — an
+  error on a path that exists — would be a poor answer. The listing is read
+  off-thread, so the row is handed to the pending-selection machinery rather
+  than looked up in a snapshot that does not exist yet.
+- A path that is **not there** leaves the field up with the reason in the
+  subtitle. Retyping one character is cheaper than typing the whole path
+  again, and dismissing the field would throw the typing away to say "no".
+
+**Tab completes** as far as the directory allows: to the one match, or to the
+longest prefix every match shares — the shell's behaviour, and the reason
+completion is worth having at all. A completed directory gains its separator,
+so Tab walks down a tree without the user reaching for `/` between levels. A
+dotfile is only a candidate once the dot has been typed, or completion in a
+home directory would offer a hundred configuration folders first. The read is
+synchronous, unlike a listing's: it is one directory, on a keystroke the user
+is waiting on, and its result is thrown away.
+
+The picker does not have it. Its header is a toolbar with a location control
+rather than a title, so there is nothing to turn into a field.
 
 ### Selection, keyboard and type-ahead
 
@@ -401,6 +459,7 @@ The browser adds:
 | Ctrl+N | new window, at the **default location** (the home directory for now, a preference later) rather than at this window's directory — a new window is a fresh start, and inheriting wherever the focused window was pointed makes it read as a copy of that window. Ctrl+double-click is the gesture for "that directory, in another window". Nothing in the picker, which answers one request in one window |
 | Ctrl+O | open the entry at the cursor — exactly what a double-click does: descend into a directory, or activate a file (in the picker, accept it). Return is not free for this, since it renames |
 | Ctrl+I | show info for the selection |
+| Ctrl+L | open the **path entry** (see below) |
 | Ctrl+1 / Ctrl+2 / Ctrl+3 | list / icon / column view |
 | Escape | cancel an inline rename, else clear the search field, else clear the selection |
 

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -478,7 +478,11 @@ progress, and can cancel it.
   or `..`, is rejected while typing. A name that collides with an existing
   entry offers to replace it or to keep editing.
 - **New folder** — creates `untitled folder`, disambiguating with a numeric
-  suffix, and immediately enters inline rename on it.
+  suffix, and immediately enters inline rename on it, scrolling the view to it
+  first: the sort can put the new folder anywhere, and a rename field off
+  screen would take the user's next keystroke unseen. Because the listing is
+  re-read off the main thread, all of this happens when that read lands, not
+  when the directory is created.
 - **Copy and move** — the clipboard holds paths and a copy/cut intent. Paste
   into a directory starts the operation, and so does a drop on one: a drag is
   the same operation reached with the pointer, and both run through the same

--- a/specs/otto-kit-window-focus.md
+++ b/specs/otto-kit-window-focus.md
@@ -107,6 +107,15 @@ commit. Where it fades, the ordering above is what guarantees it instead: the
 blur only ever turns off under a material that has already finished filling
 in, and only ever turns on under one that has not yet started to thin.
 
+**Cmd+W closes the focused window.** The toolkit handles it, so every kit
+application gets it without asking. Cmd reaches a client as `logo`, or as
+`ctrl` where the session remaps the Cmd keys (`altwin:ctrl_win`, Otto's
+default), and either counts; Alt or Shift held alongside does not. The close
+takes the same path as a close request from the compositor, so a window with
+its own close handler keeps it and an application that refuses the close keeps
+its veto. Only a toplevel window takes the shortcut — a layer surface has no
+close, and quitting a bar or an island on Cmd+W would be a surprise.
+
 ## Constraints & Edge Cases
 
 - **A window's own popup must not unfocus it.** A menu or a context menu takes


### PR DESCRIPTION
Two sessions worked in the same checkout, so this branch carries both efforts. Every commit is green on its own.

## Getting around, from the keyboard

**`Ctrl+L` turns the header title into a path field** — in place, the way Nautilus and Dolphin swap their breadcrumb, rather than as a dialog. `Return` goes there, `Escape` or a second `Ctrl+L` puts the title back, a click outside dismisses it, a click inside places the caret.

- **`Tab` completes** to the one match or to the longest prefix every match shares, and adds the `/` for a completed directory so you can walk down a tree without reaching for it. Dotfiles are only candidates once the dot is typed.
- `~`, `~/…` and absolute paths resolve; a bare name is relative to the folder on screen.
- A path to a **file** opens its parent with the file selected — what pasting one out of a terminal usually means. The listing is read off-thread, so the row goes through `pending_pick` rather than a snapshot that does not exist yet.
- A path that is not there keeps the field up with the reason in the subtitle.

**`Alt+←/→/↑/Home`** — back, forward, parent, home. `go_back` and `go_forward` existed but had no keyboard route at all.

No new surface: the field is a fourth keyboard-focus mode beside rename, save-name and the confirm sheet, painted in the same frame.

## New-folder fixes

A newly created folder is now selected, put into rename **and scrolled to**. The listing is read off-thread, so none of it can happen in the same call — it waits for the re-read. The scroll needed `sync_scroll_metrics()` first: the scroll views take their viewport during render, so anything reached from `poll()` is working with metrics from before the listing landed, and the reveal clamps short of a folder that sorted to the bottom.

Also: icon-view captions go 12pt → 13pt semibold, matching the name in a list row, with the drag ghost sharing the constant.

## Tests

`cargo test -p otto-files --lib` 199 passed, `-p otto-kit --lib` 290 passed, both verified in a clean worktree at the tip rather than against a dirty tree. Clippy `--all-targets` clean, fmt applied.

13 new otto-files tests. Two are worth naming: `a_typed_file_is_scrolled_into_view` pins the poll → re-fit → settle ordering the reveal depends on (it fails if the re-fit is dropped), and `new_folder_scrolls_the_view_to_it` does the same for New Folder.

## Also here

`6539cd2b feat(otto-kit): close the focused window on Cmd+W` was already on the branch before this work and is what the branch is named for.

Docs and spec are in step: `docs/user/files.md` has a key table for getting around, `specs/file-browser.md` gains a path-entry section and the Alt chords. The new string is translated into all nine catalogues, so otto-kit's completeness test stays green.

https://claude.ai/code/session_01DLyxnhWdLJSthwMthkxRbd