### PR TITLE
Hairline token, window shadow corners, trash sounds, settings focus

### DIFF
--- a/components/otto-bar/src/bar.rs
+++ b/components/otto-bar/src/bar.rs
@@ -25,8 +25,41 @@ pub struct RightPanel {
     pub height: f32,
 }
 
+/// Colours for a highlighted bar item (hover and active/open).
+///
+/// The bar sits over the wallpaper blur: a black scrim disappears against a
+/// dark backdrop, so in dark mode the pill is a translucent white veil — light
+/// enough to read as selected, sheer enough that the blur still shows through
+/// and the label stays white.
+struct HighlightColors {
+    hover: skia_safe::Color,
+    active: skia_safe::Color,
+    on_active: skia_safe::Color,
+}
+
+fn highlight_colors() -> HighlightColors {
+    let dark = matches!(
+        otto_kit::color_scheme::current_color_scheme(),
+        otto_kit::theme::ColorScheme::Dark
+    );
+    if dark {
+        HighlightColors {
+            hover: skia_safe::Color::from_argb(0x1A, 255, 255, 255),
+            active: skia_safe::Color::from_argb(0x40, 255, 255, 255),
+            on_active: skia_safe::Color::from_argb(0xF2, 255, 255, 255),
+        }
+    } else {
+        HighlightColors {
+            hover: skia_safe::Color::from_argb(30, 0, 0, 0),
+            active: skia_safe::Color::from_argb(80, 0, 0, 0),
+            on_active: skia_safe::Color::WHITE,
+        }
+    }
+}
+
 fn tray_menu_style() -> MenuBarStyle {
     let theme = AppContext::current_theme();
+    let hl = highlight_colors();
     MenuBarStyle {
         height: BAR_HEIGHT as f32,
         item_padding_horizontal: 3.0,
@@ -36,11 +69,11 @@ fn tray_menu_style() -> MenuBarStyle {
         icon_text_gap: 0.0,
         background_color: skia_safe::Color::TRANSPARENT,
         text_color: theme.text_primary,
-        text_active_color: skia_safe::Color::WHITE,
-        hover_color: skia_safe::Color::from_argb(30, 0, 0, 0),
-        active_color: skia_safe::Color::from_argb(80, 0, 0, 0),
+        text_active_color: hl.on_active,
+        hover_color: hl.hover,
+        active_color: hl.active,
         icon_tint: theme.text_primary,
-        icon_active_tint: skia_safe::Color::WHITE,
+        icon_active_tint: hl.on_active,
         font_size: 13.0,
         font_weight: skia_safe::font_style::Weight::SEMI_BOLD,
         item_corner_radius: 4.0,
@@ -49,6 +82,7 @@ fn tray_menu_style() -> MenuBarStyle {
 
 fn left_menu_style() -> MenuBarStyle {
     let theme = AppContext::current_theme();
+    let hl = highlight_colors();
     MenuBarStyle {
         height: BAR_HEIGHT as f32,
         item_padding_horizontal: 8.0,
@@ -58,11 +92,11 @@ fn left_menu_style() -> MenuBarStyle {
         icon_text_gap: 6.0,
         background_color: skia_safe::Color::TRANSPARENT,
         text_color: theme.text_primary,
-        text_active_color: skia_safe::Color::WHITE,
-        hover_color: skia_safe::Color::from_argb(30, 0, 0, 0),
-        active_color: skia_safe::Color::from_argb(80, 0, 0, 0),
+        text_active_color: hl.on_active,
+        hover_color: hl.hover,
+        active_color: hl.active,
         icon_tint: theme.text_primary,
-        icon_active_tint: skia_safe::Color::WHITE,
+        icon_active_tint: hl.on_active,
         font_size: 13.0,
         font_weight: skia_safe::font_style::Weight::BOLD,
         item_corner_radius: 4.0,

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -73,8 +73,23 @@ const DRAG_THRESHOLD: f32 = 6.0;
 /// installed theme actually has is the one that plays.
 const SOUND_ARRIVED: [&str; 3] = ["drag-accept", "device-added", "complete"];
 
-/// Files went away — a delete, or an undo that took a copy back.
-const SOUND_REMOVED: [&str; 2] = ["trash-empty", "device-removed"];
+/// Files went away — a move to the Trash, or an undo that took a copy back.
+///
+/// `file-trash` is the naming spec's own name for this and comes first even
+/// though no theme here ships it: a theme that does should win, and the
+/// fallbacks are what cover the ones that do not. Deliberately not
+/// `trash-empty`, which the spec reserves for the bin actually being emptied.
+const SOUND_REMOVED: [&str; 3] = ["file-trash", "item-deleted", "device-removed"];
+
+/// Files were destroyed — the Trash emptied, or a Delete Forever.
+const SOUND_DESTROYED: [&str; 3] = ["trash-empty", "item-deleted", "device-removed"];
+
+/// Files came back out of the Trash.
+///
+/// Its own sound rather than the arriving one: a put-back is the answer to a
+/// delete, and hearing the delete undone is worth more than hearing it as one
+/// more paste. The naming spec has nothing for it, so this is borrowed.
+const SOUND_RESTORED: [&str; 2] = ["complete", "device-added"];
 
 /// One undoable operation: what to call it, and everything it did.
 ///
@@ -3320,9 +3335,22 @@ impl Browser {
     /// restore, and a restore moves files back into place, so it gets the
     /// arriving sound. Undoing a copy takes files away, and gets the other
     /// one. An operation that did nothing stays quiet.
+    ///
+    /// Destroying is heard apart from deleting, and putting back apart from
+    /// pasting, because those are the pairs a user tells apart by ear: the
+    /// delete that can be taken back sounds different from the one that
+    /// cannot, and the sound that answers a delete is the put-back.
+    ///
+    /// Ordered most specific first. An operation counts under one heading in
+    /// practice, but a mixed outcome should be named by the part that cannot
+    /// be undone.
     fn play_op_sound(result: &model::OpResult) {
-        if result.trashed > 0 {
+        if result.deleted > 0 {
+            otto_kit::sound::play_first(&SOUND_DESTROYED);
+        } else if result.trashed > 0 {
             otto_kit::sound::play_first(&SOUND_REMOVED);
+        } else if result.restored > 0 {
+            otto_kit::sound::play_first(&SOUND_RESTORED);
         } else if result.moved + result.copied > 0 {
             otto_kit::sound::play_first(&SOUND_ARRIVED);
         }
@@ -6868,6 +6896,18 @@ fn run_app(
     picker_queue: Option<crate::dbus::SharedQueue>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(Mutex::new(browser));
+
+    // Resolve the file-operation sounds off the main thread now, so the first
+    // delete of the session does not pay for a walk of every theme directory
+    // at the moment it wants to make a noise.
+    let sounds: Vec<&str> = SOUND_DESTROYED
+        .iter()
+        .chain(SOUND_REMOVED.iter())
+        .chain(SOUND_RESTORED.iter())
+        .chain(SOUND_ARRIVED.iter())
+        .copied()
+        .collect();
+    otto_kit::sound::prewarm(&sounds);
 
     let app = FilesApp {
         pane_surfaces: None,

--- a/components/otto-kit/src/components/color_picker/panel.rs
+++ b/components/otto-kit/src/components/color_picker/panel.rs
@@ -290,10 +290,11 @@ pub fn draw(
     selected_field: Option<HexField>,
     theme: &Theme,
 ) {
-    canvas.draw_rrect(
-        RRect::new_rect_xy(rect, CORNER_RADIUS, CORNER_RADIUS),
-        &fill(theme.material_popup),
-    );
+    let body = RRect::new_rect_xy(rect, CORNER_RADIUS, CORNER_RADIUS);
+    canvas.draw_rrect(body, &fill(theme.material_popup));
+    // The same hairline a menu and a window carry: the panel floats over
+    // arbitrary content and needs its shape closed against it.
+    canvas.draw_rrect(body, &stroke(theme.hairline(), Theme::HAIRLINE_WIDTH));
 
     draw_switcher(canvas, rect, mode, theme);
 

--- a/components/otto-kit/src/components/context_menu/style.rs
+++ b/components/otto-kit/src/components/context_menu/style.rs
@@ -221,8 +221,15 @@ impl ContextMenuStyle {
         self.theme.material_popup
     }
 
-    /// Get the border color from theme — lighter than the background for definition
+    /// Get the border color from theme.
+    ///
+    /// The edge is only there to separate the popup from whatever it floats
+    /// over: `fill_primary` (0x35 black in the light scheme) drew a hairline
+    /// dark enough to read as a deliberate outline once the menu landed on
+    /// busy content. The shared [`Theme::hairline`] — `fill_secondary` — still
+    /// defines the shape against a light backdrop without ringing it, and is
+    /// the same line windows and panels are framed with.
     pub fn border_color(&self) -> skia_safe::Color {
-        self.theme.fill_primary
+        self.theme.hairline()
     }
 }

--- a/components/otto-kit/src/components/window/application_window.rs
+++ b/components/otto-kit/src/components/window/application_window.rs
@@ -76,7 +76,10 @@ impl ApplicationWindow {
         if let Some(layer) = surface.surface_style() {
             // layer.set_background_color(0.6, 0.6, 0.6, 0.0);
             // layer.set_blend_mode(BlendMode::BackgroundBlur);
-            layer.set_border(2.0, 1.0, 1.0, 1.0, 0.6);
+            // The window is edged with the same hairline as a menu or a panel
+            // rather than the flat white 2px it used to carry, which read as a
+            // frame of its own on a light desktop.
+            crate::surfaces::apply_hairline_border(layer);
             layer.set_corner_radius(crate::corners::radius(36.0) as f64);
             layer.set_masks_to_bounds(otto_surface_style_v1::ClipMode::Enabled);
         }

--- a/components/otto-kit/src/components/window/mod.rs
+++ b/components/otto-kit/src/components/window/mod.rs
@@ -16,10 +16,11 @@ use wayland_client::Proxy;
 
 pub use application_window::{ApplicationWindow, WindowLayout};
 
-/// Default layer augmentation - applies rounded corners
+/// Default layer augmentation - rounded corners and the palette's hairline
 fn default_layer_augmentation(layer: &otto_surface_style_v1::OttoSurfaceStyleV1) {
     layer.set_corner_radius(crate::corners::radius(16.0) as f64);
     layer.set_masks_to_bounds(otto_surface_style_v1::ClipMode::Enabled);
+    crate::surfaces::apply_hairline_border(layer);
 }
 
 type CanvasDrawFn = Arc<Mutex<Option<Box<dyn FnMut(&skia_safe::Canvas) + Send>>>>;

--- a/components/otto-kit/src/surfaces/common.rs
+++ b/components/otto-kit/src/surfaces/common.rs
@@ -9,6 +9,48 @@ pub use crate::protocols::{otto_surface_style_manager_v1, otto_surface_style_v1}
 
 use crate::{rendering::SkiaSurface, AppContext};
 
+/// Frame a styled surface with the palette's hairline.
+///
+/// The compositor strokes it inside the surface bounds, so it follows the
+/// corner radius and costs the client nothing to draw — and it is the same
+/// line [`crate::theme::Theme::hairline`] puts around a menu, so a window and the
+/// menu it opens are edged alike.
+///
+/// `OTTO_KIT_HAIRLINE` overrides the line while the look is being tuned:
+/// `#RRGGBBAA` for a colour, or a bare number for a width in device pixels
+/// (`#00000040` / `2`). Unset, or unparseable, leaves the palette alone.
+pub fn apply_hairline_border(style: &otto_surface_style_v1::OttoSurfaceStyleV1) {
+    let mut color = AppContext::current_theme().hairline();
+    let mut width = crate::theme::Theme::HAIRLINE_WIDTH;
+    if let Ok(spec) = std::env::var("OTTO_KIT_HAIRLINE") {
+        if let Some(hex) = spec.strip_prefix('#') {
+            if let Ok(argb) = u32::from_str_radix(hex, 16) {
+                let (r, g, b, a) = (
+                    argb >> 24,
+                    (argb >> 16) & 0xFF,
+                    (argb >> 8) & 0xFF,
+                    argb & 0xFF,
+                );
+                color = skia_safe::Color::from_argb(a as u8, r as u8, g as u8, b as u8);
+            }
+        } else if let Ok(w) = spec.parse::<f32>() {
+            width = w;
+        }
+    }
+    // Doubled on the way out: the compositor strokes the border centred on the
+    // surface bounds, and every window that asks for this also clips itself to
+    // them (`set_masks_to_bounds`), so the outer half is thrown away. Asking
+    // for twice the width is what makes the surviving inner half the hairline
+    // that was asked for.
+    style.set_border(
+        (width * 2.0) as f64,
+        color.r() as f64 / 255.0,
+        color.g() as f64 / 255.0,
+        color.b() as f64 / 255.0,
+        color.a() as f64 / 255.0,
+    );
+}
+
 /// Core surface with all rendering functionality built-in
 ///
 /// This struct contains the common fields and methods used by

--- a/components/otto-kit/src/surfaces/common.rs
+++ b/components/otto-kit/src/surfaces/common.rs
@@ -15,28 +15,9 @@ use crate::{rendering::SkiaSurface, AppContext};
 /// corner radius and costs the client nothing to draw — and it is the same
 /// line [`crate::theme::Theme::hairline`] puts around a menu, so a window and the
 /// menu it opens are edged alike.
-///
-/// `OTTO_KIT_HAIRLINE` overrides the line while the look is being tuned:
-/// `#RRGGBBAA` for a colour, or a bare number for a width in device pixels
-/// (`#00000040` / `2`). Unset, or unparseable, leaves the palette alone.
 pub fn apply_hairline_border(style: &otto_surface_style_v1::OttoSurfaceStyleV1) {
-    let mut color = AppContext::current_theme().hairline();
-    let mut width = crate::theme::Theme::HAIRLINE_WIDTH;
-    if let Ok(spec) = std::env::var("OTTO_KIT_HAIRLINE") {
-        if let Some(hex) = spec.strip_prefix('#') {
-            if let Ok(argb) = u32::from_str_radix(hex, 16) {
-                let (r, g, b, a) = (
-                    argb >> 24,
-                    (argb >> 16) & 0xFF,
-                    (argb >> 8) & 0xFF,
-                    argb & 0xFF,
-                );
-                color = skia_safe::Color::from_argb(a as u8, r as u8, g as u8, b as u8);
-            }
-        } else if let Ok(w) = spec.parse::<f32>() {
-            width = w;
-        }
-    }
+    let color = AppContext::current_theme().hairline();
+    let width = crate::theme::Theme::HAIRLINE_WIDTH;
     // Doubled on the way out: the compositor strokes the border centred on the
     // surface bounds, and every window that asks for this also clips itself to
     // them (`set_masks_to_bounds`), so the outer half is thrown away. Asking

--- a/components/otto-kit/src/surfaces/mod.rs
+++ b/components/otto-kit/src/surfaces/mod.rs
@@ -6,7 +6,7 @@ pub mod session_lock;
 pub mod subsurface;
 pub mod toplevel;
 
-pub use common::{BaseWaylandSurface, SurfaceError};
+pub use common::{apply_hairline_border, BaseWaylandSurface, SurfaceError};
 pub use dockitem::DockItem;
 pub use layer_shell::LayerShellSurface;
 pub use popup::PopupSurface;

--- a/components/otto-kit/src/theme.rs
+++ b/components/otto-kit/src/theme.rs
@@ -57,9 +57,40 @@ pub struct Theme {
 
     // Shadow
     pub shadow: Color,
+
+    /// The hairline around a floating surface. See [`Theme::hairline`].
+    pub hairline: Color,
 }
 
 impl Theme {
+    /// The hairline that separates a floating surface — a menu, a window, a
+    /// panel — from whatever it happens to sit over.
+    ///
+    /// One token for all of them, so the frame around a menu and the frame
+    /// around the window it opened from are the same line — and the same one
+    /// the compositor's own chrome draws, which is why it is a token of its
+    /// own rather than `fill_secondary`: the two schemes need different
+    /// alphas to land at the same weight — 10% black carries about as far on
+    /// a bright backdrop as 8% white does on a dark one — and a window edged
+    /// differently from the dock beside it reads as two lines, not one.
+    ///
+    /// Deliberately faint either way: the edge is there to close the shape,
+    /// not to outline it, and anything stronger rings the surface once it
+    /// lands on busy content.
+    pub fn hairline(&self) -> Color {
+        self.hairline
+    }
+
+    /// Width of that hairline.
+    ///
+    /// One logical point, which is what a hairline is meant to be. A
+    /// surface-style border is scaled by the compositor like the corner
+    /// radius, so this is the same line whatever the output scale — asking
+    /// for one device pixel instead left HiDPI windows edged half as thickly
+    /// as the dock beside them. Client-side draws (a panel painting its own
+    /// body) are in the same units as the rest of their canvas.
+    pub const HAIRLINE_WIDTH: f32 = 1.0;
+
     /// Light theme, with the user's accent folded in.
     pub fn light() -> Self {
         Self::light_palette().with_system_accent()
@@ -99,6 +130,8 @@ impl Theme {
             material_selection_focused: Color::from_argb(0xBF, 0x0A, 0x82, 0xFF),
 
             shadow: Color::from_argb(0x66, 0x1B, 0x1B, 0x1B),
+
+            hairline: Color::from_argb(0x1A, 0x00, 0x00, 0x00),
         }
     }
 
@@ -128,6 +161,8 @@ impl Theme {
             material_selection_focused: Color::from_argb(0xBF, 0x0A, 0x82, 0xFF),
 
             shadow: Color::from_argb(0x99, 0x00, 0x00, 0x00),
+
+            hairline: Color::from_argb(0x14, 0xFF, 0xFF, 0xFF),
         }
     }
 

--- a/components/otto-settings/src/main.rs
+++ b/components/otto-settings/src/main.rs
@@ -113,6 +113,14 @@ struct SettingsApp {
     /// desktop showing sharp through the sidebar. Shared with the draw
     /// closure, which is why it is an atomic rather than a plain flag.
     frosted: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether this is the focused window.
+    ///
+    /// Activation arrives on a configure, and everything the chrome draws in
+    /// the accent — the selected sidebar row, the switches, the traffic
+    /// lights — steps back with it. Kept apart from `frosted` because a
+    /// window with no blur at all still has to draw its background state.
+    /// Shared with the draw closure, hence the atomic.
+    active: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// A text field with the keyboard: what it edits, and the live editor.
@@ -1000,7 +1008,8 @@ impl SettingsApp {
             &self.hovered_preview,
         )
         .with_open_dropdown(*self.open_dropdown.lock().unwrap())
-        .with_open_picker(*self.open_picker.lock().unwrap());
+        .with_open_picker(*self.open_picker.lock().unwrap())
+        .with_active(self.active.load(std::sync::atomic::Ordering::Relaxed));
 
         let mut scroll = self.scroll.lock().unwrap();
         // The scroll view drives surfaces that live inside the pane, so its
@@ -1409,12 +1418,14 @@ impl App for SettingsApp {
         let size = self.size.clone();
         let controls = self.controls.clone();
         let frosted = self.frosted.clone();
+        let active = self.active.clone();
         window.on_draw(move |canvas| {
             let index = *selected.lock().unwrap();
             let (w, h) = *size.lock().unwrap();
             Settings::new(index, current_color_scheme() == ColorScheme::Dark)
                 .with_size(w, h)
                 .with_blur(frosted.load(std::sync::atomic::Ordering::Relaxed))
+                .with_active(active.load(std::sync::atomic::Ordering::Relaxed))
                 .with_controls(*controls.lock().unwrap())
                 .render_chrome(canvas);
         });
@@ -1971,12 +1982,24 @@ impl App for SettingsApp {
         // is a frost behind its materials. A configure that changes nothing
         // else still has to repaint the sidebar, which is why this runs before
         // the size early-out below.
-        let frosted = window.background_blur() && window.is_activated();
-        if self
+        let activated = window.is_activated();
+        let frosted = window.background_blur() && activated;
+        let mut repaint = self
             .frosted
             .swap(frosted, std::sync::atomic::Ordering::Relaxed)
-            != frosted
+            != frosted;
+        if self
+            .active
+            .swap(activated, std::sync::atomic::Ordering::Relaxed)
+            != activated
         {
+            // The pane draws in the accent too — a switch that is on, a
+            // slider's fill — so losing focus repaints the band as well as
+            // the chrome.
+            mark_pane_dirty(&self.pane_dirty);
+            repaint = true;
+        }
+        if repaint {
             window.request_frame();
         }
         // A configure with no size is the compositor letting the client
@@ -2449,6 +2472,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         hovered_preview: Arc::new(Mutex::new(None)),
         modifiers: Arc::new(Mutex::new(Mods::default())),
         frosted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        active: Arc::new(std::sync::atomic::AtomicBool::new(true)),
     })
     .run()?;
     Ok(())

--- a/components/otto-settings/src/view.rs
+++ b/components/otto-settings/src/view.rs
@@ -684,6 +684,10 @@ pub struct Settings {
     /// Whether the surface carries compositor background blur, so the sidebar
     /// can be painted as a translucent material rather than a flat fill.
     pub blurred: bool,
+    /// Whether this is the focused window. A background one steps back: its
+    /// traffic lights go grey, its title drops a shade, and the accent drains
+    /// out of everything that follows it — see [`Self::with_active`].
+    pub active: bool,
     /// The button under a held pointer, drawn pressed. See [`Pressed`].
     pub pressed: Option<Pressed>,
     /// The file row whose preview the pointer is over, so that preview can
@@ -715,6 +719,7 @@ impl Settings {
             open_picker: None,
             toggle_flips: HashMap::new(),
             blurred: false,
+            active: true,
             pressed: None,
             hovered_preview: None,
             controls: WindowControlsState::new(),
@@ -740,6 +745,19 @@ impl Settings {
     /// The surface has compositor blur behind it.
     pub fn with_blur(mut self, blurred: bool) -> Self {
         self.blurred = blurred;
+        self
+    }
+
+    /// Whether the window is the focused one.
+    ///
+    /// A window in the background mutes its accent, so the selected sidebar
+    /// row, the switches that are on and every other accented control stop
+    /// competing with the window the user is actually working in.
+    pub fn with_active(mut self, active: bool) -> Self {
+        self.active = active;
+        if !active {
+            self.theme.with_muted_accent();
+        }
         self
     }
 
@@ -1452,8 +1470,11 @@ impl Settings {
         // controls at the trailing edge, over the far end of the pane. The
         // pane name titles the bar either way.
         let group = TitlebarGroup::new().add(
-            self.controls
-                .apply(window_controls().with_active(true).with_dark(self.dark)),
+            self.controls.apply(
+                window_controls()
+                    .with_active(self.active)
+                    .with_dark(self.dark),
+            ),
         );
         let bar = Titlebar::new()
             .at(0.0, 0.0)
@@ -1477,7 +1498,11 @@ impl Settings {
             SIDEBAR_W + CONTENT_PAD,
             TITLEBAR_H / 2.0,
             styles::TITLE_3_EMPHASIZED,
-            self.theme.text_primary,
+            if self.active {
+                self.theme.text_primary
+            } else {
+                self.theme.text_secondary
+            },
         );
 
         // Hairline under the bar, separating it from the pane. Like the

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -639,17 +639,33 @@ browser sounds like part of the desktop rather than like an application with
 opinions about audio. Otto publishes the theme name over the settings portal
 (`org.gnome.desktop.sound theme-name`) and otto-kit plays through it.
 
-The sound follows the **effect**, not the command:
+The sound follows the **effect**, not the command, and the outcomes a user
+tells apart by ear get sounds of their own:
 
 | Outcome | Sound |
 | --- | --- |
-| files arrived — a paste, a drop, a restore | `drag-accept`, else `device-added`, else `complete` |
-| files went away — a delete, or an undo that took a copy back | `trash-empty`, else `device-removed` |
+| files were destroyed — the Trash emptied, or a Delete Forever | `trash-empty`, else `item-deleted`, else `device-removed` |
+| files went to the Trash, or an undo took a copy back | `file-trash`, else `item-deleted`, else `device-removed` |
+| files came back out of the Trash — a put-back | `complete`, else `device-added` |
+| files arrived — a paste, a drop | `drag-accept`, else `device-added`, else `complete` |
 | nothing happened | silence |
 
+The rows are tried in that order, so a mixed outcome is named by the part that
+cannot be undone.
+
+Destroying is heard apart from deleting because one can be taken back and the
+other cannot, and a put-back is heard apart from a paste because it is the
+answer to a delete rather than one more arrival. `trash-empty` is reserved for
+the bin actually being emptied, which is what the naming spec means by it.
+
+`file-trash` and `item-deleted` lead their rows as the spec's own names for
+those effects even though the common themes ship neither — a theme that has
+them should win, and the fallbacks are what cover the ones that do not. The
+spec has no name at all for a put-back, so that row is borrowed throughout.
+
 Choosing from the outcome is what makes undo sound right with no special case:
-undoing a delete is a restore, so it gets the arriving sound; undoing a copy
-takes files away, so it gets the other one.
+undoing a delete is a restore, so it gets the put-back sound; undoing a copy
+takes files away, so it gets the removal one.
 
 The preference order exists because the sound naming spec is thinner than a
 desktop needs — there is no "paste" event — and theme coverage of the drag

--- a/specs/topbar.md
+++ b/specs/topbar.md
@@ -38,7 +38,7 @@ The Top Bar is a persistent, full-width panel anchored to the top edge of the pr
    - **Drop shadow**: `set_shadow` with a soft downward offset to lift the bar off the desktop.
    - **Border**: `set_border` with a subtle 1 logical-point separator at the bottom edge using a theme-adaptive color.
 5. The bar's background fill color (drawn by Skia onto the surface before compositing) uses a semi-transparent material color from otto-kit's `Theme`, chosen based on the active color scheme.
-6. The bar adapts to system light/dark mode by reading `org.freedesktop.appearance color-scheme` from the XDG Settings portal (`org.freedesktop.portal.Settings`). It listens for `SettingChanged` signals and re-applies theme colors within one second. Color scheme values: `0` = no preference (follow otto-kit `Theme` default), `1` = prefer dark, `2` = prefer light.
+6. The bar adapts to system light/dark mode by reading `org.freedesktop.appearance color-scheme` from the XDG Settings portal (`org.freedesktop.portal.Settings`). It listens for `SettingChanged` signals and re-applies theme colors within one second. Color scheme values: `0` = no preference (follow otto-kit `Theme` default), `1` = prefer dark, `2` = prefer light. Bar item highlights (hover and open-menu) follow the same scheme: a dark translucent pill in light mode, a translucent white one in dark mode, so the highlight stays legible against the blurred wallpaper either way. Labels and icons stay white on the pill in both.
 
 ### Layout: Three Zones
 

--- a/src/surface_style/handlers/style.rs
+++ b/src/surface_style/handlers/style.rs
@@ -288,7 +288,12 @@ impl<BackendData: Backend> Dispatch<OttoSurfaceStyleV1, OttoLayerUserData> for O
                 blue,
                 alpha,
             } => {
-                let width = wl_fixed_to_f32(width);
+                // Logical points on the wire, like the corner radius: a
+                // client asking for a one-point hairline was getting a single
+                // device pixel, which on a 2x output is half the line the
+                // compositor's own chrome draws beside it.
+                let screen_scale = Config::with(|c| c.screen_scale) as f32;
+                let width = wl_fixed_to_f32(width) * screen_scale;
                 let red = wl_fixed_to_f32(red);
                 let green = wl_fixed_to_f32(green);
                 let blue = wl_fixed_to_f32(blue);

--- a/src/theme/colors_dark.rs
+++ b/src/theme/colors_dark.rs
@@ -65,4 +65,5 @@ define_colors!(COLORS, {
     materials_controls_fullscreen => "#28282880",
     materials_controls_hud => "#28282880",
     shadow_color => "#0e0e0e88",
+    hairline => "#FFFFFF14",
 });

--- a/src/theme/colors_light.rs
+++ b/src/theme/colors_light.rs
@@ -73,4 +73,5 @@ define_colors!(COLORS, {
     materials_controls_fullscreen => "#28282880",
     materials_controls_hud => "#28282880",
     shadow_color => "#1b1b1b66",
+    hairline => "#0000001A",
 });

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -112,6 +112,10 @@ pub struct ThemeColors {
     pub materials_controls_fullscreen: Color,
     pub materials_controls_hud: Color,
     pub shadow_color: Color,
+    /// The line that closes the edge of a floating surface — the dock bar, a
+    /// label balloon, a menu. Matches otto-kit's `Theme::hairline`, so a
+    /// window the compositor frames and the dock beside it draw the same line.
+    pub hairline: Color,
 }
 
 mod colors_dark;

--- a/src/workspaces/dock/render.rs
+++ b/src/workspaces/dock/render.rs
@@ -500,6 +500,9 @@ pub fn setup_label(new_layer: &Layer, label_text: String, position: DockPosition
         // The palette's tooltip material, so the balloon follows the scheme
         // like the rest of the chrome instead of sitting on one fixed grey.
         .background_color(theme_colors().materials_controls_tooltip)
+        // The hairline follows the balloon path, arrow included.
+        .border_width((otto_kit::theme::Theme::HAIRLINE_WIDTH * scale, None))
+        .border_color(theme_colors().hairline)
         .position(match arrow {
             BalloonArrow::Bottom => Point {
                 x: -label_size_width / 2.0,

--- a/src/workspaces/dock/view.rs
+++ b/src/workspaces/dock/view.rs
@@ -298,8 +298,9 @@ impl DockView {
             })
             .blend_mode(BlendMode::BackgroundBlur)
             .background_color(theme_colors().materials_medium)
-            .border_width((1.0 * draw_scale, None))
-            .border_color(theme_colors().materials_highlight)
+            // The same hairline the menus and the labels carry.
+            .border_width((otto_kit::theme::Theme::HAIRLINE_WIDTH * draw_scale, None))
+            .border_color(theme_colors().hairline)
             .shadow_color(theme_colors().shadow_color)
             .shadow_offset(((0.0, 0.0).into(), None))
             .shadow_radius((20.0, None))

--- a/src/workspaces/window_view/mod.rs
+++ b/src/workspaces/window_view/mod.rs
@@ -229,3 +229,69 @@ mod drag_damage_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod shadow_coverage_tests {
+    use super::render::{paint_window_shadow, SAFE_AREA};
+
+    /// Darkness the shadow lays down at `(x, y)` of the band, 0.0-1.0.
+    fn shadow_at(surface: &mut layers::skia::Surface, x: i32, y: i32) -> f32 {
+        let image = surface.image_snapshot();
+        let mut pixels = vec![0u8; 4];
+        let info = layers::skia::ImageInfo::new(
+            (1, 1),
+            layers::skia::ColorType::RGBA8888,
+            layers::skia::AlphaType::Premul,
+            None,
+        );
+        assert!(
+            image.read_pixels(
+                &info,
+                &mut pixels,
+                4,
+                (x, y),
+                layers::skia::image::CachingHint::Allow
+            ),
+            "no pixel at ({x}, {y})"
+        );
+        pixels[3] as f32 / 255.0
+    }
+
+    /// The window's top corners have to sit in shadow like every other corner.
+    ///
+    /// The outer pass is offset downwards to read as a light from above, which
+    /// once left the top of the window with nothing but a 3px inner line — on
+    /// a bright wallpaper the top corners looked cut out rather than lit. The
+    /// ambient pass is what closes that, so hold it here: a point just outside
+    /// the top-left corner must be within a third of the shadow the matching
+    /// point outside the bottom-left corner gets.
+    #[test]
+    fn top_corners_are_reached_by_the_shadow() {
+        let (w, h) = (600.0_f32, 400.0_f32);
+        let mut surface = layers::skia::surfaces::raster_n32_premul((
+            (w + SAFE_AREA * 2.0) as i32,
+            (h + SAFE_AREA * 2.0) as i32,
+        ))
+        .unwrap();
+        paint_window_shadow(
+            surface.canvas(),
+            w + SAFE_AREA * 2.0,
+            h + SAFE_AREA * 2.0,
+            true,
+            1.0,
+        );
+
+        // 6px diagonally out from each corner of the window box, which starts
+        // at (SAFE_AREA, SAFE_AREA) and is inset by the 24px corner radius.
+        let inset = 24.0 - 24.0 * std::f32::consts::FRAC_1_SQRT_2;
+        let out = (SAFE_AREA + inset - 6.0) as i32;
+        let top = shadow_at(&mut surface, out, out);
+        let bottom = shadow_at(&mut surface, out, (SAFE_AREA + h - inset + 6.0) as i32);
+
+        assert!(bottom > 0.0, "bottom corner has no shadow at all");
+        assert!(
+            top > bottom / 3.0,
+            "top corner is barely in shadow: {top:.3} against {bottom:.3} at the bottom"
+        );
+    }
+}

--- a/src/workspaces/window_view/render.rs
+++ b/src/workspaces/window_view/render.rs
@@ -101,6 +101,87 @@ pub fn view_window_decoration(
         .unwrap()
 }
 
+/// How far the shadow band reaches outside the window box on every side.
+pub(crate) const SAFE_AREA: f32 = 100.0;
+
+/// Paint the shadow band a window sits in, into a canvas `SAFE_AREA` larger
+/// than the window on every side.
+///
+/// Split out of the view so a test can look at the pixels: the passes below
+/// are the only thing that decides whether a corner is reached.
+pub(crate) fn paint_window_shadow(
+    canvas: &layers::skia::Canvas,
+    w: f32,
+    h: f32,
+    is_active: bool,
+    draw_scale: f32,
+) {
+    // draw shadow with different opacity based on activation state
+    let window_corner_radius = 24.0 * draw_scale;
+    let rect = layers::skia::Rect::from_xywh(
+        SAFE_AREA,
+        SAFE_AREA,
+        w - SAFE_AREA * 2.0,
+        h - SAFE_AREA * 2.0,
+    );
+
+    let rrect = layers::skia::RRect::new_rect_xy(rect, window_corner_radius, window_corner_radius);
+    canvas.clip_rrect(rrect, layers::skia::ClipOp::Difference, false);
+
+    // Inner shadow - lighter for active, very light for inactive
+    let inner_opacity = if is_active { 0.25 } else { 0.08 };
+    let mut shadow_paint = layers::skia::Paint::new(
+        layers::skia::Color4f::new(0.0, 0.0, 0.0, inner_opacity),
+        None,
+    );
+    shadow_paint.set_mask_filter(layers::skia::MaskFilter::blur(
+        layers::skia::BlurStyle::Normal,
+        3.0,
+        false,
+    ));
+    canvas.draw_rrect(rrect, &shadow_paint);
+
+    // Ambient shadow - no offset, so the top edge and the two top corners
+    // get a falloff of their own. The outer pass below is pushed down to
+    // read as a light from above, which leaves everything above the window
+    // with nothing but the 3px inner line: the corners came out bare
+    // against a bright wallpaper.
+    let ambient_opacity = if is_active { 0.18 } else { 0.07 };
+    shadow_paint.set_mask_filter(layers::skia::MaskFilter::blur(
+        layers::skia::BlurStyle::Normal,
+        14.0 * draw_scale,
+        false,
+    ));
+    shadow_paint.set_color4f(
+        layers::skia::Color4f::new(0.0, 0.0, 0.0, ambient_opacity),
+        None,
+    );
+    canvas.draw_rrect(rrect, &shadow_paint);
+
+    // Outer shadow - stronger for active, very light for inactive
+    let rect = layers::skia::Rect::from_xywh(
+        SAFE_AREA,
+        SAFE_AREA + 20.0 * draw_scale,
+        w - SAFE_AREA * 2.0,
+        h - SAFE_AREA * 2.0,
+    );
+    let rrect = layers::skia::RRect::new_rect_xy(rect, window_corner_radius, window_corner_radius);
+    shadow_paint.set_mask_filter(layers::skia::MaskFilter::blur(
+        layers::skia::BlurStyle::Normal,
+        30.0,
+        false,
+    ));
+
+    // Active: darker shadow (0.35), Inactive: very light shadow (0.12)
+    let outer_opacity = if is_active { 0.35 } else { 0.12 };
+    shadow_paint.set_color4f(
+        layers::skia::Color4f::new(0.1, 0.1, 0.1, outer_opacity),
+        None,
+    );
+
+    canvas.draw_rrect(rrect, &shadow_paint);
+}
+
 #[profiling::function]
 pub fn view_window_shadow(
     state: &WindowViewBaseModel,
@@ -109,58 +190,9 @@ pub fn view_window_shadow(
     let w = state.w;
     let h = state.h;
     let is_active = state.active;
-    const SAFE_AREA: f32 = 100.0;
     let draw_scale = Config::with(|config| config.screen_scale) as f32;
     let draw_shadow = move |canvas: &layers::skia::Canvas, w: f32, h: f32| {
-        // draw shadow with different opacity based on activation state
-        let window_corner_radius = 24.0 * draw_scale;
-        let rect = layers::skia::Rect::from_xywh(
-            SAFE_AREA,
-            SAFE_AREA,
-            w - SAFE_AREA * 2.0,
-            h - SAFE_AREA * 2.0,
-        );
-
-        let rrect =
-            layers::skia::RRect::new_rect_xy(rect, window_corner_radius, window_corner_radius);
-        canvas.clip_rrect(rrect, layers::skia::ClipOp::Difference, false);
-
-        // Inner shadow - lighter for active, very light for inactive
-        let inner_opacity = if is_active { 0.25 } else { 0.08 };
-        let mut shadow_paint = layers::skia::Paint::new(
-            layers::skia::Color4f::new(0.0, 0.0, 0.0, inner_opacity),
-            None,
-        );
-        shadow_paint.set_mask_filter(layers::skia::MaskFilter::blur(
-            layers::skia::BlurStyle::Normal,
-            3.0,
-            false,
-        ));
-        canvas.draw_rrect(rrect, &shadow_paint);
-
-        // Outer shadow - stronger for active, very light for inactive
-        let rect = layers::skia::Rect::from_xywh(
-            SAFE_AREA,
-            SAFE_AREA + 20.0 * draw_scale,
-            w - SAFE_AREA * 2.0,
-            h - SAFE_AREA * 2.0,
-        );
-        let rrect =
-            layers::skia::RRect::new_rect_xy(rect, window_corner_radius, window_corner_radius);
-        shadow_paint.set_mask_filter(layers::skia::MaskFilter::blur(
-            layers::skia::BlurStyle::Normal,
-            30.0,
-            false,
-        ));
-
-        // Active: darker shadow (0.35), Inactive: very light shadow (0.12)
-        let outer_opacity = if is_active { 0.35 } else { 0.12 };
-        shadow_paint.set_color4f(
-            layers::skia::Color4f::new(0.1, 0.1, 0.1, outer_opacity),
-            None,
-        );
-
-        canvas.draw_rrect(rrect, &shadow_paint);
+        paint_window_shadow(canvas, w, h, is_active, draw_scale);
         layers::skia::Rect::from_xywh(0.0, 0.0, w, h)
     };
     LayerTreeBuilder::default()


### PR DESCRIPTION
Four independent fixes, one commit each.

### `style(theme)`: one hairline token for floating surfaces
Windows, menus, panels, the dock and its labels each drew their own edge at their own weight — different colours, different alphas, and on a HiDPI output different thicknesses. They now share one `hairline` token, defined on both sides of the protocol:

- **otto-kit** gains `Theme::hairline` (10% black in light, 8% white in dark — the two alphas that land at the same visual weight) and `surfaces::apply_hairline_border`, used by kit windows, menus and the colour picker.
- **The compositor** gains a matching `hairline` colour, used by the dock bar and its labels.
- **`set_border` width is now logical points**, scaled by `screen_scale` like the corner radius already was. A client asking for a one-point hairline was getting a single device pixel — half the line the dock drew beside it on a 2x display.

Bar item highlights (hover and open-menu) also follow the colour scheme now: a dark translucent pill in light mode, a translucent white one in dark, so the highlight stays legible over the blurred wallpaper either way.

### `fix(render)`: let the ambient shadow reach a window's top corners
The outer pass is offset downwards to read as a light from above, which left the top corners with nothing but a thin inner line — on a bright wallpaper they looked cut out rather than lit. Shadow painting moves out of the view into `paint_window_shadow`, so a pixel test can hold the corners it covers.

### `feat(files)`: tell trashing, destroying and putting back apart by ear
A delete that can be taken back sounded like one that cannot, and a put-back sounded like a paste. Each gets its own cue, named from the sound naming spec where it has a name.

### `fix(settings)`: step the accent back when the window is not focused
Everything the chrome draws in the accent — the selected sidebar row, the switches, the traffic lights — stayed lit in a background window, leaving nothing to pick the front one out by.

Specs updated: `topbar.md` (bar highlights), `file-browser.md` (sounds).

https://claude.ai/code/session_01BeY1uJfPc5emU2qJ9TRRR5