### PR TITLE
fix(packaging): ship the emoji picker, and name the plugins playback needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libpipewire-0.3-dev libfreetype-dev libfontconfig-dev libdisplay-info-dev libpixman-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libpam0g-dev hicolor-icon-theme fonts-dejavu-core
       - name: Build workspace binaries
-        run: cargo build --locked --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p otto-rdp -p xdg-desktop-portal-otto -p otto-settings -p otto-files -p otto-launcher -p otto-quickview -p otto-media-kit
+        run: cargo build --locked --release -p otto -p otto-bar -p otto-islands -p otto-lock -p otto-greeter -p otto-rdp -p xdg-desktop-portal-otto -p otto-settings -p otto-files -p otto-launcher -p otto-emoji -p otto-quickview -p otto-media-kit
       - name: Upload workspace binaries
         uses: actions/upload-artifact@v4
         with:
@@ -243,6 +243,7 @@ jobs:
             target/release/otto-settings
             target/release/otto-files
             target/release/otto-launcher
+            target/release/otto-emoji
             target/release/otto-quickview
             target/release/otto-media-worker
           retention-days: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,10 +230,12 @@ multi-workspace support, and integrated screen sharing capabilities."""
 depends = "$auto, libdrm2, libudev1, libgbm1, libxkbcommon0, libegl1, libwayland-client0, libwayland-egl1, libinput10, libdbus-1-3, libsystemd0, libseat1, libpipewire-0.3-0, libfreetype6, libfontconfig1, libpixman-1-0, fonts-inter, wireplumber"
 section = "x11"
 priority = "optional"
-# otto-rdp loads these at runtime (pipewiresrc, and the VA-API H.264 encoder
-# it falls back from), so dpkg-shlibdeps cannot see them. Recommended, not
-# required: everything except the RDP bridge works without them.
-recommends = "gstreamer1.0-plugins-base, gstreamer1.0-plugins-bad, gstreamer1.0-pipewire"
+# GStreamer loads these at runtime — otto-rdp's pipewiresrc and the VA-API
+# H.264 encoder it falls back from, and the decoders otto-media-worker needs
+# to play a file in Quick View — so dpkg-shlibdeps cannot see them.
+# Recommended, not required: the desktop works without them, but the RDP
+# bridge and Quick View's video playback do not.
+recommends = "gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-libav, gstreamer1.0-pipewire"
 assets = [
     ["target/release/otto", "usr/bin/", "755"],
     ["target/release/otto-bar", "usr/bin/", "755"],
@@ -242,6 +244,7 @@ assets = [
     ["target/release/otto-settings", "usr/bin/", "755"],
     ["target/release/otto-files", "usr/bin/", "755"],
     ["target/release/otto-launcher", "usr/bin/", "755"],
+    ["target/release/otto-emoji", "usr/bin/", "755"],
     ["target/release/otto-quickview", "usr/bin/", "755"],
     ["target/release/otto-media-worker", "usr/bin/", "755"],
     ["target/release/otto-greeter", "usr/bin/", "755"],
@@ -287,6 +290,7 @@ assets = [
     { source = "target/release/otto-settings", dest = "/usr/bin/otto-settings", mode = "755" },
     { source = "target/release/otto-files", dest = "/usr/bin/otto-files", mode = "755" },
     { source = "target/release/otto-launcher", dest = "/usr/bin/otto-launcher", mode = "755" },
+    { source = "target/release/otto-emoji", dest = "/usr/bin/otto-emoji", mode = "755" },
     { source = "target/release/otto-quickview", dest = "/usr/bin/otto-quickview", mode = "755" },
     { source = "target/release/otto-media-worker", dest = "/usr/bin/otto-media-worker", mode = "755" },
     { source = "resources/otto-files.desktop", dest = "/usr/share/applications/otto-files.desktop", mode = "644" },
@@ -317,10 +321,15 @@ assets = [
     { source = "components/xdg-desktop-portal-otto/portals.conf.example", dest = "/usr/share/doc/otto/portals.conf.example", mode = "644", doc = true },
     { source = "components/otto-lock/otto-lock.pam", dest = "/etc/pam.d/otto-lock", mode = "644", config = true },
 ]
-# Runtime-loaded GStreamer plugins for otto-rdp — see the deb `recommends`.
+# Runtime-loaded GStreamer plugins for otto-rdp and for Quick View's video
+# playback — see the deb `recommends`. gstreamer1-libav lives in RPM Fusion
+# on Fedora; a weak dependency on a package no enabled repository carries is
+# ignored rather than fatal.
 [package.metadata.generate-rpm.recommends]
 gstreamer1-plugins-base = "*"
+gstreamer1-plugins-good = "*"
 gstreamer1-plugins-bad-free = "*"
+gstreamer1-libav = "*"
 pipewire-gstreamer = "*"
 
 [package.metadata.generate-rpm.requires]
@@ -357,6 +366,8 @@ depends = [
     "pixman",
     "noto-fonts",
     "wireplumber",
+    "gstreamer",
+    "gst-plugins-base-libs",
 ]
 optdepends = [
     "xdg-desktop-portal: Desktop integration",
@@ -364,6 +375,9 @@ optdepends = [
     "greetd: login manager otto --login hosts a greeter for",
     "gst-plugin-pipewire: otto-rdp video capture",
     "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)",
+    "gst-plugins-base: Quick View video playback (the playbin element)",
+    "gst-plugins-good: Quick View playback of MP4 and Matroska",
+    "gst-libav: Quick View playback of H.264 and AAC",
 ]
 files = [
     ["target/release/otto", "/usr/bin/otto", "755"],
@@ -375,6 +389,7 @@ files = [
     ["target/release/otto-settings", "/usr/bin/otto-settings", "755"],
     ["target/release/otto-files", "/usr/bin/otto-files", "755"],
     ["target/release/otto-launcher", "/usr/bin/otto-launcher", "755"],
+    ["target/release/otto-emoji", "/usr/bin/otto-emoji", "755"],
     ["target/release/otto-quickview", "/usr/bin/otto-quickview", "755"],
     ["target/release/otto-media-worker", "/usr/bin/otto-media-worker", "755"],
     ["target/release/xdg-desktop-portal-otto", "/usr/libexec/xdg-desktop-portal-otto", "755"],

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ arch=("x86_64")
 provides=("otto")
 conflicts=("otto")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)" "gst-plugins-base: Quick View video playback (the playbin element)" "gst-plugins-good: Quick View playback of MP4 and Matroska" "gst-libav: Quick View playback of H.264 and AAC")
 source=("https://github.com/nongio/otto/releases/download/$_tag/otto-$_ver-x86_64.tar.gz")
 sha256sums=("SKIP")
 # Files pacman must never clobber: a modified config becomes .pacnew on
@@ -38,6 +38,7 @@ package() {
     install -Dm755 target/release/otto-settings "$pkgdir/usr/bin/otto-settings"
     install -Dm755 target/release/otto-files "$pkgdir/usr/bin/otto-files"
     install -Dm755 target/release/otto-launcher "$pkgdir/usr/bin/otto-launcher"
+    install -Dm755 target/release/otto-emoji "$pkgdir/usr/bin/otto-emoji"
     install -Dm755 target/release/otto-quickview "$pkgdir/usr/bin/otto-quickview"
     # Quick View's playback worker: otto-files looks for it beside itself.
     install -Dm755 target/release/otto-media-worker "$pkgdir/usr/bin/otto-media-worker"

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -11,7 +11,7 @@ provides=("otto")
 conflicts=("otto" "otto-bin")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
 makedepends=("git" "rust" "cargo" "libdisplay-info" "clang")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)" "gst-plugins-base: Quick View video playback (the playbin element)" "gst-plugins-good: Quick View playback of MP4 and Matroska" "gst-libav: Quick View playback of H.264 and AAC")
 source=()
 sha256sums=()
 backup=("etc/otto/config.toml" "etc/pam.d/otto-lock")
@@ -47,6 +47,7 @@ build() {
     cargo build --release -p otto-settings
     cargo build --release -p otto-files
     cargo build --release -p otto-launcher
+    cargo build --release -p otto-emoji
     cargo build --release -p otto-quickview
     cargo build --release -p otto-media-kit
 }
@@ -64,6 +65,7 @@ package() {
     install -Dm755 target/release/otto-settings "$pkgdir/usr/bin/otto-settings"
     install -Dm755 target/release/otto-files "$pkgdir/usr/bin/otto-files"
     install -Dm755 target/release/otto-launcher "$pkgdir/usr/bin/otto-launcher"
+    install -Dm755 target/release/otto-emoji "$pkgdir/usr/bin/otto-emoji"
     install -Dm755 target/release/otto-quickview "$pkgdir/usr/bin/otto-quickview"
     # Quick View's playback worker: otto-files looks for it beside itself.
     install -Dm755 target/release/otto-media-worker "$pkgdir/usr/bin/otto-media-worker"

--- a/PKGBUILD-nightly-bin
+++ b/PKGBUILD-nightly-bin
@@ -10,7 +10,7 @@ arch=("x86_64")
 provides=("otto")
 conflicts=("otto" "otto-bin" "otto-git")
 depends=("libdrm" "systemd-libs" "mesa" "libxkbcommon" "wayland" "libinput" "dbus" "seatd" "pipewire" "freetype2" "fontconfig" "pixman" "noto-fonts" "gstreamer" "gst-plugins-base-libs")
-optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)")
+optdepends=("xdg-desktop-portal: Desktop integration" "fprintd: fingerprint unlock for otto-lock and otto-greeter" "greetd: login manager otto --login hosts a greeter for" "gst-plugin-pipewire: otto-rdp video capture" "gst-plugins-bad: otto-rdp hardware H.264 (VA-API)" "gst-plugins-base: Quick View video playback (the playbin element)" "gst-plugins-good: Quick View playback of MP4 and Matroska" "gst-libav: Quick View playback of H.264 and AAC")
 source=("otto-nightly-x86_64.tar.gz::https://github.com/nongio/otto/releases/download/nightly/otto-nightly-x86_64.tar.gz")
 sha256sums=("SKIP")
 noextract=("otto-nightly-x86_64.tar.gz")
@@ -39,6 +39,7 @@ package() {
     install -Dm755 target/release/otto-settings "$pkgdir/usr/bin/otto-settings"
     install -Dm755 target/release/otto-files "$pkgdir/usr/bin/otto-files"
     install -Dm755 target/release/otto-launcher "$pkgdir/usr/bin/otto-launcher"
+    install -Dm755 target/release/otto-emoji "$pkgdir/usr/bin/otto-emoji"
     install -Dm755 target/release/otto-quickview "$pkgdir/usr/bin/otto-quickview"
     # Quick View's playback worker: otto-files looks for it beside itself.
     install -Dm755 target/release/otto-media-worker "$pkgdir/usr/bin/otto-media-worker"


### PR DESCRIPTION
Two gaps found reviewing the packaging after the emoji picker and media kit landed.

## The picker was not packaged

`otto-emoji` had reached only `make-arch-tarball.sh` and `verify-install.sh` — the two scripts its own commit happened to edit — and those are precisely the two that fail on a missing file. The next release would not have shipped a broken picker, it would have failed outright:

- CI `build-binaries` never compiled `-p otto-emoji` or uploaded it, so the tarball script's `install -Dm755 target/release/otto-emoji` would hit "cannot stat" and break the release job
- `verify-install.sh` checks `/usr/bin/otto-emoji` in three places, so `test-installers` would fail for all three formats
- nothing installed it: absent from PKGBUILD, PKGBUILD-git, PKGBUILD-nightly-bin, the deb assets, the rpm assets and `[package.metadata.aur]`
- meanwhile `otto_config.example.toml` binds Ctrl+period to `otto-emoji`, so every packaged install had a shortcut to a missing binary

Added to all six. Every shipped binary is now present in every packaging surface, and all 27 files `PKGBUILD`'s `package()` installs are shipped by the tarball script.

## The plugins Quick View plays a file with were not declared

`otto-media-worker` builds a `playbin3`. GStreamer plugins are dlopened, so neither `dpkg-shlibdeps` nor rpm's autodeps can see them — they have to be named by hand, and only `otto-rdp`'s were.

- deb and rpm gain `plugins-good` (MP4, Matroska) and `libav` (H.264, AAC) in `recommends`
- Arch gains `gst-plugins-base` in `optdepends`: `depends` named `gst-plugins-base-libs`, which is the library Otto links, not the package carrying the `playbin` element it loads
- `[package.metadata.aur]` had no GStreamer at all, disagreeing with the PKGBUILDs beside it; it now matches

Kept as recommends/optdepends, matching how the RDP plugins are already treated: the desktop works without them, only playback does not.

`gstreamer1-libav` is in RPM Fusion on Fedora — a weak dependency on a package no enabled repository carries is ignored rather than fatal.

## Verifying

The packaging jobs only run on merge to main, never on PRs, so CI here will not exercise any of it. Checked locally instead: `cargo metadata` parses, the workflow YAML parses, all three PKGBUILDs pass `bash -n`, and a script cross-checking the tarball against `package()` reports nothing missing.