### PR TITLE
feat(tiling): keyboard tiling basics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,6 +5149,7 @@ dependencies = [
  "laye-rs",
  "libc",
  "otto-kit",
+ "otto-media-kit",
  "otto-quickview",
  "skia-safe",
  "smithay-client-toolkit",
@@ -5260,6 +5261,18 @@ dependencies = [
  "tracing-subscriber",
  "wayland-client",
  "wayland-protocols",
+]
+
+[[package]]
+name = "otto-media-kit"
+version = "1.2.0"
+dependencies = [
+ "gstreamer",
+ "gstreamer-app",
+ "libc",
+ "otto-kit",
+ "skia-safe",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "laye-rs"
 version = "1.16.0"
-source = "git+https://github.com/nongio/layers?tag=v1.16.0#be6a39d0ec00be1e8750c5b1f73b617daec374d7"
+source = "git+https://github.com/nongio/layers?tag=v1.16.0#5ada2ba4ef5db4f93a40dd367b6b6e9b88f53088"
 dependencies = [
  "bezier_easing",
  "bitflags 1.3.2",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "layers-debug-server"
 version = "0.3.0"
-source = "git+https://github.com/nongio/layers?tag=v1.16.0#be6a39d0ec00be1e8750c5b1f73b617daec374d7"
+source = "git+https://github.com/nongio/layers?tag=v1.16.0#5ada2ba4ef5db4f93a40dd367b6b6e9b88f53088"
 dependencies = [
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,9 +195,10 @@ too_many_arguments = "allow"
 # is a one-line change here instead of an edit per component — and no member
 # can drift onto a different revision and pull a second copy into the link.
 #
-# Pinned to a release: v1.16.0 carries the cancelled-change re-sync
-# (nongio/layers#25), without which an exposé preview can stay drawn where a
-# superseded change left it — v1.15.0 brought `Layer::set_blur_bounds` (#24).
+# Pinned to a release: v1.16.0 (re-tagged on nongio/layers#26) keeps the
+# backdrop blur from sampling past a layer's bounds, which left a window's edge
+# crisp through a frosted titlebar; it also carries the cancelled-change
+# re-sync (#25). v1.15.0 brought `Layer::set_blur_bounds` (#24).
 # For local development point this at the checkout — one edit, whole workspace:
 #   laye-rs = { path = "../layers", features = ["export-taffy"] }
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ members = [
     "components/otto-settings",
     "components/otto-files",
     "components/otto-quickview",
+    "components/otto-media-kit",
     "sample-clients/client-rainbow",
     "sample-clients/submenu",
     "sample-clients/submenu-gtk",

--- a/components/otto-bar/src/tray.rs
+++ b/components/otto-bar/src/tray.rs
@@ -501,7 +501,10 @@ async fn fetch_item(
     let title = proxy.title().await.ok();
 
     // Try to get icon pixmap
-    let pixmap_target = 24 * otto_kit::app_runner::context::AppContext::scale_factor().max(1);
+    // Match the size the icon is actually painted at, so the pixmap we keep
+    // needs the least rescaling.
+    let pixmap_target = (crate::config::TRAY_ICON_SIZE as i32)
+        * otto_kit::app_runner::context::AppContext::scale_factor().max(1);
     let (icon_data, icon_w, icon_h) = match proxy.icon_pixmap().await {
         Ok(pixmaps) if !pixmaps.is_empty() => {
             // Pick the best size (closest to target, prefer >= target when tied)

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 laye-rs.workspace = true
 otto-kit = { path = "../otto-kit" }
 otto-quickview = { path = "../otto-quickview" }
+# Playback for Quick View. Library only: the GStreamer worker is a separate
+# binary built from the same crate, found at run time.
+otto-media-kit = { path = "../otto-media-kit", default-features = false }
 smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-client = "0.31"
 tracing = "0.1"

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1012,6 +1012,7 @@ impl Browser {
             icon_chain: entry.icon_chain(),
             decoded: self.preview.as_ref().and_then(|p| p.decoded.as_ref()),
             video: None,
+            video_on_surface: false,
             first_row: 0,
             info: preview_info(&entry),
         };
@@ -1164,7 +1165,11 @@ impl Browser {
         let Some(video) = self.preview.as_mut().and_then(|p| p.video.as_mut()) else {
             return false;
         };
-        let handled = video.pointer(kind, x, y, stage);
+        // The controls are drawn in the aspect box, not the whole stage, so
+        // the hit test has to measure against the same rect — otherwise the
+        // play button answers for a band of empty column above it.
+        let content = view::preview_video_box(stage, video.snapshot().aspect());
+        let handled = video.pointer(kind, x, y, content);
         self.dirty |= handled;
         handled
     }
@@ -3868,15 +3873,21 @@ impl Browser {
                 pending = true;
             }
         }
-        let seq = self
-            .preview
-            .as_ref()
-            .and_then(|p| p.video.as_ref())
-            .map(quickview::Video::frame_seq)
-            .unwrap_or(0);
-        if seq != self.preview_video_painted {
-            self.preview_video_painted = seq;
-            pending = true;
+        // On its own subsurface the preview column's video is repainted by
+        // `sync_pane_surfaces`, which runs every pass regardless of this — so
+        // a landing frame there is not a window repaint. Only when there is no
+        // subsurface manager does the window draw it.
+        if !pane_surfaces::quickview_on_surface() {
+            let seq = self
+                .preview
+                .as_ref()
+                .and_then(|p| p.video.as_ref())
+                .map(quickview::Video::frame_seq)
+                .unwrap_or(0);
+            if seq != self.preview_video_painted {
+                self.preview_video_painted = seq;
+                pending = true;
+            }
         }
         pending
     }
@@ -4306,6 +4317,9 @@ impl Browser {
             icon_chain: entry.icon_chain(),
             decoded: self.preview.as_ref().and_then(|p| p.decoded.as_ref()),
             video: self.preview.as_ref().and_then(|p| p.video.as_ref()),
+            // The player is on its own subsurface whenever this window is
+            // running the subsurface manager, which it does by default.
+            video_on_surface: pane_surfaces::quickview_on_surface(),
             first_row: 0,
             info: preview_info(entry),
         });

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -332,6 +332,8 @@ struct Browser {
     /// The last video frame painted into the window; see
     /// [`Browser::quickview_video_frame_pending`].
     quickview_video_painted: u64,
+    /// The last preview-column video frame painted; same purpose.
+    preview_video_painted: u64,
     /// The cursor moved on its own — a delete landing its selection on the
     /// survivor — rather than through an arrow key. Quick View follows the
     /// cursor, so it has to re-decode for those moves too, and the deleted
@@ -441,6 +443,8 @@ struct Browser {
     footer_pressed: Option<view::FooterButton>,
     /// Pointer is over Quick View's close button.
     quickview_close_hovered: bool,
+    /// Pointer is over Quick View's expand button.
+    quickview_expand_hovered: bool,
     /// Where Quick View's panel actually is, in window coordinates.
     ///
     /// Written by the render path, read by the pointer handler, because the
@@ -507,6 +511,10 @@ struct PreviewPaneState {
     /// A decode for `path` is in flight.
     pending: bool,
     decoded: Option<otto_kit::preview::Preview>,
+    /// A player, when the decode said video. Opened paused: the column
+    /// follows the selection, and a video that started playing on every
+    /// arrow key would be a column that talks.
+    video: Option<quickview::Video>,
 }
 
 /// An in-place rename in progress: which row it belongs to and the text
@@ -639,6 +647,7 @@ impl Browser {
             quickview_auto: std::env::var_os("OTTO_FILES_QV_AUTO").is_some(),
             quickview_generation: 0,
             quickview_video_painted: 0,
+            preview_video_painted: 0,
             quickview_follow: false,
             trash: false,
             trash_pressed: None,
@@ -659,6 +668,7 @@ impl Browser {
             footer_hover: None,
             footer_pressed: None,
             quickview_close_hovered: false,
+            quickview_expand_hovered: false,
             quickview_panel: None,
             quickview_focus: None,
             quickview_pinch: None,
@@ -918,6 +928,7 @@ impl Browser {
             generation,
             pending: true,
             decoded: None,
+            video: None,
         });
         self.dirty = true;
         Some((entry.path, generation))
@@ -1000,6 +1011,7 @@ impl Browser {
             name: entry.name.as_str(),
             icon_chain: entry.icon_chain(),
             decoded: self.preview.as_ref().and_then(|p| p.decoded.as_ref()),
+            video: None,
             first_row: 0,
             info: preview_info(&entry),
         };
@@ -1112,7 +1124,12 @@ impl Browser {
 
     /// Show a preview decode that arrived, unless the selection has moved on
     /// since — the same staleness guard Quick View uses.
-    fn finish_preview(&mut self, generation: u64, preview: otto_kit::preview::Preview) {
+    fn finish_preview(
+        &mut self,
+        generation: u64,
+        preview: otto_kit::preview::Preview,
+        video: Option<otto_media_kit::Options>,
+    ) {
         let Some(pane) = &mut self.preview else {
             return;
         };
@@ -1120,8 +1137,36 @@ impl Browser {
             return;
         }
         pane.pending = false;
+        pane.video = video.and_then(|options| {
+            quickview::Video::open(&preview, &pane.path, options, AppContext::request_wakeup)
+        });
         pane.decoded = Some(preview);
         self.dirty = true;
+    }
+
+    /// The pointer over the preview column's video, if there is one and it
+    /// wants the event. The stage is where the picture is; the caption
+    /// under it is the listing's business.
+    fn preview_video_pointer(&mut self, kind: quickview::VideoPointer, x: f32, y: f32) -> bool {
+        if !self.preview_visible() {
+            return false;
+        }
+        let Some(entry) = self.selected_entry() else {
+            return false;
+        };
+        let pane = view::preview_pane_rect(
+            self.columns.len(),
+            self.content_h(),
+            self.pan.offset(),
+            self.miller_w,
+        );
+        let stage = view::preview_stage_rect(pane, preview_info(&entry).len());
+        let Some(video) = self.preview.as_mut().and_then(|p| p.video.as_mut()) else {
+            return false;
+        };
+        let handled = video.pointer(kind, x, y, stage);
+        self.dirty |= handled;
+        handled
     }
 
     /// Give every pane's scroll view its viewport and content height.
@@ -3758,7 +3803,7 @@ impl Browser {
         anchor: Rect,
         name: String,
         preview: otto_kit::preview::Preview,
-        video: Option<(PathBuf, otto_media_kit::player::Limits)>,
+        video: Option<(PathBuf, otto_media_kit::Options)>,
     ) {
         if std::env::var_os("OTTO_FILES_QV_TRACE").is_some() {
             eprintln!(
@@ -3772,11 +3817,12 @@ impl Browser {
         self.quickview_pending = false;
         // Re-opening onto the same panel keeps its entrance rather than
         // replaying it, so arrow-keying through a folder does not pulse.
-        let opened_at = match &self.quickview {
-            Some(session) => session.opened_at,
-            None => std::time::Instant::now(),
+        let (opened_at, expanded) = match &self.quickview {
+            Some(session) => (session.opened_at, session.expanded),
+            None => (std::time::Instant::now(), false),
         };
         let mut session = quickview::Session::new(preview, name, anchor, opened_at);
+        session.expanded = expanded;
         // Only once the decoder has said what the file is: the player is
         // started on the sniffed type, never on the name. It wakes the loop
         // from its own thread on every frame, the way a landing decode does.
@@ -3790,20 +3836,49 @@ impl Browser {
         self.dirty = true;
     }
 
-    /// Whether the open preview has a frame the window has not painted.
-    ///
-    /// Only for the window-painted panel: on its own surface the panel's
-    /// content key sees each frame for itself.
-    fn quickview_video_frame_pending(&mut self) -> bool {
-        let Some(session) = self.quickview.as_ref() else {
-            return false;
-        };
-        let seq = session.video_frame_seq();
-        if seq == self.quickview_video_painted {
-            return false;
+    /// Expand the open panel to fill its display, or bring it back.
+    fn toggle_quickview_expand(&mut self) {
+        if let Some(session) = self.quickview.as_mut() {
+            session.toggle_expanded();
+            self.dirty = true;
         }
-        self.quickview_video_painted = seq;
-        true
+    }
+
+    /// Where the panel rests when the surface layer has not said: centred in
+    /// the window, at whichever size the session asks for.
+    fn quickview_fallback_panel(&self) -> Rect {
+        let expanded = self.quickview.as_ref().is_some_and(|s| s.expanded);
+        quickview::resting_in(Rect::from_wh(self.size.0, self.size.1), expanded)
+    }
+
+    /// Whether a video has a frame the window has not painted: the preview
+    /// column's, or the open panel's where the window paints the panel
+    /// itself. On its own surface the panel's content key sees each frame
+    /// for itself, and the window is left alone.
+    fn video_frame_pending(&mut self) -> bool {
+        let mut pending = false;
+        if !pane_surfaces::quickview_on_surface() {
+            let seq = self
+                .quickview
+                .as_ref()
+                .map(quickview::Session::video_frame_seq)
+                .unwrap_or(0);
+            if seq != self.quickview_video_painted {
+                self.quickview_video_painted = seq;
+                pending = true;
+            }
+        }
+        let seq = self
+            .preview
+            .as_ref()
+            .and_then(|p| p.video.as_ref())
+            .map(quickview::Video::frame_seq)
+            .unwrap_or(0);
+        if seq != self.preview_video_painted {
+            self.preview_video_painted = seq;
+            pending = true;
+        }
+        pending
     }
 
     /// Remember where the pointer is over the Quick View panel, and which
@@ -3827,7 +3902,7 @@ impl Browser {
             None => {
                 let panel = self
                     .quickview_panel
-                    .unwrap_or_else(|| quickview::panel_rect(self.size.0, self.size.1));
+                    .unwrap_or_else(|| self.quickview_fallback_panel());
                 let content = view::quickview_content_rect(panel);
                 ((content.center_x(), content.center_y()), panel)
             }
@@ -3931,7 +4006,7 @@ impl Browser {
     fn tick_quickview_pan(&mut self) -> bool {
         let panel = self
             .quickview_panel
-            .unwrap_or_else(|| quickview::panel_rect(self.size.0, self.size.1));
+            .unwrap_or_else(|| self.quickview_fallback_panel());
         let content = view::quickview_content_rect(panel);
         let Some(session) = self.quickview.as_mut() else {
             return false;
@@ -4230,6 +4305,7 @@ impl Browser {
             name: entry.name.as_str(),
             icon_chain: entry.icon_chain(),
             decoded: self.preview.as_ref().and_then(|p| p.decoded.as_ref()),
+            video: self.preview.as_ref().and_then(|p| p.video.as_ref()),
             first_row: 0,
             info: preview_info(entry),
         });
@@ -4287,6 +4363,8 @@ impl Browser {
             }),
             footer: self.footer_h(),
             quickview_close_hovered: self.quickview_close_hovered,
+            quickview_expand_hovered: self.quickview_expand_hovered,
+            quickview_expanded: self.quickview.as_ref().is_some_and(|s| s.expanded),
             thumbs: Some(&self.thumbs),
             drop_target: self.drop_target.as_ref().map(DropTarget::highlight),
             marquee: self.marquee_band(),
@@ -4800,11 +4878,9 @@ impl App for FilesApp {
             let animating = browser.quickview_animating()
                 | browser.tick_quickview_exit()
                 | browser.tick_open_pulse()
-                // A video frame landing is a repaint only where the window
-                // paints the panel itself; on its own surface the panel's
-                // key notices for it, and the window is left alone.
-                | (browser.quickview_video_frame_pending()
-                    && !pane_surfaces::quickview_on_surface());
+                // A video frame landing in the preview column, or in a
+                // panel the window paints itself.
+                | browser.video_frame_pending();
             // The docked preview column follows the selection wherever it
             // moves — a click, an arrow key, a directory finishing a load
             // that changes what "the selection" resolves to — so this is
@@ -5556,7 +5632,7 @@ impl FilesApp {
         tokio::task::spawn_blocking(move || {
             let preview = quickview::decode(&path, panel, scale);
             let video = (path.is_file() && otto_media_kit::player::available())
-                .then(|| (path.clone(), quickview::video_limits(panel, scale)));
+                .then(|| (path.clone(), quickview::video_options(panel, scale, true)));
             state
                 .lock()
                 .unwrap()
@@ -5579,9 +5655,17 @@ impl FilesApp {
         let scale = AppContext::scale_factor().max(1) as f32;
         let state = Arc::clone(&self.state);
 
+        // Paused, and only where a worker exists: the column is a glance,
+        // and the click that starts it is the user asking for sound.
+        let autoplay = std::env::var_os("OTTO_FILES_PREVIEW_AUTOPLAY").is_some();
+        let video = (path.is_file() && otto_media_kit::player::available())
+            .then(|| quickview::video_options(panel, scale, autoplay));
         tokio::task::spawn_blocking(move || {
             let preview = quickview::decode(&path, panel, scale);
-            state.lock().unwrap().finish_preview(generation, preview);
+            state
+                .lock()
+                .unwrap()
+                .finish_preview(generation, preview, video);
             AppContext::request_wakeup();
         });
     }
@@ -5697,11 +5781,17 @@ impl FilesApp {
                 let over = view::quickview_close_rect(panel)
                     .with_outset((4.0, 4.0))
                     .contains(point);
+                let over_expand = view::quickview_expand_rect(panel)
+                    .with_outset((4.0, 4.0))
+                    .contains(point);
 
                 let mut browser = state.lock().unwrap();
                 match event.kind {
                     PointerEventKind::Press { .. } if over => {
                         browser.close_quickview();
+                    }
+                    PointerEventKind::Press { .. } if over_expand => {
+                        browser.toggle_quickview_expand();
                     }
                     PointerEventKind::Press { .. } => {
                         // A scrollbar over a zoomed picture takes the press
@@ -5714,16 +5804,20 @@ impl FilesApp {
                     PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
                         browser.quickview_focus(point, panel);
                         browser.quickview_pan_pointer(QuickviewPointer::Motion, point, panel);
-                        if browser.quickview_close_hovered != over {
+                        if browser.quickview_close_hovered != over
+                            || browser.quickview_expand_hovered != over_expand
+                        {
                             browser.quickview_close_hovered = over;
+                            browser.quickview_expand_hovered = over_expand;
                             browser.dirty = true;
                         }
                     }
                     PointerEventKind::Leave { .. } => {
                         browser.quickview_focus = None;
                         browser.quickview_pan_pointer(QuickviewPointer::Leave, point, panel);
-                        if browser.quickview_close_hovered {
+                        if browser.quickview_close_hovered || browser.quickview_expand_hovered {
                             browser.quickview_close_hovered = false;
+                            browser.quickview_expand_hovered = false;
                             browser.dirty = true;
                         }
                     }
@@ -6037,19 +6131,24 @@ impl FilesApp {
                     // over the action row rather than beside it.
                     let panel = browser
                         .quickview_panel
-                        .unwrap_or_else(|| quickview::panel_rect(width, browser.size.1));
+                        .unwrap_or_else(|| browser.quickview_fallback_panel());
                     let point = skia_safe::Point::new(x, y);
                     let over_close = view::quickview_close_rect(panel)
                         .with_outset((4.0, 4.0))
                         .contains(point);
+                    let over_expand = view::quickview_expand_rect(panel)
+                        .with_outset((4.0, 4.0))
+                        .contains(point);
                     match event.kind {
                         PointerEventKind::Press { .. } => {
-                            // The button first: it sits inside the panel, so
-                            // the "click outside dismisses" rule below would
-                            // never reach it. Then the pan's scrollbars,
-                            // which are inside it too.
+                            // The buttons first: they sit inside the panel,
+                            // so the "click outside dismisses" rule below
+                            // would never reach them. Then the pan's
+                            // scrollbars, which are inside it too.
                             if over_close || !panel.contains(point) {
                                 browser.close_quickview();
+                            } else if over_expand {
+                                browser.toggle_quickview_expand();
                             } else {
                                 browser.quickview_pan_pointer(
                                     QuickviewPointer::Press,
@@ -6064,16 +6163,22 @@ impl FilesApp {
                         PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
                             browser.quickview_focus(point, panel);
                             browser.quickview_pan_pointer(QuickviewPointer::Motion, point, panel);
-                            if browser.quickview_close_hovered != over_close {
+                            if browser.quickview_close_hovered != over_close
+                                || browser.quickview_expand_hovered != over_expand
+                            {
                                 browser.quickview_close_hovered = over_close;
+                                browser.quickview_expand_hovered = over_expand;
                                 browser.dirty = true;
                             }
                         }
                         PointerEventKind::Leave { .. } => {
                             browser.quickview_focus = None;
                             browser.quickview_pan_pointer(QuickviewPointer::Leave, point, panel);
-                            if browser.quickview_close_hovered {
+                            if browser.quickview_close_hovered
+                                || browser.quickview_expand_hovered
+                            {
                                 browser.quickview_close_hovered = false;
+                                browser.quickview_expand_hovered = false;
                                 browser.dirty = true;
                             }
                         }
@@ -6093,6 +6198,26 @@ impl FilesApp {
                     }
                     drop(browser);
                     continue;
+                }
+
+                // The preview column's video takes its own presses and a
+                // scrub in progress, before anything decides what a click on
+                // the column means.
+                let video_pointer = match event.kind {
+                    PointerEventKind::Press { .. } => Some(quickview::VideoPointer::Press),
+                    PointerEventKind::Release { .. } => Some(quickview::VideoPointer::Release),
+                    PointerEventKind::Motion { .. } | PointerEventKind::Enter { .. } => {
+                        Some(quickview::VideoPointer::Motion)
+                    }
+                    PointerEventKind::Leave { .. } => Some(quickview::VideoPointer::Leave),
+                    PointerEventKind::Axis { .. } => None,
+                };
+                if let Some(kind) = video_pointer {
+                    if browser.preview_video_pointer(kind, x, y) {
+                        drop(browser);
+                        AppContext::request_wakeup();
+                        continue;
+                    }
                 }
 
                 // The confirmation sheet is modal: it answers its own two

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -5669,11 +5669,11 @@ impl FilesApp {
         let scale = AppContext::scale_factor().max(1) as f32;
         let state = Arc::clone(&self.state);
 
-        // Paused, and only where a worker exists: the column is a glance,
-        // and the click that starts it is the user asking for sound.
-        let autoplay = std::env::var_os("OTTO_FILES_PREVIEW_AUTOPLAY").is_some();
+        // Paused, and only where a worker exists: the column is a glance that
+        // follows the selection, and the click that starts it is the user
+        // asking for sound. It opens on the first frame, not on black.
         let video = (path.is_file() && otto_media_kit::player::available())
-            .then(|| quickview::video_options(panel, scale, autoplay));
+            .then(|| quickview::video_options(panel, scale, false));
         tokio::task::spawn_blocking(move || {
             let preview = quickview::decode(&path, panel, scale);
             state

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -329,6 +329,9 @@ struct Browser {
     /// slow PDF must not land on top of a file the user moved off three keys
     /// ago.
     quickview_generation: u64,
+    /// The last video frame painted into the window; see
+    /// [`Browser::quickview_video_frame_pending`].
+    quickview_video_painted: u64,
     /// The cursor moved on its own — a delete landing its selection on the
     /// survivor — rather than through an arrow key. Quick View follows the
     /// cursor, so it has to re-decode for those moves too, and the deleted
@@ -635,6 +638,7 @@ impl Browser {
             quickview_closing: None,
             quickview_auto: std::env::var_os("OTTO_FILES_QV_AUTO").is_some(),
             quickview_generation: 0,
+            quickview_video_painted: 0,
             quickview_follow: false,
             trash: false,
             trash_pressed: None,
@@ -3754,6 +3758,7 @@ impl Browser {
         anchor: Rect,
         name: String,
         preview: otto_kit::preview::Preview,
+        video: Option<(PathBuf, otto_media_kit::player::Limits)>,
     ) {
         if std::env::var_os("OTTO_FILES_QV_TRACE").is_some() {
             eprintln!(
@@ -3771,11 +3776,34 @@ impl Browser {
             Some(session) => session.opened_at,
             None => std::time::Instant::now(),
         };
-        self.quickview = Some(quickview::Session::new(preview, name, anchor, opened_at));
+        let mut session = quickview::Session::new(preview, name, anchor, opened_at);
+        // Only once the decoder has said what the file is: the player is
+        // started on the sniffed type, never on the name. It wakes the loop
+        // from its own thread on every frame, the way a landing decode does.
+        if let Some((path, limits)) = video {
+            session.attach_video(&path, limits, AppContext::request_wakeup);
+        }
+        self.quickview = Some(session);
         // Re-opening cancels whatever was on its way out: two panels in flight
         // at once would cross over each other.
         self.quickview_closing = None;
         self.dirty = true;
+    }
+
+    /// Whether the open preview has a frame the window has not painted.
+    ///
+    /// Only for the window-painted panel: on its own surface the panel's
+    /// content key sees each frame for itself.
+    fn quickview_video_frame_pending(&mut self) -> bool {
+        let Some(session) = self.quickview.as_ref() else {
+            return false;
+        };
+        let seq = session.video_frame_seq();
+        if seq == self.quickview_video_painted {
+            return false;
+        }
+        self.quickview_video_painted = seq;
+        true
     }
 
     /// Remember where the pointer is over the Quick View panel, and which
@@ -3864,6 +3892,19 @@ impl Browser {
         let Some(session) = self.quickview.as_mut() else {
             return false;
         };
+        // A video's controls come before the pan: the two never share a
+        // panel, and the player wants the press wherever on the picture it
+        // lands.
+        let video = match kind {
+            QuickviewPointer::Press => quickview::VideoPointer::Press,
+            QuickviewPointer::Motion => quickview::VideoPointer::Motion,
+            QuickviewPointer::Release => quickview::VideoPointer::Release,
+            QuickviewPointer::Leave => quickview::VideoPointer::Leave,
+        };
+        if let Some(handled) = session.video_pointer(video, point.x, point.y, content) {
+            self.dirty |= handled;
+            return handled;
+        }
         let (handled, moved) = match kind {
             QuickviewPointer::Press => {
                 let hit = session.pan_pointer_down(point.x, point.y, content);
@@ -4758,7 +4799,12 @@ impl App for FilesApp {
             let scrolled = browser.tick_scroll();
             let animating = browser.quickview_animating()
                 | browser.tick_quickview_exit()
-                | browser.tick_open_pulse();
+                | browser.tick_open_pulse()
+                // A video frame landing is a repaint only where the window
+                // paints the panel itself; on its own surface the panel's
+                // key notices for it, and the window is left alone.
+                | (browser.quickview_video_frame_pending()
+                    && !pane_surfaces::quickview_on_surface());
             // The docked preview column follows the selection wherever it
             // moves — a click, an arrow key, a directory finishing a load
             // that changes what "the selection" resolves to — so this is
@@ -5509,10 +5555,12 @@ impl FilesApp {
 
         tokio::task::spawn_blocking(move || {
             let preview = quickview::decode(&path, panel, scale);
+            let video = (path.is_file() && otto_media_kit::player::available())
+                .then(|| (path.clone(), quickview::video_limits(panel, scale)));
             state
                 .lock()
                 .unwrap()
-                .finish_quickview(generation, anchor, name, preview);
+                .finish_quickview(generation, anchor, name, preview, video);
             // Wake the UI thread: a window showing "Opening preview…" is not
             // committing frames, so there is no frame callback to notice the
             // decode landed.

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -125,14 +125,19 @@ pub struct PaneSurfaces {
     /// A fresh answer has been asked for and has not arrived. The previous
     /// resting rect stays in use until it does.
     quickview_awaiting: bool,
-    /// Where the panel rests, frozen for the length of one opening or one
-    /// closing.
+    /// The display the panel is centred on, in window points, frozen for the
+    /// length of one opening or one closing.
     ///
     /// Recomputed only at those two moments, and never in between. The
     /// compositor's answer is relative to the *window*, so anything that moves
     /// the window — tiling it, dragging it — changes what it means. Following
     /// that continuously would drag the panel across the screen mid-animation
-    /// and, when the window moves far enough, off it.
+    /// and, when the window moves far enough, off it. The panel's own rect is
+    /// derived from this on every pass, since expanding it changes the rect
+    /// without changing where the display is.
+    quickview_display: Option<Rect>,
+    /// Where the panel was last placed to rest, whichever space it rests in.
+    /// What the pointer handler measures against.
     quickview_resting: Option<Rect>,
     /// Set when a paint was wanted but the surface still had a frame in
     /// flight. The throttle is only safe while something else keeps calling
@@ -159,6 +164,7 @@ impl PaneSurfaces {
             quickview: None,
             quickview_placement: None,
             quickview_awaiting: false,
+            quickview_display: None,
             quickview_resting: None,
             pending: false,
             stack_dirty: false,
@@ -358,12 +364,13 @@ impl PaneSurfaces {
         // The *old* rect stays in force until the new answer lands. Nulling it
         // here is what made the panel snap to the window's centre and back.
         if self.quickview_awaiting {
-            if let Some(rect) = centered_resting(pane, self.scale) {
-                self.quickview_resting = Some(rect);
+            if let Some(rect) = centered_display(pane, self.scale) {
+                self.quickview_display = Some(rect);
                 self.quickview_awaiting = false;
             }
         }
-        self.quickview_resting
+        self.quickview_display
+            .map(|display| quickview::resting_in(display, session.expanded))
     }
 
     /// The Quick View panel.
@@ -400,9 +407,13 @@ impl PaneSurfaces {
         // stays in window coordinates either way, which is what lets the
         // entrance keep growing out of the file's icon: the anchor and the
         // resting place are in the same space.
-        let resting = self
-            .resting_for(session)
-            .unwrap_or_else(|| quickview::panel_rect(f.width, f.height + f.footer));
+        let resting = self.resting_for(session).unwrap_or_else(|| {
+            quickview::resting_in(
+                Rect::from_wh(f.width, f.height + f.footer),
+                session.expanded,
+            )
+        });
+        self.quickview_resting = Some(resting);
         // Wherever the panel is *now* — part way in, at rest, or part way
         // back to its file. Asking for the entrance alone left the exit out
         // of the surface entirely: once open, `entrance_t` is pinned at 1, so
@@ -921,7 +932,7 @@ mod qv_trace {
 /// surface is created, and the reply lands a round trip later, so the first
 /// frame or two of an entrance are still centred on the window. Those frames
 /// are the smallest ones, at the file's icon, so the correction is invisible.
-fn centered_resting(pane: &PaneSurface, scale: f32) -> Option<Rect> {
+fn centered_display(pane: &PaneSurface, scale: f32) -> Option<Rect> {
     use wayland_client::Proxy;
 
     let style = pane.surface.layer()?;
@@ -936,22 +947,7 @@ fn centered_resting(pane: &PaneSurface, scale: f32) -> Option<Rect> {
     // The answer is in the same pixels the positions are set in; the rest of
     // this module works in points.
     let (x, y, width, height) = (x / scale, y / scale, width / scale, height / scale);
-
-    // The panel's share of the display, floored the same way it is floored
-    // against a window, and never quite touching the edges.
-    let panel_width = (width * quickview::PANEL_FRACTION)
-        .max(quickview::PANEL_MIN.0)
-        .min(width - 32.0);
-    let panel_height = (height * quickview::PANEL_FRACTION)
-        .max(quickview::PANEL_MIN.1)
-        .min(height - 32.0);
-
-    Some(Rect::from_xywh(
-        x + (width - panel_width) / 2.0,
-        y + (height - panel_height) / 2.0,
-        panel_width.max(1.0),
-        panel_height.max(1.0),
-    ))
+    Some(Rect::from_xywh(x, y, width, height))
 }
 
 #[cfg(test)]

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -113,6 +113,10 @@ pub struct PaneSurfaces {
     pan: Option<PaneSurface>,
     /// The Quick View panel, in a surface of its own over everything.
     quickview: Option<PaneSurface>,
+    /// The docked preview column's video player, in a surface of its own so
+    /// its per-frame repaints never touch the toplevel. Sized to the video's
+    /// shape, placed over the column's stage; see [`Self::sync_preview_video`].
+    preview_video: Option<PaneSurface>,
     /// Which panel, and which direction, [`Self::quickview_resting`] was
     /// worked out for: the session's generation and whether it is closing.
     /// `Some(closing)` once the output has been asked about for the panel
@@ -162,6 +166,7 @@ impl PaneSurfaces {
             panes: Vec::new(),
             pan: None,
             quickview: None,
+            preview_video: None,
             quickview_placement: None,
             quickview_awaiting: false,
             quickview_display: None,
@@ -189,6 +194,7 @@ impl PaneSurfaces {
         // columns and nothing here touches them.
         if f.mode != ViewMode::Columns || !enabled() {
             let mut changed = self.hide_all();
+            changed |= self.sync_preview_video(parent, f, quickview.is_some());
             changed |= self.sync_quickview(parent, f, quickview);
             self.restack(parent);
             return changed;
@@ -285,6 +291,7 @@ impl PaneSurfaces {
             painted |= pane.hide();
         }
         painted |= self.sync_pan_bar(parent, f, viewport);
+        painted |= self.sync_preview_video(parent, f, quickview.is_some());
         painted |= self.sync_quickview(parent, f, quickview);
         self.restack(parent);
         painted
@@ -316,7 +323,11 @@ impl PaneSurfaces {
         let trace = std::env::var_os("OTTO_FILES_QV_TRACE").is_some();
         let mut order: Vec<String> = Vec::new();
         let mut below: Option<WlSurface> = None;
-        let overlays = [self.pan.as_ref(), self.quickview.as_ref()];
+        let overlays = [
+            self.preview_video.as_ref(),
+            self.pan.as_ref(),
+            self.quickview.as_ref(),
+        ];
         for (index, pane) in self.panes.iter().map(Some).chain(overlays).enumerate() {
             let Some(pane) = pane else { continue };
             let surface = pane.surface.wl_surface().clone();
@@ -487,6 +498,96 @@ impl PaneSurfaces {
         painted = true;
         painted
     }
+    /// The docked preview column's video, on its own subsurface.
+    ///
+    /// Sized to the video's shape and placed over the column's stage, so the
+    /// picture updates without the toplevel — or the scene's cached preview
+    /// picture — being touched. Input stays with the toplevel, exactly like
+    /// the columns: the browser's pointer routing already hit-tests the box
+    /// in window coordinates (see `Browser::preview_video_pointer`).
+    fn sync_preview_video(&mut self, parent: &WlSurface, f: &Frame, quickview_up: bool) -> bool {
+        // Shown only for a video in the column view, and never behind the
+        // Quick View panel — which is its own, larger player.
+        let video = (f.mode == ViewMode::Columns && !quickview_up)
+            .then(|| {
+                f.preview
+                    .as_ref()
+                    .and_then(|p| p.video.map(|v| (v, p.info.len())))
+            })
+            .flatten();
+        let Some((video, info_lines)) = video else {
+            return self
+                .preview_video
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false);
+        };
+
+        let full = view::preview_pane_rect(f.panes.len(), f.height, f.pan, f.miller_w);
+        let viewport = view::content_viewport(f.width, f.height, ViewMode::Columns);
+        let stage = view::preview_stage_rect(full, info_lines);
+        let snapshot = video.snapshot();
+        let rect = view::preview_video_box(stage, snapshot.aspect());
+        // A column panned so its player would spill over the sidebar is not
+        // shown on a surface — the surface has no parent clip. The scene's
+        // in-layer draw, which is clipped, covers that transient.
+        if rect.left < viewport.left || rect.right > viewport.right || rect.width() <= 1.0 {
+            return self
+                .preview_video
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false);
+        }
+
+        if self.preview_video.is_none() {
+            self.preview_video = Self::create(parent, rect);
+            self.stack_dirty = true;
+        }
+        let scale = self.scale;
+        let Some(pane) = self.preview_video.as_mut() else {
+            return false;
+        };
+        let mut painted = pane.show();
+        pane.place(rect, scale);
+
+        let key = hash_rect(rect) ^ video.key().rotate_left(19);
+        if pane.key == key {
+            return painted;
+        }
+        use wayland_client::Proxy;
+        if AppContext::frame_in_flight(&pane.surface.wl_surface().id()) {
+            self.pending = true;
+            return painted;
+        }
+        pane.key = key;
+
+        let poster = snapshot
+            .poster
+            .as_ref()
+            .and_then(otto_kit::preview::Pixels::to_image);
+        let theme = f.theme.clone();
+        let origin = (rect.left, rect.top);
+        pane.surface.draw(|canvas| {
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+            canvas.save();
+            canvas.translate((-origin.0, -origin.1));
+            otto_media_kit::view::draw_frame(
+                canvas,
+                rect,
+                snapshot.frame.as_ref(),
+                poster.as_ref(),
+                &snapshot.state,
+                otto_media_kit::view::Interaction {
+                    scrubbing: snapshot.scrubbing,
+                    transport_opacity: 1.0,
+                },
+                &theme,
+            );
+            canvas.restore();
+        });
+        painted = true;
+        painted
+    }
 
     /// The stack's horizontal bar.
     ///
@@ -562,6 +663,9 @@ impl PaneSurfaces {
         }
         if let Some(pan) = self.pan.as_mut() {
             changed |= pan.hide();
+        }
+        if let Some(preview_video) = self.preview_video.as_mut() {
+            changed |= preview_video.hide();
         }
         changed
     }

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -796,6 +796,9 @@ fn quickview_key(panel: Rect, generation: u64, session: &quickview::Session) -> 
         // invisible to the key, and the panel never repaints out of its
         // waiting state.
         ^ if session.loading { LOADING_KEY } else { 0 }
+        // A video changes what is drawn on every frame and every tick of its
+        // clock, with nothing else about the panel moving.
+        ^ session.video_key()
 }
 
 /// The content key's contribution for a panel that is still waiting for its

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -523,11 +523,25 @@ impl PaneSurfaces {
                 .unwrap_or(false);
         };
 
+        let snapshot = video.snapshot();
+        // Held hidden until the worker has said what shape the video is. The
+        // box is sized from the aspect, so showing before it is known would
+        // put a full-height surface up and then resize it to the real box a
+        // frame later — a visible snap. The dark column ground stands in for
+        // the few milliseconds until Ready arrives, and the surface then
+        // appears once, at the right size.
+        let Some(aspect) = snapshot.aspect() else {
+            return self
+                .preview_video
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false);
+        };
+
         let full = view::preview_pane_rect(f.panes.len(), f.height, f.pan, f.miller_w);
         let viewport = view::content_viewport(f.width, f.height, ViewMode::Columns);
         let stage = view::preview_stage_rect(full, info_lines);
-        let snapshot = video.snapshot();
-        let rect = view::preview_video_box(stage, snapshot.aspect());
+        let rect = view::preview_video_box(stage, Some(aspect));
         // A column panned so its player would spill over the sidebar is not
         // shown on a surface — the surface has no parent clip. The scene's
         // in-layer draw, which is clipped, covers that transient.

--- a/components/otto-files/src/quickview.rs
+++ b/components/otto-files/src/quickview.rs
@@ -97,6 +97,22 @@ pub struct VideoSnapshot {
     pub poster: Option<Pixels>,
 }
 
+impl VideoSnapshot {
+    /// The video's width over its height, once anything has said what that
+    /// is — the frame first, then the stream's announced size, then the
+    /// poster. `None` until the worker has answered, when the caller fills
+    /// the space it has and corrects on the next frame.
+    pub fn aspect(&self) -> Option<f32> {
+        let (w, h) = self
+            .frame
+            .as_ref()
+            .map(|f| (f.width, f.height))
+            .or(self.state.size)
+            .or_else(|| self.poster.as_ref().map(|p| (p.width, p.height)))?;
+        (w > 0 && h > 0).then(|| w as f32 / h as f32)
+    }
+}
+
 impl Video {
     /// Start playing `path`, if the decoded `preview` says it is a video
     /// and a player can be started.

--- a/components/otto-files/src/quickview.rs
+++ b/components/otto-files/src/quickview.rs
@@ -19,10 +19,12 @@ use std::path::Path;
 use std::time::Instant;
 
 use otto_kit::components::scroll::{Axis, ScrollState, ScrollView};
-use otto_kit::preview::{Preview, Zoom};
+use otto_kit::preview::{Pixels, Preview, Zoom};
+use otto_media_kit::transport::TransportHit;
+use otto_media_kit::{Playback, Player};
 use otto_quickview::decode::Request;
 use otto_quickview::opening;
-use skia_safe::Rect;
+use skia_safe::{Contains, Rect};
 
 /// The title strip along the top of the panel: the file's name, and the
 /// close button. The preview's content starts below it, so neither ever
@@ -72,6 +74,37 @@ impl Pan {
     }
 }
 
+/// A video being played inside a session.
+pub struct Video {
+    pub player: Player,
+    /// The card's own artwork, drawn until the first frame arrives.
+    pub poster: Option<Pixels>,
+    /// A drag along the scrubber in progress, as a fraction of the duration.
+    pub scrubbing: Option<f32>,
+    /// Whether the video was playing when the drag began, so it resumes
+    /// when the drag ends.
+    resume: bool,
+}
+
+/// What the pointer did over a video, in the host's own vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoPointer {
+    Press,
+    Motion,
+    Release,
+    Leave,
+}
+
+/// How large a frame to ask the worker for: the panel's content at the
+/// output's scale. A frame larger than the pixels it is drawn into is
+/// decode work and copy bandwidth for nothing.
+pub fn video_limits(panel: Rect, scale: f32) -> otto_media_kit::player::Limits {
+    otto_media_kit::player::Limits {
+        max_width: ((panel.width() * scale) as u32).clamp(64, 3840),
+        max_height: ((panel.height() * scale) as u32).clamp(64, 2160),
+    }
+}
+
 /// An open preview.
 pub struct Session {
     pub preview: Preview,
@@ -103,6 +136,11 @@ pub struct Session {
     /// When the exit started, once it has. A closing session is no longer the
     /// window's open preview — it is only still on screen, going home.
     pub closing: Option<Instant>,
+    /// A playback, when the file is a video and a player could be started.
+    /// The card in `preview` stays underneath it: its artwork is the poster
+    /// until the first frame lands, and it is what is shown again if the
+    /// player fails.
+    pub video: Option<Video>,
     /// Whether `preview` is the waiting line rather than a decoded file.
     ///
     /// The panel's surface repaints only when its content key changes, and
@@ -128,8 +166,140 @@ impl Session {
             anchor,
             opened_at,
             closing: None,
+            video: None,
             loading: false,
         }
+    }
+
+    /// Start playing `path` in this session, if it can be.
+    ///
+    /// Only for a preview [`otto_quickview::payload::is_video`] vouches for:
+    /// the sandboxed decoder read the bytes and said video, which is the one
+    /// opinion that counts before a demuxer is handed the file. A worker
+    /// that cannot be found or started leaves the card as it was, and says
+    /// why in the log rather than on the panel — the card is a complete
+    /// preview on its own.
+    pub fn attach_video(
+        &mut self,
+        path: &Path,
+        limits: otto_media_kit::player::Limits,
+        wake: impl Fn() + Send + Sync + 'static,
+    ) {
+        if !otto_quickview::payload::is_video(&self.preview) {
+            return;
+        }
+        match Player::open(path, limits, wake) {
+            Ok(player) => {
+                let poster = match &self.preview {
+                    Preview::Card { hero, .. } => hero.clone(),
+                    _ => None,
+                };
+                self.video = Some(Video {
+                    player,
+                    poster,
+                    scrubbing: None,
+                    resume: false,
+                });
+            }
+            Err(err) => tracing::info!("no video playback for {}: {err}", path.display()),
+        }
+    }
+
+    /// The playback's contribution to the panel's repaint key: everything
+    /// the player view draws that changes without the panel moving.
+    pub fn video_key(&self) -> u64 {
+        let Some(video) = &self.video else {
+            return 0;
+        };
+        let state = video.player.state();
+        let playing = state.playback == Playback::Playing;
+        let millis = state.position().as_millis() as u64;
+        let scrub = video
+            .scrubbing
+            .map(|fraction| fraction.to_bits() as u64)
+            .unwrap_or(0);
+        state.frame_seq.rotate_left(29)
+            ^ millis.rotate_left(11)
+            ^ (playing as u64) << 3
+            ^ (state.playback as u64) << 5
+            ^ ((state.volume <= 0.0) as u64) << 9
+            ^ scrub.rotate_left(41)
+    }
+
+    /// Whether the playback has drawn something new since `seen`, and what
+    /// to remember as seen. For a host that paints the panel into its own
+    /// window, where there is no content key to notice a frame for it.
+    pub fn video_frame_seq(&self) -> u64 {
+        self.video
+            .as_ref()
+            .map(|video| video.player.state().frame_seq)
+            .unwrap_or(0)
+    }
+
+    /// The pointer over a playing video. `None` when there is no video and
+    /// the caller's own handling applies; `Some(handled)` otherwise.
+    pub fn video_pointer(
+        &mut self,
+        kind: VideoPointer,
+        x: f32,
+        y: f32,
+        content: Rect,
+    ) -> Option<bool> {
+        let video = self.video.as_mut()?;
+        let layout = otto_media_kit::view::transport_layout(content);
+        let point = skia_safe::Point::new(x, y);
+        let state = video.player.state();
+        let seek_to = |fraction: f32| state.duration.map(|duration| duration.mul_f32(fraction));
+        Some(match kind {
+            VideoPointer::Press => {
+                match layout.hit(point) {
+                    Some(TransportHit::PlayPause) => video.player.toggle(),
+                    Some(TransportHit::Mute) => {
+                        let volume = if state.volume <= 0.0 { 1.0 } else { 0.0 };
+                        video.player.set_volume(volume);
+                    }
+                    Some(TransportHit::Scrub(fraction)) => {
+                        video.scrubbing = Some(fraction);
+                        video.resume = state.playback == Playback::Playing;
+                        if video.resume {
+                            video.player.pause();
+                        }
+                        if let Some(position) = seek_to(fraction) {
+                            video.player.seek(position, false);
+                        }
+                    }
+                    Some(TransportHit::Bar) => {}
+                    // The picture itself is the biggest play/pause button
+                    // there is, as in every player.
+                    None if content.contains(point) => video.player.toggle(),
+                    None => return Some(false),
+                }
+                true
+            }
+            VideoPointer::Motion => {
+                let Some(_) = video.scrubbing else {
+                    return Some(false);
+                };
+                let fraction = layout.fraction_at(x);
+                video.scrubbing = Some(fraction);
+                if let Some(position) = seek_to(fraction) {
+                    video.player.seek(position, false);
+                }
+                true
+            }
+            VideoPointer::Release | VideoPointer::Leave => {
+                let Some(fraction) = video.scrubbing.take() else {
+                    return Some(false);
+                };
+                if let Some(position) = seek_to(fraction) {
+                    video.player.seek(position, true);
+                }
+                if video.resume {
+                    video.player.play();
+                }
+                true
+            }
+        })
     }
 
     /// A session on a file whose decode has only just been asked for: the

--- a/components/otto-files/src/quickview.rs
+++ b/components/otto-files/src/quickview.rs
@@ -21,7 +21,7 @@ use std::time::Instant;
 use otto_kit::components::scroll::{Axis, ScrollState, ScrollView};
 use otto_kit::preview::{Pixels, Preview, Zoom};
 use otto_media_kit::transport::TransportHit;
-use otto_media_kit::{Playback, Player};
+use otto_media_kit::{Frame, Options, Playback, Player, State};
 use otto_quickview::decode::Request;
 use otto_quickview::opening;
 use skia_safe::{Contains, Rect};
@@ -86,6 +86,154 @@ pub struct Video {
     resume: bool,
 }
 
+/// Everything a drawing of the video needs, detached from the player: for a
+/// host that records its drawing into a picture, which must own what it
+/// draws from.
+pub struct VideoSnapshot {
+    pub frame: Option<Frame>,
+    pub state: State,
+    pub scrubbing: Option<f32>,
+    /// The poster, carried only until the first frame makes it moot.
+    pub poster: Option<Pixels>,
+}
+
+impl Video {
+    /// Start playing `path`, if the decoded `preview` says it is a video
+    /// and a player can be started.
+    ///
+    /// Only for a preview [`otto_quickview::payload::is_video`] vouches for:
+    /// the sandboxed decoder read the bytes and said video, which is the one
+    /// opinion that counts before a demuxer is handed the file. A worker
+    /// that cannot be found or started leaves the card as it was, and says
+    /// why in the log rather than on the panel — the card is a complete
+    /// preview on its own.
+    pub fn open(
+        preview: &Preview,
+        path: &Path,
+        options: Options,
+        wake: impl Fn() + Send + Sync + 'static,
+    ) -> Option<Video> {
+        if !otto_quickview::payload::is_video(preview) {
+            return None;
+        }
+        match Player::open(path, options, wake) {
+            Ok(player) => {
+                let poster = match preview {
+                    Preview::Card { hero, .. } => hero.clone(),
+                    _ => None,
+                };
+                Some(Video {
+                    player,
+                    poster,
+                    scrubbing: None,
+                    resume: false,
+                })
+            }
+            Err(err) => {
+                tracing::info!("no video playback for {}: {err}", path.display());
+                None
+            }
+        }
+    }
+
+    /// The playback's contribution to a repaint key: everything the player
+    /// view draws that changes without anything around it moving.
+    pub fn key(&self) -> u64 {
+        let state = self.player.state();
+        let playing = state.playback == Playback::Playing;
+        let millis = state.position().as_millis() as u64;
+        let scrub = self
+            .scrubbing
+            .map(|fraction| fraction.to_bits() as u64)
+            .unwrap_or(0);
+        state.frame_seq.rotate_left(29)
+            ^ millis.rotate_left(11)
+            ^ (playing as u64) << 3
+            ^ (state.playback as u64) << 5
+            ^ ((state.volume <= 0.0) as u64) << 9
+            ^ scrub.rotate_left(41)
+    }
+
+    /// The newest frame's sequence number; 0 before any has arrived.
+    pub fn frame_seq(&self) -> u64 {
+        self.player.state().frame_seq
+    }
+
+    /// What to draw, detached from the player.
+    pub fn snapshot(&self) -> VideoSnapshot {
+        let frame = self.player.frame();
+        VideoSnapshot {
+            poster: if frame.is_none() {
+                self.poster.clone()
+            } else {
+                None
+            },
+            frame,
+            state: self.player.state(),
+            scrubbing: self.scrubbing,
+        }
+    }
+
+    /// The pointer over the video, drawn in `content`. Returns whether it
+    /// was taken.
+    pub fn pointer(&mut self, kind: VideoPointer, x: f32, y: f32, content: Rect) -> bool {
+        let layout = otto_media_kit::view::transport_layout(content);
+        let point = skia_safe::Point::new(x, y);
+        let state = self.player.state();
+        let seek_to = |fraction: f32| state.duration.map(|duration| duration.mul_f32(fraction));
+        match kind {
+            VideoPointer::Press => {
+                match layout.hit(point) {
+                    Some(TransportHit::PlayPause) => self.player.toggle(),
+                    Some(TransportHit::Mute) => {
+                        let volume = if state.volume <= 0.0 { 1.0 } else { 0.0 };
+                        self.player.set_volume(volume);
+                    }
+                    Some(TransportHit::Scrub(fraction)) => {
+                        self.scrubbing = Some(fraction);
+                        self.resume = state.playback == Playback::Playing;
+                        if self.resume {
+                            self.player.pause();
+                        }
+                        if let Some(position) = seek_to(fraction) {
+                            self.player.seek(position, false);
+                        }
+                    }
+                    Some(TransportHit::Bar) => {}
+                    // The picture itself is the biggest play/pause button
+                    // there is, as in every player.
+                    None if content.contains(point) => self.player.toggle(),
+                    None => return false,
+                }
+                true
+            }
+            VideoPointer::Motion => {
+                if self.scrubbing.is_none() {
+                    return false;
+                }
+                let fraction = layout.fraction_at(x);
+                self.scrubbing = Some(fraction);
+                if let Some(position) = seek_to(fraction) {
+                    self.player.seek(position, false);
+                }
+                true
+            }
+            VideoPointer::Release | VideoPointer::Leave => {
+                let Some(fraction) = self.scrubbing.take() else {
+                    return false;
+                };
+                if let Some(position) = seek_to(fraction) {
+                    self.player.seek(position, true);
+                }
+                if self.resume {
+                    self.player.play();
+                }
+                true
+            }
+        }
+    }
+}
+
 /// What the pointer did over a video, in the host's own vocabulary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VideoPointer {
@@ -95,13 +243,14 @@ pub enum VideoPointer {
     Leave,
 }
 
-/// How large a frame to ask the worker for: the panel's content at the
-/// output's scale. A frame larger than the pixels it is drawn into is
-/// decode work and copy bandwidth for nothing.
-pub fn video_limits(panel: Rect, scale: f32) -> otto_media_kit::player::Limits {
-    otto_media_kit::player::Limits {
+/// How to open a video for a box of `panel` points at the output's scale.
+/// A frame larger than the pixels it is drawn into is decode work and copy
+/// bandwidth for nothing.
+pub fn video_options(panel: Rect, scale: f32, autoplay: bool) -> Options {
+    Options {
         max_width: ((panel.width() * scale) as u32).clamp(64, 3840),
         max_height: ((panel.height() * scale) as u32).clamp(64, 2160),
+        autoplay,
     }
 }
 
@@ -141,6 +290,10 @@ pub struct Session {
     /// until the first frame lands, and it is what is shown again if the
     /// player fails.
     pub video: Option<Video>,
+    /// Whether the panel fills the space it is centred in — the display or
+    /// the window — rather than taking its usual share of it. Toggled by the
+    /// title strip's expand button and kept while arrow-keying between files.
+    pub expanded: bool,
     /// Whether `preview` is the waiting line rather than a decoded file.
     ///
     /// The panel's surface repaints only when its content key changes, and
@@ -167,73 +320,36 @@ impl Session {
             opened_at,
             closing: None,
             video: None,
+            expanded: false,
             loading: false,
         }
     }
 
-    /// Start playing `path` in this session, if it can be.
-    ///
-    /// Only for a preview [`otto_quickview::payload::is_video`] vouches for:
-    /// the sandboxed decoder read the bytes and said video, which is the one
-    /// opinion that counts before a demuxer is handed the file. A worker
-    /// that cannot be found or started leaves the card as it was, and says
-    /// why in the log rather than on the panel — the card is a complete
-    /// preview on its own.
+    /// Fill the space, or go back to the usual share of it.
+    pub fn toggle_expanded(&mut self) {
+        self.expanded = !self.expanded;
+    }
+
+    /// Start playing `path` in this session, if the preview is a video and
+    /// a player can be started. See [`Video::open`].
     pub fn attach_video(
         &mut self,
         path: &Path,
-        limits: otto_media_kit::player::Limits,
+        options: Options,
         wake: impl Fn() + Send + Sync + 'static,
     ) {
-        if !otto_quickview::payload::is_video(&self.preview) {
-            return;
-        }
-        match Player::open(path, limits, wake) {
-            Ok(player) => {
-                let poster = match &self.preview {
-                    Preview::Card { hero, .. } => hero.clone(),
-                    _ => None,
-                };
-                self.video = Some(Video {
-                    player,
-                    poster,
-                    scrubbing: None,
-                    resume: false,
-                });
-            }
-            Err(err) => tracing::info!("no video playback for {}: {err}", path.display()),
-        }
+        self.video = Video::open(&self.preview, path, options, wake);
     }
 
-    /// The playback's contribution to the panel's repaint key: everything
-    /// the player view draws that changes without the panel moving.
+    /// The playback's contribution to the panel's repaint key.
     pub fn video_key(&self) -> u64 {
-        let Some(video) = &self.video else {
-            return 0;
-        };
-        let state = video.player.state();
-        let playing = state.playback == Playback::Playing;
-        let millis = state.position().as_millis() as u64;
-        let scrub = video
-            .scrubbing
-            .map(|fraction| fraction.to_bits() as u64)
-            .unwrap_or(0);
-        state.frame_seq.rotate_left(29)
-            ^ millis.rotate_left(11)
-            ^ (playing as u64) << 3
-            ^ (state.playback as u64) << 5
-            ^ ((state.volume <= 0.0) as u64) << 9
-            ^ scrub.rotate_left(41)
+        self.video.as_ref().map(Video::key).unwrap_or(0)
     }
 
-    /// Whether the playback has drawn something new since `seen`, and what
-    /// to remember as seen. For a host that paints the panel into its own
-    /// window, where there is no content key to notice a frame for it.
+    /// The newest frame's sequence number, for a host that paints the panel
+    /// into its own window and has no content key to notice a frame for it.
     pub fn video_frame_seq(&self) -> u64 {
-        self.video
-            .as_ref()
-            .map(|video| video.player.state().frame_seq)
-            .unwrap_or(0)
+        self.video.as_ref().map(Video::frame_seq).unwrap_or(0)
     }
 
     /// The pointer over a playing video. `None` when there is no video and
@@ -246,60 +362,7 @@ impl Session {
         content: Rect,
     ) -> Option<bool> {
         let video = self.video.as_mut()?;
-        let layout = otto_media_kit::view::transport_layout(content);
-        let point = skia_safe::Point::new(x, y);
-        let state = video.player.state();
-        let seek_to = |fraction: f32| state.duration.map(|duration| duration.mul_f32(fraction));
-        Some(match kind {
-            VideoPointer::Press => {
-                match layout.hit(point) {
-                    Some(TransportHit::PlayPause) => video.player.toggle(),
-                    Some(TransportHit::Mute) => {
-                        let volume = if state.volume <= 0.0 { 1.0 } else { 0.0 };
-                        video.player.set_volume(volume);
-                    }
-                    Some(TransportHit::Scrub(fraction)) => {
-                        video.scrubbing = Some(fraction);
-                        video.resume = state.playback == Playback::Playing;
-                        if video.resume {
-                            video.player.pause();
-                        }
-                        if let Some(position) = seek_to(fraction) {
-                            video.player.seek(position, false);
-                        }
-                    }
-                    Some(TransportHit::Bar) => {}
-                    // The picture itself is the biggest play/pause button
-                    // there is, as in every player.
-                    None if content.contains(point) => video.player.toggle(),
-                    None => return Some(false),
-                }
-                true
-            }
-            VideoPointer::Motion => {
-                let Some(_) = video.scrubbing else {
-                    return Some(false);
-                };
-                let fraction = layout.fraction_at(x);
-                video.scrubbing = Some(fraction);
-                if let Some(position) = seek_to(fraction) {
-                    video.player.seek(position, false);
-                }
-                true
-            }
-            VideoPointer::Release | VideoPointer::Leave => {
-                let Some(fraction) = video.scrubbing.take() else {
-                    return Some(false);
-                };
-                if let Some(position) = seek_to(fraction) {
-                    video.player.seek(position, true);
-                }
-                if video.resume {
-                    video.player.play();
-                }
-                true
-            }
-        })
+        Some(video.pointer(kind, x, y, content))
     }
 
     /// A session on a file whose decode has only just been asked for: the
@@ -326,12 +389,14 @@ impl Session {
     /// too, so an exit still flies home to the row that is selected.
     pub fn awaiting(&mut self, name: String, is_dir: bool, anchor: Rect) {
         let opened_at = self.opened_at;
+        let expanded = self.expanded;
         let anchor = if anchor.is_empty() {
             self.anchor
         } else {
             anchor
         };
         *self = Self::waiting(name, is_dir, anchor, opened_at);
+        self.expanded = expanded;
     }
 
     /// How far into the entrance the panel is, 0 → 1.
@@ -657,13 +722,37 @@ fn waiting_preview(name: &str, is_dir: bool) -> Preview {
 
 /// Where the panel rests, centred in a window of `width` × `height`.
 pub fn panel_rect(width: f32, height: f32) -> Rect {
-    let w = (width * PANEL_FRACTION).max(PANEL_MIN.0).min(width - 32.0);
-    let h = (height * PANEL_FRACTION)
-        .max(PANEL_MIN.1)
-        .min(height - 32.0);
+    resting_in(Rect::from_wh(width, height), false)
+}
+
+/// What an expanded panel leaves around itself. Enough to still read as a
+/// card laid over the desktop rather than a window that replaced it.
+pub const EXPANDED_MARGIN: f32 = 12.0;
+
+/// Where the panel rests inside `space` — a window or a display, in points.
+///
+/// At rest it takes [`PANEL_FRACTION`] of the space, floored at
+/// [`PANEL_MIN`] and never quite touching the edges. Expanded it takes all
+/// of it bar [`EXPANDED_MARGIN`], which is what the title strip's expand
+/// button asks for.
+pub fn resting_in(space: Rect, expanded: bool) -> Rect {
+    let (width, height) = (space.width(), space.height());
+    let (w, h) = if expanded {
+        (
+            (width - EXPANDED_MARGIN * 2.0).max(1.0),
+            (height - EXPANDED_MARGIN * 2.0).max(1.0),
+        )
+    } else {
+        (
+            (width * PANEL_FRACTION).max(PANEL_MIN.0).min(width - 32.0),
+            (height * PANEL_FRACTION)
+                .max(PANEL_MIN.1)
+                .min(height - 32.0),
+        )
+    };
     Rect::from_xywh(
-        (width - w) / 2.0,
-        (height - h) / 2.0,
+        space.left + (width - w) / 2.0,
+        space.top + (height - h) / 2.0,
         w.max(1.0),
         h.max(1.0),
     )
@@ -726,6 +815,31 @@ mod tests {
     /// to fit any panel these tests use, so the fit rect fills one axis of
     /// the content box exactly and the zoom arithmetic has something to bite
     /// on.
+    #[test]
+    fn an_expanded_panel_fills_its_space_bar_the_margin() {
+        let space = Rect::from_xywh(100.0, 50.0, 1600.0, 900.0);
+        let rest = resting_in(space, false);
+        let full = resting_in(space, true);
+        assert!(rest.width() < full.width() && rest.height() < full.height());
+        assert!((full.left - (space.left + EXPANDED_MARGIN)).abs() < 0.01);
+        assert!((full.right - (space.right - EXPANDED_MARGIN)).abs() < 0.01);
+        assert!((full.top - (space.top + EXPANDED_MARGIN)).abs() < 0.01);
+        assert!((full.bottom - (space.bottom - EXPANDED_MARGIN)).abs() < 0.01);
+        // Both are centred in the same space.
+        assert!((rest.center_x() - full.center_x()).abs() < 0.01);
+        assert!((rest.center_y() - full.center_y()).abs() < 0.01);
+    }
+
+    #[test]
+    fn expanding_survives_moving_to_the_next_file() {
+        let mut session = image_session(100, 100);
+        session.toggle_expanded();
+        session.awaiting("next.png".into(), false, Rect::new_empty());
+        assert!(session.expanded);
+        session.toggle_expanded();
+        assert!(!session.expanded);
+    }
+
     fn image_session(width: u32, height: u32) -> Session {
         Session::new(
             Preview::Pixels {

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -512,6 +512,8 @@ impl Scene {
             data.name,
             data.first_row,
             data.decoded.is_some(),
+            // A video re-records on every frame and every tick of its clock.
+            data.video.map(crate::quickview::Video::key).unwrap_or(0),
             view::is_dark(),
             full.width().to_bits(),
             full.height().to_bits(),
@@ -991,6 +993,8 @@ mod tests {
             action_row: None,
             footer: 0.0,
             quickview_close_hovered: false,
+            quickview_expand_hovered: false,
+            quickview_expanded: false,
             drop_target: None,
             marquee: None,
             path_entry: false,

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -512,8 +512,14 @@ impl Scene {
             data.name,
             data.first_row,
             data.decoded.is_some(),
-            // A video re-records on every frame and every tick of its clock.
-            data.video.map(crate::quickview::Video::key).unwrap_or(0),
+            // A video re-records on every frame and every tick of its clock
+            // — but only when it is drawn in this layer. On its own subsurface
+            // the layer draws none of it, so its key must not churn per frame.
+            if data.video_on_surface {
+                0
+            } else {
+                data.video.map(crate::quickview::Video::key).unwrap_or(0)
+            },
             view::is_dark(),
             full.width().to_bits(),
             full.height().to_bits(),

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -4005,17 +4005,37 @@ pub fn draw_quickview(
     canvas.save();
     canvas.clip_rrect(RRect::new_rect_xy(panel, 12.0, 12.0), None, true);
     canvas.clip_rect(content, None, true);
-    otto_kit::preview::draw(
-        canvas,
-        content,
-        &session.preview,
-        f.theme,
-        session.first_row,
-        session.zoom,
-        &|name: &str, size: i32| {
-            icons::cached_icon_chain_at(&[name], size, icons::FULL_COLOUR_SIZE)
-        },
-    );
+    if let Some(video) = &session.video {
+        // A playing video takes the card's place. The card's artwork is the
+        // poster until the first frame lands; with none, the stage is dark.
+        let poster = video
+            .poster
+            .as_ref()
+            .and_then(otto_kit::preview::Pixels::to_image);
+        otto_media_kit::view::draw(
+            canvas,
+            content,
+            &video.player,
+            poster.as_ref(),
+            otto_media_kit::view::Interaction {
+                scrubbing: video.scrubbing,
+                transport_opacity: 1.0,
+            },
+            f.theme,
+        );
+    } else {
+        otto_kit::preview::draw(
+            canvas,
+            content,
+            &session.preview,
+            f.theme,
+            session.first_row,
+            session.zoom,
+            &|name: &str, size: i32| {
+                icons::cached_icon_chain_at(&[name], size, icons::FULL_COLOUR_SIZE)
+            },
+        );
+    }
 
     // The pan's bars, inside the same clip as the picture they belong to.
     // Nothing is drawn unless there is a zoomed picture with something under

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2126,6 +2126,9 @@ pub struct PreviewData<'a> {
     /// A player, when the decode said video and one could be started. The
     /// column then shows its frame and transport in the stage.
     pub video: Option<&'a crate::quickview::Video>,
+    /// Whether that video is presented on its own subsurface, so the scene
+    /// layer leaves the stage to the column ground rather than drawing frames.
+    pub video_on_surface: bool,
     pub first_row: usize,
     /// What the column says about the file underneath its name — kind, size,
     /// when it was last written. Already formatted, because the listing has
@@ -2358,6 +2361,7 @@ pub fn preview_content(
     let icon_chain = data.icon_chain.clone();
     let decoded = data.decoded.cloned();
     let video = data.video.map(crate::quickview::Video::snapshot);
+    let video_on_surface = data.video_on_surface;
     let first_row = data.first_row;
     let info = data.info.clone();
 
@@ -2376,6 +2380,7 @@ pub fn preview_content(
             stage,
             decoded.as_ref(),
             video.as_ref(),
+            video_on_surface,
             &icon_chain,
             first_row,
         );
@@ -2407,9 +2412,29 @@ pub fn preview_drag_picture(
             stage,
             decoded.as_ref(),
             None,
+            false,
             &icon_chain,
             first_row,
         );
+    }
+}
+
+/// The player's box within the preview column's stage: the video's own
+/// shape, not the whole stage. The picture fills the box's width and the
+/// transport rides under it, so the box is `width / aspect + transport`,
+/// capped to the stage and centred in what is left. Until the aspect is
+/// known the box is the stage and the fitted draw letterboxes — one frame,
+/// then it snaps to shape. Drawing and hit-testing both measure against this,
+/// so they cannot disagree about where the controls are.
+pub fn preview_video_box(stage: Rect, aspect: Option<f32>) -> Rect {
+    match aspect {
+        Some(aspect) if aspect > 0.0 => {
+            let width = stage.width();
+            let height = (width / aspect + otto_media_kit::transport::HEIGHT).min(stage.height());
+            let top = (stage.center_y() - height / 2.0).max(stage.top);
+            Rect::from_xywh(stage.left, top, width, height)
+        }
+        _ => stage,
     }
 }
 
@@ -2437,21 +2462,31 @@ fn draw_preview_stage(
     stage: Rect,
     decoded: Option<&otto_kit::preview::Preview>,
     video: Option<&crate::quickview::VideoSnapshot>,
+    // Whether a video is drawn on its own subsurface over this stage, in
+    // which case the stage is left to the column ground here.
+    on_surface: bool,
     icon_chain: &[String],
     first_row: usize,
 ) {
     // A video plays in the stage, transport and all, the same view Quick
     // View draws in its panel. The card the decoder produced is its poster.
     if let Some(video) = video {
+        // On its own subsurface the player draws itself; the scene layer
+        // leaves the stage to the column's ground so it is not re-recorded on
+        // every frame. See `pane_surfaces::sync_preview_video`.
+        if on_surface {
+            return;
+        }
         let poster = video
             .poster
             .as_ref()
             .and_then(otto_kit::preview::Pixels::to_image);
+        let box_rect = preview_video_box(stage, video.aspect());
         canvas.save();
         canvas.clip_rect(stage, None, false);
         otto_media_kit::view::draw_frame(
             canvas,
-            stage,
+            box_rect,
             video.frame.as_ref(),
             poster.as_ref(),
             &video.state,

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2017,6 +2017,11 @@ pub struct Frame<'a> {
     /// Pointer is over Quick View's close button, so it lights up — the same
     /// hover behaviour the sheet's close dot has.
     pub quickview_close_hovered: bool,
+    /// Pointer is over Quick View's expand button.
+    pub quickview_expand_hovered: bool,
+    /// Whether the open panel is expanded, which flips the expand button's
+    /// glyph to the collapse one.
+    pub quickview_expanded: bool,
     /// Thumbnails for the entries on screen, where any have been found. A
     /// file with one is drawn as itself instead of as its type's icon.
     ///
@@ -2118,6 +2123,9 @@ pub struct PreviewData<'a> {
     /// The decode, once it lands. `None` while it is still in flight, which
     /// is the big icon's cue to stand in for it.
     pub decoded: Option<&'a otto_kit::preview::Preview>,
+    /// A player, when the decode said video and one could be started. The
+    /// column then shows its frame and transport in the stage.
+    pub video: Option<&'a crate::quickview::Video>,
     pub first_row: usize,
     /// What the column says about the file underneath its name — kind, size,
     /// when it was last written. Already formatted, because the listing has
@@ -2349,6 +2357,7 @@ pub fn preview_content(
     let name = data.name.to_string();
     let icon_chain = data.icon_chain.clone();
     let decoded = data.decoded.cloned();
+    let video = data.video.map(crate::quickview::Video::snapshot);
     let first_row = data.first_row;
     let info = data.info.clone();
 
@@ -2366,6 +2375,7 @@ pub fn preview_content(
             &theme,
             stage,
             decoded.as_ref(),
+            video.as_ref(),
             &icon_chain,
             first_row,
         );
@@ -2396,6 +2406,7 @@ pub fn preview_drag_picture(
             &theme,
             stage,
             decoded.as_ref(),
+            None,
             &icon_chain,
             first_row,
         );
@@ -2425,9 +2436,34 @@ fn draw_preview_stage(
     theme: &Theme,
     stage: Rect,
     decoded: Option<&otto_kit::preview::Preview>,
+    video: Option<&crate::quickview::VideoSnapshot>,
     icon_chain: &[String],
     first_row: usize,
 ) {
+    // A video plays in the stage, transport and all, the same view Quick
+    // View draws in its panel. The card the decoder produced is its poster.
+    if let Some(video) = video {
+        let poster = video
+            .poster
+            .as_ref()
+            .and_then(otto_kit::preview::Pixels::to_image);
+        canvas.save();
+        canvas.clip_rect(stage, None, false);
+        otto_media_kit::view::draw_frame(
+            canvas,
+            stage,
+            video.frame.as_ref(),
+            poster.as_ref(),
+            &video.state,
+            otto_media_kit::view::Interaction {
+                scrubbing: video.scrubbing,
+                transport_opacity: 1.0,
+            },
+            theme,
+        );
+        canvas.restore();
+        return;
+    }
     // Nothing the previewer produced may leave the stage. The decoders
     // bound what they return, and each drawing path lays itself out to
     // fit, but the content is a *file's* — an archive with hundreds of
@@ -3808,6 +3844,18 @@ pub fn quickview_close_rect(panel: Rect) -> Rect {
     Rect::from_xywh(panel.right - INSET - D, strip.center_y() - D / 2.0, D, D)
 }
 
+/// The expand button, to the left of the close button.
+pub fn quickview_expand_rect(panel: Rect) -> Rect {
+    const GAP: f32 = 8.0;
+    let close = quickview_close_rect(panel);
+    Rect::from_xywh(
+        close.left - GAP - close.width(),
+        close.top,
+        close.width(),
+        close.height(),
+    )
+}
+
 /// The panel's title strip: the file's name and the close button.
 ///
 /// Chrome, not content. The preview is drawn below it, so a close button in
@@ -3881,6 +3929,78 @@ fn draw_quickview_close(canvas: &Canvas, theme: &Theme, panel: Rect, hovered: bo
         (centre.x - r, centre.y + r),
         &glyph,
     );
+}
+
+/// The expand button: the same dot as close, with two diagonal arrows —
+/// pointing out to fill the display, in to come back.
+fn draw_quickview_expand(
+    canvas: &Canvas,
+    theme: &Theme,
+    panel: Rect,
+    hovered: bool,
+    expanded: bool,
+    opacity: f32,
+) {
+    let button = quickview_expand_rect(panel);
+    let centre = Point::new(button.center_x(), button.center_y());
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(fade(
+        if hovered {
+            theme.fill_primary
+        } else {
+            theme.fill_secondary
+        },
+        opacity,
+    ));
+    canvas.draw_circle(centre, button.width() / 2.0, &paint);
+
+    let mut glyph = Paint::default();
+    glyph.set_anti_alias(true);
+    glyph.set_style(skia_safe::paint::Style::Stroke);
+    glyph.set_stroke_width(1.5);
+    glyph.set_stroke_cap(skia_safe::PaintCap::Round);
+    glyph.set_stroke_join(skia_safe::PaintJoin::Round);
+    glyph.set_color(fade(theme.text_secondary, opacity));
+
+    // Two arrows on the rising diagonal. The shaft runs from near the centre
+    // to near the rim; the head sits at the outer end when expanding and at
+    // the inner end when collapsing, so the same strokes say both things.
+    let outer = button.width() * 0.28;
+    let inner = button.width() * 0.06;
+    let head = button.width() * 0.16;
+    for sign in [-1.0f32, 1.0] {
+        // Bottom-left arrow for sign = -1, top-right for sign = 1: x grows
+        // with sign, y shrinks with it.
+        let tip_out = Point::new(centre.x + sign * outer, centre.y - sign * outer);
+        let tip_in = Point::new(centre.x + sign * inner, centre.y - sign * inner);
+        canvas.draw_line(tip_in, tip_out, &glyph);
+        let (tip, dir) = if expanded {
+            (tip_in, -sign)
+        } else {
+            (tip_out, sign)
+        };
+        // The head's two strokes come back from the tip along each axis.
+        canvas.draw_line(tip, Point::new(tip.x - dir * head, tip.y), &glyph);
+        canvas.draw_line(tip, Point::new(tip.x, tip.y + dir * head), &glyph);
+    }
+}
+
+#[cfg(test)]
+mod quickview_buttons {
+    use super::*;
+
+    #[test]
+    fn the_expand_button_sits_left_of_close_inside_the_strip() {
+        let panel = Rect::from_xywh(100.0, 100.0, 800.0, 600.0);
+        let close = quickview_close_rect(panel);
+        let expand = quickview_expand_rect(panel);
+        let strip = quickview_titlebar_rect(panel);
+        assert!(expand.right < close.left);
+        assert!(expand.top >= strip.top && expand.bottom <= strip.bottom);
+        assert!((expand.center_y() - close.center_y()).abs() < 0.01);
+    }
 }
 
 /// How much of the panel's chrome is drawn at the size the panel is now.
@@ -3999,6 +4119,14 @@ pub fn draw_quickview(
         }
 
         draw_quickview_close(canvas, f.theme, panel, f.quickview_close_hovered, chrome);
+        draw_quickview_expand(
+            canvas,
+            f.theme,
+            panel,
+            f.quickview_expand_hovered,
+            f.quickview_expanded,
+            chrome,
+        );
     }
 
     let content = quickview_content_rect(panel);
@@ -5249,6 +5377,8 @@ mod geometry_tests {
             action_row: None,
             footer: 0.0,
             quickview_close_hovered: false,
+            quickview_expand_hovered: false,
+            quickview_expanded: false,
             drop_target: None,
             marquee: None,
             path_entry: false,

--- a/components/otto-kit/src/components/menu_bar/renderer.rs
+++ b/components/otto-kit/src/components/menu_bar/renderer.rs
@@ -145,7 +145,19 @@ impl MenuBarRenderer {
                 ));
             }
 
-            canvas.draw_image_rect(&image, None, dst, &paint);
+            // The image is whatever size the icon source offered, which is
+            // rarely the box we draw into; nearest-neighbour would stair-step it.
+            let dst_px = (
+                style.icon_size * scale as f32,
+                style.icon_size * scale as f32,
+            );
+            canvas.draw_image_rect_with_sampling_options(
+                &image,
+                None,
+                dst,
+                crate::utils::icon_sampling((image.width(), image.height()), dst_px),
+                &paint,
+            );
         }
     }
 

--- a/components/otto-kit/src/components/menu_item/renderer.rs
+++ b/components/otto-kit/src/components/menu_item/renderer.rs
@@ -198,7 +198,14 @@ impl MenuItemRenderer {
                 if let Some(img) = crate::icons::named_icon_sized(name, load_size) {
                     let dst = Rect::from_xywh(icon_x, icon_y, icon_size, icon_size);
                     let paint = Paint::default();
-                    canvas.draw_image_rect(&img, None, dst, &paint);
+                    let dst_px = (icon_size * scale as f32, icon_size * scale as f32);
+                    canvas.draw_image_rect_with_sampling_options(
+                        &img,
+                        None,
+                        dst,
+                        crate::utils::icon_sampling((img.width(), img.height()), dst_px),
+                        &paint,
+                    );
                 } else {
                     // Fall back to embedded SVG icon set
                     canvas.save();
@@ -253,7 +260,15 @@ impl MenuItemRenderer {
                     let dst = Rect::from_xywh(icon_x, icon_y, icon_size, icon_size);
                     let mut paint = Paint::default();
                     paint.set_anti_alias(true);
-                    canvas.draw_image_rect(&img, None, dst, &paint);
+                    let scale = crate::app_runner::context::AppContext::scale_factor().max(1);
+                    let dst_px = (icon_size * scale as f32, icon_size * scale as f32);
+                    canvas.draw_image_rect_with_sampling_options(
+                        &img,
+                        None,
+                        dst,
+                        crate::utils::icon_sampling((img.width(), img.height()), dst_px),
+                        &paint,
+                    );
                 } else {
                     tracing::warn!(
                         "menu_item render: failed to create skia image from pixmap {}x{}",

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -37,6 +37,10 @@ use wayland_protocols::xdg::shell::client::{
     xdg_popup, xdg_positioner, xdg_surface, xdg_toplevel, xdg_wm_base,
 };
 
+use wayland_protocols::wp::cursor_shape::v1::client::{
+    wp_cursor_shape_device_v1, wp_cursor_shape_manager_v1,
+};
+
 use crate::protocols::{otto_surface_style_manager_v1, otto_surface_style_v1};
 use wayland_protocols::ext::background_effect::v1::client::{
     ext_background_effect_manager_v1, ext_background_effect_surface_v1,
@@ -71,6 +75,13 @@ pub struct TestClientState {
     /// needs one: the compositor checks it against the grab it handed out, and
     /// a made-up number is refused.
     pub last_button_serial: Option<u32>,
+    /// The serial of the most recent `wl_pointer.enter`. Naming a cursor shape
+    /// needs one, the same way starting a drag needs a press serial.
+    pub last_enter_serial: Option<u32>,
+    /// The cursor-shape protocol, when the compositor advertises it. A client
+    /// that binds this asks for a cursor by name and lets the compositor draw
+    /// it, rather than uploading a bitmap of its own.
+    pub wp_cursor_shape_manager: Option<wp_cursor_shape_manager_v1::WpCursorShapeManagerV1>,
     /// Drag and drop, when the compositor advertises it.
     pub wl_data_device_manager: Option<wl_data_device_manager::WlDataDeviceManager>,
     pub wl_data_device: Option<wl_data_device::WlDataDevice>,
@@ -94,6 +105,8 @@ impl TestClientState {
             keyboard_focused: false,
             wl_pointer: None,
             last_button_serial: None,
+            last_enter_serial: None,
+            wp_cursor_shape_manager: None,
             wl_data_device_manager: None,
             wl_data_device: None,
             drag_cancelled: false,
@@ -351,6 +364,27 @@ impl TestClient {
     ///
     /// Returns a shared reference to the toplevel state which tracks
     /// configure events.
+    /// Ask the compositor to draw `shape` as the cursor, the way a client that
+    /// binds the cursor-shape protocol does instead of uploading a bitmap.
+    ///
+    /// Returns `false` when the compositor advertises no cursor-shape global,
+    /// or when the pointer has not entered one of this client's surfaces yet —
+    /// the enter serial is what authorises the request.
+    pub fn set_cursor_shape(&mut self, shape: wp_cursor_shape_device_v1::Shape) -> bool {
+        let (Some(manager), Some(pointer), Some(serial)) = (
+            self.state.wp_cursor_shape_manager.clone(),
+            self.state.wl_pointer.clone(),
+            self.state.last_enter_serial,
+        ) else {
+            return false;
+        };
+
+        let device = manager.get_pointer(&pointer, &self.qh, ());
+        device.set_shape(serial, shape);
+        device.destroy();
+        true
+    }
+
     pub fn create_toplevel(
         &mut self,
         title: &str,
@@ -692,9 +726,37 @@ impl Dispatch<wl_registry::WlRegistry, ()> for TestClientState {
                     state.ext_background_effect_manager =
                         Some(registry.bind(name, version.min(1), qh, ()));
                 }
+                "wp_cursor_shape_manager_v1" => {
+                    state.wp_cursor_shape_manager =
+                        Some(registry.bind(name, version.min(1), qh, ()));
+                }
                 _ => {}
             }
         }
+    }
+}
+
+impl Dispatch<wp_cursor_shape_manager_v1::WpCursorShapeManagerV1, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wp_cursor_shape_manager_v1::WpCursorShapeManagerV1,
+        _event: wp_cursor_shape_manager_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1, ()> for TestClientState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wp_cursor_shape_device_v1::WpCursorShapeDeviceV1,
+        _event: wp_cursor_shape_device_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
     }
 }
 
@@ -811,14 +873,16 @@ impl Dispatch<wl_pointer::WlPointer, ()> for TestClientState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        // Only the press serials matter here: they are what authorises a drag.
-        if let wl_pointer::Event::Button {
-            serial,
-            state: wayland_client::WEnum::Value(wl_pointer::ButtonState::Pressed),
-            ..
-        } = event
-        {
-            state.last_button_serial = Some(serial);
+        // Serials are the point: a press serial authorises a drag, an enter
+        // serial authorises naming a cursor shape.
+        match event {
+            wl_pointer::Event::Button {
+                serial,
+                state: wayland_client::WEnum::Value(wl_pointer::ButtonState::Pressed),
+                ..
+            } => state.last_button_serial = Some(serial),
+            wl_pointer::Event::Enter { serial, .. } => state.last_enter_serial = Some(serial),
+            _ => {}
         }
     }
 }

--- a/components/otto-kit/src/testing.rs
+++ b/components/otto-kit/src/testing.rs
@@ -364,6 +364,32 @@ impl TestClient {
     ///
     /// Returns a shared reference to the toplevel state which tracks
     /// configure events.
+    /// Hand the compositor a cursor bitmap of this client's own, the way a
+    /// client that does not use the cursor-shape protocol does — Chromium
+    /// among them.
+    ///
+    /// Returns the cursor surface and its buffer, which the caller keeps
+    /// alive, or `None` when the pointer has not entered one of this client's
+    /// surfaces yet: the enter serial is what authorises the request.
+    pub fn set_cursor_surface(
+        &mut self,
+        width: u32,
+        height: u32,
+    ) -> Option<(wl_surface::WlSurface, ShmBuffer)> {
+        let pointer = self.state.wl_pointer.clone()?;
+        let serial = self.state.last_enter_serial?;
+        let shm = self.state.wl_shm.clone().expect("shm not bound");
+
+        let buffer = ShmBuffer::new(&shm, &self.qh, width, height);
+        let surface = self.create_surface();
+        surface.attach(Some(buffer.buffer()), 0, 0);
+        surface.damage(0, 0, width as i32, height as i32);
+        surface.commit();
+
+        pointer.set_cursor(serial, Some(&surface), 0, 0);
+        Some((surface, buffer))
+    }
+
     /// Ask the compositor to draw `shape` as the cursor, the way a client that
     /// binds the cursor-shape protocol does instead of uploading a bitmap.
     ///

--- a/components/otto-kit/src/utils/mod.rs
+++ b/components/otto-kit/src/utils/mod.rs
@@ -1,4 +1,6 @@
 //! Utility functions for otto-kit.
 
 pub mod color_extraction;
+pub mod sampling;
 pub use color_extraction::extract_accent_color;
+pub use sampling::icon_sampling;

--- a/components/otto-kit/src/utils/sampling.rs
+++ b/components/otto-kit/src/utils/sampling.rs
@@ -1,0 +1,36 @@
+//! Sampling choices for drawing images at a size other than their own.
+//!
+//! Skia's default `SamplingOptions` is nearest-neighbour, which turns any
+//! rescale into visible stair-steps. Icons in particular almost never arrive
+//! at exactly the size we draw them: an SNI tray pixmap comes in whatever
+//! sizes the app happens to publish, and a themed icon is loaded at the
+//! nearest available size. These helpers pick a filter that suits the ratio.
+
+use skia_safe::sampling_options::{CubicResampler, SamplingOptions};
+use skia_safe::{FilterMode, MipmapMode};
+
+/// Sampling for drawing an icon of `src` pixels into a `dst`-pixel box.
+///
+/// Both sizes are in *physical* pixels — multiply the logical box by the
+/// surface scale before calling.
+///
+/// - A 1:1 draw needs no filtering at all.
+/// - Shrinking by more than 2x aliases under any single-pass filter, so ask
+///   for mipmaps and let Skia pick the level.
+/// - Everything else (mild minification and any magnification) gets Mitchell,
+///   which keeps edges smooth without the ringing of a sharper cubic.
+pub fn icon_sampling(src: (i32, i32), dst: (f32, f32)) -> SamplingOptions {
+    if src.0 <= 0 || src.1 <= 0 || dst.0 <= 0.0 || dst.1 <= 0.0 {
+        return SamplingOptions::default();
+    }
+
+    let ratio = (dst.0 / src.0 as f32).min(dst.1 / src.1 as f32);
+
+    if (ratio - 1.0).abs() < 0.01 {
+        SamplingOptions::default()
+    } else if ratio < 0.5 {
+        SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear)
+    } else {
+        SamplingOptions::from(CubicResampler::mitchell())
+    }
+}

--- a/components/otto-media-kit/Cargo.toml
+++ b/components/otto-media-kit/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "otto-media-kit"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Video playback for Otto apps: a sandboxed GStreamer worker and the canvas-pure player view that draws its frames"
+
+# Two halves, deliberately unequal in weight.
+#
+# The *library* is what an application embeds: a `Player` handle that runs the
+# worker, a frame the app draws, and a transport bar drawn the way every other
+# otto-kit control is. It links otto-kit and skia — which the host already has
+# — and nothing else. GStreamer never enters an application binary.
+#
+# The *worker* binary is where GStreamer lives. It is spawned per playback,
+# sandboxed, and talks to the host over pipes and one shared frame buffer.
+[lib]
+name = "otto_media_kit"
+path = "src/lib.rs"
+
+[[bin]]
+name = "otto-media-worker"
+path = "src/bin/otto-media-worker.rs"
+required-features = ["worker"]
+
+[features]
+default = ["worker"]
+# The GStreamer-backed worker. Off for a host that only wants the library;
+# the worker is then expected to be installed alongside from another build.
+worker = ["dep:gstreamer", "dep:gstreamer-app"]
+
+[dependencies]
+otto-kit = { path = "../otto-kit" }
+libc = "0.2"
+tracing = "0.1"
+
+gstreamer = { version = "0.25", optional = true }
+gstreamer-app = { version = "0.25", optional = true }
+
+[dependencies.skia-safe]
+version = "=0.93"
+features = ["gl", "textlayout", "svg", "skottie"]
+
+[lints]
+workspace = true

--- a/components/otto-media-kit/examples/probe.rs
+++ b/components/otto-media-kit/examples/probe.rs
@@ -1,0 +1,49 @@
+//! `cargo run -p otto-media-kit --example probe -- FILE`: play a file for a
+//! few seconds with no display, printing what the worker reports. The
+//! integration check between the host half and the worker.
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+fn main() {
+    let path = PathBuf::from(std::env::args().nth(1).expect("a media file"));
+    let mut player =
+        otto_media_kit::Player::open(&path, Default::default(), || {}).expect("worker starts");
+    let started = Instant::now();
+    let mut last_seq = 0;
+    let mut frames = 0;
+    while started.elapsed() < Duration::from_secs(4) {
+        std::thread::sleep(Duration::from_millis(50));
+        let state = player.state();
+        if state.frame_seq != last_seq {
+            frames += state.frame_seq - last_seq;
+            last_seq = state.frame_seq;
+        }
+        if started.elapsed() > Duration::from_secs(2)
+            && started.elapsed() < Duration::from_millis(2100)
+        {
+            player.seek(Duration::from_secs(1), true);
+        }
+    }
+    let state = player.state();
+    let frame = player.frame();
+    println!(
+        "playback={:?} size={:?} duration={:?} position={:?} frames={frames} error={:?}",
+        state.playback,
+        state.size,
+        state.duration,
+        state.position(),
+        state.error
+    );
+    if let Some(frame) = frame {
+        let image = frame.to_image().expect("frame wraps");
+        let png = image
+            .encode(None, skia_safe::EncodedImageFormat::PNG, None)
+            .unwrap();
+        let out = std::env::var("PROBE_PNG").unwrap_or_else(|_| "/tmp/otto-media-probe.png".into());
+        std::fs::write(&out, png.as_bytes()).unwrap();
+        println!(
+            "frame seq={} {}x{} -> {out}",
+            frame.seq, frame.width, frame.height
+        );
+    }
+}

--- a/components/otto-media-kit/examples/probe.rs
+++ b/components/otto-media-kit/examples/probe.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 
 fn main() {
     let path = PathBuf::from(std::env::args().nth(1).expect("a media file"));
-    let mut player =
-        otto_media_kit::Player::open(&path, Default::default(), || {}).expect("worker starts");
+    let mut player = otto_media_kit::Player::open(&path, otto_media_kit::Options::default(), || {})
+        .expect("worker starts");
     let started = Instant::now();
     let mut last_seq = 0;
     let mut frames = 0;

--- a/components/otto-media-kit/src/bin/otto-media-worker.rs
+++ b/components/otto-media-kit/src/bin/otto-media-worker.rs
@@ -235,11 +235,21 @@ fn build(
         .and_then(|element| element.downcast::<gst_app::AppSink>().ok())
         .ok_or("the video sink has no appsink")?;
 
+    // A preroll frame arrives while the pipeline is only PAUSED — which is
+    // how a preview starts when the host does not autoplay. Delivering it too
+    // is what lets a paused player show its first frame rather than black.
+    let preroll_events = Arc::clone(&events);
+    let preroll_ring = Arc::clone(&ring);
     appsink.set_callbacks(
         gst_app::AppSinkCallbacks::builder()
             .new_sample(move |appsink| {
                 let sample = appsink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                 deliver(&sample, &events, &ring, appsink);
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .new_preroll(move |appsink| {
+                let sample = appsink.pull_preroll().map_err(|_| gst::FlowError::Eos)?;
+                deliver(&sample, &preroll_events, &preroll_ring, appsink);
                 Ok(gst::FlowSuccess::Ok)
             })
             .build(),

--- a/components/otto-media-kit/src/bin/otto-media-worker.rs
+++ b/components/otto-media-kit/src/bin/otto-media-worker.rs
@@ -1,0 +1,400 @@
+//! otto-media-worker — the process that plays.
+//!
+//! Spawned by [`otto_media_kit::Player`] with a media file on descriptor 3
+//! and a frame ring on descriptor 4, commands on stdin and events on stdout.
+//! It runs one GStreamer pipeline, hands every decoded frame to the host
+//! through the ring, plays audio itself, and exits when told to or when the
+//! host goes away.
+//!
+//! It is the only part of a host application that ever links GStreamer or
+//! parses a media container, and it is contained accordingly: no network, no
+//! new privileges, no core dumps, and a descriptor ceiling. A demuxer that
+//! crashes on a hostile file takes this process and nothing else.
+
+use std::io::{self, BufRead, Write};
+use std::os::fd::FromRawFd;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use gst::prelude::*;
+use gstreamer as gst;
+use gstreamer_app as gst_app;
+
+use otto_media_kit::protocol::{self, Command, Event, FILE_FD, FRAMES_FD};
+
+/// The events pipe, shared by the streaming thread and the bus loop.
+struct Events(Mutex<io::Stdout>);
+
+impl Events {
+    fn send(&self, event: Event) {
+        let mut out = self.0.lock().unwrap();
+        if out.write_all(event.encode().as_bytes()).is_err() || out.flush().is_err() {
+            // The host closed its end: nothing to play for.
+            std::process::exit(0);
+        }
+    }
+}
+
+/// The frame ring as the worker sees it: sized to the current frame, and
+/// written one slot at a time.
+struct Ring {
+    file: std::fs::File,
+    size: (u32, u32),
+    next_slot: u32,
+    seq: u64,
+}
+
+impl Ring {
+    fn resize(&mut self, width: u32, height: u32) -> io::Result<()> {
+        self.file.set_len(protocol::ring_bytes(width, height))?;
+        self.size = (width, height);
+        Ok(())
+    }
+
+    fn write(&mut self, rows: impl Iterator<Item = impl AsRef<[u8]>>) -> io::Result<(u32, u64)> {
+        use std::os::unix::fs::FileExt;
+        let (width, height) = self.size;
+        let slot = self.next_slot;
+        let mut at = protocol::slot_offset(slot, width, height);
+        let row_bytes = (width * protocol::BYTES_PER_PIXEL) as usize;
+        for row in rows.take(height as usize) {
+            let row = &row.as_ref()[..row_bytes.min(row.as_ref().len())];
+            self.file.write_all_at(row, at)?;
+            at += row_bytes as u64;
+        }
+        self.next_slot = (slot + 1) % protocol::SLOTS;
+        self.seq += 1;
+        Ok((slot, self.seq))
+    }
+}
+
+fn main() {
+    let mut max_width = 1920u32;
+    let mut max_height = 1080u32;
+    let mut arguments = std::env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--max-width" => {
+                max_width = arguments
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(max_width)
+            }
+            "--max-height" => {
+                max_height = arguments
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(max_height)
+            }
+            _ => {}
+        }
+    }
+
+    let events = Arc::new(Events(Mutex::new(io::stdout())));
+    let fail = |events: &Events, reason: String| -> ! {
+        events.send(Event::Error(reason));
+        std::process::exit(1);
+    };
+
+    // SAFETY: nothing else is running in this process yet.
+    if let Err(err) = unsafe { contain() } {
+        fail(&events, format!("cannot contain the media worker: {err}"));
+    }
+
+    if let Err(err) = gst::init() {
+        fail(&events, format!("GStreamer would not start: {err}"));
+    }
+
+    // SAFETY: the parent guarantees this descriptor is open and read-write.
+    let ring = Arc::new(Mutex::new(Ring {
+        file: unsafe { std::fs::File::from_raw_fd(FRAMES_FD) },
+        size: (0, 0),
+        next_slot: 0,
+        seq: 0,
+    }));
+
+    // The file is opened by GStreamer through its descriptor rather than a
+    // path: the worker never learns where the file is, and nothing can be
+    // swapped under it.
+    let pipeline = match build(
+        max_width,
+        max_height,
+        Arc::clone(&events),
+        Arc::clone(&ring),
+    ) {
+        Ok(pipeline) => pipeline,
+        Err(err) => fail(&events, err),
+    };
+
+    // Preroll now, so the first frame and the duration are known before the
+    // host asks for anything.
+    if pipeline.set_state(gst::State::Paused).is_err() {
+        fail(&events, "the file could not be opened for playback".into());
+    }
+
+    // Commands come in on their own thread and act on the pipeline directly;
+    // GStreamer is thread-safe for everything done here.
+    {
+        let pipeline = pipeline.clone();
+        let events = Arc::clone(&events);
+        std::thread::spawn(move || read_commands(pipeline, events));
+    }
+
+    let bus = pipeline.bus().expect("a pipeline has a bus");
+    let mut playing = false;
+    loop {
+        let message = bus.timed_pop(gst::ClockTime::from_mseconds(100));
+        let Some(message) = message else {
+            if playing {
+                if let Some(position) = pipeline.query_position::<gst::ClockTime>() {
+                    events.send(Event::Position(Duration::from_nanos(position.nseconds())));
+                }
+            }
+            continue;
+        };
+        use gst::MessageView;
+        match message.view() {
+            MessageView::Eos(_) => {
+                playing = false;
+                events.send(Event::Ended);
+            }
+            MessageView::Error(err) => {
+                let reason = match err.debug() {
+                    Some(debug) if std::env::var_os("OTTO_MEDIA_TRACE").is_some() => {
+                        format!("{} ({debug})", err.error())
+                    }
+                    _ => err.error().to_string(),
+                };
+                fail(&events, reason);
+            }
+            MessageView::StateChanged(change)
+                if message.src().is_some_and(|src| *src == pipeline) =>
+            {
+                match change.current() {
+                    gst::State::Playing => {
+                        playing = true;
+                        events.send(Event::Playing);
+                    }
+                    gst::State::Paused => {
+                        playing = false;
+                        events.send(Event::Paused);
+                    }
+                    _ => {}
+                }
+            }
+            MessageView::AsyncDone(_) | MessageView::DurationChanged(_) => {
+                // The duration is often only known once prerolled, and
+                // sometimes only later than that.
+                let (width, height) = ring.lock().unwrap().size;
+                if width > 0 {
+                    events.send(Event::Ready {
+                        width,
+                        height,
+                        duration: duration_of(&pipeline),
+                    });
+                }
+                if let Some(position) = pipeline.query_position::<gst::ClockTime>() {
+                    events.send(Event::Position(Duration::from_nanos(position.nseconds())));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn duration_of(pipeline: &gst::Element) -> Option<Duration> {
+    pipeline
+        .query_duration::<gst::ClockTime>()
+        .map(|d| Duration::from_nanos(d.nseconds()))
+}
+
+/// `playbin3` with our own video sink: convert and scale into RGBx no larger
+/// than the host asked for, then hand each frame to the ring.
+fn build(
+    max_width: u32,
+    max_height: u32,
+    events: Arc<Events>,
+    ring: Arc<Mutex<Ring>>,
+) -> Result<gst::Element, String> {
+    let playbin = gst::ElementFactory::make("playbin3")
+        .build()
+        .or_else(|_| gst::ElementFactory::make("playbin").build())
+        .map_err(|_| "no playbin element: is gst-plugins-base installed?".to_string())?;
+
+    let sink = gst::parse::bin_from_description(
+        &format!(
+            "videoconvert ! videoscale ! \
+             video/x-raw,format=RGBx,width=(int)[1,{max_width}],height=(int)[1,{max_height}],pixel-aspect-ratio=(fraction)1/1 ! \
+             appsink name=frames sync=true max-buffers=2 drop=true"
+        ),
+        true,
+    )
+    .map_err(|err| format!("cannot build the video sink: {err}"))?;
+    let appsink = sink
+        .by_name("frames")
+        .and_then(|element| element.downcast::<gst_app::AppSink>().ok())
+        .ok_or("the video sink has no appsink")?;
+
+    appsink.set_callbacks(
+        gst_app::AppSinkCallbacks::builder()
+            .new_sample(move |appsink| {
+                let sample = appsink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                deliver(&sample, &events, &ring, appsink);
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .build(),
+    );
+
+    playbin.set_property("video-sink", &sink);
+    playbin.set_property("uri", format!("file:///proc/self/fd/{FILE_FD}"));
+    Ok(playbin)
+}
+
+/// One decoded frame: into the ring, then announced.
+fn deliver(sample: &gst::Sample, events: &Events, ring: &Mutex<Ring>, appsink: &gst_app::AppSink) {
+    let Some(buffer) = sample.buffer() else {
+        return;
+    };
+    let Some(caps) = sample.caps() else {
+        return;
+    };
+    let Some(structure) = caps.structure(0) else {
+        return;
+    };
+    let (Ok(width), Ok(height)) = (
+        structure.get::<i32>("width"),
+        structure.get::<i32>("height"),
+    ) else {
+        return;
+    };
+    if width <= 0 || height <= 0 {
+        return;
+    }
+    let (width, height) = (width as u32, height as u32);
+
+    let Ok(map) = buffer.map_readable() else {
+        return;
+    };
+    let mut ring = ring.lock().unwrap();
+    if ring.size != (width, height) {
+        if let Err(err) = ring.resize(width, height) {
+            events.send(Event::Error(format!("cannot size the frame ring: {err}")));
+            std::process::exit(1);
+        }
+        let pipeline = appsink
+            .parent()
+            .and_then(|bin| bin.parent())
+            .and_then(|element| element.downcast::<gst::Element>().ok());
+        events.send(Event::Ready {
+            width,
+            height,
+            duration: pipeline.as_ref().and_then(duration_of),
+        });
+    }
+
+    // Rows are usually tightly packed; when the buffer carries padding the
+    // stride is whatever divides its size, which is right for every
+    // single-plane RGB layout GStreamer produces.
+    let tight = (width * protocol::BYTES_PER_PIXEL) as usize;
+    let stride = if map.len() >= tight * height as usize {
+        map.len() / height as usize
+    } else {
+        return;
+    };
+    let position = buffer
+        .pts()
+        .map(|pts| Duration::from_nanos(pts.nseconds()))
+        .unwrap_or_default();
+    match ring.write(map.as_slice().chunks(stride)) {
+        Ok((slot, seq)) => events.send(Event::Frame {
+            slot,
+            seq,
+            position,
+        }),
+        Err(err) => {
+            events.send(Event::Error(format!("cannot write a frame: {err}")));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn read_commands(pipeline: gst::Element, events: Arc<Events>) {
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        let Some(command) = Command::parse(&line) else {
+            continue;
+        };
+        match command {
+            Command::Play => {
+                let _ = pipeline.set_state(gst::State::Playing);
+            }
+            Command::Pause => {
+                let _ = pipeline.set_state(gst::State::Paused);
+            }
+            Command::Seek { position, accurate } => {
+                let flags = if accurate {
+                    gst::SeekFlags::FLUSH | gst::SeekFlags::ACCURATE
+                } else {
+                    gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT
+                };
+                let _ = pipeline.seek_simple(
+                    flags,
+                    gst::ClockTime::from_nseconds(position.as_nanos() as u64),
+                );
+            }
+            Command::Volume(volume) => {
+                pipeline.set_property("volume", volume.clamp(0.0, 1.0));
+                if pipeline.has_property("mute") {
+                    pipeline.set_property("mute", volume <= 0.0);
+                }
+            }
+            Command::Quit => break,
+        }
+    }
+    // Either told to quit or the host is gone. Tear the pipeline down so the
+    // audio device is released before exiting.
+    let _ = pipeline.set_state(gst::State::Null);
+    drop(events);
+    std::process::exit(0);
+}
+
+/// Drop what the worker will not need.
+///
+/// The same shape as Quick View's decode sandbox, minus the limits a media
+/// stack cannot live under: no `RLIMIT_FSIZE` (GStreamer writes its plugin
+/// registry cache) and a much larger address-space ceiling (hardware
+/// decoders map device memory generously).
+///
+/// # Safety
+///
+/// Call before any thread exists.
+unsafe fn contain() -> io::Result<()> {
+    if libc::chdir(c"/".as_ptr()) != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    set_limit(libc::RLIMIT_AS, 8 * 1024 * 1024 * 1024)?;
+    set_limit(libc::RLIMIT_NOFILE, 512)?;
+    set_limit(libc::RLIMIT_CORE, 0)?;
+    // Advisory, as in the decoder: a kernel that refuses unprivileged
+    // namespaces is not a reason to refuse to play.
+    if libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNET) != 0 {
+        libc::unshare(libc::CLONE_NEWNET);
+    }
+    Ok(())
+}
+
+fn set_limit(resource: libc::__rlimit_resource_t, value: u64) -> io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: value,
+        rlim_max: value,
+    };
+    // SAFETY: `limit` is fully initialised and `resource` is a valid constant.
+    if unsafe { libc::setrlimit(resource, &limit) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/components/otto-media-kit/src/lib.rs
+++ b/components/otto-media-kit/src/lib.rs
@@ -1,0 +1,33 @@
+//! Media playback for Otto applications.
+//!
+//! otto-kit draws things; it does not decode video, and it should not — a
+//! media stack is an order of magnitude more code than the toolkit it would
+//! be bolted onto, and one that parses untrusted bytes. This crate is that
+//! stack, kept out of the toolkit and out of every application binary:
+//!
+//! * [`player::Player`] — the host-side handle. It runs `otto-media-worker`
+//!   as a separate, contained process, feeds it commands (play, pause, seek,
+//!   volume) and receives its frames through one shared buffer. The host
+//!   never links GStreamer and never touches the file's bytes.
+//! * [`view`] and [`transport`] — the drawing half, canvas-pure in the
+//!   toolkit's draw/hit-test style: given a rect, a [`Player`](player::Player)
+//!   and a theme, paint the current frame and the controls, and say what is
+//!   under a point.
+//! * [`protocol`] — the pipe and frame-buffer contract between the two, in
+//!   one place so neither side can drift.
+//!
+//! The worker is `otto-media-worker`, built from this crate behind the
+//! `worker` feature (on by default), and found at run time next to the host's
+//! own executable, on `PATH`, or wherever `OTTO_MEDIA_WORKER` points.
+//!
+//! Why a process and not a thread: a demuxer fed a hostile file crashes, and
+//! a crash in a thread takes the file browser with it. The worker also
+//! carries the same containment Quick View's decoder does — no network, no
+//! new privileges, hard descriptor and memory limits — for the same reason.
+
+pub mod player;
+pub mod protocol;
+pub mod transport;
+pub mod view;
+
+pub use player::{Frame, Playback, Player, State};

--- a/components/otto-media-kit/src/lib.rs
+++ b/components/otto-media-kit/src/lib.rs
@@ -30,4 +30,4 @@ pub mod protocol;
 pub mod transport;
 pub mod view;
 
-pub use player::{Frame, Playback, Player, State};
+pub use player::{Frame, Options, Playback, Player, State};

--- a/components/otto-media-kit/src/player.rs
+++ b/components/otto-media-kit/src/player.rs
@@ -128,19 +128,25 @@ pub struct Player {
     shared: Arc<Shared>,
 }
 
-/// How large a frame the worker may hand back, in pixels. The worker scales
-/// the video down to fit, keeping its aspect; it never scales up.
+/// How to open a playback.
+///
+/// `max_width` and `max_height` cap the frames the worker hands back, in
+/// pixels: it scales the video down to fit, keeping its aspect, and never
+/// scales up. `autoplay` starts playing as soon as the stream is ready; off,
+/// the first frame is shown and playback waits for [`Player::play`].
 #[derive(Debug, Clone, Copy)]
-pub struct Limits {
+pub struct Options {
     pub max_width: u32,
     pub max_height: u32,
+    pub autoplay: bool,
 }
 
-impl Default for Limits {
+impl Default for Options {
     fn default() -> Self {
         Self {
             max_width: 1920,
             max_height: 1080,
+            autoplay: true,
         }
     }
 }
@@ -150,14 +156,14 @@ impl Player {
     ///
     /// Returns as soon as the worker is spawned; the stream's size and
     /// duration arrive through [`Player::state`] once it has prerolled. The
-    /// worker is asked to play immediately.
+    /// worker is asked to play immediately when `options.autoplay` is set.
     ///
     /// `wake` is called from another thread whenever there is something new
     /// to draw — a frame, a state change — and must be cheap: typically it
     /// pokes the host's event loop.
     pub fn open(
         path: &Path,
-        limits: Limits,
+        options: Options,
         wake: impl Fn() + Send + Sync + 'static,
     ) -> io::Result<Player> {
         // `O_NONBLOCK` so a FIFO cannot block the open; the check below then
@@ -180,9 +186,9 @@ impl Player {
         let mut command = Command::new(executable);
         command
             .arg("--max-width")
-            .arg(limits.max_width.to_string())
+            .arg(options.max_width.to_string())
             .arg("--max-height")
-            .arg(limits.max_height.to_string())
+            .arg(options.max_height.to_string())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(if std::env::var_os("OTTO_MEDIA_TRACE").is_some() {
@@ -231,7 +237,9 @@ impl Player {
                 .map_err(|err| io::Error::other(format!("cannot start event reader: {err}")))?;
         }
 
-        let _ = commands.write_all(Cmd::Play.encode().as_bytes());
+        if options.autoplay {
+            let _ = commands.write_all(Cmd::Play.encode().as_bytes());
+        }
         Ok(Player {
             child,
             commands: Some(commands),
@@ -257,10 +265,15 @@ impl Player {
         self.send(Cmd::Pause);
     }
 
-    /// Play if paused or ended, pause if playing.
+    /// Play if paused, pause if playing. Ended, it plays again from the
+    /// start: GStreamer sits at end-of-stream until it is moved.
     pub fn toggle(&mut self) {
         match self.state().playback {
             Playback::Playing => self.pause(),
+            Playback::Ended => {
+                self.seek(Duration::ZERO, true);
+                self.play();
+            }
             _ => self.play(),
         }
     }

--- a/components/otto-media-kit/src/player.rs
+++ b/components/otto-media-kit/src/player.rs
@@ -1,0 +1,550 @@
+//! The host-side handle on a playback.
+//!
+//! A [`Player`] is one worker process, one file, and the frames coming out of
+//! it. The host opens the file itself — it never hands the worker a path —
+//! creates the frame ring, spawns `otto-media-worker` with exactly those two
+//! descriptors, and reads its events on a thread of its own. Every event
+//! updates [`State`], a fresh frame is copied out of the ring, and the host's
+//! `wake` closure is called so its loop paints.
+//!
+//! Nothing here blocks the caller: opening spawns and returns, commands are a
+//! `write` to a pipe, and [`Player::frame`] hands back whatever last arrived.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::protocol::{self, Command as Cmd, Event};
+
+/// One decoded frame, RGBx, rows tightly packed.
+#[derive(Clone)]
+pub struct Frame {
+    pub width: u32,
+    pub height: u32,
+    /// Frames from one. A host that keys its repaint on this repaints once
+    /// per frame and not otherwise.
+    pub seq: u64,
+    pub position: Duration,
+    pub data: Arc<Vec<u8>>,
+}
+
+impl Frame {
+    /// The frame as a Skia image. Copies once; the image outlives the borrow
+    /// in every caller.
+    pub fn to_image(&self) -> Option<skia_safe::Image> {
+        let info = skia_safe::ImageInfo::new(
+            (self.width as i32, self.height as i32),
+            skia_safe::ColorType::RGB888x,
+            skia_safe::AlphaType::Opaque,
+            None,
+        );
+        let row_bytes = self.width as usize * protocol::BYTES_PER_PIXEL as usize;
+        if self.data.len() != row_bytes * self.height as usize {
+            return None;
+        }
+        skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(&self.data), row_bytes)
+    }
+}
+
+/// Where the playback is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Playback {
+    /// The worker is starting up, or the stream is not yet known.
+    Loading,
+    Playing,
+    Paused,
+    Ended,
+    /// The worker gave up or died. The reason is in [`State::error`].
+    Failed,
+}
+
+/// Everything the host may want to draw or decide on, as of the last event.
+#[derive(Debug, Clone)]
+pub struct State {
+    pub playback: Playback,
+    /// Frame size as it arrives, after the worker's own scaling.
+    pub size: Option<(u32, u32)>,
+    pub duration: Option<Duration>,
+    /// The last position the worker reported, and when. Read it through
+    /// [`State::position`], which advances it while playing.
+    reported: Duration,
+    reported_at: Instant,
+    pub volume: f64,
+    pub error: Option<String>,
+    /// Sequence number of the newest frame in [`Player::frame`]; 0 before
+    /// any has arrived.
+    pub frame_seq: u64,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            playback: Playback::Loading,
+            size: None,
+            duration: None,
+            reported: Duration::ZERO,
+            reported_at: Instant::now(),
+            volume: 1.0,
+            error: None,
+            frame_seq: 0,
+        }
+    }
+
+    /// The current position, interpolated from the last report while
+    /// playing so a scrubber moves smoothly between the worker's ticks.
+    pub fn position(&self) -> Duration {
+        let mut position = self.reported;
+        if self.playback == Playback::Playing {
+            position += self.reported_at.elapsed();
+        }
+        match self.duration {
+            Some(duration) => position.min(duration),
+            None => position,
+        }
+    }
+
+    fn report(&mut self, position: Duration) {
+        self.reported = position;
+        self.reported_at = Instant::now();
+    }
+}
+
+struct Shared {
+    state: Mutex<State>,
+    frame: Mutex<Option<Frame>>,
+    wake: Box<dyn Fn() + Send + Sync>,
+}
+
+/// A playback in progress. Dropping it ends the worker.
+pub struct Player {
+    child: Child,
+    commands: Option<ChildStdin>,
+    shared: Arc<Shared>,
+}
+
+/// How large a frame the worker may hand back, in pixels. The worker scales
+/// the video down to fit, keeping its aspect; it never scales up.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    pub max_width: u32,
+    pub max_height: u32,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_width: 1920,
+            max_height: 1080,
+        }
+    }
+}
+
+impl Player {
+    /// Start playing `path`.
+    ///
+    /// Returns as soon as the worker is spawned; the stream's size and
+    /// duration arrive through [`Player::state`] once it has prerolled. The
+    /// worker is asked to play immediately.
+    ///
+    /// `wake` is called from another thread whenever there is something new
+    /// to draw — a frame, a state change — and must be cheap: typically it
+    /// pokes the host's event loop.
+    pub fn open(
+        path: &Path,
+        limits: Limits,
+        wake: impl Fn() + Send + Sync + 'static,
+    ) -> io::Result<Player> {
+        // `O_NONBLOCK` so a FIFO cannot block the open; the check below then
+        // refuses anything that is not a regular file, since a device or a
+        // socket could block a read.
+        let file = File::options()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(path)?;
+        if !file.metadata()?.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "not a regular file",
+            ));
+        }
+
+        let ring = memfd("otto-media-frames")?;
+        let executable = worker_executable()?;
+
+        let mut command = Command::new(executable);
+        command
+            .arg("--max-width")
+            .arg(limits.max_width.to_string())
+            .arg("--max-height")
+            .arg(limits.max_height.to_string())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(if std::env::var_os("OTTO_MEDIA_TRACE").is_some() {
+                Stdio::inherit()
+            } else {
+                Stdio::null()
+            })
+            .env_clear();
+        for (key, value) in std::env::vars_os() {
+            if inherits(&key.to_string_lossy()) {
+                command.env(key, value);
+            }
+        }
+
+        let file_fd = file.into_raw_fd();
+        let ring_fd = ring.as_raw_fd();
+        // SAFETY: runs in the forked child between `fork` and `exec`; only
+        // raw syscalls are made.
+        unsafe {
+            command.pre_exec(move || {
+                place(file_fd, protocol::FILE_FD)?;
+                place(ring_fd, protocol::FRAMES_FD)?;
+                Ok(())
+            });
+        }
+        let mut child = command.spawn()?;
+        // The parent's copy of the file is no longer needed; the ring stays
+        // open here, since the host maps it.
+        // SAFETY: `file_fd` was handed to us by `into_raw_fd` and is not
+        // used again.
+        unsafe { libc::close(file_fd) };
+
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut commands = child.stdin.take().expect("piped stdin");
+
+        let shared = Arc::new(Shared {
+            state: Mutex::new(State::new()),
+            frame: Mutex::new(None),
+            wake: Box::new(wake),
+        });
+        {
+            let shared = Arc::clone(&shared);
+            std::thread::Builder::new()
+                .name("otto-media-events".into())
+                .spawn(move || read_events(stdout, ring, shared))
+                .map_err(|err| io::Error::other(format!("cannot start event reader: {err}")))?;
+        }
+
+        let _ = commands.write_all(Cmd::Play.encode().as_bytes());
+        Ok(Player {
+            child,
+            commands: Some(commands),
+            shared,
+        })
+    }
+
+    /// A snapshot of the playback state.
+    pub fn state(&self) -> State {
+        self.shared.state.lock().unwrap().clone()
+    }
+
+    /// The newest frame, if one has arrived.
+    pub fn frame(&self) -> Option<Frame> {
+        self.shared.frame.lock().unwrap().clone()
+    }
+
+    pub fn play(&mut self) {
+        self.send(Cmd::Play);
+    }
+
+    pub fn pause(&mut self) {
+        self.send(Cmd::Pause);
+    }
+
+    /// Play if paused or ended, pause if playing.
+    pub fn toggle(&mut self) {
+        match self.state().playback {
+            Playback::Playing => self.pause(),
+            _ => self.play(),
+        }
+    }
+
+    /// Jump to `position`. `accurate` lands on the exact frame; a scrub in
+    /// flight passes `false` and gets the nearest keyframe, which is what
+    /// keeps dragging responsive.
+    pub fn seek(&mut self, position: Duration, accurate: bool) {
+        {
+            // Show the target at once rather than the last report, so the
+            // scrubber does not jump back while the worker catches up.
+            let mut state = self.shared.state.lock().unwrap();
+            state.report(position);
+        }
+        self.send(Cmd::Seek { position, accurate });
+    }
+
+    pub fn set_volume(&mut self, volume: f64) {
+        self.shared.state.lock().unwrap().volume = volume.clamp(0.0, 1.0);
+        self.send(Cmd::Volume(volume));
+    }
+
+    fn send(&mut self, command: Cmd) {
+        if let Some(commands) = self.commands.as_mut() {
+            if commands.write_all(command.encode().as_bytes()).is_err() {
+                // The worker is gone; the event reader reports it.
+                self.commands = None;
+            }
+        }
+    }
+}
+
+impl Drop for Player {
+    fn drop(&mut self) {
+        // Ask nicely, then do not wait to find out: a Drop that blocks on a
+        // stuck demuxer would stall the host's frame loop.
+        self.send(Cmd::Quit);
+        self.commands = None;
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// The event reader: runs until the worker's stdout closes.
+fn read_events(stdout: std::process::ChildStdout, ring: File, shared: Arc<Shared>) {
+    let mut lines = BufReader::new(stdout).lines();
+    let mut mapping: Option<Mapping> = None;
+    let mut size = (0u32, 0u32);
+
+    while let Some(Ok(line)) = lines.next() {
+        let Some(event) = Event::parse(&line) else {
+            tracing::debug!("otto-media-worker said something unexpected: {line}");
+            continue;
+        };
+        match event {
+            Event::Ready {
+                width,
+                height,
+                duration,
+            } => {
+                size = (width, height);
+                mapping = Mapping::new(&ring, protocol::ring_bytes(width, height)).ok();
+                let mut state = shared.state.lock().unwrap();
+                state.size = Some((width, height));
+                state.duration = duration;
+                if state.playback == Playback::Loading {
+                    state.playback = Playback::Paused;
+                }
+            }
+            Event::Frame {
+                slot,
+                seq,
+                position,
+            } => {
+                let (width, height) = size;
+                let Some(mapping) = mapping.as_ref() else {
+                    continue;
+                };
+                let offset = protocol::slot_offset(slot, width, height) as usize;
+                let bytes = protocol::slot_bytes(width, height) as usize;
+                let Some(pixels) = mapping.slice(offset, bytes) else {
+                    continue;
+                };
+                // Copied out at once: the worker will be back to this slot
+                // two frames from now, and the host draws whenever it likes.
+                let data = Arc::new(pixels.to_vec());
+                *shared.frame.lock().unwrap() = Some(Frame {
+                    width,
+                    height,
+                    seq,
+                    position,
+                    data,
+                });
+                let mut state = shared.state.lock().unwrap();
+                state.frame_seq = seq;
+                // A frame is the most precise position report there is.
+                if state.playback != Playback::Playing {
+                    state.report(position);
+                }
+            }
+            Event::Position(position) => shared.state.lock().unwrap().report(position),
+            Event::Playing => {
+                let mut state = shared.state.lock().unwrap();
+                let position = state.position();
+                state.report(position);
+                state.playback = Playback::Playing;
+            }
+            Event::Paused => {
+                let mut state = shared.state.lock().unwrap();
+                let position = state.position();
+                state.report(position);
+                state.playback = Playback::Paused;
+            }
+            Event::Ended => {
+                let mut state = shared.state.lock().unwrap();
+                if let Some(duration) = state.duration {
+                    state.report(duration);
+                }
+                state.playback = Playback::Ended;
+            }
+            Event::Error(reason) => {
+                let mut state = shared.state.lock().unwrap();
+                state.error = Some(reason);
+                state.playback = Playback::Failed;
+            }
+        }
+        (shared.wake)();
+    }
+
+    // The pipe closed: the worker exited, cleanly or not. A playback that
+    // was still going has failed; one that had ended or was never started
+    // stays as it was.
+    let mut state = shared.state.lock().unwrap();
+    if matches!(
+        state.playback,
+        Playback::Loading | Playback::Playing | Playback::Paused
+    ) {
+        if state.error.is_none() {
+            state.error = Some("the media worker exited".into());
+        }
+        state.playback = Playback::Failed;
+        drop(state);
+        (shared.wake)();
+    }
+}
+
+/// A read-only view of the frame ring.
+struct Mapping {
+    ptr: *const u8,
+    len: usize,
+}
+
+// SAFETY: the mapping is only ever read, and only from the event thread.
+unsafe impl Send for Mapping {}
+
+impl Mapping {
+    fn new(ring: &File, len: u64) -> io::Result<Self> {
+        let len = len as usize;
+        // SAFETY: mapping a descriptor we own, read-only, shared; the worker
+        // has sized it before announcing the size mapped here.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_SHARED,
+                ring.as_raw_fd(),
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            ptr: ptr as *const u8,
+            len,
+        })
+    }
+
+    fn slice(&self, offset: usize, len: usize) -> Option<&[u8]> {
+        if offset.checked_add(len)? > self.len {
+            return None;
+        }
+        // SAFETY: bounds checked above; the mapping is readable for its
+        // whole length. The worker may write concurrently, which yields a
+        // torn frame at worst — never undefined memory.
+        Some(unsafe { std::slice::from_raw_parts(self.ptr.add(offset), len) })
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        // SAFETY: unmapping what `new` mapped.
+        unsafe { libc::munmap(self.ptr as *mut _, self.len) };
+    }
+}
+
+/// A sealed-free memfd; the worker sizes it.
+fn memfd(name: &str) -> io::Result<File> {
+    let name = std::ffi::CString::new(name).expect("no NUL in name");
+    // SAFETY: a valid C string; the descriptor is owned by the returned File.
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a fresh descriptor nobody else holds.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+/// Put `fd` on `target` for the child, clearing close-on-exec as `dup2`
+/// does. When it already is `target`, the flag is cleared by hand — Rust
+/// opens everything close-on-exec, and `dup2` onto itself is a no-op.
+fn place(fd: RawFd, target: RawFd) -> io::Result<()> {
+    // SAFETY: raw descriptor calls on descriptors this process owns.
+    unsafe {
+        if fd == target {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags < 0 || libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        } else if libc::dup2(fd, target) < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+/// Which of the host's environment the worker gets.
+///
+/// Not the Wayland or bus addresses: those are capabilities. What it does
+/// need is the audio server's socket directory, GStreamer's own settings and
+/// its registry cache, and the locale for any string it reports.
+fn inherits(key: &str) -> bool {
+    matches!(
+        key,
+        "PATH"
+            | "HOME"
+            | "XDG_RUNTIME_DIR"
+            | "XDG_CACHE_HOME"
+            | "RUST_LOG"
+            | "LANG"
+            | "LANGUAGE"
+            | "PULSE_SERVER"
+            | "PIPEWIRE_REMOTE"
+            | "LD_LIBRARY_PATH"
+            | "OTTO_MEDIA_TRACE"
+    ) || key.starts_with("GST_")
+        || key.starts_with("LIBVA_")
+}
+
+/// Where the worker binary is.
+///
+/// `OTTO_MEDIA_WORKER` names it outright — a development checkout building
+/// the worker into a different target directory. Otherwise it is looked for
+/// next to the host's own executable, which is where an install puts both,
+/// and finally on `PATH`.
+fn worker_executable() -> io::Result<PathBuf> {
+    const NAME: &str = "otto-media-worker";
+    if let Some(path) = std::env::var_os("OTTO_MEDIA_WORKER") {
+        return Ok(PathBuf::from(path));
+    }
+    if let Ok(own) = std::env::current_exe() {
+        let sibling = own.with_file_name(NAME);
+        if sibling.is_file() {
+            return Ok(sibling);
+        }
+    }
+    let on_path = std::env::var_os("PATH")
+        .map(|path| {
+            std::env::split_paths(&path)
+                .map(|dir| dir.join(NAME))
+                .find(|candidate| candidate.is_file())
+        })
+        .unwrap_or_default();
+    on_path.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "otto-media-worker is not installed next to this program or on PATH",
+        )
+    })
+}
+
+/// Whether playback is available at all on this system: the worker can be
+/// found. Cheap, so a host may ask before deciding what to draw.
+pub fn available() -> bool {
+    worker_executable().is_ok()
+}

--- a/components/otto-media-kit/src/protocol.rs
+++ b/components/otto-media-kit/src/protocol.rs
@@ -1,0 +1,250 @@
+//! What the host and the worker agree on.
+//!
+//! Three channels, all of them plain:
+//!
+//! * **commands** — lines on the worker's stdin, host → worker;
+//! * **events** — lines on the worker's stdout, worker → host;
+//! * **frames** — a memfd the host creates and the worker sizes, holding a
+//!   small ring of decoded frames. The worker announces each new frame with
+//!   an event naming the slot it landed in.
+//!
+//! Lines rather than a binary framing because they are debuggable with
+//! `cat`, and because the volume is tiny: tens of lines a second, with the
+//! pixels going through shared memory instead.
+//!
+//! Descriptors are fixed rather than negotiated, so nothing has to be told a
+//! number and nothing can be substituted after the fact.
+
+use std::time::Duration;
+
+/// The media file, read-only, on this descriptor in the worker.
+pub const FILE_FD: i32 = 3;
+/// The frame ring, read-write, on this descriptor in the worker.
+pub const FRAMES_FD: i32 = 4;
+
+/// Frames in the ring. Three is one being written, one being read, and one
+/// of slack, which is what keeps the writer from lapping the reader at the
+/// rate a video decodes and a host paints.
+pub const SLOTS: u32 = 3;
+
+/// Bytes per pixel: RGBx, the alpha byte unused. Video has no alpha and a
+/// format with a spare byte converts fastest.
+pub const BYTES_PER_PIXEL: u32 = 4;
+
+/// The ring's header size. Slot data starts here.
+pub const HEADER_BYTES: u64 = 4096;
+
+/// A frame's whole size in the ring, rows tightly packed.
+pub fn slot_bytes(width: u32, height: u32) -> u64 {
+    width as u64 * height as u64 * BYTES_PER_PIXEL as u64
+}
+
+/// Where a slot's pixels start.
+pub fn slot_offset(slot: u32, width: u32, height: u32) -> u64 {
+    HEADER_BYTES + slot as u64 * slot_bytes(width, height)
+}
+
+/// The ring's total size for a frame size.
+pub fn ring_bytes(width: u32, height: u32) -> u64 {
+    HEADER_BYTES + SLOTS as u64 * slot_bytes(width, height)
+}
+
+/// Host → worker.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Command {
+    Play,
+    Pause,
+    /// Seek to a position. `accurate` asks for the exact frame, which is slow
+    /// on long GOPs; a scrub in progress passes `false` and lands on a
+    /// keyframe instead.
+    Seek {
+        position: Duration,
+        accurate: bool,
+    },
+    /// 0.0 … 1.0.
+    Volume(f64),
+    Quit,
+}
+
+impl Command {
+    pub fn encode(&self) -> String {
+        match self {
+            Command::Play => "play\n".into(),
+            Command::Pause => "pause\n".into(),
+            Command::Seek { position, accurate } => format!(
+                "seek {} {}\n",
+                position.as_nanos(),
+                if *accurate { "accurate" } else { "fast" }
+            ),
+            Command::Volume(volume) => format!("volume {:.4}\n", volume.clamp(0.0, 1.0)),
+            Command::Quit => "quit\n".into(),
+        }
+    }
+
+    pub fn parse(line: &str) -> Option<Command> {
+        let mut words = line.split_whitespace();
+        Some(match words.next()? {
+            "play" => Command::Play,
+            "pause" => Command::Pause,
+            "seek" => Command::Seek {
+                position: Duration::from_nanos(words.next()?.parse().ok()?),
+                accurate: words.next() == Some("accurate"),
+            },
+            "volume" => Command::Volume(words.next()?.parse().ok()?),
+            "quit" => Command::Quit,
+            _ => return None,
+        })
+    }
+}
+
+/// Worker → host.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    /// The stream is known: frame size as it will arrive in the ring, and
+    /// the duration when the container declares one. The ring has been sized
+    /// for these dimensions by the time this is sent. Sent again if the
+    /// stream changes size mid-way, which re-sizes the ring.
+    Ready {
+        width: u32,
+        height: u32,
+        duration: Option<Duration>,
+    },
+    /// A frame landed in `slot`. `seq` counts frames from one; `position` is
+    /// the frame's presentation time.
+    Frame {
+        slot: u32,
+        seq: u64,
+        position: Duration,
+    },
+    /// Where playback is, sent periodically while playing and after a seek.
+    Position(Duration),
+    Playing,
+    Paused,
+    Ended,
+    /// Playback cannot continue. The worker exits after sending it.
+    Error(String),
+}
+
+impl Event {
+    pub fn encode(&self) -> String {
+        match self {
+            Event::Ready {
+                width,
+                height,
+                duration,
+            } => format!(
+                "ready {width} {height} {}\n",
+                duration.map(|d| d.as_nanos() as i128).unwrap_or(-1)
+            ),
+            Event::Frame {
+                slot,
+                seq,
+                position,
+            } => format!("frame {slot} {seq} {}\n", position.as_nanos()),
+            Event::Position(position) => format!("position {}\n", position.as_nanos()),
+            Event::Playing => "playing\n".into(),
+            Event::Paused => "paused\n".into(),
+            Event::Ended => "ended\n".into(),
+            Event::Error(reason) => format!("error {}\n", reason.replace(['\n', '\r'], " ")),
+        }
+    }
+
+    pub fn parse(line: &str) -> Option<Event> {
+        let line = line.trim_end();
+        let (word, rest) = line.split_once(' ').unwrap_or((line, ""));
+        let mut words = rest.split_whitespace();
+        Some(match word {
+            "ready" => {
+                let width = words.next()?.parse().ok()?;
+                let height = words.next()?.parse().ok()?;
+                let nanos: i128 = words.next()?.parse().ok()?;
+                Event::Ready {
+                    width,
+                    height,
+                    duration: (nanos >= 0).then(|| Duration::from_nanos(nanos as u64)),
+                }
+            }
+            "frame" => Event::Frame {
+                slot: words.next()?.parse().ok()?,
+                seq: words.next()?.parse().ok()?,
+                position: Duration::from_nanos(words.next()?.parse().ok()?),
+            },
+            "position" => Event::Position(Duration::from_nanos(words.next()?.parse().ok()?)),
+            "playing" => Event::Playing,
+            "paused" => Event::Paused,
+            "ended" => Event::Ended,
+            "error" => Event::Error(rest.to_string()),
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commands_round_trip() {
+        for command in [
+            Command::Play,
+            Command::Pause,
+            Command::Seek {
+                position: Duration::from_millis(1500),
+                accurate: true,
+            },
+            Command::Seek {
+                position: Duration::from_secs(3),
+                accurate: false,
+            },
+            Command::Volume(0.25),
+            Command::Quit,
+        ] {
+            assert_eq!(Command::parse(&command.encode()), Some(command));
+        }
+    }
+
+    #[test]
+    fn events_round_trip() {
+        for event in [
+            Event::Ready {
+                width: 1280,
+                height: 720,
+                duration: Some(Duration::from_secs(5)),
+            },
+            Event::Ready {
+                width: 1,
+                height: 1,
+                duration: None,
+            },
+            Event::Frame {
+                slot: 2,
+                seq: 17,
+                position: Duration::from_millis(566),
+            },
+            Event::Position(Duration::from_secs(1)),
+            Event::Playing,
+            Event::Paused,
+            Event::Ended,
+            Event::Error("no decoder for video/x-h266".into()),
+        ] {
+            assert_eq!(Event::parse(&event.encode()), Some(event));
+        }
+    }
+
+    #[test]
+    fn an_error_stays_one_line() {
+        let event = Event::Error("first\nsecond".into());
+        assert_eq!(event.encode().matches('\n').count(), 1);
+    }
+
+    #[test]
+    fn slots_do_not_overlap() {
+        let (w, h) = (640, 480);
+        assert_eq!(slot_offset(0, w, h), HEADER_BYTES);
+        assert_eq!(
+            slot_offset(1, w, h) - slot_offset(0, w, h),
+            slot_bytes(w, h)
+        );
+        assert_eq!(ring_bytes(w, h), slot_offset(SLOTS, w, h));
+    }
+}

--- a/components/otto-media-kit/src/transport.rs
+++ b/components/otto-media-kit/src/transport.rs
@@ -1,0 +1,304 @@
+//! The transport bar: play/pause, a scrubber, the clock, and mute.
+//!
+//! Canvas-pure, in the toolkit's draw/hit-test convention: [`layout`] places
+//! the controls along the bottom of a rect, [`draw`] paints them from a
+//! [`TransportState`], and [`TransportLayout::hit`] says what is under a
+//! point. The host owns every piece of interaction state — whether a drag is
+//! in progress, where it is — and passes it back in to draw.
+
+use std::time::Duration;
+
+use otto_kit::common::Renderable;
+use otto_kit::components::label::Label;
+use otto_kit::theme::Theme;
+use otto_kit::typography::styles;
+use skia_safe::{Canvas, Color, Contains, Paint, PathBuilder, Point, RRect, Rect};
+
+/// The bar's height. Room for a control a finger can hit and a track a
+/// pointer can.
+pub const HEIGHT: f32 = 44.0;
+const INSET: f32 = 12.0;
+const BUTTON: f32 = 28.0;
+const CLOCK_W: f32 = 52.0;
+const TRACK_H: f32 = 4.0;
+const KNOB: f32 = 12.0;
+
+/// Where everything is.
+#[derive(Debug, Clone, Copy)]
+pub struct TransportLayout {
+    pub bar: Rect,
+    pub play: Rect,
+    pub elapsed: Rect,
+    /// The scrubber's track. The thumb rides along it; hits anywhere in the
+    /// bar's height over it count as the track.
+    pub track: Rect,
+    pub remaining: Rect,
+    pub mute: Rect,
+}
+
+/// What a point lands on.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TransportHit {
+    PlayPause,
+    /// On the scrubber, at this fraction of the duration.
+    Scrub(f32),
+    Mute,
+    /// On the bar, but on nothing in it.
+    Bar,
+}
+
+/// What the bar shows.
+#[derive(Debug, Clone, Copy)]
+pub struct TransportState {
+    pub playing: bool,
+    pub position: Duration,
+    pub duration: Option<Duration>,
+    pub muted: bool,
+    /// A drag in progress: the fraction under the pointer, drawn in place
+    /// of the position.
+    pub scrubbing: Option<f32>,
+    /// Whether the bar is shown at all, 0 → 1. A host fades it out over a
+    /// playing video the pointer has left.
+    pub opacity: f32,
+}
+
+/// Lay the bar along the bottom of `bounds`.
+pub fn layout(bounds: Rect) -> TransportLayout {
+    let bar = Rect::from_ltrb(
+        bounds.left,
+        bounds.bottom - HEIGHT,
+        bounds.right,
+        bounds.bottom,
+    );
+    let cy = bar.center_y();
+    let play = Rect::from_xywh(bar.left + INSET, cy - BUTTON / 2.0, BUTTON, BUTTON);
+    let mute = Rect::from_xywh(
+        bar.right - INSET - BUTTON,
+        cy - BUTTON / 2.0,
+        BUTTON,
+        BUTTON,
+    );
+    let elapsed = Rect::from_xywh(play.right + 6.0, bar.top, CLOCK_W, HEIGHT);
+    let remaining = Rect::from_xywh(mute.left - 6.0 - CLOCK_W, bar.top, CLOCK_W, HEIGHT);
+    let track = Rect::from_ltrb(
+        elapsed.right + 6.0,
+        cy - TRACK_H / 2.0,
+        (remaining.left - 6.0).max(elapsed.right + 6.0),
+        cy + TRACK_H / 2.0,
+    );
+    TransportLayout {
+        bar,
+        play,
+        elapsed,
+        track,
+        remaining,
+        mute,
+    }
+}
+
+impl TransportLayout {
+    pub fn hit(&self, point: Point) -> Option<TransportHit> {
+        if !self.bar.contains(point) {
+            return None;
+        }
+        if self.play.with_outset((4.0, 4.0)).contains(point) {
+            return Some(TransportHit::PlayPause);
+        }
+        if self.mute.with_outset((4.0, 4.0)).contains(point) {
+            return Some(TransportHit::Mute);
+        }
+        let reach = Rect::from_ltrb(
+            self.track.left,
+            self.bar.top,
+            self.track.right,
+            self.bar.bottom,
+        );
+        if reach.contains(point) {
+            return Some(TransportHit::Scrub(self.fraction_at(point.x)));
+        }
+        Some(TransportHit::Bar)
+    }
+
+    /// The fraction of the track `x` is at, clamped to it. Used while
+    /// dragging, when the pointer may well have left the track.
+    pub fn fraction_at(&self, x: f32) -> f32 {
+        if self.track.width() <= 0.0 {
+            return 0.0;
+        }
+        ((x - self.track.left) / self.track.width()).clamp(0.0, 1.0)
+    }
+}
+
+/// Paint the bar.
+pub fn draw(canvas: &Canvas, layout: &TransportLayout, state: &TransportState, theme: &Theme) {
+    if state.opacity <= 0.0 {
+        return;
+    }
+    let alpha = |color: Color| {
+        Color::from_argb(
+            (color.a() as f32 * state.opacity) as u8,
+            color.r(),
+            color.g(),
+            color.b(),
+        )
+    };
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    // A dark scrim rather than the theme's material: the bar sits over
+    // video, whose colours it cannot know, and white glyphs over a dark
+    // band read on any of them.
+    paint.set_color(alpha(Color::from_argb(0xA0, 0x10, 0x10, 0x12)));
+    canvas.draw_rect(layout.bar, &paint);
+
+    let ink = alpha(Color::WHITE);
+    let dim = alpha(Color::from_argb(0x80, 0xFF, 0xFF, 0xFF));
+
+    // Play / pause.
+    paint.set_color(ink);
+    if state.playing {
+        let bar_w = 4.0;
+        let gap = 4.0;
+        let h = 14.0;
+        let cx = layout.play.center_x();
+        let cy = layout.play.center_y();
+        for x in [cx - gap / 2.0 - bar_w, cx + gap / 2.0] {
+            canvas.draw_round_rect(Rect::from_xywh(x, cy - h / 2.0, bar_w, h), 1.0, 1.0, &paint);
+        }
+    } else {
+        let cx = layout.play.center_x() + 1.5;
+        let cy = layout.play.center_y();
+        let h = 15.0;
+        let w = 13.0;
+        let mut path = PathBuilder::new();
+        path.move_to((cx - w / 2.0, cy - h / 2.0));
+        path.line_to((cx + w / 2.0, cy));
+        path.line_to((cx - w / 2.0, cy + h / 2.0));
+        path.close();
+        canvas.draw_path(&path.detach(), &paint);
+    }
+
+    // The clock either side of the track.
+    let fraction = state.scrubbing.unwrap_or_else(|| match state.duration {
+        Some(duration) if !duration.is_zero() => {
+            (state.position.as_secs_f32() / duration.as_secs_f32()).clamp(0.0, 1.0)
+        }
+        _ => 0.0,
+    });
+    let shown = match (state.scrubbing, state.duration) {
+        (Some(fraction), Some(duration)) => duration.mul_f32(fraction),
+        _ => state.position,
+    };
+    Label::new(clock(shown))
+        .with_style(styles::CAPTION_1)
+        .with_color(ink)
+        .centered_at(layout.elapsed.center_x(), layout.elapsed.center_y())
+        .render(canvas);
+    if let Some(duration) = state.duration {
+        Label::new(format!("-{}", clock(duration.saturating_sub(shown))))
+            .with_style(styles::CAPTION_1)
+            .with_color(dim)
+            .centered_at(layout.remaining.center_x(), layout.remaining.center_y())
+            .render(canvas);
+    }
+
+    // The track, the part played, and the thumb.
+    let radius = TRACK_H / 2.0;
+    paint.set_color(dim);
+    canvas.draw_rrect(RRect::new_rect_xy(layout.track, radius, radius), &paint);
+    if layout.track.width() > 0.0 {
+        let played = Rect::from_ltrb(
+            layout.track.left,
+            layout.track.top,
+            layout.track.left + layout.track.width() * fraction,
+            layout.track.bottom,
+        );
+        paint.set_color(alpha(theme.accent));
+        canvas.draw_rrect(RRect::new_rect_xy(played, radius, radius), &paint);
+        paint.set_color(ink);
+        canvas.draw_circle((played.right, layout.track.center_y()), KNOB / 2.0, &paint);
+    }
+
+    // Mute: a speaker, with a stroke through it when muted.
+    let m = layout.mute;
+    let cx = m.center_x() - 3.0;
+    let cy = m.center_y();
+    paint.set_color(ink);
+    let mut speaker = PathBuilder::new();
+    speaker.move_to((cx - 7.0, cy - 3.5));
+    speaker.line_to((cx - 3.0, cy - 3.5));
+    speaker.line_to((cx + 2.0, cy - 8.0));
+    speaker.line_to((cx + 2.0, cy + 8.0));
+    speaker.line_to((cx - 3.0, cy + 3.5));
+    speaker.line_to((cx - 7.0, cy + 3.5));
+    speaker.close();
+    canvas.draw_path(&speaker.detach(), &paint);
+    let mut stroke = Paint::default();
+    stroke.set_anti_alias(true);
+    stroke.set_style(skia_safe::paint::Style::Stroke);
+    stroke.set_stroke_width(2.0);
+    stroke.set_stroke_cap(skia_safe::PaintCap::Round);
+    if state.muted {
+        stroke.set_color(ink);
+        canvas.draw_line((cx + 5.0, cy - 4.0), (cx + 12.0, cy + 4.0), &stroke);
+        canvas.draw_line((cx + 12.0, cy - 4.0), (cx + 5.0, cy + 4.0), &stroke);
+    } else {
+        stroke.set_color(ink);
+        let mut arc = PathBuilder::new();
+        arc.add_arc(Rect::from_xywh(cx - 1.0, cy - 5.0, 10.0, 10.0), -45.0, 90.0);
+        canvas.draw_path(&arc.detach(), &stroke);
+        stroke.set_color(dim);
+        let mut outer = PathBuilder::new();
+        outer.add_arc(Rect::from_xywh(cx - 3.0, cy - 9.0, 18.0, 18.0), -45.0, 90.0);
+        canvas.draw_path(&outer.detach(), &stroke);
+    }
+}
+
+/// `m:ss`, or `h:mm:ss` past an hour.
+pub fn clock(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    let (hours, minutes, seconds) = (seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_clock_reads_as_a_duration() {
+        assert_eq!(clock(Duration::ZERO), "0:00");
+        assert_eq!(clock(Duration::from_secs(61)), "1:01");
+        assert_eq!(clock(Duration::from_secs(3661)), "1:01:01");
+    }
+
+    #[test]
+    fn the_track_answers_with_a_fraction() {
+        let layout = layout(Rect::from_wh(600.0, 400.0));
+        let mid = Point::new(layout.track.center_x(), layout.bar.center_y());
+        match layout.hit(mid) {
+            Some(TransportHit::Scrub(fraction)) => assert!((fraction - 0.5).abs() < 0.01),
+            other => panic!("expected a scrub, got {other:?}"),
+        }
+        assert_eq!(layout.fraction_at(-100.0), 0.0);
+        assert_eq!(layout.fraction_at(10_000.0), 1.0);
+    }
+
+    #[test]
+    fn the_buttons_are_where_they_are_drawn() {
+        let layout = layout(Rect::from_wh(600.0, 400.0));
+        assert_eq!(
+            layout.hit(Point::new(layout.play.center_x(), layout.play.center_y())),
+            Some(TransportHit::PlayPause)
+        );
+        assert_eq!(
+            layout.hit(Point::new(layout.mute.center_x(), layout.mute.center_y())),
+            Some(TransportHit::Mute)
+        );
+        assert_eq!(layout.hit(Point::new(300.0, 10.0)), None);
+    }
+}

--- a/components/otto-media-kit/src/view.rs
+++ b/components/otto-media-kit/src/view.rs
@@ -8,7 +8,7 @@
 use otto_kit::theme::Theme;
 use skia_safe::{Canvas, Color, Image, Paint, Rect};
 
-use crate::player::{Playback, Player, State};
+use crate::player::{Frame, Playback, Player, State};
 use crate::transport::{self, TransportLayout, TransportState};
 
 /// What the host is doing to the playback, which the drawing reflects.
@@ -64,6 +64,31 @@ pub fn draw(
 ) {
     let state = player.state();
     let frame = player.frame();
+    draw_frame(
+        canvas,
+        bounds,
+        frame.as_ref(),
+        poster,
+        &state,
+        interaction,
+        theme,
+    );
+}
+
+/// [`draw`] from a snapshot rather than the player itself.
+///
+/// For a host that records its drawing into a picture on another thread, or
+/// later: a [`Frame`] and a [`State`] are both `Send` and cheap to clone,
+/// while a [`Player`] is neither.
+pub fn draw_frame(
+    canvas: &Canvas,
+    bounds: Rect,
+    frame: Option<&Frame>,
+    poster: Option<&Image>,
+    state: &State,
+    interaction: Interaction,
+    theme: &Theme,
+) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
 
@@ -91,7 +116,7 @@ pub fn draw(
         canvas.draw_image_rect_with_sampling_options(&image, None, dest, sampling, &paint);
     }
 
-    if let Some(reason) = failure(&state) {
+    if let Some(reason) = failure(state) {
         use otto_kit::common::Renderable;
         let stage = stage_rect(bounds);
         otto_kit::components::label::Label::new(reason)

--- a/components/otto-media-kit/src/view.rs
+++ b/components/otto-media-kit/src/view.rs
@@ -1,0 +1,148 @@
+//! The player as a view: the current frame, fitted, with the transport
+//! under it.
+//!
+//! Canvas-pure like the rest of the drawing half. A host that wants the
+//! frame somewhere else, or no transport, uses [`Frame::to_image`] and
+//! [`transport`] directly.
+
+use otto_kit::theme::Theme;
+use skia_safe::{Canvas, Color, Image, Paint, Rect};
+
+use crate::player::{Playback, Player, State};
+use crate::transport::{self, TransportLayout, TransportState};
+
+/// What the host is doing to the playback, which the drawing reflects.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Interaction {
+    /// A scrub drag in progress, as a fraction of the duration.
+    pub scrubbing: Option<f32>,
+    /// The transport's presence, 0 → 1.
+    pub transport_opacity: f32,
+}
+
+/// Where the picture goes: the box above the transport, and the fitted
+/// rect of a frame of `size` inside it.
+pub fn picture_rect(bounds: Rect, size: (u32, u32)) -> Rect {
+    let stage = stage_rect(bounds);
+    let (w, h) = (size.0.max(1) as f32, size.1.max(1) as f32);
+    let scale = (stage.width() / w).min(stage.height() / h);
+    let (fw, fh) = (w * scale, h * scale);
+    Rect::from_xywh(
+        stage.center_x() - fw / 2.0,
+        stage.center_y() - fh / 2.0,
+        fw,
+        fh,
+    )
+}
+
+/// The box the picture is fitted into: everything but the transport.
+pub fn stage_rect(bounds: Rect) -> Rect {
+    Rect::from_ltrb(
+        bounds.left,
+        bounds.top,
+        bounds.right,
+        (bounds.bottom - transport::HEIGHT).max(bounds.top),
+    )
+}
+
+/// The transport's layout for `bounds`, for hit-testing.
+pub fn transport_layout(bounds: Rect) -> TransportLayout {
+    transport::layout(bounds)
+}
+
+/// Paint the player into `bounds`.
+///
+/// `poster` is drawn until the first frame arrives — a host passes the
+/// file's own artwork or nothing, in which case the stage is simply dark.
+pub fn draw(
+    canvas: &Canvas,
+    bounds: Rect,
+    player: &Player,
+    poster: Option<&Image>,
+    interaction: Interaction,
+    theme: &Theme,
+) {
+    let state = player.state();
+    let frame = player.frame();
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    // The stage: black behind letterboxing, the way every player does it,
+    // because a picture over anything else looks cropped.
+    paint.set_color(Color::from_argb(0xFF, 0x08, 0x08, 0x0A));
+    canvas.draw_rect(bounds, &paint);
+
+    let picture = frame
+        .as_ref()
+        .and_then(|frame| {
+            frame
+                .to_image()
+                .map(|image| (image, (frame.width, frame.height)))
+        })
+        .or_else(|| {
+            poster.map(|image| (image.clone(), (image.width() as u32, image.height() as u32)))
+        });
+    if let Some((image, size)) = picture {
+        let dest = picture_rect(bounds, size);
+        let sampling = skia_safe::SamplingOptions::new(
+            skia_safe::FilterMode::Linear,
+            skia_safe::MipmapMode::Linear,
+        );
+        canvas.draw_image_rect_with_sampling_options(&image, None, dest, sampling, &paint);
+    }
+
+    if let Some(reason) = failure(&state) {
+        use otto_kit::common::Renderable;
+        let stage = stage_rect(bounds);
+        otto_kit::components::label::Label::new(reason)
+            .with_style(otto_kit::typography::styles::CALLOUT)
+            .with_color(Color::from_argb(0xC0, 0xFF, 0xFF, 0xFF))
+            .with_width(stage.width() - 40.0)
+            .with_align(otto_kit::components::label::TextAlign::Center)
+            .centered_on(stage.left + 20.0, stage.center_y())
+            .render(canvas);
+    }
+
+    let layout = transport::layout(bounds);
+    transport::draw(
+        canvas,
+        &layout,
+        &TransportState {
+            playing: state.playback == Playback::Playing,
+            position: state.position(),
+            duration: state.duration,
+            muted: state.volume <= 0.0,
+            scrubbing: interaction.scrubbing,
+            opacity: interaction.transport_opacity,
+        },
+        theme,
+    );
+}
+
+fn failure(state: &State) -> Option<String> {
+    (state.playback == Playback::Failed).then(|| {
+        state
+            .error
+            .clone()
+            .unwrap_or_else(|| "this video could not be played".into())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wide_frame_is_letterboxed_and_a_tall_one_pillarboxed() {
+        let bounds = Rect::from_wh(400.0, 300.0 + transport::HEIGHT);
+        let wide = picture_rect(bounds, (1600, 400));
+        assert!((wide.width() - 400.0).abs() < 0.01);
+        assert!((wide.height() - 100.0).abs() < 0.01);
+        assert!((wide.center_y() - 150.0).abs() < 0.01);
+
+        let tall = picture_rect(bounds, (300, 600));
+        assert!((tall.height() - 300.0).abs() < 0.01);
+        assert!((tall.width() - 150.0).abs() < 0.01);
+        assert!((tall.center_x() - 200.0).abs() < 0.01);
+    }
+}

--- a/components/otto-quickview/src/payload.rs
+++ b/components/otto-quickview/src/payload.rs
@@ -38,6 +38,23 @@ pub fn unavailable(reason: impl Into<String>) -> PreviewPayload {
 /// answer for all of them, and because the interesting case is the payload no
 /// decoder produced: a worker that died or overran still comes back as a card
 /// with the file's icon on it rather than as a bare line of text.
+/// Whether a payload describes a video — one a host with a player can play.
+///
+/// Read off the icon chain the worker stamped from the type it *sniffed*: a
+/// card whose first icon is `video-…` came from the video previewer, and the
+/// bytes said so. The name is not consulted, for the same reason dispatch
+/// never consults it. A host that can play video checks this rather than the
+/// file's extension, so a `.mp4` full of something else is never handed to a
+/// demuxer by the previewer.
+pub fn is_video(payload: &PreviewPayload) -> bool {
+    match payload {
+        PreviewPayload::Card { icon, .. } => icon
+            .first()
+            .is_some_and(|name| name.starts_with("video-") && name != "video-x-generic"),
+        _ => false,
+    }
+}
+
 pub fn with_icon(payload: PreviewPayload, chain: Vec<String>) -> PreviewPayload {
     match payload {
         PreviewPayload::Card {

--- a/docs/developer/expose.md
+++ b/docs/developer/expose.md
@@ -170,6 +170,12 @@ snapping on release.
   resolved through `workspace_position_by_view_index`, and the hover highlight
   matches on the view index too. The two only ran in lockstep before workspaces
   could be added and removed from the strip.
+- For the length of the drag the selector is told (`set_window_drag`) that its
+  previews are drop targets, not hover targets: the lay-rs pointer handlers on
+  the previews still fire as the dragged window crosses them, and without the
+  gate they revealed the workspace close button and cleared the drop-target
+  darkening on the way out. Only `set_drop_hover` drives the previews' look
+  until `end_window_selector_drag` lifts the flag.
 - On drop with a target: `move_window_to_workspace` is called with the window's
   last known position. It drops the cached grid of the source and destination
   workspaces first (`invalidate_layout`), because the drag already re-laid the

--- a/docs/developer/otto-media-kit.md
+++ b/docs/developer/otto-media-kit.md
@@ -64,3 +64,17 @@ socket and the registry cache live there. No Wayland or bus address.
   (`PROBE_PNG` names it). Point `OTTO_MEDIA_WORKER` at the worker if it is
   not next to the example binary.
 - `GST_DEBUG=3` works as usual since `GST_*` is passed through.
+
+## Embedding in a preview surface
+
+`otto-media-kit::view::draw_frame` draws from a `Frame` + `State` snapshot
+rather than the live `Player`, so a host that records its drawing into a
+picture on another thread (as otto-files' preview column does) can paint the
+player without holding the player. `otto-files` uses it in two places behind
+one `quickview::Video`: the Quick View panel (autoplays) and the docked
+Miller preview column (opens paused on the first frame, plays on click).
+
+A paused pipeline emits its first frame as a *preroll*, not a sample, so the
+worker delivers both — otherwise a paused embed would show black. Set
+`OTTO_FILES_PREVIEW_AUTOPLAY=1` to make the docked column autoplay too, which
+is the quickest way to see the embed render frames without clicking.

--- a/docs/developer/otto-media-kit.md
+++ b/docs/developer/otto-media-kit.md
@@ -1,0 +1,66 @@
+# otto-media-kit
+
+Video playback for Otto applications, kept out of otto-kit on purpose: a
+media stack is more code than the toolkit it would be bolted onto, and it
+links GStreamer, which no application binary should.
+
+The user-facing behaviour is specified in
+[specs/quickview.md](../../specs/quickview.md#video-playback); this page is
+about the pieces.
+
+## Two halves
+
+```
+components/otto-media-kit/
+├── src/lib.rs                     the library a host embeds (no GStreamer)
+│   ├── player.rs                  Player: spawn the worker, commands, events, frames
+│   ├── protocol.rs                the pipe/ring contract shared by both halves
+│   ├── transport.rs               the control bar: layout, draw, hit-test
+│   └── view.rs                    frame fitted above the transport
+├── src/bin/otto-media-worker.rs   the worker (feature `worker`, default on)
+└── examples/probe.rs              play a file for 4 s with no display
+```
+
+Hosts depend on the library with `default-features = false` so GStreamer
+never enters their link. The worker binary is built from the same crate and
+found at run time: `OTTO_MEDIA_WORKER`, then next to the host's executable,
+then `PATH`. `otto_media_kit::player::available()` says whether one was found.
+
+## The worker's contract
+
+Descriptors are fixed, not negotiated: the media file on 3 (read-only), the
+frame ring on 4 (read-write). Commands are lines on stdin, events lines on
+stdout — `protocol.rs` has the grammar and both parsers, and its tests keep
+them round-tripping.
+
+The ring is a memfd the host creates and the worker sizes once it knows the
+frame size: a 4 KiB header then three slots of tightly packed RGBx. A `frame`
+event names the slot, the sequence number and the presentation time; the
+host copies the slot out on its event thread before the worker is back to it
+two frames later. `ready` carries the size and duration and may repeat — the
+duration is often only known after preroll.
+
+The pipeline is `playbin3` with `video-sink` set to
+`videoconvert ! videoscale ! capsfilter ! appsink`. The caps filter asks for
+RGBx within the host's limits as *ranges*, so `videoscale` keeps the aspect
+ratio and never scales up. The file is opened as
+`file:///proc/self/fd/3`: the worker never learns a path.
+
+## Containment
+
+Same shape as the decode worker in `otto-quickview`, minus what a media
+stack cannot live under: no `RLIMIT_FSIZE` (the plugin registry cache) and
+an 8 GiB address-space ceiling (hardware decoders map device memory freely).
+The environment is a whitelist — `PATH`, `HOME`, `XDG_RUNTIME_DIR`, the
+`GST_*` and `LIBVA_*` variables, the locale — because the audio server's
+socket and the registry cache live there. No Wayland or bus address.
+
+## Debugging
+
+- `OTTO_MEDIA_TRACE=1` lets the worker's stderr through and adds GStreamer's
+  debug string to error events.
+- `cargo run -p otto-media-kit --example probe -- FILE` plays four seconds
+  with no display, seeks once, and writes the last frame as a PNG
+  (`PROBE_PNG` names it). Point `OTTO_MEDIA_WORKER` at the worker if it is
+  not next to the example binary.
+- `GST_DEBUG=3` works as usual since `GST_*` is passed through.

--- a/docs/developer/otto-media-kit.md
+++ b/docs/developer/otto-media-kit.md
@@ -78,3 +78,21 @@ A paused pipeline emits its first frame as a *preroll*, not a sample, so the
 worker delivers both — otherwise a paused embed would show black. Set
 `OTTO_FILES_PREVIEW_AUTOPLAY=1` to make the docked column autoplay too, which
 is the quickest way to see the embed render frames without clicking.
+
+## Aspect and the preview-column subsurface
+
+The player box takes the video's own shape, not the whole space it sits in:
+`otto-files`' `view::preview_video_box` sizes it to `width / aspect +
+transport height`, capped and centred, so a 16:9 clip in a narrow column is a
+compact box on dark ground rather than a sliver in a field of black. Aspect
+comes from the frame, then the announced size, then the poster
+(`VideoSnapshot::aspect`); square pixels are already enforced worker-side, so
+this never distorts anamorphic content.
+
+In the preview column that box is its **own Wayland subsurface**
+(`pane_surfaces::sync_preview_video`), so a 30 fps video repaints only that
+surface — never the browser's toplevel, nor the scene's cached preview
+picture, whose key drops the video term when the video is on a surface. Input
+still belongs to the toplevel (empty input region), and the browser hit-tests
+the same box, so play and scrub work through the existing routing. The Quick
+View panel is unaffected: it is already its own surface.

--- a/docs/developer/otto-media-kit.md
+++ b/docs/developer/otto-media-kit.md
@@ -75,9 +75,9 @@ one `quickview::Video`: the Quick View panel (autoplays) and the docked
 Miller preview column (opens paused on the first frame, plays on click).
 
 A paused pipeline emits its first frame as a *preroll*, not a sample, so the
-worker delivers both — otherwise a paused embed would show black. Set
-`OTTO_FILES_PREVIEW_AUTOPLAY=1` to make the docked column autoplay too, which
-is the quickest way to see the embed render frames without clicking.
+worker delivers both — otherwise a paused embed would show black. The docked
+column always opens paused on that first frame and plays on click; only the
+Quick View panel autoplays.
 
 ## Aspect and the preview-column subsurface
 

--- a/docs/developer/tiling-plan.md
+++ b/docs/developer/tiling-plan.md
@@ -1,0 +1,520 @@
+# Tiling implementation plan
+
+Companion to [`specs/tiling.md`](../../specs/tiling.md), which describes the
+behaviour. This document describes how to get there from the code as it stands
+today, and what changes when the target audience is people coming from i3 and
+sway.
+
+## Who this is for
+
+i3 and sway users switch compositors for one of two reasons: the tree model
+they already think in, or the workflow built on top of it — keyboard-only,
+config-as-text, scriptable through `i3-msg` / `swaymsg`, a bar that reflects
+workspaces. Otto's pitch is that same model with an animated, decorated,
+per-workspace desktop around it: a tiled workspace one swipe away from a
+floating one, a dock and a top bar that keep working, exposé that already
+understands the tree.
+
+That audience changes four things relative to the spec as drafted:
+
+1. **The tree must be i3's tree.** N-ary `splith` / `splitv` containers,
+   `focus parent` / `focus child`, and — sooner than the spec's "open
+   question" — `tabbed` and `stacked` container layouts. Someone with a
+   three-year-old i3 config expects `layout toggle split` to do something.
+2. **Named actions, and an i3 preset that is only a config file.** Every
+   tiling operation is a builtin action with a name (`FocusLeft`,
+   `MoveContainerLeft`, `SplitVertical`, `LayoutTabbed`, …), bound in
+   `[keyboard_shortcuts]` exactly like `TileWindowLeft` is today. The i3
+   preset is a shipped TOML fragment, `config/presets/i3.toml`, with `Logo`
+   as `$mod` and the stock i3 defaults; the user copies it into their config
+   and edits lines. No preset key in the config format, no hidden defaults:
+   what is bound is what is in the file. The spec's non-goal "reproducing any
+   specific existing tiler's keybindings verbatim" softens to "not by
+   default".
+3. **An i3-syntax command language for scripting.** One parser for
+   `focus left`, `move container to workspace 3`,
+   `resize grow width 10 px or 5 ppt`, `split v`, `layout tabbed`,
+   `floating toggle`, `fullscreen`, `kill`, each resolving to the same named
+   action. Used by the D-Bus method, the CLI, and the headless tests, so
+   existing `i3-msg` scripts port with a rename. Shortcuts do not use it.
+4. **A scriptable surface.** `otto-msg` (CLI) over `org.otto.Shell1` with
+   `RunCommand(string)` and `GetTree() -> JSON`. Full sway-ipc socket
+   compatibility is a later, optional layer on top of the same two calls.
+
+## What exists today
+
+| Piece | Where | Reuse |
+| --- | --- | --- |
+| Half-snap zones (left / right / maximize) | `src/workspaces/tiling_overlay.rs`, `TileZone`, `zone_from_pointer` | Overlay view becomes the slot overlay for drag-into-tree; zones stay for floating workspaces |
+| Snap apply / restore with animation | `src/shell/xdg.rs` `apply_tile`, `untile`, `animated_client_size` | Extract the per-window "animate to rect, then set states" body into a helper both paths call |
+| Per-window snap state | `WindowView { tiled_zone, unmaximised_rect }` in `src/workspaces/window_view/view.rs` | `unmaximised_rect` is the spec's "floating rectangle it had before it was tiled" |
+| Usable area | `usable_zone(output)` in `src/shell/mod.rs` | The root container's rectangle, minus the outer gap |
+| Placement with transition | `Workspaces::map_window_on_output(.., Some(transition))` | Every cell move goes through this |
+| Drag grab with zone detection | `PointerMoveSurfaceGrab` in `src/shell/grabs.rs` | Gains a "workspace tiles" branch: detach + slot overlay instead of edge zones |
+| Popup re-anchoring after a move | `reposition_popups_for_window` | Called per relaid-out window |
+| Shortcut actions | `src/config/shortcuts.rs` (27 builtins), `src/input/actions.rs` | Add the tiling builtins alongside `TileWindowLeft`; `WorkspaceNum { index }` already shows the parameterised shape `MoveToWorkspace { index }` needs |
+| Headless harness | `src/headless.rs` `tile_focused`, `window_tiled_zone`, `window_floating_rect`; `tests/tiling.rs` (11 tests) | Extend with `run_command` and `tree_json` |
+| D-Bus | `org.otto.Settings`, `org.otto.Dialog1`, … via `zbus` in `src/settings_service.rs` and the portal | Same pattern for `org.otto.Shell1` |
+
+What does **not** exist: any per-workspace layout state, directional focus,
+gap hit-testing, a compact titlebar variant, a general command IPC, or a
+scaled-last-frame render path (today `apply_tile` reconfigures the client on
+every animation frame; the spec makes that the non-default "faithful" mode).
+
+## Architecture
+
+New module `src/workspaces/tiling/`, kept out of the 7000-line
+`workspaces/mod.rs`:
+
+```
+tiling/
+  tree.rs      pure data + operations, no compositor types
+  layout.rs    pure fn (tree, rect, gaps, min sizes) -> Vec<(leaf, rect)>
+  scene.rs     mirrors the tree into lay-rs flex container layers
+  command.rs   i3 grammar -> Command enum
+  state.rs     per-workspace TilingState, held on WorkspaceView
+  focus.rs     directional focus / move over resolved rects
+  mod.rs
+```
+
+**Division of labour.** `layout.rs` is the truth: it answers "what is this
+window's rectangle" synchronously, for the client configure, hit-testing,
+scanout eligibility and tests. `scene.rs` is the motion: it hands the same
+shares to the engine's Taffy layout and lets the engine animate. The two agree
+by construction because both are a linear function of the same fractions.
+
+**`tree.rs`.** `Node = Leaf(WindowId) | Container { layout: Split(Axis) | Tabbed | Stacked, children: Vec<(NodeId, f32)> }`.
+Operations from the spec, each a method returning what changed: `insert_next_to`,
+`remove`, `move_dir`, `swap_dir`, `resize`, `promote` / `demote`,
+`set_layout`, `split`, `equalize`, `focus_parent` / `focus_child`, and
+`dissolve_single_child_containers` as an invariant restored after every
+mutation. Fractions only, never pixels. Fully unit-tested with `cargo test --lib`
+before any compositor code touches it.
+
+**`layout.rs`.** Resolves the tree against the usable rectangle in logical
+pixels, applying outer/inner gaps, the lone-tile no-gap rule, per-leaf minimum
+sizes with the spec's overflow rule, and the tabbed/stacked title-strip height.
+Output rects are snapped with `workspaces::utils::snap_extent_px` so tiles land
+on the pixel grid at fractional scale (see `rendering.md`; an off-grid layer
+origin blurs the whole window).
+
+**`command.rs`.** A hand-written parser for the i3 subset in the table below.
+No dependency. Errors carry the offset so `otto-msg` can print them the way
+`swaymsg` does.
+
+**`state.rs`.** On `WorkspaceView`, `Arc<RwLock<TilingState>>`:
+
+```
+TilingState {
+  mode: Floating | Tiling,
+  tree: Tree,
+  focused: Option<NodeId>,          // may be a container after `focus parent`
+  preselect: Option<Axis>,
+  floating: HashSet<WindowId>,      // the floating layer: i3's exceptions
+  held_slots: HashMap<WindowId, SlotPath>,  // fullscreen / monocle return points
+  monocle: Option<WindowId>,
+}
+```
+
+**`scene.rs` — reusing the engine's layout.** The dock already shows the
+pattern: a Taffy *style* change is instantaneous, but a layer's *size* is an
+animated attribute that is also a Taffy input, and the engine runs animations,
+then transactions, then the layout pass, every frame. Animate a flex child's
+size with a transition and its siblings reflow fluidly; dock magnification is
+nothing else. Tiling mirrors the tree into layers this way:
+
+- one layer per container, `Display::Flex` with `flex_direction` row or
+  column and the inner gap as Taffy `gap`; the root container is sized to the
+  usable area inset by the outer gap and is `Absolute` inside `windows_layer`;
+- one flex child per leaf — the window's existing base layer, reparented
+  under its container — sized to `share × container extent` with a
+  transition; Taffy supplies positions;
+- insert: add at zero size and grow; remove: shrink to zero and detach
+  `on_animation_finish` (the fullscreen-overlay lesson: never on a
+  transaction's `on_finish`); gap drag: set the two neighbouring sizes; usable
+  area change: resize the root and everything reflows;
+- tabbed and stacked containers are `Absolute` children under a strip layer,
+  all sized to the container;
+- floating windows stay in `windows_layer` above every container, so
+  stacking is unaffected; containers must not clip (the
+  minimize-into-dock-strip clip bug is the cautionary tale).
+
+Interruptibility comes free: a new `set_size` re-targets the running
+transition. Per-frame the *drawn* rectangle is whatever Taffy resolved, while
+the client is configured once with the final rect from `layout.rs` — which is
+the spec's "fluid by default" without a bespoke animation system.
+
+**Applying a layout.** One entry point on `Otto`, `relayout_workspace(output,
+workspace, transition)`: resolve the tree with `layout.rs`, push the shares to
+`scene.rs`, then for each leaf whose final rect changed send one configure
+with the new size and xdg states (the extracted body of `apply_tile`), and
+call `reposition_popups_for_window`. Every mutation of the tree — from a
+keystroke, a map, an unmap, a drag drop, a usable-area change — ends by
+calling it.
+
+**Hooks into existing paths.**
+
+| Event | Today | With tiling |
+| --- | --- | --- |
+| `new_toplevel` / first map (`shell/mod.rs` cascade placement) | cascade | if workspace tiles and window is eligible: `insert_next_to(focused)`, relayout |
+| unmap, minimize, move to workspace | — | `remove`, relayout; destination workspace inserts |
+| focus change (`focus.rs`) | order list | also `state.focused = leaf` |
+| `resize_request` / `move_request` on a tiled window | interactive grab | resize refused; move starts the detach drag |
+| `maximize_request` | animate to usable zone | monocle: hide siblings, hold slot |
+| fullscreen | overlay layer | hold slot, restore into it |
+| `recalculate_exclusive_zones`, dock size/edge change, output mode/scale, rotation | nothing for windows | relayout every tiling workspace on that output |
+| `TileWindowLeft/Right` | half-snap | in a tiling workspace: `focus left/right` |
+| decoration mode (`xdg_decoration_handler.rs`) | SSD/CSD | SSD gets the compact bar; xdg states carry `TiledLeft/Right/Top/Bottom` per touching edge, `Maximized` only for a lone gapless tile or monocle |
+| XWayland (`apply_tile_x11`) | same rects | same rects, `_NET_WM_STATE` where an equivalent exists |
+
+**Floating, the i3 way.** A tiling workspace has a floating layer for the
+exceptions, exactly as i3 does and as the spec describes. A window floats
+automatically when it is a dialog or has a parent, when min == max size or
+`is_resizable() == false`, or when it is a utility or splash surface;
+`[tiling] float = ["app_id", …]` is the `for_window … floating enable`
+equivalent. `floating toggle` moves the focused window between the tree and
+the floating layer; `focus mode_toggle` moves focus between the two layers.
+Floating windows always draw above the tiles, keep their full titlebar and
+shadow, and are moved and resized as on a floating workspace. Nothing in the
+tree ever overlaps them.
+
+## Animation configuration
+
+Every tiling animation — a window joining or leaving the tree, a move or
+swap, a resize step, a re-fit after the usable area changed, entering or
+leaving tiling mode, monocle in and out — is driven by `relayout_workspace`
+and takes its transition from one place. That place follows the convention `[workspaces] switch_duration` /
+`switch_bounce` already set: a duration in seconds and a bounce, both
+clamped, and a duration of `0` means no animation at all — the layer is set
+without a transition and the tree lands in one frame. Nothing else is
+needed to "disable" tiling animations.
+
+```toml
+[tiling]
+# Insert, remove, move, swap, equalise, re-fit. 0 = snap.
+layout_duration = 0.3
+layout_bounce = 0.0
+# Entering and leaving tiling mode: every window flies to its cell or back.
+mode_duration = 0.4
+mode_bounce = 0.1
+# Monocle in and out.
+monocle_duration = 0.25
+# Design mode: cells chasing a dragged handle, splits, swaps, presets.
+design_duration = 0.35
+design_bounce = 0.25
+inner_gap = 8
+outer_gap = 8
+smart_gaps = true       # a lone tile drops the gaps
+float = []              # app ids that always float
+```
+
+The values are read where `relayout_workspace` picks its transition, so they
+apply live through the settings machinery like the workspace switch does. A
+`None` transition is a first-class case in `scene.rs`, not a very short one:
+insert adds the layer at its final size, remove detaches it at once, and the
+client is configured with no intermediate frame.
+
+Two things ride on top:
+
+- **Per-invocation skip.** Every named action and command accepts a
+  `no_animation` flag (`{ builtin = "FocusLeft", animate = false }` in the
+  shortcut config, `--no-animation` on `otto-msg`) so a keybinding can move a window
+  or switch the layout instantly while the same operation from the pointer or
+  from a script still animates. It is the same distinction the workspace
+  switch draws between a keybinding and a trackpad swipe, made explicit per
+  binding.
+- **`[accessibility] reduce_motion`.** A new global that forces every
+  duration above to zero, and the workspace switch's too. It maps to the
+  freedesktop `org.freedesktop.appearance` reduced-motion key when that is
+  read through the portal, so it reaches clients as well. It does not exist
+  today; adding it is part of Phase 1 because the tiling settings are the
+  first place a second animation family appears.
+
+## Named actions
+
+Phase-1 set, one builtin per operation, parameterised where i3 takes an
+argument:
+
+```
+FocusLeft/Right/Up/Down, FocusParent, FocusChild, FocusModeToggle
+MoveContainerLeft/Right/Up/Down, MoveToWorkspace { index }
+SplitHorizontal, SplitVertical, SplitToggle
+LayoutSplitH, LayoutSplitV, LayoutTabbed, LayoutStacking, LayoutToggle
+ResizeGrowWidth/ShrinkWidth/GrowHeight/ShrinkHeight { step }
+TilingDesignToggle, EqualizeContainer
+FloatingToggle, ToggleFullscreen, CloseWindow
+TilingToggle                       # workspace mode
+```
+
+`config/presets/i3.toml` binds them to the i3 defaults:
+
+```toml
+[keyboard_shortcuts]
+"Logo+h" = "FocusLeft"
+"Logo+j" = "FocusDown"
+"Logo+Shift+h" = "MoveContainerLeft"
+"Logo+v" = "SplitVertical"
+"Logo+b" = "SplitHorizontal"
+"Logo+w" = "LayoutTabbed"
+"Logo+Shift+Space" = "FloatingToggle"
+"Logo+Space" = "FocusModeToggle"
+"Logo+f" = "ToggleFullscreen"
+"Logo+Shift+q" = "CloseWindow"
+"Logo+Shift+3" = { builtin = "MoveToWorkspace", index = 2 }
+"Logo+3" = { builtin = "Workspace", index = 2 }
+# …
+```
+
+The file is documented in `docs/user/keyboard-shortcuts.md` as "copy this
+block into your config"; there is no `preset =` key and no include mechanism
+(the config loader layers fixed paths only). The example config gains the
+same block commented out.
+
+## Design mode
+
+Design mode is the friendly way to shape a tiled workspace. It is for the
+person who has never used a tiler and would not learn `split v` or
+`resize grow width 10 ppt`: enter it, and the layout's rows and columns
+become visible things you can grab, split, drag around and resize, with the
+windows running inside their cells the whole time. The keyboard actions and
+the command grammar are the power-user path to the same tree; design mode is
+the one Otto shows first, and the reason a tiling workspace does not need a
+manual.
+
+**Friendly means:**
+
+- *Nothing hidden.* Every handle is drawn, large enough to hit without
+  aiming, and lights up on hover with a cursor that says what a drag will do.
+  Nothing depends on knowing that a gap is secretly a handle.
+- *Always see the result before committing.* Drags show the shares as
+  percentages, drops show the slot before release, and a change animates so
+  the eye can follow what moved.
+- *No wrong states.* A drag stops at a window's minimum size; a split of a
+  cell that cannot be split is greyed out; a container never ends up with one
+  child. There is no way to make a layout the user then has to repair.
+- *Undo.* Every structural edit in design mode goes on the session undo
+  stack, `Ctrl+Z` reverts it, the same mechanism Otto Settings uses.
+- *Starting points.* An empty workspace in design mode offers a row of
+  layout presets — two columns, three columns, main and stack, grid — one
+  click applies one as empty slots to drop windows into.
+- *Leaves you where you were.* Leaving design mode changes nothing; the
+  windows are where the layout put them, focused as before.
+
+**Entering and leaving.** A named action (`TilingDesignToggle`, bound to
+`Logo+d` in the preset, since i3's `Logo+d` is a launcher Otto binds
+elsewhere), an item in the workspace context menu, or a long press on a gap.
+Escape, the action again, or a click on a window's content leaves it. Design
+mode is per workspace and ends when the workspace scrolls away.
+
+**What is shown.** The same overlay the edge snap already shows when a
+window is dragged to a screen edge — a translucent white pane with a white
+border and rounded corners, fading and sliding in with short ease-out
+transitions (`TilingOverlayView`) — but one per cell, so the whole workspace
+turns into a grid of those panes drawn over the windows. A cell's pane is its
+window's rectangle including the gap; the panes together tile the usable
+area exactly, so the layout's rows and columns read off the grid at a glance
+with no outlines or dimming needed. The gaps between panes are the handles.
+The focused cell's pane carries the accent-coloured border. Nested containers
+are not drawn separately: the grid *is* the tree, and dragging a bar that
+spans several panes makes the nesting visible when they move together.
+Each pane shows a small centred toolbar on hover: split horizontal, split
+vertical, layout kind (split / tabbed / stacked), close-cell. An empty slot
+is the same pane with a dashed border and a `+`.
+
+**Handles.**
+
+- *Bar handle*: drag along the container's axis to move that split; the two
+  neighbouring shares change and nothing else. The bar shows the two shares
+  as percentages while dragging. Snaps to halves, thirds and quarters within
+  a few pixels; hold `Shift` to bypass snapping. Double-click equalises the
+  container.
+- *Corner handle*: drags both splits at once.
+- *Cell drag*: drag a cell by its body to swap it with the cell it is dropped
+  on, or onto a bar handle to insert it at that split. The same slot overlay
+  as drag-to-detach shows the result before release.
+- *Container drag*: dragging the bar that borders a whole container moves the subtree,
+  same rules.
+- *Empty cells*: a split made on an empty workspace, or a cell whose window
+  closes while in design mode, leaves an empty slot outlined in dashes. The
+  next window to map fills the focused empty slot before splitting anything.
+  This is how a user lays out a workspace first and populates it after, and
+  the base for named layouts later.
+
+**Keyboard in design mode.** Every named action still works, so a keyboard
+user gets the visual feedback without giving up their bindings: arrows move
+focus between cells, the resize steps apply to the focused cell, `Enter` on
+a bar handle equalises. The two paths edit the same tree and can be mixed
+mid-session.
+
+**Adjusting cells is animated, a bit bouncy.** Design mode does not follow
+the spec's "the pointer is the animation" rule for interactive resize. When a
+bar is dragged, the shares update under the pointer but the panes and the
+windows beneath them chase it on a spring — the same
+`Transition::spring(duration, bounce)` the dock uses for magnification — so
+a fast drag lags a touch and overshoots a little before settling on release.
+A split, a swap, a preset or an equalise animates on the same spring. It is
+what makes the grid feel like a physical thing being pushed around rather
+than a wireframe. The spring is `[tiling] design_duration` /
+`design_bounce`, defaulting bouncier than the layout spring; `0` snaps like
+every other duration. Clients are reconfigured as they ack during the drag
+and once more with the final size when the spring settles, so a slow client
+never holds the panes back.
+
+**Outside design mode.** Gaps are not drag handles. A window's titlebar drag
+still detaches it and the slot overlay still works. This keeps pointer
+handling on a tiling workspace identical to a floating one until the user
+asks for the editor, and avoids a hidden hit-area competing with window
+edges.
+
+**Implementation.** A `TilingDesignView` in `src/workspaces/tiling/design.rs`
+that generalises `TilingOverlayView` from one preview pane to a set: the
+same layer recipe (30 % white fill, 80 % white 2 px border, 12 pt radius,
+0.15 s ease-out move, 0.2 s fade) per cell, plus bar and corner handle layers
+in the gaps, parented above the containers and driven from the same shares as
+`scene.rs` so the panes animate in step with the windows beneath them. The
+pointer path hit-tests the handles before windows (the same hook the dock's resize
+handle uses). Drags are a `PointerGrab` that writes shares into the tree and
+calls `relayout_workspace` with no transition. The toolbar reuses otto-kit
+buttons drawn by the compositor, as the titlebar controls are.
+
+## Command language
+
+The scripting grammar, resolving to the actions above. Phase-1 subset:
+
+```
+focus left|right|up|down|parent|child|mode_toggle
+move left|right|up|down
+move container to workspace <n|name>
+workspace <n|name|next|prev>
+split h|v|toggle
+layout splith|splitv|tabbed|stacking|toggle [split|all]
+resize grow|shrink width|height <n> px [or <n> ppt]
+resize set width <n> ppt|px [height ...]
+floating toggle|enable|disable
+fullscreen [toggle]
+kill
+tiling toggle                      # Otto: workspace mode
+gaps inner|outer <n>
+```
+
+Deferred: `mark` / `[con_mark]` criteria, `mode "resize"` binding modes,
+`scratchpad`, `assign`, `for_window`, `exec` (shortcuts already do `run`).
+
+Workspaces by number need "create on demand": i3 makes workspace 7 when you
+switch to it. Otto today has a fixed strip with `Ctrl+1..4`; `workspace <n>`
+should append workspaces until `n` exists. i3 also drops a workspace when it
+empties; Otto does **not** follow that. Otto's workspaces are persistent —
+named, reorderable, per output — and a renamed workspace vanishing because its
+last window closed would break that model. An empty workspace stays.
+
+## IPC
+
+`org.otto.Shell1` on the session bus, alongside the existing `org.otto.*`
+interfaces:
+
+- `RunCommand(s command) -> a(bs)` — one result per `;`-separated command,
+  mirroring `swaymsg`'s reply shape.
+- `GetTree() -> s` — JSON with the i3 node shape (`id`, `type`, `layout`,
+  `nodes`, `floating_nodes`, `focused`, `rect`, `app_id`, `name`, `window_properties` for X11).
+- `GetWorkspaces() -> s`, `GetOutputs() -> s`.
+- Signals `WorkspaceChanged`, `WindowChanged`, `ModeChanged` for bars.
+
+`components/otto-msg`: a `-t get_tree` / positional command CLI over that
+interface, so `otto-msg focus left` and `otto-msg -t get_tree | jq` work.
+A sway-ipc-compatible Unix socket (`$SWAYSOCK`) is a Phase-4 shim over the same
+calls; it would let waybar's `sway/workspaces`, `i3-msg`-based scripts and
+`autotiling` run as-is. Check separately whether Otto exposes
+`ext-workspace-v1` and `wlr-output-management`; waybar's `wlr/workspaces` and
+kanshi need them, and both matter to this audience independently of tiling.
+
+## Phases
+
+**Phase 0 — pure core.** `tree.rs`, `layout.rs`, `command.rs` with unit tests
+covering every spec rule (insertion by cell shape, share redistribution on
+removal, single-child dissolve, move-out-of-container, min-size overflow, lone
+tile gaps, tabbed strip height). No compositor changes. Reviewable on its own.
+
+**Phase 1 — keyboard tiling.** `TilingState` on `WorkspaceView`; mode toggle
+(shortcut + workspace context-menu item); insert/remove on map/unmap/minimize/
+move; `relayout_workspace` with the extracted animation helper; xdg tiled
+states; auto-float rules and the floating layer; `[tiling]` durations with
+`0` = snap, per-action `animate = false`, and `[accessibility] reduce_motion`;
+the named actions and `config/presets/i3.toml`; focus
+directions, moves, splits, layouts (tabbed/stacked rendered as a title strip on
+the compact bar), resize step, float toggle, monocle, fullscreen slot holding;
+`workspace <n>` create-on-demand. Headless tests in `tests/tiling_tree.rs`
+drive everything through `run_command` and assert on `tree_json` and
+geometries, the way `tests/tiling.rs` does for half-snap.
+
+**Phase 2 — pointer and chrome.** Design mode: the pane grid, bar and corner
+handles with `ew-resize`/`ns-resize`/`nwse-resize` cursor shapes, live
+reconfigure on ack, cell toolbar, empty slots, cell and container drag;
+drag-to-detach with the reused `TilingOverlayView` showing
+the slot; dropping a floating window into a tree; compact titlebar variant;
+accent focus border; no shadow on tiles; usable-area re-fit on dock/layer-shell/
+mode changes; XWayland parity; workspace-selector mode indicator.
+
+**Phase 3 — scriptability and depth.** `org.otto.Shell1` + `otto-msg`;
+`GetTree`; marks and criteria; binding modes (`mode "resize"`); scratchpad;
+per-app `assign`/`for_window` rules; persistence of mode and tree across
+restart (spec open question — recommend yes for mode, tree best-effort by
+app_id).
+
+**Phase 4 — compatibility.** Sway-ipc socket shim if there is demand.
+The spec's scaled-last-frame animation falls out of Phase 1 through
+`scene.rs`: the engine animates the layer, the buffer inside it is drawn
+scaled until the configured one lands. What remains to verify there is plane
+promotion during and after the animation, not a render-side feature.
+
+## Open: exposé on a tiled workspace
+
+Deliberately unresolved. The spec says exposé works on a tiled workspace
+exactly as on a floating one, but that is untested against the tree, and a
+tiled workspace is already an overview of itself. Questions to settle once
+Phase 1 is on screen:
+
+- whether exposé should spread tiles at all, or only pull the floating layer
+  and the tabbed/stacked hidden windows out where they can be seen;
+- what happens to the containers' layers while exposé reparents or mirrors
+  windows (`pre_expose_order` and the mirror path assume `windows_layer`
+  children);
+- whether selecting a window in exposé should also move it in the tree, or
+  only focus it;
+- how the workspace-selector previews render a tree (they replicate
+  `wallpaper_group` plus windows today).
+
+Revisit after Phase 1; nothing in Phases 1–2 depends on the answer.
+
+## Spec deltas to make
+
+Update `specs/tiling.md` when Phase 1 starts:
+
+- Non-goals: keybinding parity becomes "not the default"; add the named
+  actions, the shipped i3 preset file, and the command grammar as goals.
+- Promote tabbed/stacked from open question to behaviour.
+- Add `focus parent` / `focus child` and container focus.
+- Replace the "Resizing / Pointer" paragraph with design mode: gaps are not
+  handles outside it; add empty slots; interactive resize animates on a
+  spring rather than tracking the pointer rigidly.
+- Add the command language and IPC sections.
+- Add workspace create-on-demand (touches `workspaces-multi-output.md`).
+- Rewrite the rationale "Why the layout is not expressed as engine layout
+  nodes" to the hybrid: the compositor resolves rectangles for the client and
+  input, the engine's Taffy layout animates them.
+
+## Risks
+
+- **Configure storms.** Per-frame configures across N clients on every
+  layout change is exactly what the spec warns about. Mitigate in Phase 1 by
+  configuring only leaves whose rect changed and by throttling configures to
+  acked ones (the interactive-resize rule), not by fixed cadence.
+- **Scanout.** A lone tile or monocle must still promote to a plane
+  (`specs/plane-scanout.md`); the tiled xdg states must not change the
+  promotion gate. Verify on tty with `/tmp/otto-dump-planes`.
+- **lay-rs cancelled changes.** Re-targeting a running transition has bitten
+  exposé before; interruptible relayout leans on that fix and needs a headless
+  regression that issues two moves within one animation.
+- **Fractional scale.** Every cell rect goes through `snap_extent_px`; a test
+  at scale 1.5 asserting integer physical origins belongs in Phase 0.
+- **`workspaces/mod.rs` size.** All new logic lives in `workspaces/tiling/`;
+  `mod.rs` only gains the calls into it.

--- a/docs/developer/tiling-plan.md
+++ b/docs/developer/tiling-plan.md
@@ -70,7 +70,7 @@ New module `src/workspaces/tiling/`, kept out of the 7000-line
 tiling/
   tree.rs      pure data + operations, no compositor types
   layout.rs    pure fn (tree, rect, gaps, min sizes) -> Vec<(leaf, rect)>
-  scene.rs     mirrors the tree into lay-rs flex container layers
+  apply.rs     relayout: per-window animate + configure, transactions
   command.rs   i3 grammar -> Command enum
   state.rs     per-workspace TilingState, held on WorkspaceView
   focus.rs     directional focus / move over resolved rects
@@ -79,9 +79,11 @@ tiling/
 
 **Division of labour.** `layout.rs` is the truth: it answers "what is this
 window's rectangle" synchronously, for the client configure, hit-testing,
-scanout eligibility and tests. `scene.rs` is the motion: it hands the same
-shares to the engine's Taffy layout and lets the engine animate. The two agree
-by construction because both are a linear function of the same fractions.
+scanout eligibility and tests. `apply.rs` turns rectangles into motion and
+configures, and owns the one hard fact about animating a tiled layout: a
+resized rectangle only has real content once the client has committed a
+buffer of that size. The engine can move a layer for free; it cannot resize
+its content.
 
 **`tree.rs`.** `Node = Leaf(WindowId) | Container { layout: Split(Axis) | Tabbed | Stacked, children: Vec<(NodeId, f32)> }`.
 Operations from the spec, each a method returning what changed: `insert_next_to`,
@@ -116,39 +118,31 @@ TilingState {
 }
 ```
 
-**`scene.rs` — reusing the engine's layout.** The dock already shows the
-pattern: a Taffy *style* change is instantaneous, but a layer's *size* is an
-animated attribute that is also a Taffy input, and the engine runs animations,
-then transactions, then the layout pass, every frame. Animate a flex child's
-size with a transition and its siblings reflow fluidly; dock magnification is
-nothing else. Tiling mirrors the tree into layers this way:
+**`apply.rs` — motion paced by the client.** Moves and swaps, where sizes
+do not change, animate the window layers with a lay-rs transition and look
+right throughout: the buffer stays valid. Resizes are configured per
+animation frame, as half-snap and the MVP already do, and the window is
+drawn with whatever buffer the client has committed most recently. A client
+that keeps up (GTK, Qt, otto-kit at frame rate) shows real content on every
+frame; a slow one lags behind its rectangle for a few frames, which is the
+honest state of affairs rather than a stretched or clipped stand-in. No
+Taffy mirroring of the tree: it would move the same problem into the engine
+and reparent window layers for nothing.
 
-- one layer per container, `Display::Flex` with `flex_direction` row or
-  column and the inner gap as Taffy `gap`; the root container is sized to the
-  usable area inset by the outer gap and is `Absolute` inside `windows_layer`;
-- one flex child per leaf — the window's existing base layer, reparented
-  under its container — sized to `share × container extent` with a
-  transition; Taffy supplies positions;
-- insert: add at zero size and grow; remove: shrink to zero and detach
-  `on_animation_finish` (the fullscreen-overlay lesson: never on a
-  transaction's `on_finish`); gap drag: set the two neighbouring sizes; usable
-  area change: resize the root and everything reflows;
-- tabbed and stacked containers are `Absolute` children under a strip layer,
-  all sized to the container;
-- floating windows stay in `windows_layer` above every container, so
-  stacking is unaffected; containers must not clip (the
-  minimize-into-dock-strip clip bug is the cautionary tale).
+Two refinements on top of the MVP:
 
-Interruptibility comes free: a new `set_size` re-targets the running
-transition. Per-frame the *drawn* rectangle is whatever Taffy resolved, while
-the client is configured once with the final rect from `layout.rs` — which is
-the spec's "fluid by default" without a bespoke animation system.
+- **Transactions for the final frame.** The last configure of a relayout is
+  tracked per window; the layout is presented as settled only when every
+  affected client has committed the final size, or a short deadline passes.
+  This is sway's transaction model applied to the end of the animation, so
+  a slow client never leaves a half-applied layout on screen.
+- **Configure only what changed.** Leaves whose rectangle is unchanged get
+  no configure at all.
 
 **Applying a layout.** One entry point on `Otto`, `relayout_workspace(output,
-workspace, transition)`: resolve the tree with `layout.rs`, push the shares to
-`scene.rs`, then for each leaf whose final rect changed send one configure
-with the new size and xdg states (the extracted body of `apply_tile`), and
-call `reposition_popups_for_window`. Every mutation of the tree — from a
+workspace, transition)`: resolve the tree with `layout.rs`, then for each leaf
+whose rect changed animate the layer and configure the client through
+`apply.rs`, and call `reposition_popups_for_window`. Every mutation of the tree — from a
 keystroke, a map, an unmap, a drag drop, a usable-area change — ends by
 calling it.
 
@@ -211,7 +205,7 @@ float = []              # app ids that always float
 
 The values are read where `relayout_workspace` picks its transition, so they
 apply live through the settings machinery like the workspace switch does. A
-`None` transition is a first-class case in `scene.rs`, not a very short one:
+`None` transition is a first-class case in `apply.rs`, not a very short one:
 insert adds the layer at its final size, remove detaches it at once, and the
 client is configured with no intermediate frame.
 
@@ -372,7 +366,7 @@ that generalises `TilingOverlayView` from one preview pane to a set: the
 same layer recipe (30 % white fill, 80 % white 2 px border, 12 pt radius,
 0.15 s ease-out move, 0.2 s fade) per cell, plus bar and corner handle layers
 in the gaps, parented above the containers and driven from the same shares as
-`scene.rs` so the panes animate in step with the windows beneath them. The
+`apply.rs` so the panes animate in step with the windows beneath them. The
 pointer path hit-tests the handles before windows (the same hook the dock's resize
 handle uses). Drags are a `PointerGrab` that writes shares into the tree and
 calls `relayout_workspace` with no transition. The toolbar reuses otto-kit
@@ -502,10 +496,9 @@ restart (spec open question — recommend yes for mode, tree best-effort by
 app_id).
 
 **Phase 4 — compatibility.** Sway-ipc socket shim if there is demand.
-The spec's scaled-last-frame animation falls out of Phase 1 through
-`scene.rs`: the engine animates the layer, the buffer inside it is drawn
-scaled until the configured one lands. What remains to verify there is plane
-promotion during and after the animation, not a render-side feature.
+The spec's scaled-last-frame animation is dropped: there is no honest way
+to fill a resized rectangle before the client has drawn it. Per-frame
+configure plus end-of-animation transactions is the model.
 
 ## Open: exposé on a tiled workspace
 
@@ -539,9 +532,8 @@ Update `specs/tiling.md` when Phase 1 starts:
   spring rather than tracking the pointer rigidly.
 - Add the command language and IPC sections.
 - Add workspace create-on-demand (touches `workspaces-multi-output.md`).
-- Rewrite the rationale "Why the layout is not expressed as engine layout
-  nodes" to the hybrid: the compositor resolves rectangles for the client and
-  input, the engine's Taffy layout animates them.
+- Animation: replace "fluid by default" (scaled last frame) with per-frame
+  configure paced by the client, plus transactions for the settled frame.
 
 ## Risks
 

--- a/docs/developer/tiling-plan.md
+++ b/docs/developer/tiling-plan.md
@@ -205,6 +205,7 @@ design_bounce = 0.25
 inner_gap = 8
 outer_gap = 8
 smart_gaps = true       # a lone tile drops the gaps
+decoration = "minimal"  # "minimal" title line, or "none" for a border only
 float = []              # app ids that always float
 ```
 
@@ -377,6 +378,30 @@ handle uses). Drags are a `PointerGrab` that writes shares into the tree and
 calls `relayout_workspace` with no transition. The toolbar reuses otto-kit
 buttons drawn by the compositor, as the titlebar controls are.
 
+## Decorations on tiles
+
+Tiles want less chrome than floating windows, and i3 users disagree on how
+much less: i3 draws a one-line title bar by default, sway users very often
+set `default_border pixel 2` and keep only a coloured border. So it is a
+setting, `[tiling] decoration = "minimal" | "none"`, default `minimal`:
+
+- **minimal** — a bar one text line high with the title and a close button,
+  squared corners, no shadow. It keeps the move handle, the window menu and
+  the title, which is the spec's reason for keeping a bar at all.
+- **none** — no bar; the focused tile gets a hairline border in the accent
+  colour, the rest a neutral hairline. Moving a tile is then design mode or
+  the keyboard. This is sway's `pixel` border.
+
+Tabbed and stacked containers draw their strip in both settings, since it
+is the only way to see the hidden windows. Client-side-decorated windows are
+told they are tiled on every touching edge and square off on their own; they
+get no bar in either setting. Floating windows in a tiling workspace keep
+the full floating decoration.
+
+The variant is chosen per window in `decoration_view.rs` from the
+workspace's mode, and swapped when the window enters or leaves the tree —
+the same path the maximized (gapless, squared) variant already uses.
+
 ## Command language
 
 The scripting grammar, resolving to the actions above. Phase-1 subset:
@@ -450,7 +475,7 @@ geometries, the way `tests/tiling.rs` does for half-snap.
 handles with `ew-resize`/`ns-resize`/`nwse-resize` cursor shapes, live
 reconfigure on ack, cell toolbar, empty slots, cell and container drag;
 drag-to-detach with the reused `TilingOverlayView` showing
-the slot; dropping a floating window into a tree; compact titlebar variant;
+the slot; dropping a floating window into a tree; the minimal and none decoration variants;
 accent focus border; no shadow on tiles; usable-area re-fit on dock/layer-shell/
 mode changes; XWayland parity; workspace-selector mode indicator.
 

--- a/docs/developer/tiling-plan.md
+++ b/docs/developer/tiling-plan.md
@@ -402,6 +402,22 @@ The variant is chosen per window in `decoration_view.rs` from the
 workspace's mode, and swapped when the window enters or leaves the tree —
 the same path the maximized (gapless, squared) variant already uses.
 
+**Otto's own apps.** otto-files, otto-settings, the launcher and quick view
+draw their own titlebar through otto-kit's titlebar component, so the
+compositor-side variants never reach them. They follow the same setting
+from the client side:
+
+- the tiled xdg edge states in the configure tell the app it is tiled; the
+  otto-kit titlebar switches to its compact form and squares its corners
+  while any edge is tiled, as GTK does;
+- the `minimal` / `none` choice goes out over `org.otto.Settings` like the
+  theme and the controls side already do, so the app applies it live;
+- with `none` the app draws no bar and is moved by design mode or the
+  keyboard, like any client-decorated window.
+
+One component change in otto-kit covers every app that already implements
+the settings callback; islands, quick view and lock still need that hook.
+
 ## Command language
 
 The scripting grammar, resolving to the actions above. Phase-1 subset:

--- a/docs/user/keyboard-shortcuts.md
+++ b/docs/user/keyboard-shortcuts.md
@@ -148,6 +148,10 @@ expect.
 | `ResizeGrowHeight` / `ResizeShrinkHeight` | The same vertically |
 | `EqualizeContainer` | Give every cell in the focused container the same share |
 
+With `xkb_options = ["altwin:ctrl_win"]` (or `mac_style_modifiers`) set under
+`[input]`, the Cmd key reports as Control and a `Logo+…` binding can never
+match; bind these as `Ctrl+Alt+h` and so on instead — Cmd+Alt on the keyboard.
+
 In a tiling workspace `TileWindowLeft` and `TileWindowRight` do not half-snap:
 they move focus left and right, since every position is already a slot. Gaps,
 the layout animation and the resize step are configured under `[tiling]` — see

--- a/docs/user/keyboard-shortcuts.md
+++ b/docs/user/keyboard-shortcuts.md
@@ -128,6 +128,31 @@ desktop id or a plain command line.
 | `TileWindowRight` | Snap the focused window to the right half |
 | `ToggleDecorations` | Flip every window between client-side and server-side decoration mode |
 
+### Tiling
+
+A workspace can be switched from free-floating window placement to *tiling*,
+where every window is laid out edge to edge in a tree of splits. The mode
+belongs to one workspace on one output, so a tiled workspace and a floating one
+live a swipe apart. None of these actions is bound by default; the example
+config carries a commented block that binds them the way i3 and sway users
+expect.
+
+| Action | Effect |
+|--------|--------|
+| `TilingToggle` | Put the focused workspace into, or out of, tiling mode |
+| `FocusLeft` / `FocusRight` / `FocusUp` / `FocusDown` | Move keyboard focus to the neighbouring tile. Focus does not wrap |
+| `MoveContainerLeft` / `MoveContainerRight` / `MoveContainerUp` / `MoveContainerDown` | Move the focused window through the tree: it swaps with its neighbour, or leaves its container that way |
+| `SplitHorizontal` | The next window to open splits the focused cell left/right |
+| `SplitVertical` | …top/bottom instead. Pressing the same one again disarms it |
+| `ResizeGrowWidth` / `ResizeShrinkWidth` | Widen or narrow the focused cell by one `[tiling] resize_step`, taking from its neighbour |
+| `ResizeGrowHeight` / `ResizeShrinkHeight` | The same vertically |
+| `EqualizeContainer` | Give every cell in the focused container the same share |
+
+In a tiling workspace `TileWindowLeft` and `TileWindowRight` do not half-snap:
+they move focus left and right, since every position is already a slot. Gaps,
+the layout animation and the resize step are configured under `[tiling]` — see
+`otto_config.example.toml`.
+
 ### Applications
 
 | Action | Effect |

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -293,6 +293,9 @@ sound_enabled = true
 # Tiling. A workspace tiles because you asked it to; these are the commands
 # that shape the tree once it does. Uncomment the block to bind them — nothing
 # here is bound by default.
+# With [input] xkb_options = ["altwin:ctrl_win"] (or mac_style_modifiers), the
+# Cmd key reports as Control and a "Logo+…" binding can never match: bind these
+# as "Ctrl+Alt+h" and so on instead, which is Cmd+Alt on the keyboard.
 # "Logo+t" = "TilingToggle"                 # tile / untile this workspace
 # "Logo+h" = "FocusLeft"                    # move focus between cells
 # "Logo+j" = "FocusDown"

--- a/otto_config.example.toml
+++ b/otto_config.example.toml
@@ -290,6 +290,26 @@ sound_enabled = true
 "XF86AudioPrev" = "MediaPrev"              # Media previous track
 "XF86AudioStop" = "MediaStop"              # Media stop
 
+# Tiling. A workspace tiles because you asked it to; these are the commands
+# that shape the tree once it does. Uncomment the block to bind them — nothing
+# here is bound by default.
+# "Logo+t" = "TilingToggle"                 # tile / untile this workspace
+# "Logo+h" = "FocusLeft"                    # move focus between cells
+# "Logo+j" = "FocusDown"
+# "Logo+k" = "FocusUp"
+# "Logo+l" = "FocusRight"
+# "Logo+Shift+h" = "MoveContainerLeft"      # move the focused window in the tree
+# "Logo+Shift+j" = "MoveContainerDown"
+# "Logo+Shift+k" = "MoveContainerUp"
+# "Logo+Shift+l" = "MoveContainerRight"
+# "Logo+b" = "SplitHorizontal"              # the next window splits this cell
+# "Logo+v" = "SplitVertical"                #   left/right, or top/bottom
+# "Logo+r" = "ResizeGrowWidth"              # one resize_step of the container
+# "Logo+Shift+r" = "ResizeShrinkWidth"
+# "Logo+Ctrl+r" = "ResizeGrowHeight"
+# "Logo+Ctrl+Shift+r" = "ResizeShrinkHeight"
+# "Logo+e" = "EqualizeContainer"            # even out the focused container
+
 [dock]
 size = 1.0  # Dock size multiplier (0.5 - 2.0, default: 1.0)
 # Screen edge the dock is docked to: "bottom" (default), "left" or "right".
@@ -370,3 +390,30 @@ colorize_icons = true
 # because it starts from wherever your fingers left the workspaces.
 # switch_duration = 0.6
 # switch_bounce = 0.1
+
+[tiling]
+# A tiling workspace lays its windows out edge to edge in a tree of splits,
+# instead of letting them float and overlap. Toggle a workspace into it with
+# the "TilingToggle" shortcut above; the mode belongs to that workspace on that
+# output, so a tiled workspace and a floating one live a swipe apart.
+
+# Logical pixels between two neighbouring tiles, and between the tiles and the
+# edge of the usable area (the screen minus the dock, the top bar and any panel).
+# inner_gap = 8
+# outer_gap = 8
+
+# A workspace with a single tile drops the gaps entirely, so one window does not
+# sit inset for no reason.
+# smart_gaps = true
+
+# How long a layout change takes — a window joining or leaving the tree, a move,
+# a resize step, a re-fit after the dock changed size — and how much it
+# overshoots before it settles, the same spring the workspace scroll uses.
+# A duration of 0 snaps: windows land in their cells in one frame, with no
+# motion at all.
+# layout_duration = 0.3
+# layout_bounce = 0.0
+
+# How much of the container one ResizeGrow/ResizeShrink step moves, as a
+# fraction of its extent.
+# resize_step = 0.05

--- a/specs/quickview.md
+++ b/specs/quickview.md
@@ -47,8 +47,10 @@ one file descriptor and no network.
   application".
 - File management: rename, delete, move, copy, permissions. That is the
   browser's job.
-- Playback in v1. Audio and video show a poster and metadata; a transport is a
-  later stage, not a hidden v1 requirement.
+- Audio playback. Audio shows a card with its tags and cover art; a PCM
+  decoder and an output path are a later stage. Video *is* played — see
+  [Video playback](#video-playback) — but by a separate media crate, never by
+  the previewer or the toolkit.
 - HTML, EPUB, and anything else whose faithful rendering implies a browser
   engine. This is a permanent exclusion, not a deferral.
 - Out-of-tree previewer plug-ins. The seam for new content types is in-tree; a
@@ -344,7 +346,7 @@ the table is arranged around not compromising them.
 | Lottie animation | Full, played | Skottie — already enabled and already used by otto-kit |
 | Archive — zip, uncompressed tar | Listing only: names, sizes, dates, entry count | Nothing (see below) |
 | Audio | Metadata card: title/artist/album/duration, plus embedded cover art | Tag parsing by hand; PCM decode deferred |
-| Video | Metadata card: dimensions, duration, codec, plus the container's embedded poster when present | Frame decode deferred |
+| Video | Played, with a transport: play/pause, scrub, clock, mute. The card underneath (dimensions, duration, kind) is the poster until the first frame, and the whole preview where playback is unavailable | `otto-media-kit`'s worker, a separate binary — see [Video playback](#video-playback) |
 | HEIC, AVIF, camera RAW | Not previewed — shown as an unsupported card naming the type, under the file's icon | Deferred |
 | Anything with no decoder, and any decode that failed | The file's icon at hero size, with the type and size, or the reason it could not be shown | Nothing |
 | HTML, EPUB, Office documents | Never | — |
@@ -424,6 +426,81 @@ Decoders Otto genuinely lacks, with candidates and their cost:
   when this is built:** a hand-written token scanner covering strings, comments,
   numbers, and a keyword set per language — a few hundred lines, correct enough
   for a preview, and consistent with the project's dependency posture.
+
+### Video playback
+
+A video previews as a *playing* video, because a poster frame of a video is
+the one preview that tells you less than its icon does: which second of it
+you are looking at is arbitrary, and the thing you pressed space to find out
+— what is in it — needs motion to answer.
+
+Playback is **not a decoder** and does not run in the decode worker. The
+worker's job is one payload from one file under a deadline; a player is a
+long-lived process with a clock, an audio device and a stream of frames. So
+the two stay separate, and the seam between them is the payload the worker
+already produces:
+
+1. The decode worker sniffs the file, finds `video/*`, and produces the
+   metadata `Card` it always did, stamped with the `video-…` icon chain.
+2. The host asks `otto_quickview::payload::is_video` of the *decoded*
+   payload. The answer comes from the sniffed type — the bytes said video —
+   never from the name, for the same reason dispatch never reads the name.
+   A `.mp4` full of something else is never handed to a demuxer.
+3. If it is a video and a player is available, the host attaches an
+   `otto_media_kit::Player` to the session. The card stays underneath: its
+   artwork is the poster until the first frame lands, and it is the preview
+   again if the player cannot start or dies.
+
+`otto-media-kit` is its own crate, deliberately outside otto-kit: a media
+stack is more code than the toolkit it would be bolted onto, and it links
+GStreamer, which no application binary should. The crate has two halves:
+
+- **The library** (`otto_media_kit`) — what the host embeds. `Player` spawns
+  the worker, sends it commands and reads its events; `view` and `transport`
+  draw the current frame and the controls in the toolkit's canvas-pure
+  draw/hit-test style. It links otto-kit and Skia, which the host already
+  has, and nothing else.
+- **The worker** (`otto-media-worker`) — a separate binary where GStreamer
+  lives. It is spawned per playback with the media file on descriptor 3 and a
+  frame ring on descriptor 4, commands on stdin, events on stdout. It runs
+  `playbin3` with an `appsink`, writes each decoded frame into the ring as
+  RGBx no larger than the panel at the output's scale, plays audio itself,
+  and exits when told to or when its host goes away.
+
+The worker is contained the way the decode worker is — `chdir("/")`,
+`PR_SET_NO_NEW_PRIVS`, no core dumps, a descriptor ceiling, a network
+namespace where the kernel allows one — minus the limits a media stack cannot
+live under: no `RLIMIT_FSIZE` (GStreamer maintains its plugin registry cache)
+and a much larger address-space ceiling (hardware decoders map device memory
+generously). It keeps `XDG_RUNTIME_DIR`, `HOME` and the `GST_*` variables
+from the environment, because the audio server's socket and the registry
+cache live there; it does not keep the Wayland or bus addresses. A demuxer
+that crashes on a hostile file takes the worker and nothing else, and the
+panel shows the card again.
+
+Frames cross to the host through a memfd ring of three slots: the worker
+writes a frame into the next slot and announces it with a `frame` event; the
+host copies it out at once and wraps it as a Skia image when it draws. Three
+slots is one being written, one being read, and one of slack, which is what
+keeps the writer from lapping the reader at the rate a video decodes and a
+panel paints. The host's wake — a poke to its event loop — comes with every
+event, so a frame landing is a repaint the same way a decode landing is.
+
+**Behaviour in the panel.** A video starts playing when the panel opens on
+it, with sound. The transport runs along the bottom of the content: play or
+pause, the elapsed time, the scrubber, the time remaining, mute. A click on
+the picture itself toggles play and pause, as in every player. Dragging the
+scrubber pauses, seeks to keyframes as it goes, seeks accurately on release,
+and resumes if it was playing. Space still closes the panel — it is the
+gesture that opened it — and arrow-keying to another file ends the playback
+with the session. The worker is found next to the host's own executable, on
+`PATH`, or wherever `OTTO_MEDIA_WORKER` points; without it, a video previews
+as its card exactly as before, and the reason is in the log.
+
+**What this does not do.** Audio-only playback, subtitles, playback rate,
+fullscreen, picture-in-picture, and any frame path other than a CPU copy — a
+dmabuf ring is the obvious next step for 4K, and the protocol leaves room for
+it without changing the host side.
 
 ### The previewer seam
 

--- a/specs/quickview.md
+++ b/specs/quickview.md
@@ -486,6 +486,16 @@ keeps the writer from lapping the reader at the rate a video decodes and a
 panel paints. The host's wake — a poke to its event loop — comes with every
 event, so a frame landing is a repaint the same way a decode landing is.
 
+**In the docked preview column too.** The file browser's Miller-column
+preview pane embeds the same player, through the same seam: when the pane's
+decode says video, an `otto-media-kit` player is attached and its frame and
+transport are drawn in the pane's stage in place of the card. The difference
+is pacing — the column follows the selection as the arrow keys move it, so it
+opens *paused* on the first frame (the worker delivers its preroll frame for
+exactly this) rather than starting to play and talk on every keystroke. A
+click on its picture or its play button starts it. The panel, which the user
+opened deliberately, still autoplays.
+
 **Behaviour in the panel.** A video starts playing when the panel opens on
 it, with sound. The transport runs along the bottom of the content: play or
 pause, the elapsed time, the scrubber, the time remaining, mute. A click on
@@ -498,7 +508,9 @@ with the session. The worker is found next to the host's own executable, on
 as its card exactly as before, and the reason is in the log.
 
 **What this does not do.** Audio-only playback, subtitles, playback rate,
-fullscreen, picture-in-picture, and any frame path other than a CPU copy — a
+fullscreen from the transport (the panel has its own expand button, which
+fills the display), picture-in-picture, and any frame path other than a CPU
+copy — a
 dmabuf ring is the obvious next step for 4K, and the protocol leaves room for
 it without changing the host side.
 

--- a/specs/tiling.md
+++ b/specs/tiling.md
@@ -1,7 +1,15 @@
 # Window Tiling
 
-**Status:** draft
+**Status:** in progress
 **Related specs:** [window-decorations](window-decorations.md), [workspaces-multi-output](workspaces-multi-output.md), [window-focus-navigation](window-focus-navigation.md), [context-menus](context-menus.md)
+
+**Implementation status.** The first cut is keyboard-only: a per-workspace
+tiling mode, split containers, insertion and removal, directional focus and
+move, pre-selection, the keyboard resize step and equalise, and the layout
+animation. Not in it yet: the pointer paths (drag-to-detach and design mode),
+the floating layer and its toggle, tabbed and stacked containers, the compact
+decoration variants — a tile still keeps the full titlebar — and the command
+grammar with the interface that runs it.
 
 ## Summary
 
@@ -36,6 +44,15 @@ on one output, so a tiled workspace and a floating one coexist a swipe apart.
 - Clients are told the truth: a tiled window is told which of its edges abut
   something, so toolkits square off the right corners and hide the right
   affordances.
+- Every tiling operation is a named action that can be bound to a key, so a
+  workspace can be shaped entirely from the keyboard.
+- A preset file ships with Otto binding those actions to the i3 defaults; a
+  user copies it into their configuration and edits lines, and nothing in it
+  is bound until they do.
+- A scripting interface accepts i3's command syntax — `focus left`,
+  `move container to workspace 3`, `split v`, `layout tabbed` — resolving to
+  the same named actions, so existing scripts port with a rename. The syntax
+  is for scripting only; key bindings name actions.
 
 ## Non-Goals
 
@@ -43,7 +60,9 @@ on one output, so a tiled workspace and a floating one coexist a swipe apart.
   because the user asked it to, or because the configuration set the default.
 - A layout that overlaps windows, or a "manual" mode where the user positions
   tiles by absolute coordinates. Overlapping windows are what floating mode is.
-- Reproducing any specific existing tiler's keybindings verbatim.
+- Reproducing any specific existing tiler's keybindings *by default*. The
+  bindings are the user's; Otto ships the i3 set as a file to copy in, not as
+  a hidden default.
 - Delegating layout decisions to an external process. The layout is computed
   inside the compositor. A protocol for an external layout generator is a
   possible future addition and must not be designed out, but is not specified
@@ -71,6 +90,13 @@ moves to a different output keeps its tree and re-fits it to the new usable
 area.
 
 **Default.** Configuration may declare that new workspaces start tiled.
+
+**Workspaces on demand.** A command that names a workspace which does not
+exist yet creates it: asking for workspace 7 on an output with four appends
+workspaces until there is a seventh. A workspace is never taken away again for
+becoming empty. Otto's workspaces are named, reorderable and persistent, and
+one vanishing under the user because its last window closed would break that;
+an empty workspace stays.
 
 ### The tree
 
@@ -105,6 +131,17 @@ proportion to their existing shares. A container left with one child is
 dissolved into its parent, so the tree never keeps a container that splits
 nothing.
 
+**Container layouts.** A container lays its children out in one of three
+ways. *Split* — the default — gives each child its share of the container's
+extent along the axis. *Tabbed* and *stacked* give every child the whole of
+the container's cell and show one child at a time, the rest hidden behind a
+strip of titles drawn along the top of the cell: one row of tabs side by side
+for tabbed, one title per line for stacked. Selecting a title raises that
+child. A command sets the focused container's layout and a toggle command
+cycles it. From the outside a tabbed or stacked container is one cell:
+directional focus and move step over it as a unit, and step between its
+children only from within.
+
 **Restoring.** A window that comes back — unminimized, or unfloated — is
 inserted at the focused position, not at the one it left. A window that returns
 from fullscreen goes back to the exact slot it held, which is kept for it while
@@ -135,6 +172,14 @@ along a chosen axis. While armed, the focused window's cell shows which half the
 next window will take. Opening a window, moving one in, or pressing the command
 again disarms it.
 
+**Container focus.** Focus normally rests on a window, but it can also rest
+on a container. A *focus parent* command moves focus from the focused window
+to the container holding it, and again to that container's parent; *focus
+child* moves back down into the child it came from. While a container is
+focused its whole cell is marked, and the move, resize, layout and close
+commands act on the entire subtree — moving a focused container moves
+everything inside it. Focusing a window by any means ends container focus.
+
 **Promotion.** A command lifts the focused window out of its container and makes
 it a sibling of that container's parent, and the reverse command pushes it back
 down into the neighbouring container. Together these reshape nesting without
@@ -142,11 +187,24 @@ closing anything.
 
 ### Resizing
 
-**Pointer.** The gap between two tiles is a resize handle. Dragging it changes
-the shares of the two children on either side of that split and nothing else;
-the pointer shows a horizontal or vertical resize cursor over it. Where four
-tiles meet at a corner, the corner handle resizes both splits at once. A drag
-that would push a window below its minimum size stops there.
+**Design mode.** Outside design mode the gaps between tiles are not drag
+handles: pointer handling on a tiled workspace is the same as on a floating
+one, so no hidden hit area competes with a window's edges. A command, an item
+in the workspace's context menu, or a long press on a gap enters *design
+mode*, where the layout's cells are drawn as panes over the windows and the
+gaps between them become visible handles that light up on hover with a cursor
+saying what a drag will do. Dragging a bar handle changes the shares of the
+two children either side of that split and nothing else; where four cells meet
+at a corner, the corner handle drags both splits at once; a drag that would
+push a window below its minimum size stops there. A cell can be dragged onto
+another to swap with it, or onto a bar handle to be inserted at that split,
+and each pane offers splitting the cell and choosing its container's layout.
+A split made with nothing to fill it, or a cell whose window closes while
+design mode is open, leaves an *empty slot* drawn as a dashed pane: the next
+window to open fills the focused empty slot before it splits anything, so a
+workspace can be laid out before it is populated. Every named action keeps
+working in design mode, and leaving it changes nothing about where the windows
+are.
 
 **Keyboard.** A resize command grows or shrinks the focused window along a given
 axis by a configurable step, taking from — or giving to — the sibling in that
@@ -212,47 +270,69 @@ command arriving mid-flight re-targets the windows already in motion rather than
 queueing behind them, so holding down a move command sweeps a window across the
 layout smoothly.
 
-**Fluid by default.** During an animation a window's *drawn* rectangle follows
-the animation curve continuously, whether or not the client has caught up. The
-client is asked once for the final size, and until its new buffer arrives its
-last frame is drawn scaled into the animated rectangle. When the new buffer
-lands the window is drawn at its true resolution again. The user sees a
-continuous resize; the client sees one configure.
+**Motion is paced by the client.** A move or a swap, where no size changes,
+animates the whole way: the buffer stays valid, so the window travels
+smoothly. A resize is different — a rectangle only holds real content once the
+client has drawn a buffer of that size — so during a resize the client is
+configured with the rectangle of every animation frame and the window is drawn
+with the most recent buffer it has committed. A client that keeps up shows
+real content throughout; a slow one lags behind its rectangle for a few
+frames, which is the honest state of affairs rather than a stretched or
+clipped stand-in. Only the windows whose rectangle actually changed are
+configured at all.
 
-**Configurable.** The animation has a configurable duration and curve, and can
-be reduced to *snap*, where windows are placed at their new cells immediately
-with no motion — for a user who wants the tiler to feel instantaneous, and for
-the accessibility reduced-motion setting, which forces it regardless of the
-tiling configuration. A third setting drives the client's configure size on
-every animation frame instead of scaling its last frame: the most faithful
-resize, at the cost of reconfiguring every affected client at frame rate, and
-therefore not the default for a layout that can move a dozen windows at once.
+**Settling.** A layout change is presented as settled only once every affected
+client has committed its final size, or a short deadline has passed, so a slow
+client never leaves a half-applied layout on screen.
 
-**Interactive resize is live, not animated.** Dragging a gap resizes
-continuously under the pointer, with the affected clients reconfigured as they
-acknowledge the previous size rather than on a fixed cadence. There is no
-animation to run: the pointer is the animation. On release the layout settles
-with no further motion.
+**Configurable.** Each family of layout animation — a layout change, entering
+and leaving tiling mode, monocle, a design-mode drag — has a configurable
+duration and bounce. A duration of zero means *snap*: the windows are placed
+at their new cells in one frame with no motion and each client is configured
+once. Snap is a case of its own, not a very short animation. A single key
+binding may additionally ask for its action to run without animation, so a
+keystroke can move a window instantly while the same operation from the
+pointer or from a script still animates. An accessibility *reduce motion*
+setting forces every one of these durations, and the workspace switch's, to
+zero regardless of the tiling configuration.
+
+**Interactive resize animates too.** Dragging a handle in design mode updates
+the shares under the pointer, but the panes and the windows beneath them chase
+it on a spring rather than tracking it rigidly, so a fast drag lags a little
+and overshoots before settling. Clients are reconfigured as they acknowledge
+the previous size during the drag, and once more with the final size when the
+spring settles, so a slow client never holds the drag back. That spring has
+its own duration, bouncier than the layout one by default; a duration of zero
+makes the layout track the pointer exactly.
 
 **Dragging a window** animates the tree closing behind the detached window and
 opening again to accept it, on the same curve.
 
 ### Decorations
 
-A tiled window keeps the titlebar Otto draws — it is the move handle, and the
-route to the window's controls and menu. In a tiled workspace the bar is drawn
-in a compact variant: shorter than the floating one, with the same controls and
-title. The window frame keeps its rounded corners and its gap-borne separation
-from its neighbours when gaps are on; with gaps off the frame squares off, as it
-already does when maximized.
+How much chrome a tile keeps is a setting, because users disagree about it.
+With *minimal*, the default, a tile gets a bar one text line high with the
+title and a close button, squared corners and no shadow: it is still the move
+handle and the route to the window's controls and menu. With *none* a tile
+gets no bar at all, and moving it is design mode or the keyboard. Tabbed and
+stacked containers draw their title strip under both settings, since it is the
+only way to see the windows they hide. The window frame keeps its rounded
+corners and its gap-borne separation from its neighbours when gaps are on;
+with gaps off the frame squares off, as it already does when maximized.
 
-The focused tile is marked with a border in the accent colour. Drop shadows are
+The focused tile is marked with a border in the accent colour — a hairline one
+under *none*, where the other tiles get a neutral hairline. Drop shadows are
 not drawn on tiles — nothing overlaps, so there is nothing to cast onto — and
 return when the window floats again.
 
-A window that draws its own decorations is tiled the same way and is not given a
-bar; it is still moved by dragging whatever it treats as its titlebar, and the
-keyboard commands reach it unchanged.
+A window that draws its own decorations is tiled the same way and is given no
+bar under either setting; it is still moved by dragging whatever it treats as
+its titlebar, and the keyboard commands reach it unchanged. Because it is told
+which of its edges are tiled, it can square the corresponding corners and
+compact its own titlebar. Otto's own applications, which draw their titlebars
+themselves, follow the same setting from the client side: under *minimal* the
+titlebar takes its compact form, and under *none* they draw no bar and are
+moved by design mode or the keyboard.
 
 ### What clients are told
 
@@ -266,12 +346,25 @@ area. A window in monocle is told it is maximized.
 Windows managed through XWayland tile identically, are configured with the same
 rectangles, and carry the same states where the X11 equivalent exists.
 
+### Scripting
+
+Every tiling operation is reachable by name from a key binding, and by i3's
+command syntax from a script: `focus left|right|up|down|parent|child`,
+`move …`, `move container to workspace <n>`, `workspace <n>`, `split h|v`,
+`layout splith|splitv|tabbed|stacking|toggle`,
+`resize grow|shrink width|height <n>`, `floating toggle`, `fullscreen`,
+`kill`, `gaps inner|outer <n>`. The same interface reports the tree, the workspaces and the outputs in
+i3's shape, so a bar or a script written against i3 or sway keeps working
+after a rename. Key bindings never use that syntax: a binding names an action.
+
 ### Overview and previews
 
 Exposé, the workspace selector previews, and the app switcher work on a tiled
-workspace exactly as on a floating one — a tiled workspace's windows are simply
-already spread out. Entering exposé does not disturb the tree, and selecting a
-window from it focuses that window in place.
+workspace as far as this spec goes exactly as on a floating one — a tiled
+workspace's windows are simply already spread out. Entering exposé does not
+disturb the tree, and selecting a window from it focuses that window in place.
+What exposé should add to a workspace that is already an overview of itself is
+an open question below.
 
 ## Constraints & Edge Cases
 
@@ -327,12 +420,16 @@ dock that grows, a workspace dragged to a second screen, a scale change — is
 free if the layout never stores a pixel. It also makes the layout comparable
 across outputs, which is what lets a workspace move.
 
-**Why the drawn rectangle leads the client.** A layout change can move a dozen
-windows at once. Driving every one of their configures at frame rate turns one
-keystroke into a resize storm across a dozen clients, and the slowest of them
-decides how the animation looks. Scaling the last frame into the animated
-rectangle keeps the motion the compositor's business and the size the client's,
-which is the only way tiling animations stay smooth with a screenful of windows.
+**Why motion is paced by the client.** An earlier draft had the drawn
+rectangle lead the client: one configure for the final size, the last frame
+scaled into the animated rectangle until the new buffer arrived. That was
+dropped. There is no honest way to fill a resized rectangle before the client
+has drawn it, and a scaled stand-in reads as a stretched, blurry window at
+exactly the moment the user is watching it move. Configuring each frame, and
+drawing whatever the client has committed, keeps every pixel true; the cost —
+a configure storm across a screenful of clients — is paid down by configuring
+only the windows whose rectangle changed and by holding the settled frame
+until they have all acknowledged it.
 
 **Why the layout is not expressed as engine layout nodes.** The scene engine can
 lay out containers and animate them itself, and a split container maps neatly
@@ -343,6 +440,20 @@ would mean reading geometry back out of the render layer on the input path. The
 tree is therefore resolved to rectangles by the compositor, and those rectangles
 drive the engine's layers and its transitions. The engine animates; it does not
 decide.
+
+**Why tabbed and stacked containers are specified, not deferred.** They were
+an open question, and are now behaviour. Someone arriving with a years-old i3
+configuration expects `layout toggle split` to do something, and a tree that
+cannot hold a per-container layout kind has to be rewritten to gain one later.
+Otto's compositor-drawn titlebar is already the right thing to draw the strip
+with.
+
+**Why the compositor computes the layout and the engine only animates.** The
+tree is resolved to rectangles by the compositor, which needs each window's
+rectangle synchronously in any case; those rectangles are then handed to the
+scene engine, which animates positions and sizes towards them and decides
+nothing. The layout is never expressed as engine layout nodes, so there is no
+second source of truth to read geometry back out of on the input path.
 
 **Why keep decorations.** The titlebar is compositor-owned in Otto and is the
 window's move handle; dropping it in tiling mode would cost drag-to-rearrange,
@@ -366,13 +477,18 @@ command exists for when they want to.
 
 ## Open Questions
 
-- **Tabbed and stacked containers.** A container whose children occupy the same
-  cell, selected by a tab strip, is the natural next thing to want, and Otto's
-  compositor-drawn titlebar is well placed to draw the strip. Not specified here;
-  the tree must be able to grow a per-container layout kind without a rewrite.
 - **Persistence across sessions.** Whether a tiled workspace's tree, and the
   mode itself, should be restored on the next login.
 - **Named layouts.** Whether the user should be able to save a tree and apply it
   to a workspace, and whether an application should be able to ask for a slot.
 - **Whether the tiling mode belongs in the workspace selector UI** as a visible
   per-workspace indicator, rather than only in a menu and a shortcut.
+- **Exposé on a tiled workspace.** A tiled workspace is already an overview of
+  itself, so what exposé should add to it is unsettled:
+  - whether exposé should spread the tiles at all, or only pull out the
+    floating layer and the windows a tabbed or stacked container hides;
+  - what becomes of the containers while exposé rearranges or mirrors the
+    windows it shows;
+  - whether selecting a window in exposé should move it in the tree as well as
+    focus it;
+  - how a workspace-selector preview should render a tree.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,8 @@ pub struct Config {
     #[serde(default)]
     pub workspaces: WorkspacesConfig,
     #[serde(default)]
+    pub tiling: TilingConfig,
+    #[serde(default)]
     pub exec_once: Vec<RunCommandConfig>,
     #[serde(default)]
     pub xdg_autostart: bool,
@@ -156,6 +158,7 @@ impl Default for Config {
             login: LoginConfig::default(),
             lock: LockConfig::default(),
             workspaces: WorkspacesConfig::default(),
+            tiling: TilingConfig::default(),
             exec_once: Vec::new(),
             xdg_autostart: false,
             systemd_notify: false,
@@ -949,6 +952,108 @@ impl WorkspacesConfig {
             self.switch_duration.clamp(0.0, 10.0),
             self.switch_bounce.clamp(0.0, 1.0),
         )
+    }
+}
+
+/// Tiling settings: the gaps a tiled workspace leaves around and between its
+/// cells, how a layout change animates, and how much one resize step moves.
+///
+/// Follows the `[workspaces]` convention: a duration in seconds and a bounce,
+/// both clamped, and a duration of `0` means no animation at all — the tree
+/// lands in one frame. Nothing else is needed to turn tiling animations off.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TilingConfig {
+    /// Logical pixels between two neighbouring tiles.
+    #[serde(default = "default_tiling_inner_gap")]
+    pub inner_gap: i32,
+    /// Logical pixels between the tiles and the edge of the usable area.
+    #[serde(default = "default_tiling_outer_gap")]
+    pub outer_gap: i32,
+    /// A workspace with a single tile drops the gaps entirely, so one window
+    /// does not look inset for no reason.
+    #[serde(default = "default_tiling_smart_gaps")]
+    pub smart_gaps: bool,
+    /// Duration in seconds of the spring a layout change animates on: an
+    /// insertion, a removal, a move, an equalise, a re-fit, entering or
+    /// leaving tiling mode. `0` snaps.
+    #[serde(default = "default_tiling_layout_duration")]
+    pub layout_duration: f32,
+    /// Bounce of that same spring: `0.0` settles without overshoot. Clamped
+    /// to `0.0..1.0`.
+    #[serde(default = "default_tiling_layout_bounce")]
+    pub layout_bounce: f32,
+    /// How much of a container's extent one keyboard resize step moves, as a
+    /// fraction. Clamped to `0.01..0.5`.
+    #[serde(default = "default_tiling_resize_step")]
+    pub resize_step: f32,
+}
+
+fn default_tiling_inner_gap() -> i32 {
+    8
+}
+
+fn default_tiling_outer_gap() -> i32 {
+    8
+}
+
+fn default_tiling_smart_gaps() -> bool {
+    true
+}
+
+fn default_tiling_layout_duration() -> f32 {
+    0.3
+}
+
+fn default_tiling_layout_bounce() -> f32 {
+    0.0
+}
+
+fn default_tiling_resize_step() -> f32 {
+    0.05
+}
+
+impl Default for TilingConfig {
+    fn default() -> Self {
+        Self {
+            inner_gap: default_tiling_inner_gap(),
+            outer_gap: default_tiling_outer_gap(),
+            smart_gaps: default_tiling_smart_gaps(),
+            layout_duration: default_tiling_layout_duration(),
+            layout_bounce: default_tiling_layout_bounce(),
+            resize_step: default_tiling_resize_step(),
+        }
+    }
+}
+
+impl TilingConfig {
+    /// The transition a layout change animates with, or `None` when the
+    /// configured duration is zero — which is a first-class case, not a very
+    /// short animation: the window is placed at its cell without a transition
+    /// and the client is configured once.
+    pub fn layout_transition(&self) -> Option<layers::prelude::Transition> {
+        let duration = self.layout_duration.clamp(0.0, 10.0);
+        if duration <= f32::EPSILON {
+            return None;
+        }
+        Some(layers::prelude::Transition::spring(
+            duration,
+            self.layout_bounce.clamp(0.0, 1.0),
+        ))
+    }
+
+    /// The gaps a workspace lays out with.
+    pub fn gaps(&self) -> crate::workspaces::tiling::Gaps {
+        crate::workspaces::tiling::Gaps {
+            inner: self.inner_gap.max(0),
+            outer: self.outer_gap.max(0),
+            smart: self.smart_gaps,
+        }
+    }
+
+    /// One keyboard resize step, as a share of the container.
+    pub fn step(&self) -> f32 {
+        self.resize_step.clamp(0.01, 0.5)
     }
 }
 

--- a/src/config/shortcuts.rs
+++ b/src/config/shortcuts.rs
@@ -135,6 +135,27 @@ pub enum BuiltinAction {
     MediaPrev,
     MediaStop,
     LockSession,
+    // ── Tiling (see specs/tiling.md) ─────────────────────────────────────
+    /// Put the focused workspace into, or out of, tiling mode.
+    TilingToggle,
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
+    MoveContainerLeft,
+    MoveContainerRight,
+    MoveContainerUp,
+    MoveContainerDown,
+    /// Arm the next insertion to split the focused cell left/right.
+    SplitHorizontal,
+    /// Arm the next insertion to split the focused cell top/bottom.
+    SplitVertical,
+    ResizeGrowWidth,
+    ResizeShrinkWidth,
+    ResizeGrowHeight,
+    ResizeShrinkHeight,
+    /// Give every child of the focused container the same share.
+    EqualizeContainer,
 }
 
 #[derive(Debug, Error)]
@@ -253,6 +274,22 @@ fn parse_builtin(name: &str, index: Option<usize>) -> Result<BuiltinAction, Shor
         "MediaPrev" => BuiltinAction::MediaPrev,
         "MediaStop" => BuiltinAction::MediaStop,
         "LockSession" => BuiltinAction::LockSession,
+        "TilingToggle" => BuiltinAction::TilingToggle,
+        "FocusLeft" => BuiltinAction::FocusLeft,
+        "FocusRight" => BuiltinAction::FocusRight,
+        "FocusUp" => BuiltinAction::FocusUp,
+        "FocusDown" => BuiltinAction::FocusDown,
+        "MoveContainerLeft" => BuiltinAction::MoveContainerLeft,
+        "MoveContainerRight" => BuiltinAction::MoveContainerRight,
+        "MoveContainerUp" => BuiltinAction::MoveContainerUp,
+        "MoveContainerDown" => BuiltinAction::MoveContainerDown,
+        "SplitHorizontal" => BuiltinAction::SplitHorizontal,
+        "SplitVertical" => BuiltinAction::SplitVertical,
+        "ResizeGrowWidth" => BuiltinAction::ResizeGrowWidth,
+        "ResizeShrinkWidth" => BuiltinAction::ResizeShrinkWidth,
+        "ResizeGrowHeight" => BuiltinAction::ResizeGrowHeight,
+        "ResizeShrinkHeight" => BuiltinAction::ResizeShrinkHeight,
+        "EqualizeContainer" => BuiltinAction::EqualizeContainer,
         "Screen" => {
             let index = index.ok_or_else(|| ShortcutError::MissingIndex(name.to_string()))?;
             BuiltinAction::Screen { index }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -919,6 +919,72 @@ impl HeadlessHandle {
         });
     }
 
+    /// The cursor Otto would draw right now, as
+    /// `(kind, width_px, height_px, centre_pixel_rgba)`.
+    ///
+    /// `kind` is `"named:<icon>"` for a cursor Otto draws from the theme —
+    /// what a client using the cursor-shape protocol gets — `"surface"` for a
+    /// bitmap the client uploaded itself, and `"hidden"` for no cursor. The
+    /// size is in physical pixels, so it compares directly against
+    /// `cursor_size * scale`. The centre pixel says which theme the art came
+    /// out of, which size alone cannot: rescaled art from the wrong theme is
+    /// the right size and still the wrong cursor.
+    pub fn cursor_render_state(&self) -> (String, u32, u32, [u8; 4]) {
+        self.query(move |state| {
+            let scale = state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().integer_scale())
+                .unwrap_or(1);
+
+            match state.cursor_manager.get_render_cursor(scale) {
+                crate::cursor::RenderCursor::Hidden => ("hidden".to_string(), 0, 0, [0; 4]),
+                crate::cursor::RenderCursor::Surface { .. } => {
+                    ("surface".to_string(), 0, 0, [0; 4])
+                }
+                crate::cursor::RenderCursor::Named { icon, cursor, .. } => {
+                    let (_, image) = cursor.frame(0);
+                    let centre = ((image.height / 2) * image.width + image.width / 2) as usize * 4;
+                    let pixel = image
+                        .pixels_rgba
+                        .get(centre..centre + 4)
+                        .map(|p| [p[0], p[1], p[2], p[3]])
+                        .unwrap_or([0; 4]);
+                    (
+                        format!("named:{}", icon.name()),
+                        image.width,
+                        image.height,
+                        pixel,
+                    )
+                }
+            }
+        })
+    }
+
+    /// Switch the compositor to `theme` at `size` logical pixels, the way the
+    /// settings app does at runtime, and return the physical size every cursor
+    /// it draws should then come out at.
+    ///
+    /// Tests use this to run against a theme they planted themselves, rather
+    /// than whichever one the machine happens to have installed.
+    pub fn use_cursor_theme(&self, theme: &str, size: u32) -> u32 {
+        let theme = theme.to_string();
+        self.query(move |state| {
+            state
+                .cursor_manager
+                .reload(&theme, size.clamp(1, 255) as u8);
+            state.cursor_texture_cache.clear();
+            let scale = state
+                .workspaces
+                .outputs()
+                .next()
+                .map(|o| o.current_scale().integer_scale())
+                .unwrap_or(1);
+            size * scale as u32
+        })
+    }
+
     /// Whether Otto currently draws a titlebar for this window — the window
     /// state, not the scene.
     pub fn window_is_decorated(&self, title: &str) -> bool {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -32,6 +32,9 @@ use crate::{
 /// The tiling zones a window can be snapped to, re-exported for tests and
 /// external callers driving the headless compositor.
 pub use crate::workspaces::TileZone;
+/// The tiling tree's axis and direction types, re-exported so a test can
+/// drive the tiling actions without reaching into the compositor's modules.
+pub use crate::workspaces::tiling::{Axis, Direction};
 
 const OUTPUT_NAME: &str = "headless";
 const DEFAULT_WIDTH: i32 = 1920;
@@ -796,6 +799,112 @@ impl HeadlessHandle {
                 .unmaximised_rect;
             Some((rect.loc.x, rect.loc.y, rect.size.w, rect.size.h))
         })
+    }
+
+    // ── The tiling tree ──────────────────────────────────────────────────
+
+    /// Toggle the current workspace between floating and tiling — the
+    /// `TilingToggle` shortcut's entry point.
+    pub fn toggle_tiling(&self) {
+        self.with_state(|state| {
+            state.handle_tiling_toggle();
+        });
+    }
+
+    /// Does the current workspace on the headless output tile?
+    pub fn workspace_tiling_enabled(&self) -> bool {
+        self.query(|state| {
+            let Some(output) = headless_output(state) else {
+                return false;
+            };
+            state.workspaces.output_tiles(&output)
+        })
+    }
+
+    /// Titles of the windows in the current workspace's tree, in layout order
+    /// (left to right, top to bottom).
+    pub fn tiling_tree_leaves(&self) -> Vec<String> {
+        self.query(|state| {
+            let Some(output) = headless_output(state) else {
+                return Vec::new();
+            };
+            let Some(workspace) = state.workspaces.current_tiling_workspace(&output) else {
+                return Vec::new();
+            };
+            let leaves = workspace.tiling.read().unwrap().tree.leaves();
+            leaves
+                .iter()
+                .filter_map(|id| state.workspaces.windows_map.get(id))
+                .map(|w| w.xdg_title())
+                .collect()
+        })
+    }
+
+    /// The cells the current workspace's tree resolves to, in layout order:
+    /// `(title, (x, y, width, height))` in logical pixels. This is the layout
+    /// truth — what the clients are configured with — rather than what the
+    /// windows have drawn so far.
+    pub fn tiling_cell_rects(&self) -> Vec<(String, (i32, i32, i32, i32))> {
+        self.query(|state| {
+            let Some(output) = headless_output(state) else {
+                return Vec::new();
+            };
+            let Some(workspace) = state.workspaces.current_tiling_workspace(&output) else {
+                return Vec::new();
+            };
+            state.recalculate_exclusive_zones(&output);
+            let zone = state.usable_zone(&output);
+            let gaps = crate::config::Config::with(|c| c.tiling.gaps());
+            let area = crate::workspaces::tiling::Rect::new(
+                zone.loc.x,
+                zone.loc.y,
+                zone.size.w,
+                zone.size.h,
+            );
+            let tree = workspace.tiling.read().unwrap();
+            crate::workspaces::tiling::layout::resolve(&tree.tree, area, gaps)
+                .into_iter()
+                .filter_map(|(id, rect)| {
+                    let title = state.workspaces.windows_map.get(&id)?.xdg_title();
+                    Some((title, (rect.x, rect.y, rect.w, rect.h)))
+                })
+                .collect()
+        })
+    }
+
+    /// Move focus to the neighbouring tile in `direction`.
+    pub fn tiling_focus(&self, direction: Direction) {
+        self.with_state(move |state| {
+            state.handle_tiling_focus(direction);
+        });
+    }
+
+    /// Move the focused tile through the tree in `direction`.
+    pub fn tiling_move(&self, direction: Direction) {
+        self.with_state(move |state| {
+            state.handle_tiling_move(direction);
+        });
+    }
+
+    /// Arm the next insertion to split the focused cell along `axis`.
+    pub fn tiling_split(&self, axis: Axis) {
+        self.with_state(move |state| {
+            state.handle_tiling_split(axis);
+        });
+    }
+
+    /// Grow or shrink the focused cell along `axis` by one resize step.
+    pub fn tiling_resize(&self, axis: Axis, grow: bool) {
+        self.with_state(move |state| {
+            state.handle_tiling_resize(axis, grow);
+        });
+    }
+
+    /// Even out the shares of the focused container.
+    pub fn tiling_equalize(&self) {
+        self.with_state(|state| {
+            state.handle_tiling_equalize();
+        });
     }
 
     /// The area a maximized window fills on the headless output — output
@@ -1600,6 +1709,9 @@ fn run_headless_loop(
             state.running.store(false, Ordering::SeqCst);
         } else {
             state.workspaces.refresh_space();
+            // Pick up any tiling tree a close, minimize or workspace move
+            // left dirty; a no-op flag read when nothing changed.
+            state.flush_tiling_relayout();
             state.popups.cleanup();
             send_frames(&mut state);
             display_handle.flush_clients().unwrap();
@@ -1669,4 +1781,13 @@ fn find_node_by_key(
         }
     }
     None
+}
+
+/// The headless output, or `None` before it has been created.
+fn headless_output<B: Backend>(state: &Otto<B>) -> Option<Output> {
+    state
+        .workspaces
+        .outputs()
+        .find(|o| o.name() == OUTPUT_NAME)
+        .cloned()
 }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -17,6 +17,7 @@ use crate::{
         Config,
     },
     state::Backend,
+    workspaces::tiling::{Axis, Direction},
     Otto,
 };
 
@@ -60,6 +61,15 @@ pub enum KeyAction {
     MediaStop,
     /// Lock the session by launching the configured locker
     LockSession,
+    // ── Tiling ───────────────────────────────────────────────────────────
+    TilingToggle,
+    TilingFocus(crate::workspaces::tiling::Direction),
+    TilingMove(crate::workspaces::tiling::Direction),
+    TilingSplit(crate::workspaces::tiling::Axis),
+    /// Grow (`+`) or shrink (`-`) the focused cell along the given axis by
+    /// one `[tiling] resize_step`.
+    TilingResize(crate::workspaces::tiling::Axis, bool),
+    TilingEqualize,
     /// The hardware power button was pressed; `[power_management].on_power_button`
     /// decides what that means
     PowerButton,
@@ -479,11 +489,28 @@ impl<BackendData: Backend> Otto<BackendData> {
     }
 
     pub(crate) fn handle_tile_left(&mut self) {
+        // "The half-snap tiling commands have no effect in a tiled workspace
+        // beyond focusing the window in that direction" (specs/tiling.md).
+        if self.workspace_under_focus_tiles() {
+            self.handle_tiling_focus(crate::workspaces::tiling::Direction::Left);
+            return;
+        }
         self.tile_focused_window(crate::workspaces::TileZone::LeftHalf);
     }
 
     pub(crate) fn handle_tile_right(&mut self) {
+        if self.workspace_under_focus_tiles() {
+            self.handle_tiling_focus(crate::workspaces::tiling::Direction::Right);
+            return;
+        }
         self.tile_focused_window(crate::workspaces::TileZone::RightHalf);
+    }
+
+    /// Does the workspace a shortcut would act on tile?
+    fn workspace_under_focus_tiles(&self) -> bool {
+        self.tiling_output()
+            .map(|output| self.workspaces.output_tiles(&output))
+            .unwrap_or(false)
     }
 
     pub(crate) fn handle_close_window(&mut self) {
@@ -668,6 +695,12 @@ impl<BackendData: Backend> Otto<BackendData> {
             KeyAction::TileLeft => self.handle_tile_left(),
             KeyAction::TileRight => self.handle_tile_right(),
             KeyAction::CloseWindow => self.handle_close_window(),
+            KeyAction::TilingToggle => self.handle_tiling_toggle(),
+            KeyAction::TilingFocus(dir) => self.handle_tiling_focus(dir),
+            KeyAction::TilingMove(dir) => self.handle_tiling_move(dir),
+            KeyAction::TilingSplit(axis) => self.handle_tiling_split(axis),
+            KeyAction::TilingResize(axis, grow) => self.handle_tiling_resize(axis, grow),
+            KeyAction::TilingEqualize => self.handle_tiling_equalize(),
             other => self.process_common_key_action(other),
         }
     }
@@ -749,6 +782,24 @@ pub fn resolve_shortcut_action(config: &Config, action: &ShortcutAction) -> Opti
             BuiltinAction::MediaPrev => Some(KeyAction::MediaPrev),
             BuiltinAction::MediaStop => Some(KeyAction::MediaStop),
             BuiltinAction::LockSession => Some(KeyAction::LockSession),
+            BuiltinAction::TilingToggle => Some(KeyAction::TilingToggle),
+            BuiltinAction::FocusLeft => Some(KeyAction::TilingFocus(Direction::Left)),
+            BuiltinAction::FocusRight => Some(KeyAction::TilingFocus(Direction::Right)),
+            BuiltinAction::FocusUp => Some(KeyAction::TilingFocus(Direction::Up)),
+            BuiltinAction::FocusDown => Some(KeyAction::TilingFocus(Direction::Down)),
+            BuiltinAction::MoveContainerLeft => Some(KeyAction::TilingMove(Direction::Left)),
+            BuiltinAction::MoveContainerRight => Some(KeyAction::TilingMove(Direction::Right)),
+            BuiltinAction::MoveContainerUp => Some(KeyAction::TilingMove(Direction::Up)),
+            BuiltinAction::MoveContainerDown => Some(KeyAction::TilingMove(Direction::Down)),
+            BuiltinAction::SplitHorizontal => Some(KeyAction::TilingSplit(Axis::Row)),
+            BuiltinAction::SplitVertical => Some(KeyAction::TilingSplit(Axis::Column)),
+            BuiltinAction::ResizeGrowWidth => Some(KeyAction::TilingResize(Axis::Row, true)),
+            BuiltinAction::ResizeShrinkWidth => Some(KeyAction::TilingResize(Axis::Row, false)),
+            BuiltinAction::ResizeGrowHeight => Some(KeyAction::TilingResize(Axis::Column, true)),
+            BuiltinAction::ResizeShrinkHeight => {
+                Some(KeyAction::TilingResize(Axis::Column, false))
+            }
+            BuiltinAction::EqualizeContainer => Some(KeyAction::TilingEqualize),
         },
         ShortcutAction::RunCommand(run) => {
             Some(KeyAction::Run((run.cmd.clone(), run.args.clone())))

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -165,6 +165,24 @@ impl<Backend: crate::state::Backend> Otto<Backend> {
                 KeyAction::MediaStop => {
                     self.handle_media_stop();
                 }
+                KeyAction::TilingToggle => {
+                    self.handle_tiling_toggle();
+                }
+                KeyAction::TilingFocus(dir) => {
+                    self.handle_tiling_focus(dir);
+                }
+                KeyAction::TilingMove(dir) => {
+                    self.handle_tiling_move(dir);
+                }
+                KeyAction::TilingSplit(axis) => {
+                    self.handle_tiling_split(axis);
+                }
+                KeyAction::TilingResize(axis, grow) => {
+                    self.handle_tiling_resize(axis, grow);
+                }
+                KeyAction::TilingEqualize => {
+                    self.handle_tiling_equalize();
+                }
 
                 action => match action {
                     KeyAction::None
@@ -415,6 +433,24 @@ impl Otto<UdevData> {
                 }
                 KeyAction::MediaStop => {
                     self.handle_media_stop();
+                }
+                KeyAction::TilingToggle => {
+                    self.handle_tiling_toggle();
+                }
+                KeyAction::TilingFocus(dir) => {
+                    self.handle_tiling_focus(dir);
+                }
+                KeyAction::TilingMove(dir) => {
+                    self.handle_tiling_move(dir);
+                }
+                KeyAction::TilingSplit(axis) => {
+                    self.handle_tiling_split(axis);
+                }
+                KeyAction::TilingResize(axis, grow) => {
+                    self.handle_tiling_resize(axis, grow);
+                }
+                KeyAction::TilingEqualize => {
+                    self.handle_tiling_equalize();
                 }
                 action => match action {
                     KeyAction::None

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -45,6 +45,7 @@ mod element;
 mod grabs;
 mod layer;
 pub(crate) mod ssd;
+mod tiling;
 #[cfg(feature = "xwayland")]
 mod x11;
 mod xdg;
@@ -979,6 +980,13 @@ impl<BackendData: crate::state::Backend> crate::state::Otto<BackendData> {
 
         // Fullscreen/maximized windows own their geometry already.
         if window.is_fullscreen() || window.is_maximized() {
+            return;
+        }
+
+        // On a tiling workspace the tree owns the window's rectangle: it
+        // joins the tree next to whatever is focused and the relayout places
+        // it, so none of the floating placement below applies.
+        if self.tiling_adopt_window(window) {
             return;
         }
 

--- a/src/shell/tiling.rs
+++ b/src/shell/tiling.rs
@@ -1,0 +1,755 @@
+//! The compositor side of tiling: turning a workspace's tree into window
+//! rectangles, and the hooks that keep the tree in step with what maps,
+//! unmaps and takes focus.
+//!
+//! The tree and the layout are pure and live in `src/workspaces/tiling/`;
+//! nothing here decides *where* a window goes, only how it gets there. See
+//! `specs/tiling.md` for the behaviour and `docs/developer/tiling-plan.md`
+//! for the phases.
+
+use std::sync::Arc;
+
+use layers::prelude::Transition;
+use smithay::{
+    desktop::WindowSurface,
+    output::Output,
+    reexports::{
+        wayland_protocols::xdg::shell::server::xdg_toplevel, wayland_server::backend::ObjectId,
+    },
+    utils::{Logical, Rectangle, Size},
+};
+
+use crate::{
+    config::Config,
+    shell::WindowElement,
+    state::{Backend, Otto},
+    workspaces::{
+        tiling::{layout, Axis, Direction, Gaps, Rect},
+        workspace::WorkspaceView,
+        Workspaces,
+    },
+};
+
+/// How close a cell's edge has to be to the usable area's for that edge to
+/// count as "abutting the screen" rather than a neighbour — the outer gap,
+/// plus a pixel of slack for rounding.
+fn edge_tolerance(gaps: Gaps) -> i32 {
+    gaps.outer + 1
+}
+
+impl Workspaces {
+    /// Drop `id` from every tiling tree that holds it, and mark those
+    /// workspaces for a relayout.
+    ///
+    /// Called from unmap, minimize and the workspace move: a window that
+    /// leaves a tiled workspace is removed from its tree and its share goes
+    /// back to its siblings (`specs/tiling.md`, *Removal*). The relayout
+    /// itself needs the compositor, so it rides on the dirty flag and is
+    /// picked up by [`Otto::flush_tiling_relayout`] on the next event-loop
+    /// iteration.
+    pub fn tiling_forget_window(&self, id: &ObjectId) {
+        for ows in self.output_workspaces.values() {
+            for view in ows.workspace_views.iter() {
+                let Ok(mut state) = view.tiling.write() else {
+                    continue;
+                };
+                if !state.tree.remove(id) {
+                    continue;
+                }
+                state.dirty = true;
+                if state.focused.as_ref() == Some(id) {
+                    state.focused = state.tree.leaves().first().cloned();
+                }
+            }
+        }
+    }
+
+    /// Does this output's current workspace tile?
+    pub fn output_tiles(&self, output: &Output) -> bool {
+        self.current_tiling_workspace(output)
+            .map(|view| view.tiling.read().map(|s| s.enabled).unwrap_or(false))
+            .unwrap_or(false)
+    }
+
+    /// The workspace view currently on screen for `output`.
+    pub fn current_tiling_workspace(&self, output: &Output) -> Option<Arc<WorkspaceView>> {
+        let ows = self.output_workspaces.get(&output.name())?;
+        ows.workspace_views.get(ows.current_workspace).cloned()
+    }
+}
+
+impl<BackendData: Backend> Otto<BackendData> {
+    // ── Where a command applies ──────────────────────────────────────────
+
+    /// The output a tiling command acts on: the focused window's, else the
+    /// focused output.
+    pub(crate) fn tiling_output(&self) -> Option<Output> {
+        self.focused_window()
+            .and_then(|w| self.workspaces.output_for_window(&w))
+            .or_else(|| self.workspaces.focused_output().cloned())
+    }
+
+    /// The window holding keyboard focus, if any.
+    pub(crate) fn focused_window(&self) -> Option<WindowElement> {
+        self.seat
+            .get_keyboard()
+            .and_then(|keyboard| keyboard.current_focus())
+            .and_then(|focus| match focus {
+                crate::focus::KeyboardFocusTarget::Window(window) => Some(window),
+                _ => None,
+            })
+    }
+
+    /// The leaf a command acts relative to: the tree's remembered focus, or
+    /// the keyboard-focused window when that is a leaf.
+    fn tiling_focused_leaf(&self, workspace: &WorkspaceView) -> Option<ObjectId> {
+        let state = workspace.tiling.read().ok()?;
+        if let Some(focused) = state.focused.clone() {
+            if state.tree.contains(&focused) {
+                return Some(focused);
+            }
+        }
+        let window = self.focused_window()?;
+        let id = window.id();
+        state.tree.contains(&id).then_some(id)
+    }
+
+    // ── Eligibility ──────────────────────────────────────────────────────
+
+    /// Can this window join a tree at all?
+    ///
+    /// The same refusals `maximize_request` makes, plus the spec's automatic
+    /// float rules: a window with a parent (a dialog), one pinned to a single
+    /// size, a fullscreen or minimized one stays floating above the tiles and
+    /// the layout ignores it.
+    pub fn is_tileable(&self, window: &WindowElement) -> bool {
+        let Some(toplevel) = window.toplevel() else {
+            // XWayland tiles in a later phase; an X11 window floats for now.
+            return false;
+        };
+        if toplevel.parent().is_some() {
+            return false;
+        }
+        if !window.is_resizable() {
+            return false;
+        }
+        if window.is_fullscreen() || window.is_minimised() {
+            return false;
+        }
+        toplevel.with_pending_state(|state| {
+            state
+                .capabilities
+                .contains(xdg_toplevel::WmCapabilities::Maximize)
+        })
+    }
+
+    // ── Resolving and applying a layout ──────────────────────────────────
+
+    /// The area a tree fills on `output`, in logical pixels, with fresh
+    /// exclusive zones — the same rectangle a maximized window gets.
+    fn tiling_area(&mut self, output: &Output) -> Rectangle<i32, Logical> {
+        self.recalculate_exclusive_zones(output);
+        self.usable_zone(output)
+    }
+
+    /// Resolve the current workspace's tree on `output` and move every window
+    /// whose cell changed.
+    ///
+    /// `animate` false means no transition at all rather than a very short
+    /// one: the window is placed at its cell and the client configured once
+    /// (`[tiling] layout_duration = 0` takes the same path).
+    pub fn relayout_workspace(&mut self, output: &Output, animate: bool) {
+        let Some(workspace) = self.workspaces.current_tiling_workspace(output) else {
+            return;
+        };
+        {
+            let Ok(mut state) = workspace.tiling.write() else {
+                return;
+            };
+            state.dirty = false;
+            if !state.enabled {
+                return;
+            }
+        }
+
+        let zone = self.tiling_area(output);
+        let gaps = Config::with(|c| c.tiling.gaps());
+        let area = Rect::new(zone.loc.x, zone.loc.y, zone.size.w, zone.size.h);
+        let rects = {
+            let Ok(state) = workspace.tiling.read() else {
+                return;
+            };
+            layout::resolve(&state.tree, area, gaps)
+        };
+        if rects.is_empty() {
+            return;
+        }
+
+        let transition = if animate {
+            Config::with(|c| c.tiling.layout_transition())
+        } else {
+            None
+        };
+        // A lone tile that fills the usable area outright — gaps off, or smart
+        // gaps with one window — really is maximized, and is the one case the
+        // client is told so (`specs/tiling.md`, *What clients are told*).
+        let lone_maximized = rects.len() == 1
+            && rects[0].1 == Rect::new(zone.loc.x, zone.loc.y, zone.size.w, zone.size.h);
+
+        let cells: Vec<Rect> = rects.iter().map(|(_, rect)| *rect).collect();
+        for (id, rect) in rects.iter() {
+            let Some(window) = self.workspaces.windows_map.get(id).cloned() else {
+                continue;
+            };
+            let target =
+                Rectangle::<i32, Logical>::new((rect.x, rect.y).into(), (rect.w, rect.h).into());
+            if self.workspaces.element_geometry(&window) == Some(target) {
+                continue;
+            }
+            let edges = tiled_edges(*rect, &cells, zone, edge_tolerance(gaps));
+            self.apply_tiled_rect(
+                &window,
+                output,
+                target,
+                edges,
+                lone_maximized,
+                transition.clone(),
+            );
+        }
+    }
+
+    /// Animate one window into `target` and tell the client about it.
+    ///
+    /// This is [`Otto::apply_tile`]'s per-window body for an arbitrary
+    /// rectangle and an arbitrary set of tiled edges. It is duplicated rather
+    /// than shared because `apply_tile` is keyed off `TileZone`;
+    /// TODO: unify the two once the half-snap path is folded into the tree.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_tiled_rect(
+        &mut self,
+        window: &WindowElement,
+        output: &Output,
+        target: Rectangle<i32, Logical>,
+        edges: (bool, bool, bool, bool),
+        maximize: bool,
+        transition: Option<Transition>,
+    ) {
+        let Some(current_geometry) = self.workspaces.element_geometry(window) else {
+            return;
+        };
+
+        // A window in the tree owns no floating zone: the tree is what places
+        // it, so the half-snap marker must not linger and fight the layout.
+        let id = window.id();
+        if let Some(mut view) = self.workspaces.get_window_view(&id) {
+            if view.tiled_zone.is_some() {
+                view.tiled_zone = None;
+                self.workspaces.set_window_view(&id, view);
+            }
+        }
+
+        match window.underlying_surface() {
+            WindowSurface::Wayland(_) => {}
+            #[cfg(feature = "xwayland")]
+            WindowSurface::X11(_) => return,
+            #[cfg(not(feature = "xwayland"))]
+            _ => return,
+        }
+        let Some(toplevel) = window.toplevel().cloned() else {
+            return;
+        };
+
+        // Same reason as `maximize_request`: the state lands on the
+        // animation's last frame, this flag has to be true now.
+        window.set_is_maximized(maximize);
+        let (left, right, top, bottom) = edges;
+
+        match transition {
+            Some(ref transition) => {
+                let animation = self
+                    .layers_engine
+                    .add_animation_from_transition(transition, false);
+
+                // Both rects are decorated (space) rects; the client is
+                // configured without the titlebar Otto draws on top of it —
+                // stripped per frame by `animated_client_size`.
+                let current_size = Size::<i32, Logical>::from((
+                    current_geometry.size.w.max(1),
+                    current_geometry.size.h.max(1),
+                ));
+                let new_size = target.size;
+
+                let s = toplevel.clone();
+                let w = window.clone();
+                self.layers_engine.on_animation_update(
+                    animation,
+                    move |p: f32| {
+                        let size = super::xdg::animated_client_size(&w, current_size, new_size, p);
+                        s.with_pending_state(|state| {
+                            if (p - 1.0).abs() < f32::EPSILON {
+                                set_tiled_states(state, left, right, top, bottom, maximize);
+                            }
+                            state.size = Some(size);
+                        });
+                        s.send_configure();
+                    },
+                    false,
+                );
+                self.layers_engine.start_animation(animation, 0.0);
+            }
+            None => {
+                let size = window.client_size(target.size);
+                toplevel.with_pending_state(|state| {
+                    set_tiled_states(state, left, right, top, bottom, maximize);
+                    state.size = Some(size);
+                });
+                toplevel.send_configure();
+            }
+        }
+
+        // Pin the destination output: `target` came from this output's usable
+        // zone, and the window may still have its pre-layout size here.
+        // `activate` is false — a relayout moves everything at once and must
+        // not restack the workspace.
+        self.workspaces
+            .map_window_on_output(output, window, target.loc, false, transition);
+
+        // The window sits at a new rect now, so its menus have to be placed
+        // against it again.
+        self.reposition_popups_for_window(window);
+    }
+
+    /// Relayout every output whose current workspace was left dirty by an
+    /// unmap, a minimize or a workspace move. Called once per event-loop
+    /// iteration; costs a flag read per output when nothing changed.
+    pub fn flush_tiling_relayout(&mut self) {
+        let dirty: Vec<Output> = self
+            .workspaces
+            .outputs()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter(|output| {
+                self.workspaces
+                    .current_tiling_workspace(output)
+                    .and_then(|view| view.tiling.read().ok().map(|s| s.enabled && s.dirty))
+                    .unwrap_or(false)
+            })
+            .collect();
+        for output in dirty {
+            self.relayout_workspace(&output, true);
+        }
+    }
+
+    // ── Entering and leaving tiling mode ─────────────────────────────────
+
+    /// Put `output`'s current workspace into, or out of, tiling mode.
+    ///
+    /// Entering, every eligible window joins the tree most-recently-focused
+    /// first and its current rect is remembered as its floating one; leaving,
+    /// each one animates back to that rect with the tiled states dropped.
+    pub fn set_workspace_tiling(&mut self, output: &Output, enabled: bool) {
+        let Some(workspace) = self.workspaces.current_tiling_workspace(output) else {
+            return;
+        };
+        let already = workspace.tiling.read().map(|s| s.enabled).unwrap_or(false);
+        if already == enabled {
+            return;
+        }
+
+        if !enabled {
+            let leaves = {
+                let Ok(mut state) = workspace.tiling.write() else {
+                    return;
+                };
+                let leaves = state.tree.leaves();
+                state.clear();
+                state.enabled = false;
+                leaves
+            };
+            for id in leaves {
+                let Some(window) = self.workspaces.windows_map.get(&id).cloned() else {
+                    continue;
+                };
+                window.set_is_maximized(false);
+                self.restore_to_floating(&window);
+            }
+            return;
+        }
+
+        {
+            let Ok(mut state) = workspace.tiling.write() else {
+                return;
+            };
+            state.clear();
+            state.enabled = true;
+        }
+
+        // `windows_list` is bottom-to-top, so walking it backwards gives the
+        // stacking order most recently focused first, which is the order the
+        // spec asks the tree to be built in.
+        let ids: Vec<ObjectId> = workspace
+            .windows_list
+            .read()
+            .map(|list| list.iter().rev().cloned().collect())
+            .unwrap_or_default();
+
+        for id in ids {
+            let Some(window) = self.workspaces.windows_map.get(&id).cloned() else {
+                continue;
+            };
+            if !self.is_tileable(&window) {
+                continue;
+            }
+            // The rect it had before it was tiled is what leaving tiling mode
+            // (and floating it by hand, later) restores it to.
+            if let Some(geometry) = self.workspaces.element_geometry(&window) {
+                if let Some(mut view) = self.workspaces.get_window_view(&id) {
+                    view.unmaximised_rect = geometry;
+                    view.tiled_zone = None;
+                    self.workspaces.set_window_view(&id, view);
+                }
+            }
+            self.tiling_insert_leaf(output, &workspace, id);
+        }
+
+        // Building the tree walked every window, so the tree's idea of focus
+        // is the last one inserted. Hand it back to the window the user was
+        // actually on, so the next insertion splits *that* cell.
+        if let Some(focused) = self.focused_window().map(|w| w.id()) {
+            if let Ok(mut state) = workspace.tiling.write() {
+                if state.tree.contains(&focused) {
+                    state.focused = Some(focused);
+                }
+            }
+        }
+
+        self.relayout_workspace(output, true);
+    }
+
+    /// Insert `id` into `workspace`'s tree next to whatever is focused there.
+    fn tiling_insert_leaf(
+        &mut self,
+        output: &Output,
+        workspace: &Arc<WorkspaceView>,
+        id: ObjectId,
+    ) {
+        let zone = self.tiling_area(output);
+        let gaps = Config::with(|c| c.tiling.gaps());
+        let area = Rect::new(zone.loc.x, zone.loc.y, zone.size.w, zone.size.h);
+
+        let Ok(mut state) = workspace.tiling.write() else {
+            return;
+        };
+        let focused = state
+            .focused
+            .clone()
+            .filter(|focused| state.tree.contains(focused));
+        // Which way the focused cell splits follows its shape: a cell wider
+        // than it is tall becomes a row, a taller one a column.
+        let cell_is_wide = match focused.as_ref() {
+            Some(focused) => layout::resolve(&state.tree, area, gaps)
+                .iter()
+                .find(|(leaf, _)| leaf == focused)
+                .map(|(_, rect)| rect.is_wide())
+                .unwrap_or(true),
+            None => true,
+        };
+        let preselect = state.take_preselect();
+        state
+            .tree
+            .insert_next_to(focused.as_ref(), id.clone(), preselect, cell_is_wide);
+        state.focused = Some(id);
+    }
+
+    // ── Hooks into the rest of the compositor ────────────────────────────
+
+    /// A freshly mapped window on a tiling workspace joins the tree.
+    ///
+    /// Returns true when the window belongs to a tree, so the caller skips
+    /// the floating cascade placement — including for a window that is
+    /// already a leaf, which a later commit must not re-place.
+    pub fn tiling_adopt_window(&mut self, window: &WindowElement) -> bool {
+        let Some(output) = self.workspaces.output_for_window(window) else {
+            return false;
+        };
+        let Some(workspace) = self.workspaces.current_tiling_workspace(&output) else {
+            return false;
+        };
+        let id = window.id();
+        let (enabled, known) = {
+            let Ok(state) = workspace.tiling.read() else {
+                return false;
+            };
+            (state.enabled, state.tree.contains(&id))
+        };
+        if !enabled {
+            return false;
+        }
+        if known {
+            return true;
+        }
+        if !self.is_tileable(window) {
+            return false;
+        }
+
+        self.tiling_insert_leaf(&output, &workspace, id);
+        self.relayout_workspace(&output, true);
+        true
+    }
+
+    /// Keyboard focus landed on `id`; if it is a leaf, the tree's commands
+    /// act relative to it from now on.
+    pub fn tiling_note_focus(&mut self, id: &ObjectId) {
+        for ows in self.workspaces.output_workspaces.values() {
+            for view in ows.workspace_views.iter() {
+                let Ok(mut state) = view.tiling.write() else {
+                    continue;
+                };
+                if state.enabled && state.tree.contains(id) {
+                    state.focused = Some(id.clone());
+                }
+            }
+        }
+    }
+
+    // ── Shortcut handlers ────────────────────────────────────────────────
+
+    pub(crate) fn handle_tiling_toggle(&mut self) {
+        let Some(output) = self.tiling_output() else {
+            return;
+        };
+        let enabled = self.workspaces.output_tiles(&output);
+        self.set_workspace_tiling(&output, !enabled);
+    }
+
+    pub(crate) fn handle_tiling_focus(&mut self, direction: Direction) {
+        let Some(output) = self.tiling_output() else {
+            return;
+        };
+        let Some(workspace) = self.workspaces.current_tiling_workspace(&output) else {
+            return;
+        };
+        let Some(from) = self.tiling_focused_leaf(&workspace) else {
+            return;
+        };
+        let zone = self.tiling_area(&output);
+        let gaps = Config::with(|c| c.tiling.gaps());
+        let area = Rect::new(zone.loc.x, zone.loc.y, zone.size.w, zone.size.h);
+        let next = {
+            let Ok(state) = workspace.tiling.read() else {
+                return;
+            };
+            if !state.enabled {
+                return;
+            }
+            let rects = layout::resolve(&state.tree, area, gaps);
+            layout::neighbour(&rects, &from, direction)
+        };
+        let Some(next) = next else {
+            // Focus never wraps inside a workspace.
+            return;
+        };
+        let Some(window) = self.workspaces.windows_map.get(&next).cloned() else {
+            return;
+        };
+        self.workspaces.raise_element(&window.id(), true, true);
+        self.set_keyboard_focus_on_window(&window);
+        if let Ok(mut state) = workspace.tiling.write() {
+            state.focused = Some(next);
+        }
+        drop(workspace);
+    }
+
+    pub(crate) fn handle_tiling_move(&mut self, direction: Direction) {
+        let Some((output, workspace, leaf)) = self.tiling_target() else {
+            return;
+        };
+        let moved = workspace
+            .tiling
+            .write()
+            .map(|mut state| state.tree.move_dir(&leaf, direction))
+            .unwrap_or(false);
+        if moved {
+            self.relayout_workspace(&output, true);
+        }
+    }
+
+    pub(crate) fn handle_tiling_split(&mut self, axis: Axis) {
+        let Some((_, workspace, _)) = self.tiling_target() else {
+            return;
+        };
+        if let Ok(mut state) = workspace.tiling.write() {
+            state.set_preselect(axis);
+        }
+        drop(workspace);
+    }
+
+    pub(crate) fn handle_tiling_resize(&mut self, axis: Axis, grow: bool) {
+        let Some((output, workspace, leaf)) = self.tiling_target() else {
+            return;
+        };
+        let step = Config::with(|c| c.tiling.step());
+        let delta = if grow { step } else { -step };
+        let resized = workspace
+            .tiling
+            .write()
+            .map(|mut state| state.tree.resize(&leaf, axis, delta))
+            .unwrap_or(false);
+        if resized {
+            self.relayout_workspace(&output, true);
+        }
+    }
+
+    pub(crate) fn handle_tiling_equalize(&mut self) {
+        let Some((output, workspace, leaf)) = self.tiling_target() else {
+            return;
+        };
+        let changed = workspace
+            .tiling
+            .write()
+            .map(|mut state| state.tree.equalize_container_of(&leaf))
+            .unwrap_or(false);
+        if changed {
+            self.relayout_workspace(&output, true);
+        }
+    }
+
+    /// The output, workspace and focused leaf a tree-editing command needs,
+    /// or `None` when the focused workspace does not tile.
+    fn tiling_target(&mut self) -> Option<(Output, Arc<WorkspaceView>, ObjectId)> {
+        let output = self.tiling_output()?;
+        let workspace = self.workspaces.current_tiling_workspace(&output)?;
+        if !workspace.tiling.read().ok()?.enabled {
+            return None;
+        }
+        let leaf = self.tiling_focused_leaf(&workspace)?;
+        Some((output, workspace, leaf))
+    }
+}
+
+/// Replace whatever maximized/tiled flags a client was told with this cell's.
+///
+/// A tiled window is never told it is maximized unless it is the one case
+/// where its rectangle really is the whole usable area — a lone tile with the
+/// gaps off (`specs/tiling.md`, *What clients are told*).
+fn set_tiled_states(
+    state: &mut smithay::wayland::shell::xdg::ToplevelState,
+    left: bool,
+    right: bool,
+    top: bool,
+    bottom: bool,
+    maximize: bool,
+) {
+    state.states.unset(xdg_toplevel::State::Maximized);
+    state.states.unset(xdg_toplevel::State::TiledLeft);
+    state.states.unset(xdg_toplevel::State::TiledRight);
+    state.states.unset(xdg_toplevel::State::TiledTop);
+    state.states.unset(xdg_toplevel::State::TiledBottom);
+    if maximize {
+        state.states.set(xdg_toplevel::State::Maximized);
+        return;
+    }
+    if left {
+        state.states.set(xdg_toplevel::State::TiledLeft);
+    }
+    if right {
+        state.states.set(xdg_toplevel::State::TiledRight);
+    }
+    if top {
+        state.states.set(xdg_toplevel::State::TiledTop);
+    }
+    if bottom {
+        state.states.set(xdg_toplevel::State::TiledBottom);
+    }
+}
+
+/// Which of a cell's edges abut another tile or the edge of the usable area.
+///
+/// Returned as `(left, right, top, bottom)`; a client squares off the
+/// corresponding corners (`specs/tiling.md`, *What clients are told*).
+fn tiled_edges(
+    rect: Rect,
+    others: &[Rect],
+    zone: Rectangle<i32, Logical>,
+    tolerance: i32,
+) -> (bool, bool, bool, bool) {
+    let zone_left = zone.loc.x;
+    let zone_right = zone.loc.x + zone.size.w;
+    let zone_top = zone.loc.y;
+    let zone_bottom = zone.loc.y + zone.size.h;
+
+    let mut left = rect.x - zone_left <= tolerance;
+    let mut right = zone_right - (rect.x + rect.w) <= tolerance;
+    let mut top = rect.y - zone_top <= tolerance;
+    let mut bottom = zone_bottom - (rect.y + rect.h) <= tolerance;
+
+    for other in others {
+        if *other == rect {
+            continue;
+        }
+        let rows_overlap = other.y < rect.y + rect.h && rect.y < other.y + other.h;
+        let cols_overlap = other.x < rect.x + rect.w && rect.x < other.x + other.w;
+        if rows_overlap && other.x + other.w <= rect.x {
+            left = true;
+        }
+        if rows_overlap && other.x >= rect.x + rect.w {
+            right = true;
+        }
+        if cols_overlap && other.y + other.h <= rect.y {
+            top = true;
+        }
+        if cols_overlap && other.y >= rect.y + rect.h {
+            bottom = true;
+        }
+    }
+    (left, right, top, bottom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zone() -> Rectangle<i32, Logical> {
+        Rectangle::new((0, 30).into(), (1000, 700).into())
+    }
+
+    #[test]
+    fn a_lone_tile_abuts_the_usable_area_on_every_side() {
+        let rect = Rect::new(8, 38, 984, 684);
+        assert_eq!(
+            tiled_edges(rect, &[rect], zone(), 9),
+            (true, true, true, true)
+        );
+    }
+
+    #[test]
+    fn a_middle_column_abuts_its_neighbours_left_and_right() {
+        let left = Rect::new(0, 30, 300, 700);
+        let middle = Rect::new(300, 30, 400, 700);
+        let right = Rect::new(700, 30, 300, 700);
+        let cells = [left, middle, right];
+        // Gaps off: every edge of the middle cell touches something.
+        assert_eq!(
+            tiled_edges(middle, &cells, zone(), 0),
+            (true, true, true, true)
+        );
+        // The outer cells touch the screen on their outer edge and the middle
+        // one on the other.
+        assert_eq!(
+            tiled_edges(left, &cells, zone(), 0),
+            (true, true, true, true)
+        );
+    }
+
+    #[test]
+    fn a_cell_with_nothing_beyond_it_is_not_tiled_on_that_edge() {
+        // A single narrow cell parked in the middle of a much larger zone
+        // touches nothing at all.
+        let rect = Rect::new(400, 300, 100, 100);
+        assert_eq!(
+            tiled_edges(rect, &[rect], zone(), 0),
+            (false, false, false, false)
+        );
+    }
+}

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -16,13 +16,13 @@ use smithay::{
             Resource,
         },
     },
-    utils::{Rectangle, Serial},
+    utils::{Logical, Rectangle, Serial, Size},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
         seat::WaylandFocus,
         shell::xdg::{
             Configure, PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler,
-            XdgShellState,
+            XdgShellState, XdgToplevelSurfaceData,
         },
     },
 };
@@ -1177,18 +1177,12 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
                 .layers_engine
                 .add_animation_from_transition(&transition, false);
 
-            // The client is configured in ITS OWN geometry, which excludes the
-            // server-side titlebar: the bar is drawn above the client surface
-            // and already counted in the element geometry we animate from.
-            let current_client_size = window.client_size(current_element_geometry.size);
-            let new_client_size = window.client_size(new_geometry.size);
-
             // Use minimum size for windows that open already maximized (size 0,0)
-            let current_width = current_client_size.w.max(600) as f32;
-            let current_height = current_client_size.h.max(400) as f32;
-
-            let new_width = new_client_size.w as f32;
-            let new_height = new_client_size.h as f32;
+            let current_size = Size::<i32, Logical>::from((
+                current_element_geometry.size.w.max(600),
+                current_element_geometry.size.h.max(400),
+            ));
+            let new_size = new_geometry.size;
 
             // The client is told it is maximized NOW, not on the animation's
             // last frame: a client that draws its own decoration decides from
@@ -1200,14 +1194,13 @@ impl<BackendData: Backend> XdgShellHandler for Otto<BackendData> {
             });
 
             let s = surface.clone();
+            let w = window.clone();
             self.layers_engine.on_animation_update(
                 animation,
                 move |p: f32| {
-                    let width = current_width.interpolate(&new_width, p) as i32;
-                    let height = current_height.interpolate(&new_height, p) as i32;
-                    let size = Rectangle::new((0, 0).into(), (width, height).into());
+                    let size = animated_client_size(&w, current_size, new_size, p);
                     s.with_pending_state(|state| {
-                        state.size = Some(size.size);
+                        state.size = Some(size);
                     });
                     s.send_configure();
                 },
@@ -1787,14 +1780,13 @@ impl<BackendData: Backend> Otto<BackendData> {
 
                 // `current_geometry` and `target` are both decorated (space)
                 // rects; the client is configured without the titlebar Otto
-                // draws on top of it.
-                let current_client_size = window.client_size(current_geometry.size);
-                let new_client_size = window.client_size(target.size);
-
-                let current_width = current_client_size.w.max(600) as f32;
-                let current_height = current_client_size.h.max(400) as f32;
-                let new_width = new_client_size.w as f32;
-                let new_height = new_client_size.h as f32;
+                // draws on top of it — stripped per frame, see
+                // `animated_client_size`.
+                let current_size = Size::<i32, Logical>::from((
+                    current_geometry.size.w.max(600),
+                    current_geometry.size.h.max(400),
+                ));
+                let new_size = target.size;
 
                 let maximize = matches!(zone, TileZone::Maximize);
                 // Same reason as in `maximize_request`: the state below lands on
@@ -1804,12 +1796,11 @@ impl<BackendData: Backend> Otto<BackendData> {
                 let tiled_right = matches!(zone, TileZone::RightHalf);
 
                 let s = toplevel.clone();
+                let w = window.clone();
                 self.layers_engine.on_animation_update(
                     animation,
                     move |p: f32| {
-                        let width = current_width.interpolate(&new_width, p) as i32;
-                        let height = current_height.interpolate(&new_height, p) as i32;
-                        let size = Rectangle::new((0, 0).into(), (width, height).into());
+                        let size = animated_client_size(&w, current_size, new_size, p);
                         s.with_pending_state(|state| {
                             if (p - 1.0).abs() < f32::EPSILON {
                                 // Replace any prior maximized/tiled flags with this zone's.
@@ -1831,7 +1822,7 @@ impl<BackendData: Backend> Otto<BackendData> {
                                     }
                                 }
                             }
-                            state.size = Some(size.size);
+                            state.size = Some(size);
                         });
                         s.send_configure();
                     },
@@ -1861,6 +1852,53 @@ impl<BackendData: Backend> Otto<BackendData> {
         // The window sits at its new rect now, so its menus have to be placed
         // against it again.
         self.reposition_popups_for_window(window);
+    }
+
+    /// Re-send the client size of a window whose geometry is owned by a zone
+    /// — maximized, or tiled — after something under it changed: the client
+    /// size is the zone minus Otto's titlebar, and a window that just gained
+    /// or lost that titlebar is otherwise a bar's height off its zone. Does
+    /// nothing for a floating window.
+    pub fn refit_window_to_zone(&mut self, window: &WindowElement) {
+        let Some(toplevel) = window.toplevel().cloned() else {
+            return;
+        };
+        let id = window.id();
+        let tiled_zone = self
+            .workspaces
+            .get_window_view(&id)
+            .and_then(|view| view.tiled_zone);
+        let zone = match (window.is_maximized(), tiled_zone) {
+            (true, _) => crate::workspaces::TileZone::Maximize,
+            (false, Some(zone)) => zone,
+            (false, None) => return,
+        };
+        let Some(output) = self
+            .workspaces
+            .output_for_window(window)
+            .or_else(|| self.workspaces.outputs_for_element(window).first().cloned())
+        else {
+            return;
+        };
+        self.recalculate_exclusive_zones(&output);
+        let target = zone.target_rect(self.usable_zone(&output));
+        let size = window.client_size(target.size);
+        toplevel.with_pending_state(|state| {
+            state.size = Some(size);
+        });
+        // Before the initial configure the size simply rides along with it.
+        let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .initial_configure_sent
+        });
+        if initial_configure_sent {
+            toplevel.send_pending_configure();
+        }
     }
 
     /// Forget that `window` is tiled, without moving it: a window the user
@@ -2210,6 +2248,28 @@ fn clamp_popup_to_target(
     if geo.loc.y < target.loc.y {
         geo.loc.y = target.loc.y;
     }
+}
+
+/// The size to configure a client with, `p` of the way through a maximize or
+/// tile animation from `from` to `to` — both decorated (space) rects.
+///
+/// The titlebar is stripped HERE, on every frame, rather than once when the
+/// animation is set up: a client can change its decoration mode while the
+/// animation is in flight. Chrome restoring a maximized window does exactly
+/// that — it asks to be maximized, then asks for client-side decorations — and
+/// a height fixed at set-up time would leave it a titlebar short of its zone,
+/// with a strip of desktop showing under the maximized window.
+pub(crate) fn animated_client_size(
+    window: &WindowElement,
+    from: Size<i32, Logical>,
+    to: Size<i32, Logical>,
+    p: f32,
+) -> Size<i32, Logical> {
+    let from = window.client_size(from);
+    let to = window.client_size(to);
+    let width = (from.w as f32).interpolate(&(to.w as f32), p) as i32;
+    let height = (from.h as f32).interpolate(&(to.h as f32), p) as i32;
+    Size::from((width, height))
 }
 
 /// Where a window goes when it is unmaximized but never had a size of its own

--- a/src/state/app_management.rs
+++ b/src/state/app_management.rs
@@ -348,6 +348,10 @@ impl<BackendData: Backend> Otto<BackendData> {
         // which window of an app was used last; per-workspace stacking cannot say.
         self.workspaces.note_window_focused(&window.id());
 
+        // Directional focus, moves and resizes act relative to the focused
+        // leaf, so a focus change that lands on a tile updates the tree too.
+        self.tiling_note_focus(&window.id());
+
         let keyboard = self.seat.get_keyboard().unwrap();
         let serial = SERIAL_COUNTER.next_serial();
 

--- a/src/state/screencopy.rs
+++ b/src/state/screencopy.rs
@@ -84,6 +84,11 @@ pub struct PendingScreencopy {
     pub width: u32,
     pub height: u32,
     pub stride: u32,
+    /// Whether the client asked for the pointer to be drawn into the capture
+    /// (`grim -c`). The cursor normally scans out on its own KMS plane, which
+    /// the capture blit never sees, so this has to reach the render loop to
+    /// force the cursor to composite with everything else.
+    pub overlay_cursor: bool,
 }
 
 fn find_output_for_wl<BackendData: Backend>(
@@ -262,6 +267,7 @@ where
                     width: data.width,
                     height: data.height,
                     stride: data.stride,
+                    overlay_cursor: data.overlay_cursor,
                 });
                 // Wake the render loop — the compositor may be idle with no pending
                 // damage, so `should_draw` would normally be false and screencopy

--- a/src/state/seat_handler.rs
+++ b/src/state/seat_handler.rs
@@ -15,6 +15,77 @@ use crate::focus::{KeyboardFocusTarget, PointerFocusTarget};
 
 use super::{Backend, Otto};
 
+/// Live toggle for the cursor trace: `touch` this path to start logging what
+/// each client asks the pointer to look like, remove it to stop. A file check
+/// per cursor change costs nothing next to what a cursor change already does,
+/// and it beats a rebuild-and-relogin cycle to answer one question.
+const CURSOR_TRACE_TOGGLE: &str = "/tmp/otto-cursordbg";
+
+impl<BackendData: Backend> Otto<BackendData> {
+    /// Record where a cursor came from, which is the thing a screenshot cannot
+    /// tell you: a client either names a shape and lets Otto draw it, or hands
+    /// over a bitmap of its own. Only the first is Otto's to get right, so a
+    /// pointer that looks wrong over one window and right over every other is
+    /// not diagnosable without knowing which of the two it is.
+    fn log_cursor_image(&self, image: &CursorImageStatus) {
+        if !std::path::Path::new(CURSOR_TRACE_TOGGLE).exists() {
+            return;
+        }
+
+        let scale = self
+            .workspaces
+            .outputs()
+            .next()
+            .map(|o| o.current_scale().integer_scale())
+            .unwrap_or(1);
+
+        match image {
+            CursorImageStatus::Hidden => {
+                tracing::info!(target: "otto::cursordbg", "hidden");
+            }
+            CursorImageStatus::Named(icon) => {
+                let drawn = self
+                    .cursor_manager
+                    .get_cursor_with_name(*icon, scale)
+                    .map(|cursor| {
+                        let (_, image) = cursor.frame(0);
+                        format!("{}x{}", image.width, image.height)
+                    })
+                    .unwrap_or_else(|| "unresolved".to_string());
+                tracing::info!(
+                    target: "otto::cursordbg",
+                    "named {} -> {drawn} (scale {scale}, Otto draws it)",
+                    icon.name(),
+                );
+            }
+            CursorImageStatus::Surface(surface) => {
+                use smithay::backend::renderer::utils::with_renderer_surface_state;
+                use smithay::wayland::compositor::with_states;
+
+                let buffer_scale = with_states(surface, |states| {
+                    states
+                        .cached_state
+                        .get::<smithay::wayland::compositor::SurfaceAttributes>()
+                        .current()
+                        .buffer_scale
+                });
+                // Logical size: what the buffer covers on screen once its own
+                // scale is applied. Compare it against `cursor_size` — a client
+                // bitmap half the configured size is the client's own doing.
+                let logical = with_renderer_surface_state(surface, |state| state.buffer_size())
+                    .flatten()
+                    .map(|d| format!("{}x{}", d.w, d.h))
+                    .unwrap_or_else(|| "?".to_string());
+                let configured = crate::config::Config::with(|c| c.cursor_size);
+                tracing::info!(
+                    target: "otto::cursordbg",
+                    "surface {logical} logical, buffer_scale {buffer_scale} (client drew it; cursor_size is {configured}, output scale {scale})",
+                );
+            }
+        }
+    }
+}
+
 impl<BackendData: Backend> SeatHandler for Otto<BackendData> {
     type KeyboardFocus = KeyboardFocusTarget<BackendData>;
     type PointerFocus = PointerFocusTarget<BackendData>;
@@ -41,6 +112,7 @@ impl<BackendData: Backend> SeatHandler for Otto<BackendData> {
     }
 
     fn cursor_image(&mut self, _seat: &smithay::input::Seat<Self>, image: CursorImageStatus) {
+        self.log_cursor_image(&image);
         *self.cursor_status.lock().unwrap() = image.clone();
         self.cursor_manager.set_cursor_image(image);
     }

--- a/src/state/xdg_decoration_handler.rs
+++ b/src/state/xdg_decoration_handler.rs
@@ -26,6 +26,11 @@ impl<BackendData: Backend> Otto<BackendData> {
             state.decoration_mode = Some(mode);
         });
 
+        // Flag the window first: a maximized or tiled window is re-fitted to
+        // its zone by `set_surface_decorated`, and that size must ride the
+        // same configure as the mode.
+        self.set_surface_decorated(toplevel.wl_surface(), mode == DecorationMode::ServerSide);
+
         let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {
             states
                 .data_map
@@ -38,8 +43,6 @@ impl<BackendData: Backend> Otto<BackendData> {
         if initial_configure_sent {
             toplevel.send_pending_configure();
         }
-
-        self.set_surface_decorated(toplevel.wl_surface(), mode == DecorationMode::ServerSide);
     }
 
     /// Show or hide Otto's titlebar for a surface, whichever protocol asked.
@@ -67,6 +70,12 @@ impl<BackendData: Backend> Otto<BackendData> {
                 }
                 self.update_window_view(&window);
                 self.workspaces.update_workspace_model();
+                // A zone-owned window's client size is the zone minus the
+                // titlebar it just gained or lost — re-derive it, whether
+                // the change lands mid-animation (Chrome restoring a
+                // maximized window negotiates client-side decorations
+                // AFTER asking to be maximized) or long after.
+                self.refit_window_to_zone(&window);
             }
         }
     }

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -1668,6 +1668,9 @@ impl Otto<UdevData> {
 
         {
             self.workspaces.refresh_space();
+            // Pick up any tiling tree a close, minimize or workspace move left
+            // dirty; a no-op flag read when nothing changed.
+            self.flush_tiling_relayout();
             self.popups.cleanup();
             self.update_dnd();
         }

--- a/src/udev/render.rs
+++ b/src/udev/render.rs
@@ -2862,10 +2862,20 @@ pub(super) fn render_output_frame<'a>(
     }
 
     // Screencopy frames composite everything into the primary swapchain so
-    // the capture blit sees the full image; the cursor keeps its own plane
-    // so captures exclude the pointer.
+    // the capture blit sees the full image. The cursor normally keeps its own
+    // plane, which the blit never reads, so captures exclude the pointer —
+    // unless a client asked for it (`grim -c`), in which case the cursor has
+    // to come down off the plane and composite with everything else or the
+    // request is silently ignored.
+    let screencopy_wants_cursor = pending_screencopy
+        .iter()
+        .any(|p| p.overlay_cursor && &p.output == output);
     let frame_flags = if screencopy_pending {
-        smithay::backend::drm::compositor::FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT
+        if screencopy_wants_cursor {
+            smithay::backend::drm::compositor::FrameFlags::empty()
+        } else {
+            smithay::backend::drm::compositor::FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT
+        }
     } else {
         smithay::backend::drm::compositor::FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT
             | smithay::backend::drm::compositor::FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT_ANY

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -826,6 +826,9 @@ pub fn run_winit() {
             state.running.store(false, Ordering::SeqCst);
         } else {
             state.workspaces.refresh_space();
+            // Pick up any tiling tree a close, minimize or workspace move
+            // left dirty; a no-op flag read when nothing changed.
+            state.flush_tiling_relayout();
             state.popups.cleanup();
             // Tell any window that has moved where it is now. Diffed against
             // what was last sent, so a desktop at rest sends nothing.

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -508,6 +508,10 @@ impl Workspaces {
 
     pub fn start_window_selector_drag(&self, window_id: &ObjectId) {
         *self.expose_dragged_window.lock().unwrap() = Some(window_id.clone());
+        // The workspace previews are drop targets for the length of the drag,
+        // not things the pointer hovers: no close buttons, and the darkening
+        // that marks the target must survive the pointer crossing the preview.
+        self.set_selectors_window_drag(true);
         // Hide the selection overlay while dragging; it is restored in end_window_selector_drag
         // once the animation completes.
         let num_workspaces = self.with_model(|m| m.workspaces.len());
@@ -531,7 +535,16 @@ impl Workspaces {
             *dragging = None;
         }
         drop(dragging);
+        self.set_selectors_window_drag(false);
         self.expose_set_visible(true);
+    }
+
+    /// Tell every output's workspace selector whether an expose window drag is
+    /// in flight, so its previews stop treating the pointer as a hover.
+    fn set_selectors_window_drag(&self, dragging: bool) {
+        for ows in self.output_workspaces.values() {
+            ows.workspace_selector.set_window_drag(dragging);
+        }
     }
     /// Returns a clone of the expose_dragged_window Arc for use in animation callbacks.
     pub fn expose_dragged_window_handle(&self) -> Arc<std::sync::Mutex<Option<ObjectId>>> {

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -62,7 +62,6 @@ pub use dnd_view::DndView;
 pub use dock::{DockModel, DockView};
 pub use osd::OsdView;
 pub use popup_overlay::PopupOverlayView;
-pub use tiling::TilingState;
 pub use tiling_overlay::{zone_from_pointer, TileZone, TilingOverlayView};
 pub use workspace::WORKSPACE_SPACING;
 pub use workspace_selector::{WorkspaceSelectorView, WORKSPACE_SELECTOR_PREVIEW_WIDTH};
@@ -2766,6 +2765,9 @@ impl Workspaces {
             return None;
         }
 
+        // A minimized window is out of the tree, exactly as a closed one is.
+        self.tiling_forget_window(&id);
+
         if let Some(window) = self.windows_map.get_mut(&id) {
             window.set_is_minimised(true);
         }
@@ -3319,6 +3321,11 @@ impl Workspaces {
     /// Returns the surface IDs from removed popups that need cleanup
     pub fn unmap_window(&mut self, window_id: &ObjectId) -> Vec<ObjectId> {
         tracing::info!("workspaces::unmap_window: {:?}", window_id);
+
+        // A window that goes away leaves its tiling tree; the surviving tiles
+        // take its share and the workspace is relaid out on the next
+        // event-loop iteration (see `Otto::flush_tiling_relayout`).
+        self.tiling_forget_window(window_id);
 
         let mut workspace_index = None;
 
@@ -5008,6 +5015,10 @@ impl Workspaces {
     ) {
         let location = location.into();
         let id = we.id();
+
+        // Leaving a workspace means leaving its tree. The destination's tree
+        // adopts the window when it maps there.
+        self.tiling_forget_window(&id);
 
         // Unmap from every space (and view) that currently holds the window.
         let mut source_indices: Vec<(String, usize)> = Vec::new();

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -37,6 +37,7 @@ mod dock;
 mod osd;
 mod popup_overlay;
 mod tiling_overlay;
+pub mod tiling;
 pub mod trash;
 pub mod workspace;
 
@@ -61,6 +62,7 @@ pub use dnd_view::DndView;
 pub use dock::{DockModel, DockView};
 pub use osd::OsdView;
 pub use popup_overlay::PopupOverlayView;
+pub use tiling::TilingState;
 pub use tiling_overlay::{zone_from_pointer, TileZone, TilingOverlayView};
 pub use workspace::WORKSPACE_SPACING;
 pub use workspace_selector::{WorkspaceSelectorView, WORKSPACE_SELECTOR_PREVIEW_WIDTH};

--- a/src/workspaces/tiling/layout.rs
+++ b/src/workspaces/tiling/layout.rs
@@ -1,0 +1,318 @@
+//! Resolving a [`Tree`] to rectangles, and directional neighbour lookup.
+//!
+//! Pure: rectangles are plain `i32` logical pixels, and the same input always
+//! produces the same output. This is the authority on "what is this window's
+//! rectangle" — the client configure, hit-testing and the tests all read it
+//! from here.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use super::tree::{Axis, Direction, Node, NodeId, Tree};
+
+/// A rectangle in logical pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+}
+
+impl Rect {
+    pub fn new(x: i32, y: i32, w: i32, h: i32) -> Self {
+        Self { x, y, w, h }
+    }
+
+    /// Is this cell wider than it is tall? Decides which way an insertion
+    /// splits it (see `specs/tiling.md`, *Insertion*).
+    pub fn is_wide(&self) -> bool {
+        self.w >= self.h
+    }
+
+    fn inset(self, by: i32) -> Rect {
+        Rect {
+            x: self.x + by,
+            y: self.y + by,
+            w: (self.w - 2 * by).max(0),
+            h: (self.h - 2 * by).max(0),
+        }
+    }
+}
+
+/// Gap configuration for one workspace.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Gaps {
+    /// Between two siblings.
+    pub inner: i32,
+    /// Between the tree and the edge of the usable area.
+    pub outer: i32,
+    /// A lone tile drops the gaps entirely.
+    pub smart: bool,
+}
+
+/// Resolve `tree` against `area`, in layout order.
+///
+/// The outer gap insets `area`; the inner gap sits between siblings. With
+/// `gaps.smart` a lone tile fills `area` outright — no outer gap and, having
+/// no siblings, no inner one either.
+pub fn resolve<L: Clone + Eq + Hash + Debug>(
+    tree: &Tree<L>,
+    area: Rect,
+    gaps: Gaps,
+) -> Vec<(L, Rect)> {
+    let Some(root) = tree.root() else {
+        return Vec::new();
+    };
+    let lone = tree.len() <= 1;
+    let outer = if gaps.smart && lone { 0 } else { gaps.outer };
+    let inner = if gaps.smart && lone { 0 } else { gaps.inner };
+
+    let mut out = Vec::new();
+    place(tree, root, area.inset(outer), inner, &mut out);
+    out
+}
+
+fn place<L: Clone + Eq + Hash + Debug>(
+    tree: &Tree<L>,
+    node: NodeId,
+    rect: Rect,
+    inner: i32,
+    out: &mut Vec<(L, Rect)>,
+) {
+    match tree.node(node) {
+        Some(Node::Leaf(leaf)) => out.push((leaf.clone(), rect)),
+        Some(Node::Container { axis, children }) => {
+            let n = children.len();
+            if n == 0 {
+                return;
+            }
+            let extent = match axis {
+                Axis::Row => rect.w,
+                Axis::Column => rect.h,
+            };
+            // The gaps come off the top, so the children divide what is left.
+            let usable = (extent - inner * (n as i32 - 1)).max(0);
+            let mut offset = 0;
+            let mut used = 0;
+            for (i, child) in children.iter().enumerate() {
+                // The last child takes whatever rounding left over, so the
+                // children fill the container exactly.
+                let size = if i + 1 == n {
+                    usable - used
+                } else {
+                    (child.share * usable as f32).round() as i32
+                };
+                let size = size.max(0);
+                let child_rect = match axis {
+                    Axis::Row => Rect {
+                        x: rect.x + offset,
+                        y: rect.y,
+                        w: size,
+                        h: rect.h,
+                    },
+                    Axis::Column => Rect {
+                        x: rect.x,
+                        y: rect.y + offset,
+                        w: rect.w,
+                        h: size,
+                    },
+                };
+                place(tree, child.node, child_rect, inner, out);
+                used += size;
+                offset += size + inner;
+            }
+        }
+        None => {}
+    }
+}
+
+/// The leaf `from` moves focus to when the user asks for `dir`.
+///
+/// Candidates are the cells that lie that way and overlap `from`'s span on
+/// the perpendicular axis; the nearest edge wins, ties broken by the smaller
+/// perpendicular offset. Focus never wraps.
+pub fn neighbour<L: Clone + Eq>(rects: &[(L, Rect)], from: &L, dir: Direction) -> Option<L> {
+    let origin = rects.iter().find(|(l, _)| l == from)?.1;
+
+    let mut best: Option<(L, i32, i32)> = None;
+    for (leaf, rect) in rects {
+        if leaf == from {
+            continue;
+        }
+        let (ahead, distance, perpendicular) = match dir {
+            Direction::Left => (
+                rect.x + rect.w <= origin.x,
+                origin.x - (rect.x + rect.w),
+                (rect.y - origin.y).abs(),
+            ),
+            Direction::Right => (
+                rect.x >= origin.x + origin.w,
+                rect.x - (origin.x + origin.w),
+                (rect.y - origin.y).abs(),
+            ),
+            Direction::Up => (
+                rect.y + rect.h <= origin.y,
+                origin.y - (rect.y + rect.h),
+                (rect.x - origin.x).abs(),
+            ),
+            Direction::Down => (
+                rect.y >= origin.y + origin.h,
+                rect.y - (origin.y + origin.h),
+                (rect.x - origin.x).abs(),
+            ),
+        };
+        if !ahead {
+            continue;
+        }
+        let overlaps = match dir.axis() {
+            // Horizontal travel: the candidate has to share some rows.
+            Axis::Row => rect.y < origin.y + origin.h && origin.y < rect.y + rect.h,
+            Axis::Column => rect.x < origin.x + origin.w && origin.x < rect.x + rect.w,
+        };
+        if !overlaps {
+            continue;
+        }
+        let better = match &best {
+            None => true,
+            Some((_, d, p)) => distance < *d || (distance == *d && perpendicular < *p),
+        };
+        if better {
+            best = Some((leaf.clone(), distance, perpendicular));
+        }
+    }
+    best.map(|(leaf, _, _)| leaf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row_of_three() -> Tree<u32> {
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, true);
+        tree.insert_next_to(Some(&1), 2, None, true);
+        tree.insert_next_to(Some(&2), 3, None, true);
+        tree.equalize_all();
+        tree
+    }
+
+    const AREA: Rect = Rect {
+        x: 0,
+        y: 30,
+        w: 1000,
+        h: 700,
+    };
+
+    #[test]
+    fn a_lone_tile_fills_the_area_inside_the_outer_gap() {
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, true);
+        let gaps = Gaps {
+            inner: 8,
+            outer: 8,
+            smart: false,
+        };
+        let rects = resolve(&tree, AREA, gaps);
+        assert_eq!(rects, vec![(1, Rect::new(8, 38, 984, 684))]);
+    }
+
+    #[test]
+    fn smart_gaps_drop_every_gap_for_a_lone_tile() {
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, true);
+        let gaps = Gaps {
+            inner: 8,
+            outer: 8,
+            smart: true,
+        };
+        let rects = resolve(&tree, AREA, gaps);
+        assert_eq!(rects, vec![(1, AREA)]);
+    }
+
+    #[test]
+    fn two_tiles_split_the_area_with_an_inner_gap() {
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, true);
+        tree.insert_next_to(Some(&1), 2, None, true);
+        let gaps = Gaps {
+            inner: 10,
+            outer: 0,
+            smart: true,
+        };
+        let rects = resolve(&tree, AREA, gaps);
+        assert_eq!(
+            rects,
+            vec![
+                (1, Rect::new(0, 30, 495, 700)),
+                (2, Rect::new(505, 30, 495, 700)),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_last_child_absorbs_the_rounding_remainder() {
+        let tree = row_of_three();
+        let gaps = Gaps {
+            inner: 0,
+            outer: 0,
+            smart: false,
+        };
+        // 1000 / 3 does not divide: the cells must still add up to 1000.
+        let rects = resolve(&tree, AREA, gaps);
+        let total: i32 = rects.iter().map(|(_, r)| r.w).sum();
+        assert_eq!(total, 1000);
+        assert_eq!(rects[0].1.x, 0);
+        assert_eq!(rects[2].1.x + rects[2].1.w, 1000);
+    }
+
+    #[test]
+    fn gaps_do_not_change_the_total_extent() {
+        let tree = row_of_three();
+        let gaps = Gaps {
+            inner: 7,
+            outer: 5,
+            smart: false,
+        };
+        let rects = resolve(&tree, AREA, gaps);
+        assert_eq!(rects[0].1.x, 5);
+        assert_eq!(rects[2].1.x + rects[2].1.w, 995);
+        for w in rects.windows(2) {
+            assert_eq!(w[1].1.x - (w[0].1.x + w[0].1.w), 7);
+        }
+    }
+
+    #[test]
+    fn an_empty_tree_resolves_to_nothing() {
+        let tree = Tree::<u32>::new();
+        assert!(resolve(&tree, AREA, Gaps::default()).is_empty());
+    }
+
+    #[test]
+    fn neighbour_picks_the_nearest_cell_in_that_direction() {
+        let tree = row_of_three();
+        let rects = resolve(&tree, AREA, Gaps::default());
+        assert_eq!(neighbour(&rects, &1, Direction::Right), Some(2));
+        assert_eq!(neighbour(&rects, &2, Direction::Right), Some(3));
+        assert_eq!(neighbour(&rects, &3, Direction::Right), None);
+        assert_eq!(neighbour(&rects, &2, Direction::Left), Some(1));
+        assert_eq!(neighbour(&rects, &1, Direction::Up), None);
+    }
+
+    #[test]
+    fn neighbour_needs_an_overlap_on_the_perpendicular_axis() {
+        // Left column, right column split into a top and a bottom cell.
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, true);
+        tree.insert_next_to(Some(&1), 2, None, true);
+        tree.insert_next_to(Some(&2), 3, None, false);
+        let rects = resolve(&tree, AREA, Gaps::default());
+        // From the left cell, right lands on the top-right one: they share the
+        // upper rows, and it is the first candidate found at that distance.
+        assert_eq!(neighbour(&rects, &1, Direction::Right), Some(2));
+        // From the bottom-right cell, up is the top-right one, not the left.
+        assert_eq!(neighbour(&rects, &3, Direction::Up), Some(2));
+        assert_eq!(neighbour(&rects, &3, Direction::Left), Some(1));
+        assert_eq!(neighbour(&rects, &2, Direction::Down), Some(3));
+    }
+}

--- a/src/workspaces/tiling/mod.rs
+++ b/src/workspaces/tiling/mod.rs
@@ -14,6 +14,6 @@ pub mod layout;
 pub mod state;
 pub mod tree;
 
-pub use layout::{neighbour, resolve, Gaps, Rect};
+pub use layout::{Gaps, Rect};
 pub use state::TilingState;
-pub use tree::{Axis, Direction, Node, NodeId, Tree};
+pub use tree::{Axis, Direction};

--- a/src/workspaces/tiling/mod.rs
+++ b/src/workspaces/tiling/mod.rs
@@ -1,0 +1,19 @@
+//! Tiling: the tree, the layout that resolves it to rectangles, and the
+//! per-workspace state that holds both.
+//!
+//! `tree` and `layout` are pure — no Smithay, no lay-rs, no pixels beyond a
+//! plain rectangle — so they are unit-testable on their own with
+//! `cargo test --lib tiling`. The compositor side (animating windows into
+//! their cells, xdg states, hooks into map/unmap/focus) lives in
+//! `src/shell/tiling.rs`.
+//!
+//! See `specs/tiling.md` for the behaviour and
+//! `docs/developer/tiling-plan.md` for how the phases fit together.
+
+pub mod layout;
+pub mod state;
+pub mod tree;
+
+pub use layout::{neighbour, resolve, Gaps, Rect};
+pub use state::TilingState;
+pub use tree::{Axis, Direction, Node, NodeId, Tree};

--- a/src/workspaces/tiling/state.rs
+++ b/src/workspaces/tiling/state.rs
@@ -1,0 +1,65 @@
+//! Per-workspace tiling state.
+//!
+//! Tiling is a property of one workspace on one output (see
+//! `specs/tiling.md`), so this hangs off `WorkspaceView` rather than off the
+//! compositor.
+
+use smithay::reexports::wayland_server::backend::ObjectId;
+
+use super::tree::{Axis, Tree};
+
+/// Everything one workspace knows about its tiling.
+#[derive(Debug, Default)]
+pub struct TilingState {
+    /// Is this workspace tiling? A floating workspace keeps an empty tree.
+    pub enabled: bool,
+    /// The tree of split containers and window leaves.
+    pub tree: Tree<ObjectId>,
+    /// The leaf insertions and directional commands act relative to.
+    pub focused: Option<ObjectId>,
+    /// An armed split axis: the next insertion splits the focused cell this
+    /// way rather than following the cell's shape. Cleared by the insertion.
+    pub preselect: Option<Axis>,
+}
+
+impl TilingState {
+    /// Arm a split along `axis`, or disarm it when the same axis is asked for
+    /// twice (the spec's "pressing the command again disarms it").
+    pub fn set_preselect(&mut self, axis: Axis) {
+        self.preselect = if self.preselect == Some(axis) {
+            None
+        } else {
+            Some(axis)
+        };
+    }
+
+    /// Consume the armed split, if any.
+    pub fn take_preselect(&mut self) -> Option<Axis> {
+        self.preselect.take()
+    }
+
+    /// Forget everything: leaving tiling mode empties the tree.
+    pub fn clear(&mut self) {
+        self.tree = Tree::default();
+        self.focused = None;
+        self.preselect = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_repeated_preselect_disarms() {
+        let mut state = TilingState::default();
+        state.set_preselect(Axis::Row);
+        assert_eq!(state.preselect, Some(Axis::Row));
+        state.set_preselect(Axis::Row);
+        assert_eq!(state.preselect, None);
+        state.set_preselect(Axis::Column);
+        assert_eq!(state.preselect, Some(Axis::Column));
+        assert_eq!(state.take_preselect(), Some(Axis::Column));
+        assert_eq!(state.preselect, None);
+    }
+}

--- a/src/workspaces/tiling/state.rs
+++ b/src/workspaces/tiling/state.rs
@@ -17,6 +17,12 @@ pub struct TilingState {
     pub tree: Tree<ObjectId>,
     /// The leaf insertions and directional commands act relative to.
     pub focused: Option<ObjectId>,
+    /// Something removed a window from the tree and the workspace's windows
+    /// have not been moved into their new cells yet. The removal happens
+    /// wherever the window went away — unmap, minimize, a workspace move —
+    /// and only the compositor can run the relayout, so it rides on this flag
+    /// and is picked up on the next event-loop iteration.
+    pub dirty: bool,
     /// An armed split axis: the next insertion splits the focused cell this
     /// way rather than following the cell's shape. Cleared by the insertion.
     pub preselect: Option<Axis>,
@@ -43,6 +49,7 @@ impl TilingState {
         self.tree = Tree::default();
         self.focused = None;
         self.preselect = None;
+        self.dirty = false;
     }
 }
 

--- a/src/workspaces/tiling/tree.rs
+++ b/src/workspaces/tiling/tree.rs
@@ -1,0 +1,997 @@
+//! The tiling tree: a pure arena of split containers and window leaves.
+//!
+//! Nothing in this file knows about Smithay, lay-rs or pixels. A leaf is
+//! keyed by an opaque id (`ObjectId` at the call site, a `u32` in the tests),
+//! and every extent is a *share*: a fraction of the parent container's extent
+//! along its axis. Shares within one container always sum to `1.0`, which is
+//! what lets a tree be re-fitted to a different output, scale or rotation
+//! without losing its shape (see `specs/tiling.md`).
+//!
+//! Invariants, restored after every mutation:
+//!
+//! * a container's shares sum to `1.0`;
+//! * no container has fewer than two children — one left with a single child
+//!   is dissolved into its parent;
+//! * every node's `parent` back-pointer agrees with its parent's child list.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+/// Index into the tree's arena. Only meaningful for the tree that issued it.
+pub type NodeId = usize;
+
+/// Smallest and largest share a single child may hold, so a resize can never
+/// squeeze a window out of existence.
+pub const MIN_SHARE: f32 = 0.05;
+pub const MAX_SHARE: f32 = 0.95;
+
+/// The direction a container lays its children out in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Axis {
+    /// Children side by side, left to right.
+    Row,
+    /// Children stacked, top to bottom.
+    Column,
+}
+
+impl Axis {
+    /// The other axis.
+    pub fn other(self) -> Axis {
+        match self {
+            Axis::Row => Axis::Column,
+            Axis::Column => Axis::Row,
+        }
+    }
+}
+
+/// A direction for focus, movement and resize commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl Direction {
+    /// The container axis this direction travels along.
+    pub fn axis(self) -> Axis {
+        match self {
+            Direction::Left | Direction::Right => Axis::Row,
+            Direction::Up | Direction::Down => Axis::Column,
+        }
+    }
+
+    /// Does this direction go towards *later* children of a container?
+    pub fn is_forward(self) -> bool {
+        matches!(self, Direction::Right | Direction::Down)
+    }
+}
+
+/// One child of a container: the node, and the fraction of the container's
+/// extent it takes along the container's axis.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Child {
+    pub node: NodeId,
+    pub share: f32,
+}
+
+/// A node of the tree.
+#[derive(Debug, Clone)]
+pub enum Node<L> {
+    /// A window.
+    Leaf(L),
+    /// A split holding two or more children in order.
+    Container { axis: Axis, children: Vec<Child> },
+}
+
+#[derive(Debug, Clone)]
+struct Slot<L> {
+    node: Node<L>,
+    parent: Option<NodeId>,
+}
+
+/// A tiling tree over leaves of type `L`.
+#[derive(Debug, Clone)]
+pub struct Tree<L> {
+    slots: Vec<Option<Slot<L>>>,
+    free: Vec<NodeId>,
+    root: Option<NodeId>,
+}
+
+impl<L> Default for Tree<L> {
+    fn default() -> Self {
+        Self {
+            slots: Vec::new(),
+            free: Vec::new(),
+            root: None,
+        }
+    }
+}
+
+impl<L: Clone + Eq + Hash + Debug> Tree<L> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The root node, or `None` for an empty tree.
+    pub fn root(&self) -> Option<NodeId> {
+        self.root
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.root.is_none()
+    }
+
+    /// The node at `id`, if it is still live.
+    pub fn node(&self, id: NodeId) -> Option<&Node<L>> {
+        self.slots.get(id).and_then(|s| s.as_ref()).map(|s| &s.node)
+    }
+
+    /// The container `id` belongs to, or `None` for the root.
+    pub fn parent_of(&self, id: NodeId) -> Option<NodeId> {
+        self.slots
+            .get(id)
+            .and_then(|s| s.as_ref())
+            .and_then(|s| s.parent)
+    }
+
+    /// Every leaf, in layout order (left to right, top to bottom).
+    pub fn leaves(&self) -> Vec<L> {
+        let mut out = Vec::new();
+        if let Some(root) = self.root {
+            self.collect_leaves(root, &mut out);
+        }
+        out
+    }
+
+    /// Every leaf *node id*, in layout order.
+    pub fn leaf_nodes(&self) -> Vec<NodeId> {
+        let mut out = Vec::new();
+        if let Some(root) = self.root {
+            self.collect_leaf_nodes(root, &mut out);
+        }
+        out
+    }
+
+    pub fn len(&self) -> usize {
+        self.leaf_nodes().len()
+    }
+
+    /// Is `leaf` in this tree?
+    pub fn contains(&self, leaf: &L) -> bool {
+        self.node_of(leaf).is_some()
+    }
+
+    /// The node holding `leaf`.
+    pub fn node_of(&self, leaf: &L) -> Option<NodeId> {
+        self.slots
+            .iter()
+            .enumerate()
+            .find_map(|(id, slot)| match slot {
+                Some(Slot {
+                    node: Node::Leaf(l),
+                    ..
+                }) if l == leaf => Some(id),
+                _ => None,
+            })
+    }
+
+    /// The container the leaf sits in, if it is not the lone root.
+    pub fn container_of(&self, leaf: &L) -> Option<NodeId> {
+        self.node_of(leaf).and_then(|n| self.parent_of(n))
+    }
+
+    // ── Insertion ────────────────────────────────────────────────────────
+
+    /// Insert `new_leaf` next to `focused`, per the spec's insertion rule.
+    ///
+    /// * an empty tree gains `new_leaf` as its root;
+    /// * with a `preselect` axis armed, the focused leaf is replaced by a new
+    ///   container of that axis holding the old leaf and the new one, 50/50;
+    /// * otherwise, when the focused leaf's parent already splits along the
+    ///   shape of its cell (`cell_is_wide` ⇒ [`Axis::Row`]), the new leaf
+    ///   becomes a sibling right after it, taking half of its share;
+    /// * otherwise the focused leaf is split along that axis, 50/50.
+    ///
+    /// With no focused leaf the last leaf in layout order stands in for it.
+    pub fn insert_next_to(
+        &mut self,
+        focused: Option<&L>,
+        new_leaf: L,
+        preselect: Option<Axis>,
+        cell_is_wide: bool,
+    ) -> NodeId {
+        if self.root.is_none() {
+            let n = self.alloc(Node::Leaf(new_leaf), None);
+            self.root = Some(n);
+            return n;
+        }
+
+        let target = focused
+            .and_then(|f| self.node_of(f))
+            .or_else(|| self.leaf_nodes().last().copied());
+        let Some(target) = target else {
+            let n = self.alloc(Node::Leaf(new_leaf), None);
+            self.root = Some(n);
+            return n;
+        };
+
+        let shape_axis = if cell_is_wide {
+            Axis::Row
+        } else {
+            Axis::Column
+        };
+        let axis = preselect.unwrap_or(shape_axis);
+
+        // Without a pre-selection, a parent that already splits along the
+        // shape's axis takes the new window as a plain sibling: that is what
+        // keeps successive windows filling the screen in a spiral instead of
+        // nesting a container per window.
+        if preselect.is_none() {
+            if let Some(parent) = self.parent_of(target) {
+                if self.axis_of(parent) == Some(axis) {
+                    return self.insert_sibling_after(parent, target, new_leaf);
+                }
+            }
+        }
+
+        self.split_leaf(target, axis, new_leaf)
+    }
+
+    /// Replace the leaf at `target` with a container of `axis` holding the old
+    /// leaf and `new_leaf`, half each. Returns the new leaf's node.
+    fn split_leaf(&mut self, target: NodeId, axis: Axis, new_leaf: L) -> NodeId {
+        let parent = self.parent_of(target);
+        let new_node = self.alloc(Node::Leaf(new_leaf), None);
+        let container = self.alloc(
+            Node::Container {
+                axis,
+                children: vec![
+                    Child {
+                        node: target,
+                        share: 0.5,
+                    },
+                    Child {
+                        node: new_node,
+                        share: 0.5,
+                    },
+                ],
+            },
+            parent,
+        );
+        self.set_parent(target, Some(container));
+        self.set_parent(new_node, Some(container));
+        self.replace_in_parent(target, container, parent);
+        new_node
+    }
+
+    /// Add `new_leaf` right after `after` in `parent`, taking half of
+    /// `after`'s share.
+    fn insert_sibling_after(&mut self, parent: NodeId, after: NodeId, new_leaf: L) -> NodeId {
+        let new_node = self.alloc(Node::Leaf(new_leaf), Some(parent));
+        if let Some(Node::Container { children, .. }) = self.node_mut(parent) {
+            if let Some(index) = children.iter().position(|c| c.node == after) {
+                let half = children[index].share / 2.0;
+                children[index].share = half;
+                children.insert(
+                    index + 1,
+                    Child {
+                        node: new_node,
+                        share: half,
+                    },
+                );
+            } else {
+                children.push(Child {
+                    node: new_node,
+                    share: 0.0,
+                });
+            }
+        }
+        self.normalize(parent);
+        new_node
+    }
+
+    // ── Removal ──────────────────────────────────────────────────────────
+
+    /// Drop `leaf` from the tree, giving its share to its siblings in
+    /// proportion to theirs and dissolving any container left with one child.
+    ///
+    /// Returns `true` when the leaf was there.
+    pub fn remove(&mut self, leaf: &L) -> bool {
+        let Some(node) = self.node_of(leaf) else {
+            return false;
+        };
+        match self.parent_of(node) {
+            None => {
+                self.root = None;
+                self.free_node(node);
+            }
+            Some(parent) => {
+                self.detach_child(parent, node);
+                self.free_node(node);
+                self.dissolve_upwards(parent);
+            }
+        }
+        true
+    }
+
+    /// Take `child` out of `container`, spreading its share over what is left.
+    fn detach_child(&mut self, container: NodeId, child: NodeId) {
+        let Some(Node::Container { children, .. }) = self.node_mut(container) else {
+            return;
+        };
+        let Some(index) = children.iter().position(|c| c.node == child) else {
+            return;
+        };
+        let freed = children.remove(index).share;
+        let rest: f32 = children.iter().map(|c| c.share).sum();
+        if children.is_empty() {
+            return;
+        }
+        if rest > f32::EPSILON {
+            for c in children.iter_mut() {
+                c.share += freed * (c.share / rest);
+            }
+        } else {
+            let equal = 1.0 / children.len() as f32;
+            for c in children.iter_mut() {
+                c.share = equal;
+            }
+        }
+        self.normalize(container);
+    }
+
+    /// Dissolve `container` into its parent while it holds a single child,
+    /// walking upwards. Returns the node that ends up in `container`'s place.
+    fn dissolve_upwards(&mut self, container: NodeId) -> NodeId {
+        let mut current = container;
+        // What now occupies the slot `container` held: itself when nothing
+        // dissolved, otherwise the child that was promoted into its place.
+        let mut anchor = container;
+        loop {
+            let single = match self.node(current) {
+                Some(Node::Container { children, .. }) if children.len() == 1 => {
+                    Some(children[0].node)
+                }
+                _ => None,
+            };
+            let Some(only) = single else {
+                return anchor;
+            };
+            let parent = self.parent_of(current);
+            self.set_parent(only, parent);
+            self.replace_in_parent(current, only, parent);
+            self.free_node(current);
+            anchor = only;
+            match parent {
+                Some(p) => current = p,
+                None => return anchor,
+            }
+        }
+    }
+
+    // ── Movement ─────────────────────────────────────────────────────────
+
+    /// Move `leaf` one step in `dir`.
+    ///
+    /// Along its container's axis it swaps with the neighbouring sibling;
+    /// at the edge, or across the axis, it leaves the container and is
+    /// inserted into the grandparent at the corresponding side — splitting
+    /// that ancestor (the root included) when the axis does not match.
+    pub fn move_dir(&mut self, leaf: &L, dir: Direction) -> bool {
+        let Some(node) = self.node_of(leaf) else {
+            return false;
+        };
+        let Some(parent) = self.parent_of(node) else {
+            // A lone root leaf has nowhere to go.
+            return false;
+        };
+
+        if self.axis_of(parent) == Some(dir.axis()) {
+            let (index, len) = {
+                let Some(Node::Container { children, .. }) = self.node(parent) else {
+                    return false;
+                };
+                let Some(index) = children.iter().position(|c| c.node == node) else {
+                    return false;
+                };
+                (index, children.len())
+            };
+            let target = if dir.is_forward() {
+                index + 1
+            } else {
+                index.wrapping_sub(1)
+            };
+            if target < len {
+                if let Some(Node::Container { children, .. }) = self.node_mut(parent) {
+                    // The whole entry swaps, so the share travels with the
+                    // window rather than staying with the slot.
+                    children.swap(index, target);
+                }
+                return true;
+            }
+        }
+
+        self.move_out(node, dir)
+    }
+
+    /// Lift `node` out of its container and re-insert it one level up.
+    fn move_out(&mut self, node: NodeId, dir: Direction) -> bool {
+        let Some(parent) = self.parent_of(node) else {
+            return false;
+        };
+        self.detach_child(parent, node);
+        self.set_parent(node, None);
+        let anchor = self.dissolve_upwards(parent);
+        let grandparent = self.parent_of(anchor);
+
+        match grandparent {
+            Some(g) if self.axis_of(g) == Some(dir.axis()) => {
+                let index = match self.node(g) {
+                    Some(Node::Container { children, .. }) => {
+                        children.iter().position(|c| c.node == anchor).unwrap_or(0)
+                    }
+                    _ => 0,
+                };
+                let at = if dir.is_forward() { index + 1 } else { index };
+                self.set_parent(node, Some(g));
+                if let Some(Node::Container { children, .. }) = self.node_mut(g) {
+                    let at = at.min(children.len());
+                    children.insert(at, Child { node, share: 0.0 });
+                }
+                // Equalising the container the window landed in is the simple
+                // rule for this cut; a share that survives the trip through
+                // two levels of nesting is a later refinement.
+                self.equalize(g);
+                true
+            }
+            other => {
+                // Axis mismatch (or no grandparent at all): wrap the anchor —
+                // the root, when it has no parent — in a new container of the
+                // travelled axis and put the window on the matching side.
+                let container = self.alloc(
+                    Node::Container {
+                        axis: dir.axis(),
+                        children: Vec::new(),
+                    },
+                    other,
+                );
+                let children = if dir.is_forward() {
+                    vec![
+                        Child {
+                            node: anchor,
+                            share: 0.5,
+                        },
+                        Child { node, share: 0.5 },
+                    ]
+                } else {
+                    vec![
+                        Child { node, share: 0.5 },
+                        Child {
+                            node: anchor,
+                            share: 0.5,
+                        },
+                    ]
+                };
+                if let Some(Node::Container { children: slot, .. }) = self.node_mut(container) {
+                    *slot = children;
+                }
+                self.set_parent(anchor, Some(container));
+                self.set_parent(node, Some(container));
+                self.replace_in_parent(anchor, container, other);
+                true
+            }
+        }
+    }
+
+    // ── Resize ───────────────────────────────────────────────────────────
+
+    /// Grow `leaf`'s share along `axis` by `delta`, taking it from the next
+    /// sibling (or the previous one when the leaf is last).
+    ///
+    /// The nearest ancestor container that splits along `axis` and has more
+    /// than one child is the one that moves, so a resize command does
+    /// something as long as more than one window is tiled. Shares are clamped
+    /// to `[MIN_SHARE, MAX_SHARE]`.
+    pub fn resize(&mut self, leaf: &L, axis: Axis, delta: f32) -> bool {
+        let Some(node) = self.node_of(leaf) else {
+            return false;
+        };
+
+        let mut child = node;
+        let mut container = self.parent_of(node);
+        while let Some(c) = container {
+            let matches = matches!(
+                self.node(c),
+                Some(Node::Container { axis: a, children }) if *a == axis && children.len() > 1
+            );
+            if matches {
+                break;
+            }
+            child = c;
+            container = self.parent_of(c);
+        }
+        let Some(container) = container else {
+            return false;
+        };
+
+        let Some(Node::Container { children, .. }) = self.node_mut(container) else {
+            return false;
+        };
+        let Some(index) = children.iter().position(|c| c.node == child) else {
+            return false;
+        };
+        let other = if index + 1 < children.len() {
+            index + 1
+        } else if index > 0 {
+            index - 1
+        } else {
+            return false;
+        };
+
+        let mine = children[index].share;
+        let theirs = children[other].share;
+        let mut applied = mine.clamp(MIN_SHARE, MAX_SHARE) + delta;
+        applied = applied.clamp(MIN_SHARE, MAX_SHARE) - mine;
+        if theirs - applied < MIN_SHARE {
+            applied = theirs - MIN_SHARE;
+        }
+        if applied.abs() < f32::EPSILON {
+            return false;
+        }
+        children[index].share = mine + applied;
+        children[other].share = theirs - applied;
+        self.normalize(container);
+        true
+    }
+
+    // ── Equalising ───────────────────────────────────────────────────────
+
+    /// Give every child of `container` the same share.
+    pub fn equalize(&mut self, container: NodeId) {
+        if let Some(Node::Container { children, .. }) = self.node_mut(container) {
+            if children.is_empty() {
+                return;
+            }
+            let equal = 1.0 / children.len() as f32;
+            for c in children.iter_mut() {
+                c.share = equal;
+            }
+        }
+    }
+
+    /// Equalise the container `leaf` sits in.
+    pub fn equalize_container_of(&mut self, leaf: &L) -> bool {
+        match self.container_of(leaf) {
+            Some(container) => {
+                self.equalize(container);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Equalise every container in the tree.
+    pub fn equalize_all(&mut self) {
+        let ids: Vec<NodeId> = (0..self.slots.len())
+            .filter(|id| matches!(self.node(*id), Some(Node::Container { .. })))
+            .collect();
+        for id in ids {
+            self.equalize(id);
+        }
+    }
+
+    // ── Arena plumbing ───────────────────────────────────────────────────
+
+    fn axis_of(&self, id: NodeId) -> Option<Axis> {
+        match self.node(id) {
+            Some(Node::Container { axis, .. }) => Some(*axis),
+            _ => None,
+        }
+    }
+
+    fn node_mut(&mut self, id: NodeId) -> Option<&mut Node<L>> {
+        self.slots
+            .get_mut(id)
+            .and_then(|s| s.as_mut())
+            .map(|s| &mut s.node)
+    }
+
+    fn alloc(&mut self, node: Node<L>, parent: Option<NodeId>) -> NodeId {
+        let slot = Slot { node, parent };
+        match self.free.pop() {
+            Some(id) => {
+                self.slots[id] = Some(slot);
+                id
+            }
+            None => {
+                self.slots.push(Some(slot));
+                self.slots.len() - 1
+            }
+        }
+    }
+
+    fn free_node(&mut self, id: NodeId) {
+        if id < self.slots.len() && self.slots[id].is_some() {
+            self.slots[id] = None;
+            self.free.push(id);
+        }
+    }
+
+    fn set_parent(&mut self, id: NodeId, parent: Option<NodeId>) {
+        if let Some(Some(slot)) = self.slots.get_mut(id) {
+            slot.parent = parent;
+        }
+    }
+
+    /// Put `new` where `old` sat in `parent` (or make it the root), keeping
+    /// the share `old` held.
+    fn replace_in_parent(&mut self, old: NodeId, new: NodeId, parent: Option<NodeId>) {
+        match parent {
+            None => {
+                self.root = Some(new);
+                self.set_parent(new, None);
+            }
+            Some(p) => {
+                if let Some(Node::Container { children, .. }) = self.node_mut(p) {
+                    if let Some(entry) = children.iter_mut().find(|c| c.node == old) {
+                        entry.node = new;
+                    }
+                }
+                self.set_parent(new, Some(p));
+            }
+        }
+    }
+
+    /// Re-scale a container's shares so they sum to one.
+    fn normalize(&mut self, container: NodeId) {
+        if let Some(Node::Container { children, .. }) = self.node_mut(container) {
+            if children.is_empty() {
+                return;
+            }
+            let total: f32 = children.iter().map(|c| c.share).sum();
+            if total.abs() < f32::EPSILON {
+                let equal = 1.0 / children.len() as f32;
+                for c in children.iter_mut() {
+                    c.share = equal;
+                }
+            } else {
+                for c in children.iter_mut() {
+                    c.share /= total;
+                }
+            }
+        }
+    }
+
+    fn collect_leaves(&self, id: NodeId, out: &mut Vec<L>) {
+        match self.node(id) {
+            Some(Node::Leaf(l)) => out.push(l.clone()),
+            Some(Node::Container { children, .. }) => {
+                let kids: Vec<NodeId> = children.iter().map(|c| c.node).collect();
+                for k in kids {
+                    self.collect_leaves(k, out);
+                }
+            }
+            None => {}
+        }
+    }
+
+    fn collect_leaf_nodes(&self, id: NodeId, out: &mut Vec<NodeId>) {
+        match self.node(id) {
+            Some(Node::Leaf(_)) => out.push(id),
+            Some(Node::Container { children, .. }) => {
+                let kids: Vec<NodeId> = children.iter().map(|c| c.node).collect();
+                for k in kids {
+                    self.collect_leaf_nodes(k, out);
+                }
+            }
+            None => {}
+        }
+    }
+
+    /// Panic unless every invariant holds. Test-only.
+    #[cfg(test)]
+    fn assert_invariants(&self) {
+        let Some(root) = self.root else {
+            return;
+        };
+        self.assert_node(root, None);
+    }
+
+    #[cfg(test)]
+    fn assert_node(&self, id: NodeId, parent: Option<NodeId>) {
+        assert_eq!(self.parent_of(id), parent, "parent back-pointer of {id}");
+        if let Some(Node::Container { children, .. }) = self.node(id) {
+            assert!(
+                children.len() >= 2,
+                "container {id} has {} children",
+                children.len()
+            );
+            let total: f32 = children.iter().map(|c| c.share).sum();
+            assert!(
+                (total - 1.0).abs() < 1e-4,
+                "container {id} shares sum to {total}"
+            );
+            for c in children {
+                self.assert_node(c.node, Some(id));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shares(tree: &Tree<u32>, container: NodeId) -> Vec<f32> {
+        match tree.node(container) {
+            Some(Node::Container { children, .. }) => children.iter().map(|c| c.share).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn wide(tree: &mut Tree<u32>, focused: Option<u32>, leaf: u32) {
+        tree.insert_next_to(focused.as_ref(), leaf, None, true);
+    }
+
+    #[test]
+    fn first_window_becomes_the_root() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        assert_eq!(tree.leaves(), vec![1]);
+        assert!(tree.parent_of(tree.root().unwrap()).is_none());
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_wide_cell_splits_into_a_row() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        let root = tree.root().unwrap();
+        assert!(matches!(
+            tree.node(root),
+            Some(Node::Container {
+                axis: Axis::Row,
+                ..
+            })
+        ));
+        assert_eq!(shares(&tree, root), vec![0.5, 0.5]);
+        assert_eq!(tree.leaves(), vec![1, 2]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_tall_cell_splits_into_a_column() {
+        let mut tree = Tree::<u32>::new();
+        tree.insert_next_to(None, 1, None, false);
+        tree.insert_next_to(Some(&1), 2, None, false);
+        let root = tree.root().unwrap();
+        assert!(matches!(
+            tree.node(root),
+            Some(Node::Container {
+                axis: Axis::Column,
+                ..
+            })
+        ));
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_matching_parent_axis_takes_a_sibling_at_half_the_focused_share() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        // 2's parent is a Row and its cell is still wide: 3 becomes a sibling.
+        wide(&mut tree, Some(2), 3);
+        let root = tree.root().unwrap();
+        assert_eq!(tree.leaves(), vec![1, 2, 3]);
+        assert_eq!(shares(&tree, root), vec![0.5, 0.25, 0.25]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_mismatched_shape_splits_the_focused_cell() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        // 2's cell is now tall, so 3 splits it into a column instead.
+        tree.insert_next_to(Some(&2), 3, None, false);
+        let root = tree.root().unwrap();
+        assert_eq!(shares(&tree, root), vec![0.5, 0.5]);
+        let second = match tree.node(root) {
+            Some(Node::Container { children, .. }) => children[1].node,
+            _ => unreachable!(),
+        };
+        assert!(matches!(
+            tree.node(second),
+            Some(Node::Container {
+                axis: Axis::Column,
+                ..
+            })
+        ));
+        assert_eq!(tree.leaves(), vec![1, 2, 3]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_preselect_splits_even_when_the_axis_matches() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        tree.insert_next_to(Some(&2), 3, Some(Axis::Column), true);
+        assert_eq!(tree.leaves(), vec![1, 2, 3]);
+        let root = tree.root().unwrap();
+        assert_eq!(shares(&tree, root), vec![0.5, 0.5]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn removal_redistributes_proportionally() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        wide(&mut tree, Some(2), 3);
+        // shares: 0.5, 0.25, 0.25 — dropping the first gives the rest half each
+        // of what it held, in proportion: 0.25/0.5 of 0.5 to each.
+        assert!(tree.remove(&1));
+        let root = tree.root().unwrap();
+        assert_eq!(tree.leaves(), vec![2, 3]);
+        let s = shares(&tree, root);
+        assert!((s[0] - 0.5).abs() < 1e-5, "{s:?}");
+        assert!((s[1] - 0.5).abs() < 1e-5, "{s:?}");
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_container_left_with_one_child_dissolves() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        tree.insert_next_to(Some(&2), 3, None, false);
+        // Dropping 3 leaves the column with one child: it must vanish.
+        assert!(tree.remove(&3));
+        let root = tree.root().unwrap();
+        match tree.node(root) {
+            Some(Node::Container { children, .. }) => {
+                assert_eq!(children.len(), 2);
+                assert!(children
+                    .iter()
+                    .all(|c| matches!(tree.node(c.node), Some(Node::Leaf(_)))));
+            }
+            other => panic!("unexpected root {other:?}"),
+        }
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn removing_the_last_leaf_empties_the_tree() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        assert!(tree.remove(&1));
+        assert!(tree.is_empty());
+        assert_eq!(tree.leaves(), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn move_swaps_with_the_sibling_along_the_axis() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        assert!(tree.move_dir(&1, Direction::Right));
+        assert_eq!(tree.leaves(), vec![2, 1]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn move_at_the_edge_splits_the_root_along_the_new_axis() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        wide(&mut tree, Some(2), 3);
+        // 3 is last in a row; moving it down leaves the row and splits the
+        // root into a column with the row on top.
+        assert!(tree.move_dir(&3, Direction::Down));
+        let root = tree.root().unwrap();
+        assert!(matches!(
+            tree.node(root),
+            Some(Node::Container {
+                axis: Axis::Column,
+                ..
+            })
+        ));
+        assert_eq!(tree.leaves(), vec![1, 2, 3]);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn move_out_of_a_nested_container_joins_the_grandparent() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        tree.insert_next_to(Some(&2), 3, None, false); // column [2,3] on the right
+                                                       // 3 is the bottom of the column; moving it right leaves the column and
+                                                       // joins the root row after it. The column then dissolves.
+        assert!(tree.move_dir(&3, Direction::Right));
+        assert_eq!(tree.leaves(), vec![1, 2, 3]);
+        let root = tree.root().unwrap();
+        assert_eq!(shares(&tree, root).len(), 3);
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn a_lone_root_leaf_cannot_move() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        assert!(!tree.move_dir(&1, Direction::Left));
+    }
+
+    #[test]
+    fn resize_takes_from_the_next_sibling_and_clamps() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        assert!(tree.resize(&1, Axis::Row, 0.1));
+        let s = shares(&tree, tree.root().unwrap());
+        assert!((s[0] - 0.6).abs() < 1e-5, "{s:?}");
+        assert!((s[1] - 0.4).abs() < 1e-5, "{s:?}");
+
+        // Grow past the clamp: the sibling never drops below MIN_SHARE.
+        for _ in 0..20 {
+            tree.resize(&1, Axis::Row, 0.1);
+        }
+        let s = shares(&tree, tree.root().unwrap());
+        assert!(s[1] >= MIN_SHARE - 1e-5, "{s:?}");
+        assert!(s[0] <= MAX_SHARE + 1e-5, "{s:?}");
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn resize_climbs_to_the_nearest_ancestor_on_that_axis() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        tree.insert_next_to(Some(&2), 3, None, false); // column [2,3]
+                                                       // 3 has no row sibling — the resize has to move the root row's split.
+        assert!(tree.resize(&3, Axis::Row, 0.1));
+        let s = shares(&tree, tree.root().unwrap());
+        assert!((s[0] - 0.4).abs() < 1e-5, "{s:?}");
+        assert!((s[1] - 0.6).abs() < 1e-5, "{s:?}");
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn resize_on_a_lone_tile_does_nothing() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        assert!(!tree.resize(&1, Axis::Row, 0.1));
+    }
+
+    #[test]
+    fn equalize_evens_out_a_container() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        wide(&mut tree, Some(2), 3);
+        assert!(tree.equalize_container_of(&1));
+        let s = shares(&tree, tree.root().unwrap());
+        for share in &s {
+            assert!((share - 1.0 / 3.0).abs() < 1e-5, "{s:?}");
+        }
+        tree.assert_invariants();
+    }
+
+    #[test]
+    fn equalize_all_evens_out_every_container() {
+        let mut tree = Tree::<u32>::new();
+        wide(&mut tree, None, 1);
+        wide(&mut tree, Some(1), 2);
+        tree.insert_next_to(Some(&2), 3, None, false);
+        tree.resize(&1, Axis::Row, 0.2);
+        tree.equalize_all();
+        let s = shares(&tree, tree.root().unwrap());
+        assert!((s[0] - 0.5).abs() < 1e-5, "{s:?}");
+        tree.assert_invariants();
+    }
+}

--- a/src/workspaces/workspace.rs
+++ b/src/workspaces/workspace.rs
@@ -57,6 +57,11 @@ pub struct WorkspaceView {
     /// Stacking order (bottom→top ObjectIds) saved when expose opens,
     /// so it can be restored verbatim when expose closes without selection.
     pre_expose_order: Arc<RwLock<Vec<ObjectId>>>,
+    /// Whether this workspace tiles, and the tree it tiles by. Tiling is a
+    /// property of one workspace on one output (`specs/tiling.md`), so it
+    /// lives here rather than on the compositor. Disabled by default: Otto is
+    /// a floating desktop, and a workspace tiles because the user asked.
+    pub tiling: Arc<RwLock<crate::workspaces::tiling::TilingState>>,
 }
 
 impl fmt::Debug for WorkspaceView {
@@ -228,6 +233,7 @@ impl WorkspaceView {
             display_number: Arc::new(RwLock::new(index)),
             window_base_layers: Arc::new(RwLock::new(HashMap::new())),
             pre_expose_order: Arc::new(RwLock::new(Vec::new())),
+            tiling: Arc::new(RwLock::new(Default::default())),
         }
     }
 

--- a/src/workspaces/workspace_selector.rs
+++ b/src/workspaces/workspace_selector.rs
@@ -238,6 +238,10 @@ pub struct WorkspaceSelectorViewState {
     removing: Vec<usize>,
     /// The lifted copy of the workspace being dragged, if one is in flight.
     drag_ghost: Option<WorkspaceGhostState>,
+    /// Whether an expose window is riding the pointer across this strip. The
+    /// previews are drop targets then, not things being pointed at: no close
+    /// button may appear and the drop-target darkening must not be cleared.
+    window_drag: bool,
 }
 
 impl Hash for WorkspaceSelectorViewState {
@@ -249,6 +253,7 @@ impl Hash for WorkspaceSelectorViewState {
         self.editing.hash(state);
         self.removing.hash(state);
         self.drag_ghost.hash(state);
+        self.window_drag.hash(state);
     }
 }
 
@@ -336,6 +341,7 @@ impl WorkspaceSelectorView {
             editing: None,
             removing: Vec::new(),
             drag_ghost: None,
+            window_drag: false,
         };
         let view = View::new(
             "workspace_selector_view",
@@ -617,6 +623,19 @@ impl WorkspaceSelectorView {
         // Update view state to trigger re-render with new hover indication
         let mut state = self.view.get_state().clone();
         state.drop_hover_index = workspace_index;
+        self.view.update_state(&state);
+    }
+
+    /// Mark whether an expose window drag is in flight over this strip. While
+    /// it is, the previews stop reacting to the pointer as hover: the pointer
+    /// is carrying a window, and the only feedback is the drop-target darkening
+    /// driven by [`Self::set_drop_hover`].
+    pub fn set_window_drag(&self, dragging: bool) {
+        let mut state = self.view.get_state();
+        if state.window_drag == dragging {
+            return;
+        }
+        state.window_drag = dragging;
         self.view.update_state(&state);
     }
 
@@ -1229,9 +1248,11 @@ fn render_workspace_selector_view(
                         // A drag sweeps the pointer across every preview it
                         // passes, and the release leaves it parked on one.
                         // None of that is hovering — the pointer is carrying a
-                        // workspace, not pointing at one — so no close button
-                        // may appear for as long as the lifted copy is out.
-                        if view_ref.get_state().drag_ghost.is_some() {
+                        // workspace, or an expose window, not pointing at one —
+                        // so no close button may appear for as long as either
+                        // is riding the cursor.
+                        let state = view_ref.get_state();
+                        if state.drag_ghost.is_some() || state.window_drag {
                             return;
                         }
                         let key = format!("workspace_selector_desktop_remove_{}", workspace_index);
@@ -1245,6 +1266,11 @@ fn render_workspace_selector_view(
                 .on_pointer_out({
                     let view_ref = view.clone();
                     move |layer: &Layer, x, y| {
+                        // Nothing was revealed while a window was being
+                        // dragged across, so there is nothing to hide either.
+                        if view_ref.get_state().window_drag {
+                            return;
+                        }
                         let key = format!("workspace_selector_desktop_remove_{}", workspace_index);
                         let Some(remove_button) = view_ref.layer_by_key(key.as_str()) else {
                             return;
@@ -1344,15 +1370,25 @@ fn render_workspace_selector_view(
                                     }
                                 }
                             })
+                            // The darkening also marks the drop target of an
+                            // expose window drag; that one is owned by the
+                            // drop-hover state, not by the pointer crossing
+                            // the preview, so leave it alone for the drag.
                             .on_pointer_release({
                                 let view_ref = view.clone();
                                 move |layer: &Layer, _x, _y| {
+                                    if view_ref.get_state().window_drag {
+                                        return;
+                                    }
                                     clear_preview_filter(layer, &view_ref, workspace_index);
                                 }
                             })
                             .on_pointer_out({
                                 let view_ref = view.clone();
                                 move |layer: &Layer, _x, _y| {
+                                    if view_ref.get_state().window_drag {
+                                        return;
+                                    }
                                     clear_preview_filter(layer, &view_ref, workspace_index);
                                 }
                             })

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -565,6 +565,7 @@ pub fn run_x11() {
             state.running.store(false, Ordering::SeqCst);
         } else {
             state.workspaces.refresh_space();
+            state.flush_tiling_relayout();
             state.popups.cleanup();
             display_handle.flush_clients().unwrap();
         }

--- a/tests/cursor_shape.rs
+++ b/tests/cursor_shape.rs
@@ -1,0 +1,212 @@
+//! What a client gets when it names a cursor instead of drawing one.
+//!
+//! A client that binds `wp_cursor_shape_manager_v1` never uploads a pointer
+//! bitmap: it names a shape and the compositor draws it from the configured
+//! theme. That makes the theme and the size of every such cursor Otto's
+//! responsibility, and both have gone wrong.
+//!
+//! Cursor themes name the same icon two ways — a modern name (`default`,
+//! `pointer`) and a legacy X11 one (`left_ptr`, `hand2`) — and a theme with no
+//! `Inherits=` still falls back to `default`, usually Adwaita. Resolving the
+//! modern name to exhaustion first found the icon in the *fallback* theme and
+//! never tried the legacy name in the configured one, so the desktop drew the
+//! fallback theme's art almost everywhere and the user's own theme only where
+//! the two names coincide (`move`). Separately, a theme that ships a single
+//! small bitmap drew a pointer a fraction of `cursor_size` on a HiDPI screen,
+//! because the nearest available art was emitted unscaled.
+//!
+//! The two failures need separate assertions. Size alone cannot catch the
+//! lookup bug — rescaled art from the wrong theme is the right size and still
+//! the wrong cursor — so these tests check the pixels too, against themes they
+//! plant themselves rather than whatever the machine has installed.
+
+#[cfg(feature = "headless")]
+mod cursor_shape_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+    use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape;
+
+    /// Art in the theme the user configured. Every cursor should be this
+    /// colour; any other means Otto went to a different theme for it.
+    const CONFIGURED: [u8; 4] = [10, 200, 30, 255];
+    /// Art in the theme the configured one implicitly falls back to.
+    const FALLBACK: [u8; 4] = [200, 10, 30, 255];
+
+    /// The configured theme ships one small bitmap, as several legacy X11
+    /// themes do, so the resampling has real work to do.
+    const CONFIGURED_ART_PX: u32 = 32;
+    /// The fallback theme's art is a different size again, so art taken from
+    /// the wrong theme is wrong in both colour and (unresampled) size.
+    const FALLBACK_ART_PX: u32 = 48;
+
+    /// The cursor size to configure, in logical pixels. Deliberately unequal
+    /// to either theme's art, so the right answer is never one Otto could
+    /// reach by emitting a bitmap unscaled.
+    const CURSOR_SIZE: u32 = 40;
+
+    /// Encode a single-frame xcursor file: one `size`×`size` image filled with
+    /// `fill`, in the RGBA byte order the parser hands back.
+    fn write_cursor(path: &Path, size: u32, fill: [u8; 4]) {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"Xcur");
+        out.extend_from_slice(&16u32.to_le_bytes()); // header length
+        out.extend_from_slice(&0x0001_0000u32.to_le_bytes()); // file version
+        out.extend_from_slice(&1u32.to_le_bytes()); // one table entry
+
+        out.extend_from_slice(&0xfffd_0002u32.to_le_bytes()); // image chunk
+        out.extend_from_slice(&size.to_le_bytes()); // nominal size
+        out.extend_from_slice(&28u32.to_le_bytes()); // its position
+
+        for word in [0x24u32, 0xfffd_0002, size, 1, size, size, 0, 0, 0] {
+            out.extend_from_slice(&word.to_le_bytes());
+        }
+        for _ in 0..(size * size) {
+            out.extend_from_slice(&fill);
+        }
+
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, out).unwrap();
+    }
+
+    /// Plant two themes and point `XCURSOR_PATH` at them.
+    ///
+    /// `legacy` has no `index.theme`, so it implicitly inherits `default` —
+    /// and it carries its icons only under the old X11 names, exactly the
+    /// shape of theme that used to lose every modern name to the fallback.
+    fn plant_themes() -> PathBuf {
+        let root = std::env::temp_dir().join("otto-cursor-shape-themes");
+        let _ = std::fs::remove_dir_all(&root);
+
+        for name in ["left_ptr", "hand2", "xterm", "watch", "move"] {
+            write_cursor(
+                &root.join("legacy/cursors").join(name),
+                CONFIGURED_ART_PX,
+                CONFIGURED,
+            );
+        }
+        for name in ["default", "pointer", "text", "wait", "move"] {
+            write_cursor(
+                &root.join("default/cursors").join(name),
+                FALLBACK_ART_PX,
+                FALLBACK,
+            );
+        }
+
+        std::env::set_var("XCURSOR_PATH", &root);
+        root
+    }
+
+    /// A mapped window with the pointer resting inside it. The pointer has to
+    /// be over one of the client's surfaces: the `wl_pointer.enter` serial is
+    /// what authorises naming a shape.
+    fn window_with_pointer(handle: &HeadlessHandle, client: &mut TestClient) {
+        let toplevel = client.create_toplevel("cursor-shape", 400, 300);
+        handle.wait(Duration::from_millis(120));
+        client.roundtrip().expect("roundtrip");
+        toplevel.lock().unwrap().commit_frame();
+        client.roundtrip().expect("roundtrip");
+        handle.wait(Duration::from_millis(120));
+
+        let (x, y, w, h) = handle
+            .window_logical_geometry("cursor-shape")
+            .expect("the window is mapped");
+        handle.pointer_move(x as f64 + w as f64 / 2.0, y as f64 + h as f64 / 2.0);
+        handle.wait(Duration::from_millis(80));
+        client.roundtrip().expect("roundtrip");
+    }
+
+    /// Name `shape`, let the compositor settle, and report what it drew.
+    fn shape_render_state(
+        handle: &HeadlessHandle,
+        client: &mut TestClient,
+        shape: Shape,
+    ) -> (String, u32, u32, [u8; 4]) {
+        assert!(
+            client.set_cursor_shape(shape),
+            "the compositor should advertise wp_cursor_shape_manager_v1 and the \
+             pointer should have entered the window"
+        );
+        client.roundtrip().expect("roundtrip");
+        handle.wait(Duration::from_millis(80));
+        handle.cursor_render_state()
+    }
+
+    /// Start a compositor already using the planted legacy theme, with a
+    /// client whose pointer is inside its window. Returns the size in physical
+    /// pixels every cursor should come out at.
+    fn setup() -> (HeadlessHandle, TestClient, u32) {
+        plant_themes();
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut client = TestClient::connect(&handle.socket_name).expect("connect");
+        window_with_pointer(&handle, &mut client);
+        let expected = handle.use_cursor_theme("legacy", CURSOR_SIZE);
+        (handle, client, expected)
+    }
+
+    /// A named shape must be drawn by the compositor rather than handed back
+    /// as a client bitmap, and it must come out at the configured size — not
+    /// at whatever size the theme happens to ship art for.
+    #[test]
+    #[serial]
+    fn a_named_shape_is_drawn_at_the_configured_size() {
+        let (handle, mut client, expected) = setup();
+
+        let (kind, w, h, _) = shape_render_state(&handle, &mut client, Shape::Pointer);
+
+        assert!(
+            kind.starts_with("named:"),
+            "a cursor-shape request should resolve to a compositor-drawn cursor, got {kind}"
+        );
+        assert_ne!(
+            expected, CONFIGURED_ART_PX,
+            "the test is pointless unless the requested size differs from the art"
+        );
+        assert_eq!(
+            (w, h),
+            (expected, expected),
+            "{kind} came out {w}x{h}; a theme shipping only {CONFIGURED_ART_PX}px art \
+             should still be drawn at cursor_size * scale = {expected}px"
+        );
+
+        handle.stop();
+    }
+
+    /// The bug this guards: `pointer` resolved in the fallback theme while
+    /// `move` resolved in the configured one, so the pointer changed theme
+    /// mid-gesture. Every shape must come out of the theme the user chose.
+    #[test]
+    #[serial]
+    fn every_named_shape_comes_from_the_configured_theme() {
+        let (handle, mut client, expected) = setup();
+
+        // `default`, `pointer`, `text` and `wait` exist in both planted themes
+        // — under their modern names in the fallback and their legacy names in
+        // the configured one, which is what used to split the cursor across
+        // two themes. `move` is spelled the same in both and never split.
+        for shape in [
+            Shape::Default,
+            Shape::Pointer,
+            Shape::Text,
+            Shape::Wait,
+            Shape::Move,
+        ] {
+            let (kind, w, h, pixel) = shape_render_state(&handle, &mut client, shape);
+
+            assert_eq!(
+                pixel, CONFIGURED,
+                "{kind} was drawn from the fallback theme, not the configured one \
+                 (pixel {pixel:?}, expected {CONFIGURED:?})"
+            );
+            assert_eq!(
+                (w, h),
+                (expected, expected),
+                "{kind} came out {w}x{h}, but every named cursor should be {expected}px"
+            );
+        }
+
+        handle.stop();
+    }
+}

--- a/tests/cursor_shape.rs
+++ b/tests/cursor_shape.rs
@@ -210,3 +210,95 @@ mod cursor_shape_tests {
         handle.stop();
     }
 }
+
+/// Whether a client's own cursor bitmap survives the pointer moving inside
+/// the window it set the cursor for.
+///
+/// A client that does not use the cursor-shape protocol uploads a bitmap and
+/// expects it to stay up until the pointer leaves. The compositor resets to
+/// its default cursor on every pointer-focus change, which is correct — but
+/// only if focus is actually stable while the pointer stays over one surface.
+/// Otto was seen resetting to `default` eight times for every cursor the
+/// client set, over a window the pointer never left, which leaves the client's
+/// cursor mostly not drawn at all.
+#[cfg(feature = "headless")]
+mod client_cursor_tests {
+    use otto::headless::{HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    /// The client's cursor bitmap, sized so it cannot be confused with
+    /// anything Otto would draw from a theme.
+    const CURSOR_PX: u32 = 48;
+
+    #[test]
+    #[serial]
+    fn a_client_cursor_survives_the_pointer_moving_inside_its_window() {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let mut client = TestClient::connect(&handle.socket_name).expect("connect");
+
+        let toplevel = client.create_toplevel("client-cursor", 400, 300);
+        handle.wait(Duration::from_millis(120));
+        client.roundtrip().expect("roundtrip");
+        toplevel.lock().unwrap().commit_frame();
+        client.roundtrip().expect("roundtrip");
+        handle.wait(Duration::from_millis(120));
+
+        let (x, y, w, h) = handle
+            .window_logical_geometry("client-cursor")
+            .expect("the window is mapped");
+        let (cx, cy) = (x as f64 + w as f64 / 2.0, y as f64 + h as f64 / 2.0);
+
+        handle.pointer_move(cx, cy);
+        handle.wait(Duration::from_millis(80));
+        client.roundtrip().expect("roundtrip");
+
+        let cursor = client
+            .set_cursor_surface(CURSOR_PX, CURSOR_PX)
+            .expect("the pointer should have entered the window");
+        client.roundtrip().expect("roundtrip");
+        handle.wait(Duration::from_millis(80));
+
+        let (kind, ..) = handle.cursor_render_state();
+        assert_eq!(
+            kind, "surface",
+            "the compositor should be drawing the client's own bitmap right after it set one"
+        );
+
+        // Walk the pointer around well inside the window. Every one of these
+        // stays over the same surface, so none of them is a focus change and
+        // none should take the client's cursor away.
+        let mut stomped = Vec::new();
+        for (i, (dx, dy)) in [(6.0, 0.0), (0.0, 6.0), (-6.0, 0.0), (0.0, -6.0)]
+            .into_iter()
+            .cycle()
+            .take(12)
+            .enumerate()
+        {
+            handle.pointer_move(cx + dx, cy + dy);
+            handle.wait(Duration::from_millis(30));
+            client.roundtrip().expect("roundtrip");
+
+            let (kind, ..) = handle.cursor_render_state();
+            if kind != "surface" {
+                stomped.push(format!("move {i}: {kind}"));
+            }
+        }
+
+        // Drop the client before stopping: the compositor holds the cursor
+        // surface as its current cursor image, and tearing the compositor down
+        // underneath a live client wedges the shutdown.
+        drop(cursor);
+        drop(client);
+        handle.wait(Duration::from_millis(80));
+
+        assert!(
+            stomped.is_empty(),
+            "the client's cursor was replaced by one of Otto's while the pointer \
+             stayed inside its window: {stomped:?}"
+        );
+
+        handle.stop();
+    }
+}

--- a/tests/tiling_tree.rs
+++ b/tests/tiling_tree.rs
@@ -1,0 +1,350 @@
+//! End-to-end tests for the tiling tree.
+//!
+//! Drives the same entry points the `TilingToggle`, `Focus*`, `MoveContainer*`
+//! shortcuts land on, and asserts on the cells the tree resolves to — the
+//! rectangles the clients are configured with. The test client never resizes
+//! its own buffer, so a window's *position* is what shows it moved.
+
+#[cfg(feature = "headless")]
+mod tiling_tree_tests {
+    use otto::headless::{Axis, Direction, HeadlessConfig, HeadlessHandle};
+    use otto_kit::testing::TestClient;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    /// One window, with the client that owns it kept alive so the window can
+    /// be closed by dropping it.
+    struct Window {
+        /// Kept alive so dropping it closes the window.
+        #[allow(dead_code)]
+        client: TestClient,
+        title: String,
+    }
+
+    fn spawn(handle: &HeadlessHandle, title: &str) -> Window {
+        let mut client =
+            TestClient::connect(&handle.socket_name).expect("Failed to connect to compositor");
+        let _toplevel = client.create_toplevel(title, 640, 480);
+        handle.wait(Duration::from_millis(100));
+        let _ = client.roundtrip();
+        handle.settle(300);
+        Window {
+            client,
+            title: title.to_string(),
+        }
+    }
+
+    /// A compositor with `titles` mapped and settled, floating.
+    fn setup(titles: &[&str]) -> (HeadlessHandle, Vec<Window>) {
+        let handle = HeadlessHandle::start(HeadlessConfig::default());
+        let windows: Vec<Window> = titles.iter().map(|t| spawn(&handle, t)).collect();
+        handle.settle(300);
+        (handle, windows)
+    }
+
+    /// Cells keyed by title, in layout order.
+    fn cells(handle: &HeadlessHandle) -> Vec<(String, (i32, i32, i32, i32))> {
+        handle.tiling_cell_rects()
+    }
+
+    /// Rectangles that agree to within one inner gap — enough slack for the
+    /// gap an extra sibling costs its container, and for integer rounding.
+    fn assert_close(got: (i32, i32, i32, i32), want: (i32, i32, i32, i32), what: &str) {
+        const SLACK: i32 = 8;
+        let deltas = [
+            (got.0 - want.0).abs(),
+            (got.1 - want.1).abs(),
+            (got.2 - want.2).abs(),
+            (got.3 - want.3).abs(),
+        ];
+        assert!(
+            deltas.iter().all(|d| *d <= SLACK),
+            "{what}: {got:?} is not within {SLACK}px of {want:?}"
+        );
+    }
+
+    fn cell(handle: &HeadlessHandle, title: &str) -> (i32, i32, i32, i32) {
+        cells(handle)
+            .into_iter()
+            .find(|(t, _)| t == title)
+            .unwrap_or_else(|| panic!("{title} should be a tile"))
+            .1
+    }
+
+    // ── Entering tiling mode ─────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn tiling_two_windows_fills_the_usable_zone_side_by_side() {
+        let (handle, windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        assert!(handle.workspace_tiling_enabled(), "the workspace tiles");
+        let cells = cells(&handle);
+        assert_eq!(cells.len(), 2, "both windows joined the tree: {cells:?}");
+
+        let (zx, zy, zw, zh) = handle.usable_zone();
+        // The defaults: an 8px gap around the tree and between the tiles.
+        let (_, left) = &cells[0];
+        let (_, right) = &cells[1];
+        assert_eq!(left.0, zx + 8, "the first cell starts inside the outer gap");
+        assert_eq!(left.1, zy + 8);
+        assert_eq!(left.3, zh - 16, "cells fill the usable height");
+        assert_eq!(
+            right.0 - (left.0 + left.2),
+            8,
+            "one inner gap between the two cells"
+        );
+        assert_eq!(
+            right.0 + right.2,
+            zx + zw - 8,
+            "the tree ends inside the outer gap"
+        );
+
+        drop(windows);
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn windows_are_moved_into_their_cells() {
+        let (handle, windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        for (title, rect) in cells(&handle) {
+            let geometry = handle
+                .window_logical_geometry(&title)
+                .expect("tiles stay mapped");
+            assert_eq!(
+                (geometry.0, geometry.1),
+                (rect.0, rect.1),
+                "{title} should sit at its cell origin"
+            );
+        }
+
+        drop(windows);
+        handle.stop();
+    }
+
+    // ── Insertion ────────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn a_third_window_splits_the_focused_cell() {
+        let (handle, mut windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-b");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        let before = cell(&handle, "tile-b");
+        let other_before = cell(&handle, "tile-a");
+
+        let third = spawn(&handle, "tile-c");
+        handle.settle(600);
+
+        let leaves = handle.tiling_tree_leaves();
+        assert_eq!(
+            leaves.len(),
+            3,
+            "the new window joined the tree: {leaves:?}"
+        );
+
+        // The insertion takes half of the focused window's share and leaves
+        // the other tile alone: together the two cells still cover the
+        // rectangle tile-b used to have, minus the gap between them.
+        let b = cell(&handle, "tile-b");
+        let c = cell(&handle, "tile-c");
+        let union = (
+            b.0.min(c.0),
+            b.1.min(c.1),
+            (b.0 + b.2).max(c.0 + c.2) - b.0.min(c.0),
+            (b.1 + b.3).max(c.1 + c.3) - b.1.min(c.1),
+        );
+        // Within the inner gap the extra child costs: the two cells still
+        // stand where tile-b's one did.
+        assert_close(union, before, "the split stays inside the focused cell");
+        assert!(
+            b.2 * b.3 < before.2 * before.3,
+            "the focused cell gave up half its space: {b:?} was {before:?}"
+        );
+        assert_close(
+            cell(&handle, "tile-a"),
+            other_before,
+            "the other siblings keep their place",
+        );
+
+        windows.push(third);
+        drop(windows);
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn a_preselect_forces_the_axis_of_the_next_split() {
+        let (handle, mut windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-b");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        let before = cell(&handle, "tile-b");
+        // Split top/bottom, whatever shape the focused cell has.
+        handle.tiling_split(Axis::Column);
+
+        let third = spawn(&handle, "tile-c");
+        handle.settle(600);
+
+        let b = cell(&handle, "tile-b");
+        let c = cell(&handle, "tile-c");
+        assert_eq!(
+            (b.0, b.2),
+            (before.0, before.2),
+            "the column keeps its width"
+        );
+        assert_eq!((c.0, c.2), (before.0, before.2));
+        assert!(c.1 > b.1, "the new cell took the bottom half: {b:?} {c:?}");
+
+        windows.push(third);
+        drop(windows);
+        handle.stop();
+    }
+
+    // ── Removal ──────────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn closing_a_tile_gives_its_space_to_the_survivor() {
+        let (handle, mut windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+        assert_eq!(handle.tiling_tree_leaves().len(), 2);
+
+        // Dropping the client destroys its toplevel, which unmaps the window.
+        let closed = windows.pop().expect("two windows");
+        assert_eq!(closed.title, "tile-b");
+        drop(closed);
+        handle.wait(Duration::from_millis(100));
+        handle.settle(600);
+
+        let leaves = handle.tiling_tree_leaves();
+        assert_eq!(leaves, vec!["tile-a".to_string()], "one tile is left");
+
+        // A lone tile with smart gaps on fills the usable area outright.
+        let (zx, zy, zw, zh) = handle.usable_zone();
+        assert_eq!(cell(&handle, "tile-a"), (zx, zy, zw, zh));
+
+        drop(windows);
+        handle.stop();
+    }
+
+    // ── Navigation and movement ──────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn focus_right_moves_the_keyboard_focus_to_the_next_cell() {
+        let (handle, windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        let cells = cells(&handle);
+        let leftmost = cells[0].0.clone();
+        let rightmost = cells[1].0.clone();
+        handle.focus_window(&leftmost);
+        handle.settle(100);
+
+        handle.tiling_focus(Direction::Right);
+        handle.settle(300);
+        assert_eq!(handle.focused_window_title(), Some(rightmost.clone()));
+
+        // Focus never wraps: there is nothing further right.
+        handle.tiling_focus(Direction::Right);
+        handle.settle(300);
+        assert_eq!(handle.focused_window_title(), Some(rightmost.clone()));
+
+        handle.tiling_focus(Direction::Left);
+        handle.settle(300);
+        assert_eq!(handle.focused_window_title(), Some(leftmost));
+
+        drop(windows);
+        handle.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn moving_a_tile_swaps_it_with_its_neighbour() {
+        let (handle, windows) = setup(&["tile-a", "tile-b"]);
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+
+        let before = handle.tiling_tree_leaves();
+        assert_eq!(before.len(), 2);
+        handle.focus_window(&before[1]);
+        handle.settle(100);
+
+        handle.tiling_move(Direction::Left);
+        handle.settle(600);
+
+        let after = handle.tiling_tree_leaves();
+        assert_eq!(
+            after,
+            vec![before[1].clone(), before[0].clone()],
+            "the two tiles traded places"
+        );
+
+        drop(windows);
+        handle.stop();
+    }
+
+    // ── Leaving tiling mode ──────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn leaving_tiling_mode_restores_the_floating_rects() {
+        let (handle, windows) = setup(&["tile-a", "tile-b"]);
+        handle.move_window("tile-a", 120, 90);
+        handle.move_window("tile-b", 700, 300);
+        handle.settle(300);
+        let before: Vec<(String, (i32, i32, i32, i32))> = ["tile-a", "tile-b"]
+            .iter()
+            .map(|t| {
+                (
+                    t.to_string(),
+                    handle.window_logical_geometry(t).expect("mapped"),
+                )
+            })
+            .collect();
+
+        handle.focus_window("tile-a");
+        handle.toggle_tiling();
+        handle.settle(600);
+        assert!(handle.workspace_tiling_enabled());
+
+        handle.toggle_tiling();
+        handle.settle(600);
+        assert!(!handle.workspace_tiling_enabled());
+        assert!(
+            handle.tiling_tree_leaves().is_empty(),
+            "the tree is emptied on the way out"
+        );
+
+        for (title, rect) in before {
+            let now = handle
+                .window_logical_geometry(&title)
+                .expect("still mapped");
+            assert_eq!(
+                (now.0, now.1),
+                (rect.0, rect.1),
+                "{title} went back to where it floated"
+            );
+        }
+
+        drop(windows);
+        handle.stop();
+    }
+}


### PR DESCRIPTION
First cut of i3-style tiling: a workspace can be switched from free-floating
placement to a tree of split containers, shaped entirely from the keyboard.

## What landed

- **Tree, layout, state** — `src/workspaces/tiling/`: a pure n-ary tree of
  `splith`/`splitv` containers with insertion by cell shape, proportional
  redistribution on removal, single-child dissolve, directional focus and move,
  resize and equalise; a pure layout pass resolving the tree against the usable
  area with inner/outer gaps, smart gaps and pixel-grid snapping; and a
  per-workspace `TilingState` (mode, tree, focus, pre-selection) hanging off
  `WorkspaceView`, so a tiled workspace and a floating one live a swipe apart.
- **Config** — a `[tiling]` section: `inner_gap`, `outer_gap`, `smart_gaps`,
  `layout_duration` / `layout_bounce` (0 = snap, following the `[workspaces]`
  convention) and `resize_step`.
- **Actions** — `TilingToggle`, `FocusLeft/Right/Up/Down`,
  `MoveContainerLeft/Right/Up/Down`, `SplitHorizontal`, `SplitVertical`,
  `ResizeGrowWidth/ShrinkWidth/GrowHeight/ShrinkHeight` and
  `EqualizeContainer`, bound like every other builtin. None is bound by
  default. In a tiling workspace `TileWindowLeft`/`TileWindowRight` move focus
  instead of half-snapping.
- **Integration** — `src/shell/tiling.rs`: relayout on map, unmap, minimize,
  workspace move and focus change; windows animate into their cells on the
  configured spring; xdg tiled edge states per touching edge; auto-float rules
  keep dialogs and fixed-size windows out of the tree.
- **Tests** — 30 unit tests over the tree and the layout
  (`cargo test --lib tiling`) and 8 headless end-to-end tests driving real
  clients (`cargo test --features headless --test tiling_tree`).

## How to try it

Nothing is bound out of the box. Add to `[keyboard_shortcuts]`:

```toml
"Logo+t" = "TilingToggle"
"Logo+h" = "FocusLeft"
"Logo+j" = "FocusDown"
"Logo+k" = "FocusUp"
"Logo+l" = "FocusRight"
"Logo+Shift+h" = "MoveContainerLeft"
"Logo+Shift+j" = "MoveContainerDown"
"Logo+Shift+k" = "MoveContainerUp"
"Logo+Shift+l" = "MoveContainerRight"
"Logo+b" = "SplitHorizontal"
"Logo+v" = "SplitVertical"
"Logo+r" = "ResizeGrowWidth"
"Logo+Shift+r" = "ResizeShrinkWidth"
"Logo+e" = "EqualizeContainer"
```

If your config sets `xkb_options = ["altwin:ctrl_win"]` or
`mac_style_modifiers`, the Cmd key reports as Control and a `Logo+…` binding
can never match — use `Ctrl+Alt+h` and so on instead (Cmd+Alt on the
keyboard). The example config and the shortcuts doc now say so.

## Deliberately not in this cut

Pointer paths (drag-to-detach, design mode with its handles and empty slots),
the floating layer and `floating toggle`, the minimal/none decoration variants
(a tile keeps its full titlebar for now), tabbed and stacked containers, the
i3 command grammar and the IPC that runs it, and XWayland float rules.

The roadmap for all of that, and the reasoning behind the animation model, is
in [`docs/developer/tiling-plan.md`](docs/developer/tiling-plan.md);
`specs/tiling.md` is synced to it in this branch.

https://claude.ai/code/session_01K5RH5bd2oA61U27vgpfajD