### PR TITLE
fix(input): light the caps lock LED

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2779,6 +2779,10 @@ pub trait Backend {
     fn set_cursor(&mut self, image: &CursorImageStatus); //, renderer: &mut SkiaRenderer);
     fn renderer_context(&mut self) -> Option<layers::skia::gpu::DirectContext>;
     fn request_redraw(&mut self) {}
+    /// Push the keyboard LED state (Caps/Num/Scroll Lock) to the hardware.
+    /// Only a backend that owns the input devices has anything to do; under
+    /// a host compositor the host owns the LEDs.
+    fn update_keyboard_leds(&mut self, _led_state: smithay::input::keyboard::LedState) {}
     /// Invalidate any pre-computed (vblank-prefetched) scene update. Called
     /// on client commits: a commit can create scene layers (e.g. a popup)
     /// AFTER the prefetch ran, and drawing from the stale prefetch renders

--- a/src/state/seat_handler.rs
+++ b/src/state/seat_handler.rs
@@ -47,9 +47,9 @@ impl<BackendData: Backend> SeatHandler for Otto<BackendData> {
     fn led_state_changed(
         &mut self,
         _seat: &smithay::input::Seat<Self>,
-        _led_state: smithay::input::keyboard::LedState,
+        led_state: smithay::input::keyboard::LedState,
     ) {
-        println!("keyboard led_state_changed {:?}", _led_state);
+        self.backend_data.update_keyboard_leds(led_state);
     }
 }
 

--- a/src/udev/init.rs
+++ b/src/udev/init.rs
@@ -192,6 +192,14 @@ pub fn run_udev() {
                     crate::config::Config::with(|config| {
                         super::input_config::apply_device_config(&mut device, &config.input);
                     });
+                    // A keyboard plugged in while Caps Lock is on must light up
+                    // too: the LED state only changes on key events.
+                    if device.has_capability(smithay::reexports::input::DeviceCapability::Keyboard)
+                    {
+                        if let Some(led_state) = data.seat.get_keyboard().map(|k| k.led_state()) {
+                            device.led_update(led_state.into());
+                        }
+                    }
                     data.backend_data.input_devices.push(device);
                 }
                 smithay::backend::input::InputEvent::DeviceRemoved { device } => {

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -103,6 +103,15 @@ impl Backend for UdevData {
         self.session.seat()
     }
 
+    fn update_keyboard_leds(&mut self, led_state: smithay::input::keyboard::LedState) {
+        use smithay::reexports::input::DeviceCapability;
+        for device in &mut self.input_devices {
+            if device.has_capability(DeviceCapability::Keyboard) {
+                device.led_update(led_state.into());
+            }
+        }
+    }
+
     fn backend_name(&self) -> &'static str {
         "udev"
     }


### PR DESCRIPTION
The seat's `led_state_changed` handler only printed the new state, so the keyboard's Caps/Num/Scroll Lock lights never followed the modifiers. xkb tracked the lock correctly and clients saw the modifier — nothing ever told the hardware.

- A new `Backend::update_keyboard_leds` hook, a no-op by default so winit and X11 leave the host compositor's LEDs alone.
- The udev backend pushes the state to every keyboard among the libinput devices it already tracks in `input_devices`.
- A keyboard plugged in later is seeded from the seat's current LED state, since the state only changes on key events.

## Testing

Needs the udev backend on real hardware: run from a tty and press Caps Lock — the light should follow the modifier. Plugging in a second keyboard while Caps Lock is on should light that one too.

https://claude.ai/code/session_017yRNNT32DTBHG8XKAmMm38