### PR TITLE
perf: throttle layer-shell surfaces hidden behind windows

### DIFF
--- a/docs/developer/render_loop.md
+++ b/docs/developer/render_loop.md
@@ -103,6 +103,17 @@ The hidden rate is deliberately not zero: Chromium 115+ treats a window that
 receives no callbacks at all as discardable and evicts its render process. A
 2 Hz trickle satisfies that heuristic while saving essentially all the work.
 
+A window covers what is beneath it only when it is opaque: a client that
+committed an `ext-background-effect-v1` blur region shows the content behind
+it through the frost, so it can be occluded but never occludes.
+
+`background`/`bottom` layer-shell surfaces (wallpaper, desktop widgets) follow
+the same rule (`occluded_layer_surface_ids`): one fully inside a single opaque
+window on the output's current workspace, or behind a fullscreen window, gets
+the 2 Hz trickle; every other layer surface is paced at the output refresh.
+The set is empty while exposé or show-desktop is active, since both put the
+desktop back on screen.
+
 ## Udev (DRM/GBM) backend — `src/udev/`
 
 This is the production loop, and the only one with real VBlank timing.

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -3,8 +3,8 @@ screen_scale = 1.0
 locales = ["en_US", "en"]  # Language preferences for app names/desktop entries, most specific first. Use standard locale identifiers with region codes (e.g., ["fr_FR", "fr"], ["zh_CN", "zh"]); matching falls back from region to bare language.
 
 # Occlusion culling: skip rendering of layers fully hidden behind opaque layers.
-# Improves GPU/CPU throughput when windows overlap. Disable if you see missing content.
-# occlusion_culling = false
+# Improves GPU/CPU throughput when windows overlap. On by default; disable if you see missing content.
+# occlusion_culling = true
 
 # Theme
 cursor_size = 24

--- a/specs/plane-scanout.md
+++ b/specs/plane-scanout.md
@@ -414,6 +414,12 @@ so seeding it alone would leave the window underneath sharp.
   never zero (Chromium's buffer-eviction heuristic blanks canvases when
   callbacks stop entirely). Union coverage is deliberately not computed;
   single-window containment cannot false-positive on partial visibility.
