### PR TITLE
chore(deps): pin smithay to the text-input cursor rectangle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7017,7 +7017,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/nongio/smithay?branch=feat%2Fdmabuf-scanout#90db50ef7419506c7db0daf5f3f57ea34d6d149e"
+source = "git+https://github.com/nongio/smithay?branch=feat%2Fdmabuf-scanout#f06b126149b7377289841e87d4c95f9712cbee2b"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/nongio/smithay?branch=feat%2Fdmabuf-scanout#90db50ef7419506c7db0daf5f3f57ea34d6d149e"
+source = "git+https://github.com/nongio/smithay?branch=feat%2Fdmabuf-scanout#f06b126149b7377289841e87d4c95f9712cbee2b"
 dependencies = [
  "drm",
  "libdisplay-info",


### PR DESCRIPTION
`main`'s lock pinned `nongio/smithay@90db50ef`, but the fork branch it tracks moved to `f06b1261` when the text-input cursor-rectangle getter landed on it for the emoji picker. Left alone, the next `cargo update` would pick that up silently.

This pins the rev instead, so main sits on a commit that has been built and tested.

Only the two `source =` lines change. Running `cargo update -p smithay` would also churn a dozen Windows-only transitive deps, which is noise on a Linux compositor, so the lock is edited directly and checked with `cargo metadata --locked`.

Verified: `cargo clippy --workspace --all-targets --locked -- -D warnings` and `cargo test --lib --locked` (290 passed).