+  A window with a committed `ext-background-effect-v1` blur region is
+  translucent and never counts as a cover. `background`/`bottom`
+  layer-shell surfaces are classified the same way: fully inside one
+  opaque window (or behind a fullscreen one) on the output's current
+  workspace → 2 Hz, otherwise output refresh; never during exposé or
+  show-desktop.
 - Otto maintains a session-wide adaptive plane budget on top of the
   per-output decomposition decision above: it follows the kernel log for
   display-engine underrun reports and sheds plane usage globally when one

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,7 +81,7 @@ pub struct Config {
     pub keyboard_shortcuts: ShortcutMap,
     #[serde(default)]
     pub virtual_outputs: Vec<VirtualOutputConfig>,
-    #[serde(default)]
+    #[serde(default = "default_occlusion_culling")]
     pub occlusion_culling: bool,
     #[serde(default)]
     pub login: LoginConfig,
@@ -152,7 +152,7 @@ impl Default for Config {
             keyboard_shortcuts: shortcuts::default_shortcut_map(),
             shortcut_bindings: Vec::new(),
             virtual_outputs: Vec::new(),
-            occlusion_culling: false,
+            occlusion_culling: true,
             login: LoginConfig::default(),
             lock: LockConfig::default(),
             workspaces: WorkspacesConfig::default(),
@@ -1037,6 +1037,10 @@ fn default_accent_color() -> String {
 }
 
 fn default_rounded_corners() -> bool {
+    true
+}
+
+fn default_occlusion_culling() -> bool {
     true
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2630,10 +2630,12 @@ pub fn post_repaint<'a>(
         smithay::reexports::wayland_server::backend::ObjectId,
         window_throttle::WindowThrottleState,
     >,
+    occluded_layer_ids: &std::collections::HashSet<
+        smithay::reexports::wayland_server::backend::ObjectId,
+    >,
 ) {
     let time = time.into();
     let default_throttle = Duration::ZERO;
-    let layer_throttle = Some(Duration::ZERO);
 
     window_elements.iter().for_each(|window| {
         window.with_surfaces(|surface, states| {
@@ -2690,7 +2692,20 @@ pub fn post_repaint<'a>(
             }
         });
 
-        layer_surface.send_frame(output, time, layer_throttle, surface_primary_scanout_output);
+        // Background/bottom surfaces hidden behind a window get the same 2 Hz
+        // trickle as an occluded window (see `occluded_layer_surface_ids`);
+        // everything else paints at full rate.
+        let layer_throttle = if occluded_layer_ids.contains(&layer_surface.wl_surface().id()) {
+            window_throttle::WindowThrottleState::Occluded.throttle()
+        } else {
+            Duration::ZERO
+        };
+        layer_surface.send_frame(
+            output,
+            time,
+            Some(layer_throttle),
+            surface_primary_scanout_output,
+        );
         if let Some(dmabuf_feedback) = dmabuf_feedback {
             layer_surface.send_dmabuf_feedback(
                 output,

--- a/src/state/window_throttle.rs
+++ b/src/state/window_throttle.rs
@@ -22,7 +22,12 @@ use std::time::Duration;
 
 use std::time::Instant;
 
+use smithay::desktop::layer_map_for_output;
+use smithay::output::Output;
 use smithay::reexports::wayland_server::backend::ObjectId;
+use smithay::reexports::wayland_server::Resource;
+use smithay::utils::{Logical, Rectangle};
+use smithay::wayland::shell::wlr_layer::Layer as WlrLayer;
 
 use crate::shell::WindowElement;
 use crate::workspaces::Workspaces;
@@ -235,6 +240,106 @@ pub fn classify_windows(
     result
 }
 
+/// Whether a `background`/`bottom` layer-shell surface at `rect` is hidden by
+/// the windows on its output's current workspace. Same single-cover rule as
+/// `Workspaces::occluded_window_ids`: a fullscreen window covers everything
+/// beneath it, otherwise the surface must sit entirely inside one window —
+/// union coverage is not attempted, so a partially visible surface can never
+/// be misclassified. All rectangles are output-local logical.
+pub fn layer_surface_covered(
+    rect: Rectangle<i32, Logical>,
+    fullscreen: bool,
+    window_rects: &[Rectangle<i32, Logical>],
+) -> bool {
+    fullscreen || window_rects.iter().any(|w| w.contains_rect(rect))
+}
+
+/// Windows that show what is behind them and therefore never occlude: any
+/// surface in their tree committed an `ext-background-effect-v1` blur region
+/// (`Otto::background_effects`), so the wallpaper is visible through the
+/// frost and has to keep painting.
+#[allow(clippy::mutable_key_type)]
+pub fn translucent_window_ids(
+    windows: &[&WindowElement],
+    effect_surfaces: &HashSet<ObjectId>,
+) -> HashSet<ObjectId> {
+    if effect_surfaces.is_empty() {
+        return HashSet::new();
+    }
+    windows
+        .iter()
+        .filter(|w| {
+            let mut translucent = false;
+            w.with_surfaces(|surface, _| {
+                translucent |= effect_surfaces.contains(&surface.id());
+            });
+            translucent
+        })
+        .map(|w| w.id())
+        .collect()
+}
+
+/// The `background`/`bottom` layer-shell surfaces on `output` that no user can
+/// see because a window on that output's current workspace covers them. They
+/// get the Occluded frame-callback trickle in `post_repaint` — a live
+/// wallpaper or an animated desktop widget behind a maximized window would
+/// otherwise keep painting at full rate. `top`/`overlay` surfaces stack above
+/// windows and are never in this set. Windows in `translucent` (see
+/// [`translucent_window_ids`]) do not cover anything. Empty while exposé or
+/// show-desktop is active: both pull the windows away and put the desktop on
+/// screen.
+#[allow(clippy::mutable_key_type)]
+pub fn occluded_layer_surface_ids(
+    workspaces: &Workspaces,
+    output: &Output,
+    expose_active: bool,
+    translucent: &HashSet<ObjectId>,
+) -> HashSet<ObjectId> {
+    let mut occluded = HashSet::new();
+    if expose_active || workspaces.get_show_desktop() {
+        return occluded;
+    }
+    let Some(ows) = workspaces.output_workspaces.get(&output.name()) else {
+        return occluded;
+    };
+    let Some(space) = ows.spaces.get(ows.current_workspace) else {
+        return occluded;
+    };
+    let fullscreen = workspaces
+        .get_fullscreen_window_on_output(output)
+        .is_some_and(|w| !translucent.contains(&w.id()));
+    // Window locations are space-global; the layer map is output-local.
+    let origin = space
+        .output_geometry(output)
+        .map(|g| g.loc)
+        .unwrap_or_default();
+    let window_rects: Vec<Rectangle<i32, Logical>> = if fullscreen {
+        Vec::new()
+    } else {
+        space
+            .elements()
+            .filter(|w| !w.is_minimised() && !translucent.contains(&w.id()))
+            .filter_map(|w| {
+                let loc = space.element_location(w)?;
+                Some(Rectangle::new(loc - origin, w.geometry().size))
+            })
+            .collect()
+    };
+    let map = layer_map_for_output(output);
+    for layer in map
+        .layers()
+        .filter(|l| matches!(l.layer(), WlrLayer::Background | WlrLayer::Bottom))
+    {
+        let Some(geo) = map.layer_geometry(layer) else {
+            continue;
+        };
+        if layer_surface_covered(geo, fullscreen, &window_rects) {
+            occluded.insert(layer.wl_surface().id());
+        }
+    }
+    occluded
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,5 +539,34 @@ mod tests {
         assert!(!WindowThrottleState::Occluded.is_activated());
         assert!(!WindowThrottleState::Minimized.is_activated());
         assert!(!WindowThrottleState::HiddenWorkspace.is_activated());
+    }
+
+    fn rect(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, Logical> {
+        Rectangle::new((x, y).into(), (w, h).into())
+    }
+
+    #[test]
+    fn layer_surface_covered_by_single_window() {
+        let wallpaper = rect(0, 0, 1920, 1080);
+        let widget = rect(1500, 100, 300, 200);
+        let maximized = rect(0, 0, 1920, 1080);
+        let small = rect(100, 100, 800, 600);
+
+        // Maximized window hides both the wallpaper and the widget.
+        assert!(layer_surface_covered(wallpaper, false, &[maximized]));
+        assert!(layer_surface_covered(widget, false, &[maximized]));
+        // A small window hides neither: the wallpaper is bigger than it, the
+        // widget is outside it.
+        assert!(!layer_surface_covered(wallpaper, false, &[small]));
+        assert!(!layer_surface_covered(widget, false, &[small]));
+        // Two windows that together cover the widget do not count — only
+        // single-window containment is trusted.
+        let left = rect(1500, 100, 150, 200);
+        let right = rect(1650, 100, 150, 200);
+        assert!(!layer_surface_covered(widget, false, &[left, right]));
+        // Fullscreen covers everything regardless of the window list.
+        assert!(layer_surface_covered(wallpaper, true, &[]));
+        // Nothing above: visible.
+        assert!(!layer_surface_covered(wallpaper, false, &[]));
     }
 }

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -860,9 +860,7 @@ impl Otto<UdevData> {
         }
 
         // Classify every window into its visibility state so post_repaint can
-        // pick a per-window frame-callback throttle. `occluded_ids` is empty
-        // for v1 — we rely on the fullscreen detection inside the classifier
-        // for the main "background app behind a maximized window" case.
+        // pick a per-window frame-callback throttle.
         let expose_active = self.workspaces.mirrors_active();
         tracing::debug!(
             target: "otto::planes",
@@ -880,7 +878,15 @@ impl Otto<UdevData> {
         crate::render_phase_stats::log_if_due();
 
         #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
-        let occluded_ids = self.workspaces.occluded_window_ids();
+        let effect_surfaces: std::collections::HashSet<_> =
+            self.background_effects.keys().cloned().collect();
+        #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+        let translucent_ids = crate::state::window_throttle::translucent_window_ids(
+            &all_window_elements,
+            &effect_surfaces,
+        );
+        #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+        let occluded_ids = self.workspaces.occluded_window_ids(&translucent_ids);
         #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
         let captured_ids = crate::screenshare::screencast_window_ids(
             &self.screenshare_sessions,
@@ -898,6 +904,13 @@ impl Otto<UdevData> {
             expose_active,
             &captured_ids,
             &interacting_ids,
+        );
+        #[allow(clippy::mutable_key_type)] // ObjectId as key — see window_throttle.rs
+        let occluded_layer_ids = crate::state::window_throttle::occluded_layer_surface_ids(
+            &self.workspaces,
+            &output,
+            expose_active,
+            &translucent_ids,
         );
 
         // ── Shadow-only / direct scanout window selection ─────────────────────
@@ -1206,6 +1219,7 @@ impl Otto<UdevData> {
             &self.clock,
             scene_has_damage,
             &window_throttle_states,
+            &occluded_layer_ids,
             &mut self.pending_screencopy_frames,
             expose_active,
             fullscreen_window.as_ref(),
@@ -2273,6 +2287,9 @@ pub(super) fn render_output_frame<'a>(
         smithay::reexports::wayland_server::backend::ObjectId,
         crate::state::window_throttle::WindowThrottleState,
     >,
+    occluded_layer_ids: &std::collections::HashSet<
+        smithay::reexports::wayland_server::backend::ObjectId,
+    >,
     pending_screencopy: &mut Vec<crate::state::screencopy::PendingScreencopy>,
     expose_active: bool,
     fullscreen_window: Option<&WindowElement>,
@@ -2938,6 +2955,7 @@ pub(super) fn render_output_frame<'a>(
             }),
         clock.now(),
         window_throttle_states,
+        occluded_layer_ids,
     );
 
     if rendered {

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -718,6 +718,20 @@ pub fn run_winit() {
                                     &std::collections::HashSet::new(),
                                     &interacting_ids,
                                 );
+                            let effect_surfaces: std::collections::HashSet<_> =
+                                state.background_effects.keys().cloned().collect();
+                            let translucent_ids =
+                                crate::state::window_throttle::translucent_window_ids(
+                                    &all_window_elements,
+                                    &effect_surfaces,
+                                );
+                            let occluded_layer_ids =
+                                crate::state::window_throttle::occluded_layer_surface_ids(
+                                    &state.workspaces,
+                                    &output,
+                                    expose_active,
+                                    &translucent_ids,
+                                );
                             post_repaint(
                                 &output,
                                 &render_output_result.states,
@@ -725,6 +739,7 @@ pub fn run_winit() {
                                 None,
                                 time,
                                 &window_throttle_states,
+                                &occluded_layer_ids,
                             );
                         }
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -5328,9 +5328,12 @@ impl Workspaces {
     /// throttle classifier's Occluded bucket. Union coverage is deliberately
     /// not attempted: the single-cover case (a maximized or large window over
     /// smaller ones) is the one that matters, and containment in one window
-    /// cannot false-positive on a partially visible window.
+    /// cannot false-positive on a partially visible window. Windows in
+    /// `translucent` (blur-effect clients, see
+    /// `window_throttle::translucent_window_ids`) can be occluded but never
+    /// occlude: what is behind them shows through.
     #[allow(clippy::mutable_key_type)]
-    pub fn occluded_window_ids(&self) -> HashSet<ObjectId> {
+    pub fn occluded_window_ids(&self, translucent: &HashSet<ObjectId>) -> HashSet<ObjectId> {
         use smithay::utils::{Physical, Rectangle};
         let mut occluded = HashSet::new();
         let scale = Config::with(|c| c.screen_scale);
@@ -5362,7 +5365,9 @@ impl Workspaces {
             if above.iter().any(|a| a.contains_rect(rect)) {
                 occluded.insert(window.id());
             }
-            above.push(rect);
+            if !translucent.contains(&window.id()) {
+                above.push(rect);
+            }
         }
         occluded
     }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -487,6 +487,7 @@ pub fn run_x11() {
                             None,
                             time,
                             &window_throttle_states,
+                            &std::collections::HashSet::new(),
                         );
                     }
 


### PR DESCRIPTION
`background`/`bottom` layer-shell surfaces were sent frame callbacks at the
output refresh rate regardless of what covered them, so a live wallpaper or an
animated desktop widget kept painting at full rate under a maximized window.
They now get the same 2 Hz `Occluded` trickle a hidden window gets.

A window counts as a cover only when it is opaque. A client that committed an
`ext-background-effect-v1` blur region shows what is behind it through the
frost, so it can be occluded but never occludes — which also fixes the existing
window-to-window rule, where a blurred terminal (foot) on top was wrongly
demoting the windows behind it to 2 Hz.

Also flips `occlusion_culling` to default on. It was only ever exercised when
Otto was started from the repo directory, where the untracked local
`otto_config.toml` sets it; a greeter session ran with it off.

## Verified on hardware

udev backend on a Framework 13, with a `bottom` layer-shell probe that repaints
on every frame callback:

| scene | callbacks/s |
|---|---|
| uncovered | ~46 |
| `foot --maximized` on top (blur effect) | ~35 — not throttled |
| `weston-terminal --maximized` on top (opaque) | **2.0**, decaying as the desktop idles |
| that window closed | ~36 |

## Notes

- Single-cover rule only, matching `occluded_window_ids`: containment in one
  window cannot false-positive on a partially visible surface. Two windows that
  jointly cover a surface do not count.
- The set is empty during exposé and show-desktop, which put the desktop back
  on screen.
- `top`/`overlay` surfaces stack above windows and are never in the set.
- Computed on udev and winit; x11 passes an empty set, as it already does for
  the window classifier.
- Docs: `docs/developer/render_loop.md`, `specs/plane-scanout.md`.

https://claude.ai/code/session_016Bvc1qihe7SekodkntGvnK