### PR TITLE
feat(files): a command palette, dry runs and scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           # The file browser and the two crates only it links (verified with
           # `cargo tree -p otto-files --depth 1`). Its unit tests are the
           # largest suite in the workspace, so they run only when it changed.
-          FILES='^components/(otto-files|otto-quickview|otto-media-kit)/'
+          BROWSER='^components/(otto-files|otto-quickview|otto-media-kit)/'
           PACKAGING='^PKGBUILD|^(Cargo\.toml)$|^(resources|scripts)/|^\.github/workflows/ci\.yml$'
 
           shared=false; matches "$SHARED" && shared=true
@@ -103,7 +103,7 @@ jobs:
           if $shared || $kit || echo "$FILES" | grep -qP "$UI"; then ui=true; else ui=false; fi
           echo "ui=$ui" >> "$GITHUB_OUTPUT"
 
-          if $shared || $kit || matches "$FILES"; then files=true; else files=false; fi
+          if $shared || $kit || matches "$BROWSER"; then files=true; else files=false; fi
           echo "files=$files" >> "$GITHUB_OUTPUT"
 
           if matches "$PACKAGING"; then packaging=true; else packaging=false; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       portal: ${{ steps.filter.outputs.portal }}
       packaging: ${{ steps.filter.outputs.packaging }}
       rust: ${{ steps.filter.outputs.rust }}
+      files: ${{ steps.filter.outputs.files }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -76,6 +77,10 @@ jobs:
           PORTAL='^components/xdg-desktop-portal-otto/'
           # Every component except the two with their own filters above.
           UI='^components/(?!otto-rdp/|xdg-desktop-portal-otto/)|^sample-clients/'
+          # The file browser and the two crates only it links (verified with
+          # `cargo tree -p otto-files --depth 1`). Its unit tests are the
+          # largest suite in the workspace, so they run only when it changed.
+          FILES='^components/(otto-files|otto-quickview|otto-media-kit)/'
           PACKAGING='^PKGBUILD|^(Cargo\.toml)$|^(resources|scripts)/|^\.github/workflows/ci\.yml$'
 
           shared=false; matches "$SHARED" && shared=true
@@ -98,13 +103,16 @@ jobs:
           if $shared || $kit || echo "$FILES" | grep -qP "$UI"; then ui=true; else ui=false; fi
           echo "ui=$ui" >> "$GITHUB_OUTPUT"
 
+          if $shared || $kit || matches "$FILES"; then files=true; else files=false; fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
           if matches "$PACKAGING"; then packaging=true; else packaging=false; fi
           echo "packaging=$packaging" >> "$GITHUB_OUTPUT"
 
           if $compositor || $ui || $rdp || $portal; then rust=true; else rust=false; fi
           echo "rust=$rust" >> "$GITHUB_OUTPUT"
 
-          echo "--- compositor=$compositor ui=$ui rdp=$rdp portal=$portal packaging=$packaging rust=$rust"
+          echo "--- compositor=$compositor ui=$ui files=$files rdp=$rdp portal=$portal packaging=$packaging rust=$rust"
 
   format:
     runs-on: ubuntu-24.04
@@ -172,8 +180,13 @@ jobs:
       - name: Run tests
         timeout-minutes: 20
         # otto-rdp is bin-only, so this never covers it — see the RDP step.
+        # otto-files has its own step below, gated on its own paths.
         if: needs.changes.outputs.compositor == 'true' || needs.changes.outputs.ui == 'true'
-        run: cargo test --locked --lib --workspace
+        run: cargo test --locked --lib --workspace --exclude otto-files
+      - name: Run file browser tests
+        timeout-minutes: 15
+        if: needs.changes.outputs.files == 'true'
+        run: cargo test --locked --lib -p otto-files
       - name: Run headless integration tests
         timeout-minutes: 15
         if: needs.changes.outputs.compositor == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5171,6 +5171,7 @@ dependencies = [
  "otto-media-kit",
  "otto-quickview",
  "serde",
+ "serde_json",
  "skia-safe",
  "smithay-client-toolkit",
  "tokio",

--- a/components/otto-files/Cargo.toml
+++ b/components/otto-files/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["full"] }
 # The sidebar's user configuration; see `places_config`.
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
+serde_json = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 

--- a/components/otto-files/scripts/unzip
+++ b/components/otto-files/scripts/unzip
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Extract the selected zip archives, each into a folder of its own.
+
+A sample script for Otto Files' command palette. Copy it to
+~/.config/otto/files-scripts/ and it shows up as "Extract Archive" whenever
+every selected item is a .zip. The protocol is described at the top of
+components/otto-files/src/scripts.rs.
+
+    unzip describe          what this script offers, once, at startup
+    unzip preview < json    what a run would do — nothing is touched
+    unzip run < json        do it, and say what changed
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def describe():
+    return {
+        "commands": [
+            {
+                "id": "extract",
+                "title": "Extract Archive",
+                "keywords": ["unzip", "unpack", "decompress", "expand"],
+                "group": "file",
+                "when": {"targets": "some", "extensions": ["zip"], "kinds": "files"},
+                "arg": {
+                    "prompt": "Extract into",
+                    "label": "folder",
+                    "placeholder": "{stem}",
+                    "initial": "{stem}",
+                    "preview": True,
+                },
+                "undo": "Extract",
+            }
+        ]
+    }
+
+
+def plan(request):
+    """One (archive, folder, conflict) per target. The argument is a pattern
+    so that several archives can each get their own folder: `{stem}` is the
+    archive's name without `.zip`, `{n}` counts from 1."""
+    pattern = (request.get("arg") or "").strip() or "{stem}"
+    directory = request["situation"]["path"]
+    out = []
+    seen = set()
+    for n, archive in enumerate(request["targets"], start=1):
+        stem = os.path.splitext(os.path.basename(archive))[0]
+        name = pattern.replace("{stem}", stem).replace("{n}", str(n))
+        folder = os.path.join(directory, name)
+        conflict = os.path.exists(folder) or "/" in name or folder in seen
+        seen.add(folder)
+        out.append((archive, folder, conflict))
+    return out
+
+
+def preview(request):
+    plans = plan(request)
+    rows = [
+        {
+            "from": os.path.basename(archive),
+            "to": os.path.basename(folder) + "/",
+            "conflict": conflict,
+        }
+        for archive, folder, conflict in plans
+    ]
+    conflicts = sum(1 for _, _, c in plans if c)
+    if conflicts:
+        note = f"{conflicts} folder{'s' if conflicts != 1 else ''} already there"
+    else:
+        note = f"Extracts {len(plans)} archive{'s' if len(plans) != 1 else ''}"
+    return {"rows": rows, "note": note}
+
+
+def run(request):
+    plans = plan(request)
+    if any(conflict for _, _, conflict in plans):
+        sys.exit(preview(request)["note"])
+    changes = []
+    for archive, folder, _ in plans:
+        result = subprocess.run(
+            ["unzip", "-q", "-d", folder, archive],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            sys.exit((result.stderr or result.stdout).strip() or "unzip failed")
+        changes.append({"kind": "created", "path": folder})
+    count = len(plans)
+    return {
+        "status": f"Extracted {count} archive{'s' if count != 1 else ''}",
+        "changes": changes,
+        "reload": True,
+    }
+
+
+def main():
+    verb = sys.argv[1] if len(sys.argv) > 1 else ""
+    if verb == "describe":
+        out = describe()
+    elif verb in ("preview", "run"):
+        request = json.load(sys.stdin)
+        out = preview(request) if verb == "preview" else run(request)
+    else:
+        sys.exit(f"usage: {sys.argv[0]} describe|preview|run")
+    json.dump(out, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/otto-files/scripts/unzip
+++ b/components/otto-files/scripts/unzip
@@ -16,24 +16,75 @@ import os
 import subprocess
 import sys
 
+# What the script says, per language; see the zip sample for how the host
+# and the script share the choosing.
+STRINGS = {
+    "en": {
+        "title": "Extract Archive",
+        "keywords": ["unzip", "unpack", "decompress", "expand"],
+        "prompt": "Extract into",
+        "label": "folder",
+        "undo": "Extract",
+        "taken": "{count} folder already there",
+        "taken_many": "{count} folders already there",
+        "extracts": "Extracts {count} archive",
+        "extracts_many": "Extracts {count} archives",
+        "done": "Extracted {count} archive",
+        "done_many": "Extracted {count} archives",
+    },
+    "it": {
+        "title": "Estrai archivio",
+        "keywords": ["unzip", "decomprimi", "scompatta", "espandi"],
+        "prompt": "Estrai in",
+        "label": "cartella",
+        "undo": "Estrazione",
+        "taken": "{count} cartella esiste già",
+        "taken_many": "{count} cartelle esistono già",
+        "extracts": "Estrae {count} archivio",
+        "extracts_many": "Estrae {count} archivi",
+        "done": "Estratto {count} archivio",
+        "done_many": "Estratti {count} archivi",
+    },
+}
+
+
+def strings(locale):
+    tag = (locale or "en").replace("_", "-").lower()
+    for candidate in (tag, tag.split("-")[0], "en"):
+        for key in STRINGS:
+            if key.lower() == candidate:
+                return STRINGS[key]
+    return STRINGS["en"]
+
+
+def tr(request, key, count=1, **args):
+    table = strings(request.get("locale") or os.environ.get("OTTO_LOCALE"))
+    if count != 1 and key + "_many" in table:
+        key += "_many"
+    return table[key].format(count=count, **args)
+
+
+def by_locale(key):
+    return {tag: table[key] for tag, table in STRINGS.items()}
+
 
 def describe():
     return {
         "commands": [
             {
                 "id": "extract",
-                "title": "Extract Archive",
-                "keywords": ["unzip", "unpack", "decompress", "expand"],
+                "title": by_locale("title"),
+                "keywords": by_locale("keywords"),
                 "group": "file",
                 "when": {"targets": "some", "extensions": ["zip"], "kinds": "files"},
                 "arg": {
-                    "prompt": "Extract into",
-                    "label": "folder",
+                    "prompt": by_locale("prompt"),
+                    "label": by_locale("label"),
                     "placeholder": "{stem}",
                     "initial": "{stem}",
                     "preview": True,
                 },
-                "undo": "Extract",
+                "undo": by_locale("undo"),
             }
         ]
     }
@@ -69,9 +120,9 @@ def preview(request):
     ]
     conflicts = sum(1 for _, _, c in plans if c)
     if conflicts:
-        note = f"{conflicts} folder{'s' if conflicts != 1 else ''} already there"
+        note = tr(request, "taken", count=conflicts)
     else:
-        note = f"Extracts {len(plans)} archive{'s' if len(plans) != 1 else ''}"
+        note = tr(request, "extracts", count=len(plans))
     return {"rows": rows, "note": note}
 
 
@@ -91,7 +142,7 @@ def run(request):
         changes.append({"kind": "created", "path": folder})
     count = len(plans)
     return {
-        "status": f"Extracted {count} archive{'s' if count != 1 else ''}",
+        "status": tr(request, "done", count=count),
         "changes": changes,
         "reload": True,
     }

--- a/components/otto-files/scripts/unzip
+++ b/components/otto-files/scripts/unzip
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Extract the selected zip archives, each into a folder of its own.
+"""Extract the selected zip archives, each into a folder named after it.
 
 A sample script for Otto Files' command palette. Copy it to
 ~/.config/otto/files-scripts/ and it shows up as "Extract Archive" whenever
-every selected item is a .zip. The protocol is described at the top of
-components/otto-files/src/scripts.rs.
+every selected item is a .zip. It asks nothing: Return extracts "Holiday.zip"
+into "Holiday/", and refuses when that folder is already there. The protocol
+is described at the top of components/otto-files/src/scripts.rs.
 
     unzip describe          what this script offers, once, at startup
     unzip preview < json    what a run would do — nothing is touched
@@ -22,8 +23,6 @@ STRINGS = {
     "en": {
         "title": "Extract Archive",
         "keywords": ["unzip", "unpack", "decompress", "expand"],
-        "prompt": "Extract into",
-        "label": "folder",
         "undo": "Extract",
         "taken": "{count} folder already there",
         "taken_many": "{count} folders already there",
@@ -35,8 +34,6 @@ STRINGS = {
     "it": {
         "title": "Estrai archivio",
         "keywords": ["unzip", "decomprimi", "scompatta", "espandi"],
-        "prompt": "Estrai in",
-        "label": "cartella",
         "undo": "Estrazione",
         "taken": "{count} cartella esiste già",
         "taken_many": "{count} cartelle esistono già",
@@ -77,13 +74,6 @@ def describe():
                 "keywords": by_locale("keywords"),
                 "group": "file",
                 "when": {"targets": "some", "extensions": ["zip"], "kinds": "files"},
-                "arg": {
-                    "prompt": by_locale("prompt"),
-                    "label": by_locale("label"),
-                    "placeholder": "{stem}",
-                    "initial": "{stem}",
-                    "preview": True,
-                },
                 "undo": by_locale("undo"),
             }
         ]
@@ -91,18 +81,15 @@ def describe():
 
 
 def plan(request):
-    """One (archive, folder, conflict) per target. The argument is a pattern
-    so that several archives can each get their own folder: `{stem}` is the
-    archive's name without `.zip`, `{n}` counts from 1."""
-    pattern = (request.get("arg") or "").strip() or "{stem}"
+    """One (archive, folder, conflict) per target: each archive goes into a
+    folder named after it, next to it."""
     directory = request["situation"]["path"]
     out = []
     seen = set()
-    for n, archive in enumerate(request["targets"], start=1):
+    for archive in request["targets"]:
         stem = os.path.splitext(os.path.basename(archive))[0]
-        name = pattern.replace("{stem}", stem).replace("{n}", str(n))
-        folder = os.path.join(directory, name)
-        conflict = os.path.exists(folder) or "/" in name or folder in seen
+        folder = os.path.join(directory, stem)
+        conflict = os.path.exists(folder) or folder in seen
         seen.add(folder)
         out.append((archive, folder, conflict))
     return out

--- a/components/otto-files/scripts/zip
+++ b/components/otto-files/scripts/zip
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Compress the selection into a zip archive.
+
+A sample script for Otto Files' command palette. Copy it to
+~/.config/otto/files-scripts/ and it shows up as "Compress to Zip" whenever
+something is selected. The protocol is described at the top of
+components/otto-files/src/scripts.rs.
+
+    zip describe          what this script offers, once, at startup
+    zip preview < json    what a run would do — nothing is touched
+    zip run < json        do it, and say what changed
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def describe():
+    return {
+        "commands": [
+            {
+                "id": "compress",
+                "title": "Compress to Zip",
+                "keywords": ["archive", "zip", "pack"],
+                "group": "file",
+                "when": {"targets": "some"},
+                "arg": {
+                    "prompt": "Archive name",
+                    "label": "name",
+                    "placeholder": "Archive.zip",
+                    "initial": "{stem}.zip",
+                    "preview": True,
+                },
+                "undo": "Compress",
+            }
+        ]
+    }
+
+
+def archive_name(request):
+    """The archive the argument names. `{stem}` is the first target's name
+    without its extension, or the folder's name when several are selected,
+    which is what a person means by "zip these"."""
+    targets = request["targets"]
+    if len(targets) == 1:
+        stem = os.path.splitext(os.path.basename(targets[0]))[0]
+    else:
+        stem = os.path.basename(request["situation"]["path"]) or "Archive"
+    name = (request.get("arg") or "").strip() or "{stem}.zip"
+    name = name.replace("{stem}", stem).replace("{count}", str(len(targets)))
+    if not name.lower().endswith(".zip"):
+        name += ".zip"
+    return name
+
+
+def plan(request):
+    name = archive_name(request)
+    directory = request["situation"]["path"]
+    destination = os.path.join(directory, name)
+    conflict = os.path.exists(destination) or "/" in name
+    return name, destination, conflict
+
+
+def preview(request):
+    name, _, conflict = plan(request)
+    rows = [
+        {"from": os.path.basename(t), "to": name, "conflict": conflict}
+        for t in request["targets"]
+    ]
+    count = len(rows)
+    if conflict:
+        note = f"“{name}” is already there"
+    else:
+        note = f"{count} item{'s' if count != 1 else ''} into “{name}”"
+    return {"rows": rows, "note": note}
+
+
+def run(request):
+    name, destination, conflict = plan(request)
+    if conflict:
+        sys.exit(f"“{name}” is already there")
+    directory = request["situation"]["path"]
+    # Paths relative to the listing's directory, so the archive holds
+    # "Photos/a.png" rather than "/home/me/Pictures/Photos/a.png".
+    relative = [os.path.relpath(t, directory) for t in request["targets"]]
+    result = subprocess.run(
+        ["zip", "-r", "-q", "-y", destination, *relative],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit((result.stderr or result.stdout).strip() or "zip failed")
+    count = len(relative)
+    return {
+        "status": f"Compressed {count} item{'s' if count != 1 else ''} into “{name}”",
+        "changes": [{"kind": "created", "path": destination}],
+        "reload": True,
+    }
+
+
+def main():
+    verb = sys.argv[1] if len(sys.argv) > 1 else ""
+    if verb == "describe":
+        out = describe()
+    elif verb in ("preview", "run"):
+        request = json.load(sys.stdin)
+        out = preview(request) if verb == "preview" else run(request)
+    else:
+        sys.exit(f"usage: {sys.argv[0]} describe|preview|run")
+    json.dump(out, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/otto-files/scripts/zip
+++ b/components/otto-files/scripts/zip
@@ -81,7 +81,7 @@ def describe():
                     "prompt": by_locale("prompt"),
                     "label": by_locale("label"),
                     "placeholder": "Archive.zip",
-                    "initial": "{stem}.zip",
+                    "initial": "Archive.zip",
                     "preview": True,
                 },
                 "undo": by_locale("undo"),
@@ -91,16 +91,9 @@ def describe():
 
 
 def archive_name(request):
-    """The archive the argument names. `{stem}` is the first target's name
-    without its extension, or the folder's name when several are selected,
-    which is what a person means by "zip these"."""
-    targets = request["targets"]
-    if len(targets) == 1:
-        stem = os.path.splitext(os.path.basename(targets[0]))[0]
-    else:
-        stem = os.path.basename(request["situation"]["path"]) or "Archive"
-    name = (request.get("arg") or "").strip() or "{stem}.zip"
-    name = name.replace("{stem}", stem).replace("{count}", str(len(targets)))
+    """The archive the argument names — "Archive.zip" when nothing is
+    typed, and always a .zip."""
+    name = (request.get("arg") or "").strip() or "Archive.zip"
     if not name.lower().endswith(".zip"):
         name += ".zip"
     return name
@@ -115,11 +108,11 @@ def plan(request):
 
 
 def preview(request):
+    # Every target lands in the one archive, so the rows only name what goes
+    # in — no arrow, nothing per row to be wrong — and the note says where,
+    # or that the name is taken.
     name, _, conflict = plan(request)
-    rows = [
-        {"from": os.path.basename(t), "to": name, "conflict": conflict}
-        for t in request["targets"]
-    ]
+    rows = [{"from": os.path.basename(t)} for t in request["targets"]]
     count = len(rows)
     if conflict:
         note = tr(request, "exists", name=name)

--- a/components/otto-files/scripts/zip
+++ b/components/otto-files/scripts/zip
@@ -16,24 +16,75 @@ import os
 import subprocess
 import sys
 
+# What the script says, per language. `describe` hands the whole table over
+# and the host picks; at preview and run time the host says which locale it
+# is in (OTTO_LOCALE, and "locale" in the request) and `tr` picks here.
+STRINGS = {
+    "en": {
+        "title": "Compress to Zip",
+        "keywords": ["archive", "zip", "pack"],
+        "prompt": "Archive name",
+        "label": "name",
+        "undo": "Compress",
+        "exists": "“{name}” is already there",
+        "into": "{count} item into “{name}”",
+        "into_many": "{count} items into “{name}”",
+        "done": "Compressed {count} item into “{name}”",
+        "done_many": "Compressed {count} items into “{name}”",
+    },
+    "it": {
+        "title": "Comprimi in Zip",
+        "keywords": ["archivio", "zip", "comprimi"],
+        "prompt": "Nome dell’archivio",
+        "label": "nome",
+        "undo": "Compressione",
+        "exists": "“{name}” esiste già",
+        "into": "{count} elemento in “{name}”",
+        "into_many": "{count} elementi in “{name}”",
+        "done": "Compresso {count} elemento in “{name}”",
+        "done_many": "Compressi {count} elementi in “{name}”",
+    },
+}
+
+
+def strings(locale):
+    """The table for a locale: exact, then its language, then English."""
+    tag = (locale or "en").replace("_", "-").lower()
+    for candidate in (tag, tag.split("-")[0], "en"):
+        for key in STRINGS:
+            if key.lower() == candidate:
+                return STRINGS[key]
+    return STRINGS["en"]
+
+
+def tr(request, key, count=1, **args):
+    table = strings(request.get("locale") or os.environ.get("OTTO_LOCALE"))
+    if count != 1 and key + "_many" in table:
+        key += "_many"
+    return table[key].format(count=count, **args)
+
+
+def by_locale(key):
+    return {tag: table[key] for tag, table in STRINGS.items()}
+
 
 def describe():
     return {
         "commands": [
             {
                 "id": "compress",
-                "title": "Compress to Zip",
-                "keywords": ["archive", "zip", "pack"],
+                "title": by_locale("title"),
+                "keywords": by_locale("keywords"),
                 "group": "file",
                 "when": {"targets": "some"},
                 "arg": {
-                    "prompt": "Archive name",
-                    "label": "name",
+                    "prompt": by_locale("prompt"),
+                    "label": by_locale("label"),
                     "placeholder": "Archive.zip",
                     "initial": "{stem}.zip",
                     "preview": True,
                 },
-                "undo": "Compress",
+                "undo": by_locale("undo"),
             }
         ]
     }
@@ -71,16 +122,16 @@ def preview(request):
     ]
     count = len(rows)
     if conflict:
-        note = f"“{name}” is already there"
+        note = tr(request, "exists", name=name)
     else:
-        note = f"{count} item{'s' if count != 1 else ''} into “{name}”"
+        note = tr(request, "into", count=count, name=name)
     return {"rows": rows, "note": note}
 
 
 def run(request):
     name, destination, conflict = plan(request)
     if conflict:
-        sys.exit(f"“{name}” is already there")
+        sys.exit(tr(request, "exists", name=name))
     directory = request["situation"]["path"]
     # Paths relative to the listing's directory, so the archive holds
     # "Photos/a.png" rather than "/home/me/Pictures/Photos/a.png".
@@ -95,7 +146,7 @@ def run(request):
         sys.exit((result.stderr or result.stdout).strip() or "zip failed")
     count = len(relative)
     return {
-        "status": f"Compressed {count} item{'s' if count != 1 else ''} into “{name}”",
+        "status": tr(request, "done", count=count, name=name),
         "changes": [{"kind": "created", "path": destination}],
         "reload": True,
     }

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3749,9 +3749,9 @@ impl Browser {
             // standing; the palette says so in its note rather than as an
             // error, since a half-typed pattern is not wrong.
             let _ = self.select_matching(&typed);
-            let note = self
-                .path_bar_note()
-                .unwrap_or_else(|| otto_kit::t_owned!("files-nothing-matches"));
+            let note = self.path_bar_note().unwrap_or_else(|| {
+                otto_kit::t_owned!("files-nothing-matches", pattern = typed.as_str())
+            });
             if let Some(palette) = self.palette.as_mut() {
                 palette.set_note(Some(note));
             }
@@ -4155,9 +4155,16 @@ impl Browser {
                             conflict: line.conflict,
                             excluded: line.excluded,
                         },
-                        title: line.to.clone(),
+                        // A line in the run that names no outcome — "these
+                        // go in" — is just the name; there is no arrow to
+                        // draw. A line toggled out keeps its shape.
+                        title: if line.to.is_empty() && !line.excluded {
+                            line.from.clone()
+                        } else {
+                            line.to.clone()
+                        },
                         badge: None,
-                        subtitle: Some(line.from.clone()),
+                        subtitle: (!line.to.is_empty() || line.excluded).then(|| line.from.clone()),
                         shortcut: None,
                         highlighted: highlight == Some(index),
                     }
@@ -8002,8 +8009,24 @@ impl FilesApp {
         if browser.palette_auto.is_none() || browser.visible(depth).is_empty() {
             return;
         }
+        // Scripts describe themselves in the background, and the palette
+        // offers what has answered when it opens — so a query typed this
+        // early would miss them; a script's run lands later too, and the
+        // Undo it leaves behind is only offered once it has. Wait for a
+        // later pass; a person cannot press Ctrl+P that soon.
+        if !browser.commands.settled() {
+            return;
+        }
+        // One segment per pass, so the wait above holds between them as well.
         let query = browser.palette_auto.take().unwrap_or_default();
-        browser.columns[depth].cursor = Some(0);
+        let (segment, rest) = match query.split_once('|') {
+            Some((segment, rest)) => (segment.to_owned(), Some(rest.to_owned())),
+            None => (query, None),
+        };
+        browser.palette_auto = rest;
+        if browser.columns[depth].cursor.is_none() {
+            browser.columns[depth].cursor = Some(0);
+        }
         let mods = KeyMods {
             shift: false,
             ctrl: false,
@@ -8014,31 +8037,27 @@ impl FilesApp {
         // newline is Return, which runs the command; and `|` opens the palette
         // again for another go — `$'select m\t*\n|rename\tHoliday {n}'`
         // selects everything and then shows the rename's dry run on it.
-        for segment in query.split('|') {
-            if browser.palette.is_none() {
-                browser.open_palette();
-            }
-            if segment == "1" {
-                continue;
-            }
-            for ch in segment.chars() {
-                let key = match ch {
-                    '\t' => palette::Key::Tab,
-                    '\n' => palette::Key::Enter,
-                    '\u{1b}' => palette::Key::Escape,
-                    '\u{2193}' => palette::Key::Down,
-                    '\u{2191}' => palette::Key::Up,
-                    ch => palette::Key::Edit(TextInputKey::Char(ch)),
-                };
-                let Some(outcome) = browser
-                    .palette
-                    .as_mut()
-                    .map(|palette| palette.on_key(key, mods))
-                else {
-                    break;
-                };
-                browser.settle_palette(outcome, 0);
-            }
+        if browser.palette.is_none() {
+            browser.open_palette();
+        }
+        let keys = if segment == "1" { "" } else { segment.as_str() };
+        for ch in keys.chars() {
+            let key = match ch {
+                '\t' => palette::Key::Tab,
+                '\n' => palette::Key::Enter,
+                '\u{1b}' => palette::Key::Escape,
+                '\u{2193}' => palette::Key::Down,
+                '\u{2191}' => palette::Key::Up,
+                ch => palette::Key::Edit(TextInputKey::Char(ch)),
+            };
+            let Some(outcome) = browser
+                .palette
+                .as_mut()
+                .map(|palette| palette.on_key(key, mods))
+            else {
+                break;
+            };
+            browser.settle_palette(outcome, 0);
         }
         browser.dirty = true;
     }
@@ -10516,7 +10535,7 @@ mod palette_tests {
         }
         assert_eq!(
             browser.palette_message().as_deref(),
-            Some(otto_kit::t_owned!("files-nothing-matches").as_str())
+            Some(otto_kit::t_owned!("files-nothing-matches", pattern = "*.pngx").as_str())
         );
         assert!(browser.palette.as_ref().unwrap().error().is_none());
     }

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -6084,6 +6084,14 @@ impl App for FilesApp {
                     .as_ref()
                     .map(|p| p.placeholder())
                     .unwrap_or_default();
+                // The rest of the best answer, shown ahead of the caret in
+                // the field's own size — taking it is the same as having typed
+                // it. Read before the field is borrowed to draw.
+                let suggestion = browser
+                    .palette
+                    .as_ref()
+                    .and_then(|palette| palette.suggestion_tail())
+                    .map(str::to_string);
                 if let Some(palette) = browser.palette.as_mut() {
                     let input = palette.input_mut();
                     input.state.placeholder = placeholder;
@@ -6091,6 +6099,17 @@ impl App for FilesApp {
                     canvas.save();
                     canvas.translate((field.left + lead, field.top));
                     input.render_at(canvas, field.width() - lead, field.height());
+                    if let Some(tail) = suggestion {
+                        // From the caret, in the field's own style: the two
+                        // runs have to read as one line of text, one half of
+                        // it already typed.
+                        let caret = input.caret_rect();
+                        Label::new(tail)
+                            .with_style(input.style.text_style.clone())
+                            .with_color(theme.text_tertiary)
+                            .centered_on(caret.left, field.height() / 2.0)
+                            .render(canvas);
+                    }
                     canvas.restore();
                     palette_caret = caret_in_window(input, (field.left + lead, field.top));
                 }

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
-    command, model, palette, pane_surfaces, perf, picker, quickview, scene, thumbcache, thumbnails,
-    view,
+    command, model, palette, pane_surfaces, perf, picker, quickview, remembered, rename, scene,
+    thumbcache, thumbnails, view,
 };
 
 use std::cell::RefCell;
@@ -447,6 +447,13 @@ struct Browser {
     /// here rather than by the palette because the palette is I/O-free and
     /// clock-free, and a scroll view keeps time.
     palette_scroll: ScrollView,
+    /// Where the palette was last left, as an offset from where it opens, so
+    /// the next open finds it there. Kept for the session always; written to
+    /// the state file as well once the host has handed one over.
+    palette_memory: Option<(f32, f32)>,
+    /// Whether the remembered offset is also kept on disk — set by the host,
+    /// never by a test.
+    palette_memory_on_disk: bool,
     /// The display the palette may be dragged around, in window points, as the
     /// compositor last answered. `None` until it has, and the drag then falls
     /// back to the window's own edges.
@@ -895,12 +902,18 @@ impl Browser {
             palette: None,
             palette_selection: None,
             palette_offset: (0.0, 0.0),
+            palette_memory: None,
+            palette_memory_on_disk: false,
             palette_scroll: ScrollView::new(Rect::new_empty()),
             palette_display: None,
             palette_caret: None,
             palette_drag: None,
             palette_quickview: false,
-            commands: command::Registry::builtin(),
+            commands: {
+                let mut registry = command::Registry::builtin();
+                registry.add(Box::new(rename::RenameProvider));
+                registry
+            },
             path_entry: None,
             typeahead: None,
             pending_restore: false,
@@ -3539,6 +3552,7 @@ impl Browser {
                 .into_iter()
                 .map(|e| e.path)
                 .collect(),
+            siblings: visible.iter().map(|entry| entry.name.clone()).collect(),
             cursor_name: cursor.map(|entry| entry.name.clone()),
             cursor_is_dir: cursor.is_some_and(|entry| entry.is_dir),
             trash: self.trash,
@@ -3581,11 +3595,14 @@ impl Browser {
             commands,
             view::palette_field_style(AppContext::current_theme()),
         ));
-        self.palette_offset = (0.0, 0.0);
+        // Where it was last left, if anywhere — brought back on screen below
+        // in case the window has shrunk since.
+        self.palette_offset = self.palette_memory.unwrap_or_default();
         self.palette_scroll = ScrollView::new(Rect::new_empty());
         self.palette_display = None;
         self.palette_caret = None;
         self.palette_drag = None;
+        self.clamp_palette();
         self.dirty = true;
     }
 
@@ -3642,6 +3659,29 @@ impl Browser {
         };
         self.restore_palette_selection();
         if typed.trim().is_empty() {
+            if let Some(palette) = self.palette.as_mut() {
+                palette.set_preview(Vec::new());
+            }
+            self.dirty = true;
+            return;
+        }
+        // A provider's command: ask it for the dry run and show that.
+        if command::Request::new(id.clone(), None)
+            .namespace()
+            .is_some()
+        {
+            let situation = self.situation();
+            let request = command::Request::new(id, Some(typed));
+            let preview = self.commands.preview(&request, &situation);
+            if let Some(palette) = self.palette.as_mut() {
+                match preview {
+                    Some(preview) => {
+                        palette.set_preview(preview.rows);
+                        palette.set_note(preview.note);
+                    }
+                    None => palette.set_preview(Vec::new()),
+                }
+            }
             self.dirty = true;
             return;
         }
@@ -3833,6 +3873,7 @@ impl Browser {
     /// palette back, mutably, to render its text field into the same canvas.
     fn palette_frame(&mut self) -> Option<pane_surfaces::PaletteFrame> {
         self.palette.as_ref()?;
+        self.clamp_palette();
         let rows = self.palette_layout();
         let message = self.palette_message();
         let prompt = self.palette.as_ref().and_then(|p| p.prompt());
@@ -3934,6 +3975,52 @@ impl Browser {
         self.dirty = true;
     }
 
+    /// Keep the card inside the bounds it may be dragged around: a remembered
+    /// position from a larger window, or a display answer that has just
+    /// arrived, may otherwise leave it out of reach.
+    fn clamp_palette(&mut self) {
+        if self.palette.is_none() {
+            return;
+        }
+        let card = self.palette_card();
+        let resting = (
+            card.left - self.palette_offset.0,
+            card.top - self.palette_offset.1,
+        );
+        let bounds = self.palette_bounds();
+        let left = card
+            .left
+            .clamp(bounds.left, (bounds.right - card.width()).max(bounds.left));
+        let top = card.top.clamp(
+            bounds.top,
+            (bounds.bottom - view::PALETTE_FIELD_H).max(bounds.top),
+        );
+        let offset = (left - resting.0, top - resting.1);
+        if offset != self.palette_offset {
+            self.palette_offset = offset;
+            self.dirty = true;
+        }
+    }
+
+    /// The card has been let go of: it stays where it is, and the next open
+    /// finds it there.
+    fn palette_dropped(&mut self) {
+        self.palette_memory = Some(self.palette_offset);
+        if self.palette_memory_on_disk {
+            let mut remembered = remembered::Remembered::load();
+            remembered.palette.offset = Some(self.palette_offset);
+            remembered.save();
+        }
+        self.dirty = true;
+    }
+
+    /// Take on what was remembered from the last run, and remember on disk
+    /// from here on.
+    pub fn remember(&mut self, remembered: &remembered::Remembered) {
+        self.palette_memory = remembered.palette.offset;
+        self.palette_memory_on_disk = true;
+    }
+
     /// How far the palette may be dragged, in window points: the display when
     /// the compositor has said where it is, and the window until then.
     fn palette_bounds(&self) -> Rect {
@@ -3989,6 +4076,19 @@ impl Browser {
                         subtitle: completion.subtitle.clone(),
                         shortcut: None,
                         highlighted: highlight == Some(index),
+                    }
+                }
+                palette::Row::Preview(line) => {
+                    let line = &palette.preview()[*line];
+                    PaletteRowData {
+                        kind: view::PaletteRowKind::Preview {
+                            conflict: line.conflict,
+                        },
+                        title: line.to.clone(),
+                        badge: None,
+                        subtitle: Some(line.from.clone()),
+                        shortcut: None,
+                        highlighted: false,
                     }
                 }
             })
@@ -4125,6 +4225,23 @@ impl Browser {
         std::mem::take(&mut self.palette_quickview)
     }
 
+    /// Take on board what a provider's command did: the status line, the undo
+    /// entry, the re-read. The one place a provider's outcome touches the
+    /// window, so a provider in another process would go through the same
+    /// door.
+    fn apply_effect(&mut self, effect: command::Effect) {
+        if let Some(status) = effect.status {
+            self.status = Some(status);
+        }
+        if let Some(label) = effect.undo_label {
+            self.record_undo(label, effect.changes);
+        }
+        if effect.reload {
+            self.reload_all();
+        }
+        self.dirty = true;
+    }
+
     /// Carry out a request the palette produced.
     ///
     /// The host answers for its own namespace because it is the only thing
@@ -4134,8 +4251,14 @@ impl Browser {
     fn run_request(&mut self, request: &command::Request, serial: u32) -> Result<Followup, String> {
         use command::id;
 
-        if let Some(result) = self.commands.run(request) {
-            return result.map(|()| Followup::Nothing);
+        if request.namespace().is_some() {
+            let situation = self.situation();
+            let effect = self
+                .commands
+                .run(request, &situation)
+                .unwrap_or_else(|| Err(format!("{} has no provider", request.id)))?;
+            self.apply_effect(effect);
+            return Ok(Followup::Nothing);
         }
 
         let arg = request.arg.as_deref().unwrap_or_default().trim();
@@ -7800,27 +7923,39 @@ impl FilesApp {
         }
         let query = browser.palette_auto.take().unwrap_or_default();
         browser.columns[depth].cursor = Some(0);
-        browser.open_palette();
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
         // A value other than a bare "1" is typed in, so a screenshot can be
         // taken of the palette part-way through a query rather than at rest.
-        if query != "1" && !query.is_empty() {
-            let mods = KeyMods {
-                shift: false,
-                ctrl: false,
-            };
-            // A tab in the value is a Tab press, so argument mode can be
-            // looked at too: `OTTO_FILES_PALETTE_AUTO=$'go to path\t/usr/'`.
-            for ch in query.chars() {
+        // A tab is a Tab press, so argument mode can be looked at too; a
+        // newline is Return, which runs the command; and `|` opens the palette
+        // again for another go — `$'select m\t*\n|rename\tHoliday {n}'`
+        // selects everything and then shows the rename's dry run on it.
+        for segment in query.split('|') {
+            if browser.palette.is_none() {
+                browser.open_palette();
+            }
+            if segment == "1" {
+                continue;
+            }
+            for ch in segment.chars() {
                 let key = match ch {
                     '\t' => palette::Key::Tab,
+                    '\n' => palette::Key::Enter,
                     '\u{2193}' => palette::Key::Down,
                     '\u{2191}' => palette::Key::Up,
                     ch => palette::Key::Edit(TextInputKey::Char(ch)),
                 };
-                if let Some(palette) = browser.palette.as_mut() {
-                    palette.on_key(key, mods);
-                }
-                browser.refresh_palette_completions();
+                let Some(outcome) = browser
+                    .palette
+                    .as_mut()
+                    .map(|palette| palette.on_key(key, mods))
+                else {
+                    break;
+                };
+                browser.settle_palette(outcome, 0);
             }
         }
         browser.dirty = true;
@@ -8169,7 +8304,9 @@ impl FilesApp {
                     }
                     // The card stays where it was let go of.
                     PointerEventKind::Release { .. } => {
-                        browser.dirty |= browser.palette_drag.take().is_some();
+                        if browser.palette_drag.take().is_some() {
+                            browser.palette_dropped();
+                        }
                     }
                     PointerEventKind::Axis { vertical, .. } => {
                         browser.palette_wheel(
@@ -9041,6 +9178,7 @@ impl FilesApp {
                     PointerEventKind::Release { .. } => {
                         // The palette stays where it was let go of.
                         if browser.palette_drag.take().is_some() {
+                            browser.palette_dropped();
                             drop(browser);
                             window_for_events.request_frame();
                             continue;
@@ -9555,7 +9693,9 @@ fn app_id() -> &'static str {
 
 /// Open a browser window at `start` and run until it is closed.
 pub fn run_browser(start: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    run_app(Browser::new(start), None)
+    let mut browser = Browser::new(start);
+    browser.remember(&remembered::Remembered::load());
+    run_app(browser, None)
 }
 
 /// Open the Trash window and run until it is closed.
@@ -10299,6 +10439,100 @@ mod palette_tests {
         assert!(browser.palette.as_ref().unwrap().error().is_none());
     }
 
+    /// The whole rename, through the palette: the command is offered for the
+    /// selection, the dry run appears line by line as the pattern is typed
+    /// with its summary under it, a taken name is called out and refused, and
+    /// Return renames everything in one undo step.
+    #[test]
+    fn renaming_a_selection_shows_its_dry_run_and_then_does_it() {
+        let (mut browser, dir) =
+            browser_over(&["IMG_001.jpg", "IMG_002.jpg", "Holiday 2.jpg", "notes.txt"]);
+        browser.clear_selection();
+        browser.select_matching("IMG*").unwrap();
+        browser.open_palette();
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        let type_in = |browser: &mut Browser, text: &str| {
+            for ch in text.chars() {
+                let outcome = browser
+                    .palette
+                    .as_mut()
+                    .unwrap()
+                    .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+                browser.settle_palette(outcome, 0);
+            }
+        };
+        type_in(&mut browser, "rename 2");
+        let outcome = browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .on_key(palette::Key::Tab, mods);
+        browser.settle_palette(outcome, 0);
+        assert!(browser.palette.as_ref().unwrap().prompt().is_some());
+
+        // The initial `{name}` is selected whole; typing replaces it.
+        type_in(&mut browser, "Holiday {n}");
+        let rows = browser.palette_rows();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].title, "Holiday 1.jpg");
+        assert_eq!(rows[0].subtitle.as_deref(), Some("IMG_001.jpg"));
+        assert_eq!(
+            rows[0].kind,
+            view::PaletteRowKind::Preview { conflict: false }
+        );
+        assert_eq!(
+            rows[1].kind,
+            view::PaletteRowKind::Preview { conflict: true },
+            "Holiday 2.jpg is already in the folder"
+        );
+        assert_eq!(
+            browser.palette_message().as_deref(),
+            Some(otto_kit::t_owned!("files-rename-conflicts", count = 1).as_str())
+        );
+        // Return refuses while a name is taken, and nothing has moved.
+        let outcome = browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .on_key(palette::Key::Enter, mods);
+        browser.settle_palette(outcome, 0);
+        assert!(browser.palette.is_some());
+        assert!(dir.0.join("IMG_001.jpg").exists());
+
+        // A pattern that clears: everything renamed, one undo step.
+        for _ in 0..3 {
+            let outcome = browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Backspace), mods);
+            browser.settle_palette(outcome, 0);
+        }
+        type_in(&mut browser, "{n@5}");
+        assert_eq!(
+            browser.palette_message().as_deref(),
+            Some(otto_kit::t_owned!("files-rename-preview", count = 2, total = 2).as_str())
+        );
+        let outcome = browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .on_key(palette::Key::Enter, mods);
+        browser.settle_palette(outcome, 0);
+        assert!(browser.palette.is_none(), "a clean run closes the palette");
+        assert!(dir.0.join("Holiday 5.jpg").exists());
+        assert!(dir.0.join("Holiday 6.jpg").exists());
+        assert!(!dir.0.join("IMG_001.jpg").exists());
+        let undos = browser.undo.len();
+        browser.undo_last();
+        assert_eq!(browser.undo.len(), undos - 1);
+        assert!(dir.0.join("IMG_001.jpg").exists());
+        assert!(dir.0.join("IMG_002.jpg").exists());
+    }
+
     #[test]
     fn select_matching_picks_the_files_the_pattern_names() {
         let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt", "D.PNG"]);
@@ -10734,17 +10968,42 @@ mod palette_tests {
         assert_eq!(browser.palette_display, None);
     }
 
-    /// A fresh open puts it back where it belongs: a panel that reappeared
-    /// wherever it was last left is a placement to undo before the window can
-    /// be read.
+    /// The next open finds the card where it was last left — and brought back
+    /// inside the window if that has shrunk in the meantime.
     #[test]
-    fn the_palette_opens_where_it_belongs_however_it_was_left() {
+    fn the_palette_reopens_where_it_was_left() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        browser.palette_drag = Some((10.0, 10.0));
+        browser.drag_palette_to(400.0, 300.0);
+        browser.palette_dropped();
+        let left_at = browser.palette_card();
+        browser.close_palette();
+
+        browser.open_palette();
+        assert_eq!(browser.palette_card(), left_at);
+        browser.close_palette();
+
+        // A narrower window: still on screen.
+        browser.size = (500.0, 800.0);
+        browser.open_palette();
+        let card = browser.palette_card();
+        assert!(card.right <= 500.0 + 0.5, "clamped into the smaller window");
+        assert!(card.left >= 0.0);
+    }
+
+    #[test]
+    fn a_palette_never_dropped_opens_where_it_belongs() {
         let (mut browser, _dir) = browser_over(&["a.txt"]);
         browser.size = (1200.0, 800.0);
         browser.open_palette();
         let resting = browser.palette_card();
         browser.palette_drag = Some((10.0, 10.0));
         browser.drag_palette_to(400.0, 300.0);
+        // Closed mid-drag, never let go of: nothing to remember.
+        browser.palette_drag = None;
+        browser.palette_memory = None;
         browser.close_palette();
 
         browser.open_palette();

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3636,8 +3636,15 @@ impl Browser {
         }
         if id == command::id::SELECT_MATCHING {
             // A pattern that matches nothing leaves the restored selection
-            // standing and says nothing: it is half-typed, not wrong.
+            // standing; the palette says so in its note rather than as an
+            // error, since a half-typed pattern is not wrong.
             let _ = self.select_matching(&typed);
+            let note = self
+                .path_bar_note()
+                .unwrap_or_else(|| otto_kit::t_owned!("files-nothing-matches"));
+            if let Some(palette) = self.palette.as_mut() {
+                palette.set_note(Some(note));
+            }
         }
         self.dirty = true;
     }
@@ -3953,6 +3960,11 @@ impl Browser {
         let palette = self.palette.as_ref()?;
         if let Some(error) = palette.error() {
             return Some(error.to_string());
+        }
+        // What the argument being typed is doing right now, when the host
+        // has said — the live answer to a previewed pattern.
+        if let Some(note) = palette.note() {
+            return Some(note.to_string());
         }
         // Only about the *command* list. An argument with nothing under it —
         // a name, a pattern, anything free-text — has no completions by
@@ -6006,6 +6018,24 @@ impl Browser {
             .unwrap_or_else(|| path.to_string_lossy().into_owned())
     }
 
+    /// The path bar's caption: how much of the listing is selected, while
+    /// anything is. One item counts too — the header only speaks up past one,
+    /// but the bar is where the selection is read at a glance.
+    fn path_bar_note(&self) -> Option<String> {
+        if self.columns.is_empty() {
+            return None;
+        }
+        let depth = self.active.min(self.columns.len() - 1);
+        let selected = self.columns[depth].selection.len();
+        (selected > 0).then(|| {
+            otto_kit::t_owned!(
+                "files-status-selected",
+                count = selected as i64,
+                total = self.visible_len(depth) as i64
+            )
+        })
+    }
+
     fn subtitle(&self) -> String {
         // A first preview pays D-Bus activation, so this can be visible for a
         // moment. Saying so beats a keystroke that appears to do nothing.
@@ -6206,6 +6236,7 @@ impl Browser {
             path_bar: self.path_crumbs(),
             path_bar_h: self.path_bar_h(),
             path_crumb_hover: self.path_crumb_hover,
+            path_bar_note: self.path_bar_note(),
             path_entry: self.path_entry.is_some(),
             trash: self.trash.then(|| view::TrashChrome {
                 // Put Back acts on the selection; Empty Trash acts on the can.
@@ -10085,6 +10116,69 @@ mod palette_tests {
     }
 
     /// A pattern selects what is on screen, and nothing else.
+    #[test]
+    fn the_path_bar_counts_the_selection() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt"]);
+        browser.clear_selection();
+        assert_eq!(browser.path_bar_note(), None);
+        browser.select_matching("*.png").unwrap();
+        assert_eq!(
+            browser.path_bar_note().as_deref(),
+            Some(otto_kit::t_owned!("files-status-selected", count = 2, total = 3).as_str())
+        );
+    }
+
+    /// Typing a pattern says what it is picking as it goes, and says plainly
+    /// when it picks nothing — in the palette, not as an error.
+    #[test]
+    fn a_previewed_pattern_reports_its_count_in_the_palette() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt"]);
+        browser.clear_selection();
+        browser.open_palette();
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        for ch in "select m".chars() {
+            browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+        }
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .on_key(palette::Key::Tab, mods);
+        assert!(browser.palette.as_ref().unwrap().prompt().is_some());
+        for ch in "*.png".chars() {
+            let outcome = browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+            browser.settle_palette(outcome, 0);
+        }
+        assert_eq!(
+            browser.palette_message().as_deref(),
+            Some(otto_kit::t_owned!("files-status-selected", count = 2, total = 3).as_str())
+        );
+        for ch in "x".chars() {
+            let outcome = browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+            browser.settle_palette(outcome, 0);
+        }
+        assert_eq!(
+            browser.palette_message().as_deref(),
+            Some(otto_kit::t_owned!("files-nothing-matches").as_str())
+        );
+        assert!(browser.palette.as_ref().unwrap().error().is_none());
+    }
+
     #[test]
     fn select_matching_picks_the_files_the_pattern_names() {
         let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt", "D.PNG"]);

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -7177,6 +7177,8 @@ impl FilesApp {
             for ch in query.chars() {
                 let key = match ch {
                     '\t' => palette::Key::Tab,
+                    '\u{2193}' => palette::Key::Down,
+                    '\u{2191}' => palette::Key::Up,
                     ch => palette::Key::Edit(TextInputKey::Char(ch)),
                 };
                 if let Some(palette) = browser.palette.as_mut() {

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -442,6 +442,13 @@ struct Browser {
     /// would be a placement the user has to undo before they can read the
     /// window under it.
     palette_offset: (f32, f32),
+    /// The display the palette may be dragged around, in window points, as the
+    /// compositor last answered. `None` until it has, and the drag then falls
+    /// back to the window's own edges.
+    palette_display: Option<Rect>,
+    /// Where the palette's caret is, in window points, when the card is on a
+    /// surface of its own and so is painted outside the window's draw.
+    palette_caret: Option<(f32, f32, f32, f32)>,
     /// A drag of the palette in progress: where in the card the pointer took
     /// hold, so the card follows the pointer without jumping to centre on it.
     palette_drag: Option<(f32, f32)>,
@@ -567,13 +574,13 @@ struct SelectionMark {
 /// several places — a command's title, its group's label, an argument's name.
 /// Gathering it here keeps the draw closure from having to hold the palette
 /// borrowed while it paints.
-struct PaletteRowData {
-    kind: view::PaletteRowKind,
-    title: String,
-    badge: Option<String>,
-    subtitle: Option<String>,
-    shortcut: Option<String>,
-    highlighted: bool,
+pub struct PaletteRowData {
+    pub kind: view::PaletteRowKind,
+    pub title: String,
+    pub badge: Option<String>,
+    pub subtitle: Option<String>,
+    pub shortcut: Option<String>,
+    pub highlighted: bool,
 }
 
 /// What the host window still has to do after a palette command ran.
@@ -883,6 +890,8 @@ impl Browser {
             palette: None,
             palette_selection: None,
             palette_offset: (0.0, 0.0),
+            palette_display: None,
+            palette_caret: None,
             palette_drag: None,
             palette_quickview: false,
             commands: command::Registry::builtin(),
@@ -3545,6 +3554,8 @@ impl Browser {
             view::palette_field_style(AppContext::current_theme()),
         ));
         self.palette_offset = (0.0, 0.0);
+        self.palette_display = None;
+        self.palette_caret = None;
         self.palette_drag = None;
         self.dirty = true;
     }
@@ -3700,27 +3711,122 @@ impl Browser {
         view::palette_rect(self.size.0, &view_rows, message).with_offset(self.palette_offset)
     }
 
-    /// The band a drag takes hold of: the card's top, where the field is.
+    /// A press at `(x, y)` in window points, while the palette is up.
     ///
-    /// The field rather than a bar of its own — the palette is one card with a
-    /// line of text across the top of it, and a strip above that line would be
-    /// chrome for its own sake.
-    fn palette_grip_at(&mut self, x: f32, y: f32) -> bool {
+    /// The card is a handle and nothing else: a press anywhere on it takes
+    /// hold of it, and a press anywhere else lets the palette go. Rows are not
+    /// clicked — picking is the keyboard's, and a card that is all handle can
+    /// be dragged from wherever it was caught, which is what a card that
+    /// wanders off the window needs.
+    ///
+    /// One method rather than two because the press reaches the browser two
+    /// ways — through the palette's own catcher surface when the card has one,
+    /// and through the toplevel when it is painted into the window — and both
+    /// arrive here in the same coordinates.
+    fn palette_press(&mut self, x: f32, y: f32) {
         let card = self.palette_card();
-        let grip = Rect::from_ltrb(
-            card.left,
-            card.top,
-            card.right,
-            card.top + view::PALETTE_FIELD_H,
+        if card.contains(skia_safe::Point::new(x, y)) {
+            self.palette_drag = Some((x - card.left, y - card.top));
+        } else {
+            // A click outside the card dismisses the palette and stops there,
+            // rather than also selecting whatever file was underneath.
+            self.close_palette();
+        }
+        self.dirty = true;
+    }
+
+    /// Everything the palette's own surface needs, with its text owned.
+    ///
+    /// Owned rather than borrowed because the surface's draw closure needs the
+    /// palette back, mutably, to render its text field into the same canvas.
+    fn palette_frame(&mut self) -> Option<pane_surfaces::PaletteFrame> {
+        self.palette.as_ref()?;
+        let rows = self.palette_rows();
+        let message = self.palette_message();
+        let prompt = self.palette.as_ref().and_then(|p| p.prompt());
+        let view_rows: Vec<view::PaletteRow<'_>> = rows
+            .iter()
+            .map(|row| view::PaletteRow {
+                kind: row.kind,
+                title: &row.title,
+                badge: row.badge.as_deref(),
+                subtitle: row.subtitle.as_deref(),
+                shortcut: row.shortcut.as_deref(),
+                highlighted: row.highlighted,
+            })
+            .collect();
+        let resting = view::palette_rect(self.size.0, &view_rows, message.is_some());
+        drop(view_rows);
+        Some(pane_surfaces::PaletteFrame {
+            resting,
+            card: resting.with_offset(self.palette_offset),
+            prompt,
+            message,
+            rows,
+        })
+    }
+
+    /// Paint the palette's text field, in window points.
+    ///
+    /// Split out of the card's drawing because the field renders itself and so
+    /// needs the palette borrowed mutably, which the card's owned frame
+    /// deliberately does not hold. Records where the caret ended up, since on
+    /// its own surface this runs outside the window's draw and so outside the
+    /// chain that reports it.
+    fn paint_palette_field(&mut self, canvas: &skia_safe::Canvas) {
+        let width = self.size.0;
+        let field = view::palette_field_rect(width);
+        let prompt = self.palette.as_ref().and_then(|p| p.prompt());
+        // The prompt is not part of the field, so the field starts after it:
+        // what is typed is the argument, and the prefix cannot be edited.
+        let lead = prompt
+            .as_deref()
+            .map(|prompt| {
+                otto_kit::typography::styles::BODY_EMPHASIZED
+                    .font()
+                    .measure_str(prompt, None)
+                    .0
+                    + 8.0
+            })
+            .unwrap_or(0.0);
+        let placeholder = self
+            .palette
+            .as_ref()
+            .map(|p| p.placeholder())
+            .unwrap_or_default();
+        let offset = self.palette_offset;
+        let Some(palette) = self.palette.as_mut() else {
+            return;
+        };
+        let input = palette.input_mut();
+        input.state.placeholder = placeholder;
+        input.set_size(field.width() - lead, field.height());
+        let origin = (field.left + lead, field.top);
+        canvas.save();
+        canvas.translate(origin);
+        input.render_at(canvas, field.width() - lead, field.height());
+        canvas.restore();
+        // Reported in window points like every other caret, which stays
+        // meaningful once the card is dragged clear of the window: the offset
+        // says where it went.
+        self.palette_caret = caret_in_window(
+            self.palette.as_ref().expect("checked above").input(),
+            (origin.0 + offset.0, origin.1 + offset.1),
         );
-        grip.contains(skia_safe::Point::new(x, y))
     }
 
     /// Follow the pointer, keeping the card on screen.
     ///
-    /// Clamped against the window rather than let go: a panel dragged off the
-    /// edge is one the user has to guess the way back to, and it holds the
-    /// keyboard while it is gone.
+    /// On its own surface the card may leave the window — that is the point of
+    /// the surface — so the window's edges are no longer the limit. The
+    /// *display's* are: a panel dragged off the screen is one nobody can find
+    /// the way back to, and it holds the keyboard while it is gone.
+    ///
+    /// The client is never told where its own window sits, so where the
+    /// display is has to be asked for; see
+    /// [`pane_surfaces::PaneSurfaces::palette_display`]. Until the answer
+    /// arrives the window stands in for it, which is the old behaviour and
+    /// wrong only in being too strict.
     fn drag_palette_to(&mut self, x: f32, y: f32) {
         let Some((grab_x, grab_y)) = self.palette_drag else {
             return;
@@ -3732,13 +3838,25 @@ impl Browser {
             card.left - self.palette_offset.0,
             card.top - self.palette_offset.1,
         );
-        let left = (x - grab_x).clamp(0.0, (self.size.0 - card.width()).max(0.0));
-        // Never above the window, and never so far down that the field is off
-        // the bottom: the list can hang past the edge, but the line being
-        // typed may not.
-        let top = (y - grab_y).clamp(0.0, (self.size.1 - view::PALETTE_FIELD_H).max(0.0));
+        let bounds = self.palette_bounds();
+        let left = (x - grab_x).clamp(bounds.left, (bounds.right - card.width()).max(bounds.left));
+        // Never above the top edge, and never so far down that the field is
+        // off the bottom: the list may hang past it, but the line being typed
+        // may not.
+        let top = (y - grab_y).clamp(
+            bounds.top,
+            (bounds.bottom - view::PALETTE_FIELD_H).max(bounds.top),
+        );
         self.palette_offset = (left - resting.0, top - resting.1);
         self.dirty = true;
+    }
+
+    /// How far the palette may be dragged, in window points: the display when
+    /// the compositor has said where it is, and the window until then.
+    fn palette_bounds(&self) -> Rect {
+        self.palette_display
+            .filter(|_| pane_surfaces::palette_on_surface())
+            .unwrap_or_else(|| Rect::from_wh(self.size.0, self.size.1))
     }
 
     /// The palette's rows as the view wants them, scrolled so the highlight is
@@ -6150,6 +6268,10 @@ struct FilesApp {
     /// render path for the pointer callback below. See
     /// [`pane_surfaces::PaneSurfaces::quickview_target`].
     quickview_target: Arc<Mutex<Option<(wayland_client::backend::ObjectId, Rect)>>>,
+    /// The palette's surface and where it sits in window points, for the same
+    /// reason Quick View has one: dragged clear of the window, the card is
+    /// over pixels the toplevel is never told about.
+    palette_target: Arc<Mutex<Option<(wayland_client::backend::ObjectId, Rect)>>>,
     /// The picker's request queue, when this process is serving
     /// `org.otto.FilePicker1`. `None` in the browser.
     picker_queue: Option<crate::dbus::SharedQueue>,
@@ -6378,7 +6500,7 @@ impl App for FilesApp {
             // sheet. Its card is drawn from rows gathered first, then the
             // field's text over the box the card left for it — the same
             // two-step the rename and path fields take.
-            if browser.palette.is_some() {
+            if browser.palette.is_some() && !pane_surfaces::palette_on_surface() {
                 let width = browser.size.0;
                 let rows = browser.palette_rows();
                 let message = browser.palette_message();
@@ -6408,6 +6530,7 @@ impl App for FilesApp {
                         prompt: prompt.as_deref(),
                         rows: view_rows,
                         message: message.as_deref(),
+                        on_surface: false,
                     },
                 );
                 canvas.restore();
@@ -6454,6 +6577,11 @@ impl App for FilesApp {
             // the one the keys are going to.
             otto_kit::AppContext::report_text_cursor(
                 palette_caret
+                    .or(browser
+                        .palette
+                        .is_some()
+                        .then_some(browser.palette_caret)
+                        .flatten())
                     .or(rename_caret)
                     .or(path_caret)
                     .or(save_caret)
@@ -6488,6 +6616,9 @@ impl App for FilesApp {
 
         self.install_dnd(&window);
         self.install_quickview_pointer();
+        if pane_surfaces::palette_on_surface() {
+            self.install_palette_pointer();
+        }
         self.install_info_window_pointer();
         self.install_pointer(&window, self.context_menu.clone().unwrap());
         self.install_frame_loop(&window);
@@ -7600,7 +7731,7 @@ impl FilesApp {
         let quickview = browser
             .quickview_visible()
             .map(|session| (session, browser.quickview_generation));
-        let painted = match self.pane_surfaces.as_mut() {
+        let mut painted = match self.pane_surfaces.as_mut() {
             Some(panes) => panes.sync(&parent, &frame, quickview),
             None => false,
         };
@@ -7617,6 +7748,33 @@ impl FilesApp {
             .pane_surfaces
             .as_ref()
             .and_then(pane_surfaces::PaneSurfaces::quickview_target);
+
+        // The palette's card, on its own surface. Synced apart from the rest
+        // because painting it needs the browser back mutably — its field
+        // renders itself — which the `Frame` above cannot allow while it
+        // lives. See `PaneSurfaces::sync_palette`.
+        if pane_surfaces::palette_on_surface() {
+            let theme = browser.theme();
+            let size = browser.size;
+            let palette = browser.palette_frame();
+            // Ask where the display is while the card is up, so a drag knows
+            // how far it may go. The answer is relative to the window, so it
+            // is only worth having for as long as the window stays put.
+            browser.palette_display = self
+                .pane_surfaces
+                .as_mut()
+                .filter(|_| palette.is_some())
+                .and_then(pane_surfaces::PaneSurfaces::palette_display);
+            if let Some(panes) = self.pane_surfaces.as_mut() {
+                painted |= panes.sync_palette(&parent, &theme, size, palette.as_ref(), |canvas| {
+                    browser.paint_palette_field(canvas)
+                });
+            }
+            *self.palette_target.lock().unwrap() = self
+                .pane_surfaces
+                .as_ref()
+                .and_then(pane_surfaces::PaneSurfaces::palette_target);
+        }
         painted
     }
 
@@ -7786,6 +7944,77 @@ impl FilesApp {
             };
             if repaint {
                 window.request_frame();
+            }
+        });
+    }
+
+    /// The palette's card handles its own pointer, for the same reason Quick
+    /// View's does: dragged clear of the window, it sits over pixels the
+    /// toplevel is never told about.
+    ///
+    /// Everything is put back into window points before it is acted on, so the
+    /// card is hit-tested against the same rects it was painted from and a
+    /// click means the same thing whichever surface it arrived on.
+    ///
+    /// A drag continues to arrive here even once the pointer has left the
+    /// card, because a held button holds the pointer to the surface that took
+    /// the press. That is what lets the card keep up with a fast drag instead
+    /// of being dropped the moment the pointer outruns it.
+    fn install_palette_pointer(&self) {
+        let state = Arc::clone(&self.state);
+        let target = Arc::clone(&self.palette_target);
+
+        AppContext::register_pointer_callback(move |events| {
+            for event in events {
+                use smithay_client_toolkit::seat::pointer::PointerEventKind;
+                use wayland_client::Proxy;
+                let trace = std::env::var_os("OTTO_FILES_PALETTE_TRACE").is_some();
+                let Some((surface, rect)) = target.lock().unwrap().clone() else {
+                    if trace {
+                        eprintln!("palette ptr: no target; event on {:?}", event.surface.id());
+                    }
+                    continue;
+                };
+                if event.surface.id() != surface {
+                    if trace {
+                        eprintln!(
+                            "palette ptr: event on {:?} {:?}, catcher is {:?}",
+                            event.surface.id(),
+                            event.kind,
+                            surface
+                        );
+                    }
+                    continue;
+                }
+                // Surface-local, as the compositor reports it, shifted back
+                // into the window points everything else measures in.
+                let x = event.position.0 as f32 + rect.left;
+                let y = event.position.1 as f32 + rect.top;
+                if trace {
+                    eprintln!(
+                        "palette ptr: {:?} local=({:.0},{:.0}) rect={:?} -> window=({x:.0},{y:.0})",
+                        event.kind, event.position.0, event.position.1, rect
+                    );
+                }
+                let mut browser = state.lock().unwrap();
+                if browser.palette.is_none() {
+                    continue;
+                }
+                match event.kind {
+                    PointerEventKind::Press { .. } => {
+                        browser.palette_press(x, y);
+                    }
+                    PointerEventKind::Motion { .. } if browser.palette_drag.is_some() => {
+                        browser.drag_palette_to(x, y);
+                    }
+                    // The card stays where it was let go of.
+                    PointerEventKind::Release { .. } => {
+                        browser.dirty |= browser.palette_drag.take().is_some();
+                    }
+                    _ => {}
+                }
+                drop(browser);
+                AppContext::request_wakeup();
             }
         });
     }
@@ -8793,64 +9022,7 @@ impl FilesApp {
                         // there, rather than also selecting whatever file
                         // happened to be underneath.
                         if browser.palette.is_some() {
-                            // The top band is the handle, so a press there is
-                            // a drag rather than a pick.
-                            if browser.palette_grip_at(x, y) {
-                                let card = browser.palette_card();
-                                browser.palette_drag = Some((x - card.left, y - card.top));
-                                return;
-                            }
-                            let (x, y) = (
-                                x - browser.palette_offset.0,
-                                y - browser.palette_offset.1,
-                            );
-                            let rows = browser.palette_rows();
-                            let view_rows: Vec<view::PaletteRow<'_>> = rows
-                                .iter()
-                                .map(|row| view::PaletteRow {
-                                    kind: row.kind,
-                                    title: &row.title,
-                                    badge: None,
-                                    subtitle: None,
-                                    shortcut: None,
-                                    highlighted: row.highlighted,
-                                })
-                                .collect();
-                            let hit = view::palette_row_at(x, y, width, &view_rows);
-                            let inside = view::palette_rect(
-                                width,
-                                &view_rows,
-                                browser.palette_message().is_some(),
-                            )
-                            .contains(skia_safe::Point::new(x, y));
-                            drop(view_rows);
-                            drop(rows);
-                            match hit {
-                                Some(row) => {
-                                    let picked = browser
-                                        .palette
-                                        .as_mut()
-                                        .is_some_and(|palette| palette.highlight_row(row));
-                                    if picked {
-                                        let mods = KeyMods {
-                                            shift: false,
-                                            ctrl: false,
-                                        };
-                                        if let Some(outcome) = browser
-                                            .palette
-                                            .as_mut()
-                                            .map(|palette| palette.on_key(palette::Key::Enter, mods))
-                                        {
-                                            browser.settle_palette(outcome, serial);
-                                        }
-                                    }
-                                }
-                                None if !inside => {
-                                    browser.close_palette();
-                                }
-                                None => {}
-                            }
-                            browser.dirty = true;
+                            browser.palette_press(x, y);
                             return;
                         }
 
@@ -9350,6 +9522,7 @@ fn run_app(
         modifiers: Arc::new(Mutex::new(Modifiers::default())),
         context_menu: None,
         quickview_target: Arc::new(Mutex::new(None)),
+        palette_target: Arc::new(Mutex::new(None)),
         picker_queue,
     };
 
@@ -10136,15 +10309,35 @@ mod palette_tests {
         assert!(!dir.0.join("reports").exists());
     }
 
-    /// The card follows the pointer, and stays where it is let go of.
+    /// The whole card is a handle: a press anywhere on it — the field, a row,
+    /// the bottom edge — takes hold, and the card then follows the pointer and
+    /// stays where it is let go of. Nothing on it is clicked.
     #[test]
-    fn the_palette_is_dragged_by_its_top_band() {
+    fn the_palette_is_a_handle_all_over() {
         let (mut browser, _dir) = browser_over(&["a.txt"]);
         browser.size = (1200.0, 800.0);
         browser.open_palette();
         let card = browser.palette_card();
-        assert!(browser.palette_grip_at(card.center_x(), card.top + 4.0));
-        assert!(!browser.palette_grip_at(card.center_x(), card.bottom - 4.0));
+        let rows = browser
+            .palette
+            .as_ref()
+            .map(|p| p.rows().len())
+            .unwrap_or(0);
+        assert!(rows > 1, "the resting list should offer something");
+
+        // A press on a row is a grab, not a pick: the highlight does not move
+        // and nothing runs.
+        let before = browser.palette.as_ref().and_then(|p| p.highlighted());
+        browser.palette_press(card.center_x(), card.bottom - 4.0);
+        assert!(browser.palette_drag.is_some());
+        assert!(
+            browser.palette.is_some(),
+            "a press on the card must not close it"
+        );
+        assert_eq!(
+            browser.palette.as_ref().and_then(|p| p.highlighted()),
+            before
+        );
 
         browser.palette_drag = Some((10.0, 10.0));
         browser.drag_palette_to(400.0, 300.0);
@@ -10153,10 +10346,24 @@ mod palette_tests {
         assert_eq!(moved.top, 290.0);
     }
 
+    /// A press anywhere else lets the palette go, and the click is spent on
+    /// that: the selection underneath is exactly what it was.
+    #[test]
+    fn a_press_off_the_palette_closes_it_and_nothing_else() {
+        let (mut browser, _dir) = browser_over(&["a.txt", "b.txt"]);
+        browser.size = (1200.0, 800.0);
+        let selection = browser.columns[0].selection.clone();
+        browser.open_palette();
+        browser.palette_press(20.0, 700.0);
+        assert!(browser.palette.is_none());
+        assert!(browser.palette_drag.is_none());
+        assert_eq!(browser.columns[0].selection, selection);
+    }
+
     /// And cannot be dragged off the window, where it would hold the keyboard
     /// from somewhere the user cannot see.
     #[test]
-    fn the_palette_cannot_be_dragged_off_the_window() {
+    fn the_palette_is_held_to_the_window_until_the_display_is_known() {
         let (mut browser, _dir) = browser_over(&["a.txt"]);
         browser.size = (1200.0, 800.0);
         browser.open_palette();
@@ -10170,6 +10377,51 @@ mod palette_tests {
         let card = browser.palette_card();
         assert!(card.left <= 1200.0 - card.width() + 0.5);
         assert!(card.top <= 800.0 - view::PALETTE_FIELD_H + 0.5);
+    }
+
+    /// On its own surface the card may leave the window — that is what the
+    /// surface is for — but not the display. The window here sits 200 points
+    /// in from the display's left edge, so a card dragged to -100 is off the
+    /// window and still on screen.
+    #[test]
+    fn the_palette_leaves_the_window_but_not_the_display() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        // In window points, so the display starts left of and above the
+        // window's own origin — which is what negative coordinates mean here.
+        browser.palette_display = Some(Rect::from_ltrb(-200.0, -100.0, 1720.0, 980.0));
+        browser.palette_drag = Some((10.0, 10.0));
+
+        browser.drag_palette_to(-100.0, -50.0);
+        let card = browser.palette_card();
+        assert!(card.left < 0.0, "the card should hang off the window");
+        assert!(card.top < 0.0, "the card should rise above the window");
+
+        // And no further than the display.
+        browser.drag_palette_to(-5000.0, -5000.0);
+        let card = browser.palette_card();
+        assert!(card.left >= -200.0 - 0.5);
+        assert!(card.top >= -100.0 - 0.5);
+
+        browser.drag_palette_to(5000.0, 5000.0);
+        let card = browser.palette_card();
+        assert!(card.left <= 1720.0 - card.width() + 0.5);
+        assert!(card.top <= 980.0 - view::PALETTE_FIELD_H + 0.5);
+    }
+
+    /// The answer is relative to the window, so it only means anything for as
+    /// long as the window stays put — one palette session.
+    #[test]
+    fn a_fresh_palette_asks_where_the_display_is_again() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        browser.palette_display = Some(Rect::from_ltrb(-200.0, -100.0, 1720.0, 980.0));
+        browser.close_palette();
+
+        browser.open_palette();
+        assert_eq!(browser.palette_display, None);
     }
 
     /// A fresh open puts it back where it belongs: a panel that reappeared

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1,4 +1,7 @@
-use crate::{model, pane_surfaces, perf, picker, quickview, scene, thumbcache, thumbnails, view};
+use crate::{
+    command, model, palette, pane_surfaces, perf, picker, quickview, scene, thumbcache, thumbnails,
+    view,
+};
 
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -324,6 +327,12 @@ struct Browser {
     /// is both unreliable and rude to whoever is using that desktop.
     /// `OTTO_FILES_QV_AUTO=1`.
     quickview_auto: bool,
+    /// Open the command palette as soon as the window has a listing, so it can
+    /// be looked at without anyone pressing a key. Driving the real keyboard
+    /// means injecting into whatever session the test runs in, which is both
+    /// unreliable and rude to whoever is using that desktop.
+    /// `OTTO_FILES_PALETTE_AUTO=1`, optionally `=<query>` to type one in too.
+    palette_auto: Option<String>,
     /// Bumped for every decode started. A result arriving with a stale
     /// generation is dropped: arrow-keying is much faster than decoding, and a
     /// slow PDF must not land on top of a file the user moved off three keys
@@ -416,6 +425,16 @@ struct Browser {
     /// column's snapshot yet when `new_folder` returns — the pane and the name
     /// are held here until the re-read lands.
     pending_rename: Option<(usize, String)>,
+    /// The command palette, open on Ctrl+P. While it is up it takes the
+    /// keyboard whole; the browser underneath is untouched until a command
+    /// actually runs. See `specs/file-command-palette.md`.
+    palette: Option<palette::Palette>,
+    /// A palette command asked for Quick View. The panel and its decode belong
+    /// to the window around the browser, so the request is left here for it.
+    palette_quickview: bool,
+    /// Where commands come from. The built-ins today, and the seam a later
+    /// extension system hangs off — see [`crate::command`].
+    commands: command::Registry,
     /// The path entry, open on Ctrl+L. While it is up the header's title is
     /// replaced by the field, and every key belongs to it — it is where you
     /// are, made editable, rather than a dialog asking where to go.
@@ -511,6 +530,75 @@ struct Browser {
     /// asking for is this times that — and applying it incrementally instead
     /// would compound rounding across a gesture that can run for seconds.
     quickview_pinch: Option<f32>,
+}
+
+/// One of the palette's rows, with its text owned.
+///
+/// The view draws from borrowed strings, and a row's text is assembled from
+/// several places — a command's title, its group's label, an argument's name.
+/// Gathering it here keeps the draw closure from having to hold the palette
+/// borrowed while it paints.
+struct PaletteRowData {
+    kind: view::PaletteRowKind,
+    title: String,
+    badge: Option<String>,
+    subtitle: Option<String>,
+    shortcut: Option<String>,
+    highlighted: bool,
+}
+
+/// What the host window still has to do after a palette command ran.
+///
+/// Almost everything a command does is the browser's own; Quick View is not —
+/// the panel and its decode belong to the window around the browser, so that
+/// one command is handed back rather than run in place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Followup {
+    Nothing,
+    QuickView,
+}
+
+/// How many path completions the palette is offered at once. A directory can
+/// hold thousands, and a list nobody will scroll costs a syscall each to
+/// stat — see [`Browser::path_completions`].
+const PALETTE_COMPLETION_LIMIT: usize = 64;
+
+/// The stable id a view mode is named by across the command seam. Not the
+/// label: a label is localised, and an id is what a request carries.
+fn view_id(mode: ViewMode) -> &'static str {
+    match mode {
+        ViewMode::List => "list",
+        ViewMode::Grid => "grid",
+        ViewMode::Columns => "columns",
+    }
+}
+
+fn view_from_id(id: &str) -> Option<ViewMode> {
+    match id {
+        "list" => Some(ViewMode::List),
+        "grid" => Some(ViewMode::Grid),
+        "columns" => Some(ViewMode::Columns),
+        _ => None,
+    }
+}
+
+fn sort_id(key: SortKey) -> &'static str {
+    match key {
+        SortKey::Name => "name",
+        SortKey::Size => "size",
+        SortKey::Kind => "kind",
+        SortKey::Modified => "modified",
+    }
+}
+
+fn sort_from_id(id: &str) -> Option<SortKey> {
+    match id {
+        "name" => Some(SortKey::Name),
+        "size" => Some(SortKey::Size),
+        "kind" => Some(SortKey::Kind),
+        "modified" => Some(SortKey::Modified),
+        _ => None,
+    }
 }
 
 /// What a pointer event over the Quick View panel is, as far as the pan's
@@ -763,6 +851,9 @@ impl Browser {
             last_boundary_click: None,
             rename: None,
             pending_rename: None,
+            palette: None,
+            palette_quickview: false,
+            commands: command::Registry::builtin(),
             path_entry: None,
             typeahead: None,
             pending_restore: false,
@@ -789,6 +880,7 @@ impl Browser {
             quickview_pending: false,
             quickview_closing: None,
             quickview_auto: std::env::var_os("OTTO_FILES_QV_AUTO").is_some(),
+            palette_auto: std::env::var("OTTO_FILES_PALETTE_AUTO").ok(),
             quickview_generation: 0,
             quickview_video_painted: 0,
             preview_video_painted: 0,
@@ -1878,6 +1970,11 @@ impl Browser {
     /// keyboard from everything, then the path entry, then the picker's name
     /// field, and the filter strip's query last.
     fn focused_input(&mut self) -> Option<&mut TextInput> {
+        // The palette takes the keyboard whole while it is up, so its field is
+        // the one blinking whatever else is open behind it.
+        if let Some(palette) = self.palette.as_mut() {
+            return Some(palette.input_mut());
+        }
         if let Some(session) = self.rename.as_mut() {
             return Some(&mut session.input);
         }
@@ -2244,39 +2341,55 @@ impl Browser {
             self.dirty = true;
             return;
         }
-        let target = session.original.with_file_name(&new_name);
-        match std::fs::rename(&session.original, &target) {
-            Ok(()) => {
-                if let Some(column) = self.columns.get_mut(session.depth) {
-                    column.selection.clear();
-                    // The renamed file, by its new path: the key moves with
-                    // the file, so remembering the old one would leave the
-                    // selection pointing at something that is not there.
-                    column
-                        .selection
-                        .insert(target.to_string_lossy().into_owned());
-                }
-                self.status = Some(otto_kit::t_owned!(
-                    "files-renamed-to",
-                    name = new_name.as_str()
-                ));
-                self.record_undo(
-                    otto_kit::t!("files-undo-rename"),
-                    vec![model::Change::Moved {
-                        from: session.original.clone(),
-                        to: target.clone(),
-                    }],
-                );
-                self.reload_all();
-            }
-            Err(err) => {
-                self.status = Some(otto_kit::t_owned!(
-                    "files-rename-failed",
-                    error = err.to_string()
-                ));
-            }
+        // The failure is reported in the status line rather than raised: the
+        // field is already gone, so there is nothing left to fix in place.
+        if let Err(error) = self.rename_path(session.depth, &session.original, &new_name) {
+            self.status = Some(error);
+            self.dirty = true;
         }
+    }
+
+    /// Rename `original` to `new_name`, and leave the selection on it.
+    ///
+    /// The one place a rename actually happens — the in-place field and the
+    /// command palette both come through here, so they cannot drift apart over
+    /// what a rename records on the undo stack.
+    fn rename_path(&mut self, depth: usize, original: &Path, new_name: &str) -> Result<(), String> {
+        let new_name = new_name.trim();
+        let old_name = original
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if new_name.is_empty() || new_name == old_name {
+            self.dirty = true;
+            return Ok(());
+        }
+        if new_name.contains('/') {
+            return Err(otto_kit::t_owned!("files-name-invalid"));
+        }
+        let target = original.with_file_name(new_name);
+        std::fs::rename(original, &target)
+            .map_err(|err| otto_kit::t_owned!("files-rename-failed", error = err.to_string()))?;
+        if let Some(column) = self.columns.get_mut(depth) {
+            column.selection.clear();
+            // The renamed file, by its new path: the key moves with the file,
+            // so remembering the old one would leave the selection pointing at
+            // something that is not there.
+            column
+                .selection
+                .insert(target.to_string_lossy().into_owned());
+        }
+        self.status = Some(otto_kit::t_owned!("files-renamed-to", name = new_name));
+        self.record_undo(
+            otto_kit::t!("files-undo-rename"),
+            vec![model::Change::Moved {
+                from: original.to_path_buf(),
+                to: target,
+            }],
+        );
+        self.reload_all();
         self.dirty = true;
+        Ok(())
     }
 
     /// Discard the field's text and leave the file as it was.
@@ -3333,6 +3446,421 @@ impl Browser {
             input.state.set_caret(caret, false);
         }
         self.dirty = true;
+    }
+
+    // -----------------------------------------------------------------------
+    // The command palette — see `specs/file-command-palette.md`
+    // -----------------------------------------------------------------------
+
+    /// The window as a command provider sees it.
+    ///
+    /// A description, not a handle: everything here could be written down and
+    /// sent to a provider in another process, which is what keeps the seam
+    /// worth having.
+    fn situation(&self) -> command::Situation {
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let visible = self.visible(depth);
+        let cursor = self.columns[depth]
+            .cursor
+            .and_then(|index| visible.get(index).copied());
+        command::Situation {
+            path: self.current_directory(),
+            selection: self
+                .selected_entries()
+                .into_iter()
+                .map(|e| e.path)
+                .collect(),
+            cursor_name: cursor.map(|entry| entry.name.clone()),
+            cursor_is_dir: cursor.is_some_and(|entry| entry.is_dir),
+            trash: self.trash,
+            recent: self.recent,
+            can_paste: !self.clipboard.is_empty()
+                || clipboard::first_available(clipboard::file_mime_preference()).is_some(),
+            can_undo: !self.undo.is_empty(),
+            can_go_back: !self.back.is_empty(),
+            can_go_forward: !self.forward.is_empty(),
+            can_go_up: self.current_directory().parent().is_some(),
+            has_entries: !visible.is_empty(),
+            show_hidden: self.show_hidden,
+            view: view_id(self.mode).to_string(),
+            sort: sort_id(self.sort).to_string(),
+            places: self
+                .places
+                .iter()
+                .map(|place| command::PlaceRef {
+                    label: place.label.clone(),
+                    path: place.path.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Ctrl+P. Asks every provider what it can offer *now* and opens onto the
+    /// answer; nothing re-gathers while the palette is up.
+    fn open_palette(&mut self) {
+        let situation = self.situation();
+        let commands = self.commands.commands(&situation);
+        self.palette = Some(palette::Palette::open(
+            commands,
+            view::palette_field_style(AppContext::current_theme()),
+        ));
+        self.dirty = true;
+    }
+
+    /// Close it without running anything. The browser underneath is exactly as
+    /// it was — the palette never changed it by being open.
+    fn close_palette(&mut self) -> bool {
+        let was_open = self.palette.take().is_some();
+        if was_open {
+            self.dirty = true;
+        }
+        was_open
+    }
+
+    /// Fill in what a half-typed path could be completed to.
+    ///
+    /// The palette itself never touches the disk, so this is the host's half
+    /// of the bargain: it is called after every key, and does nothing at all
+    /// unless a path argument is open.
+    fn refresh_palette_completions(&mut self) {
+        let Some(mut palette) = self.palette.take() else {
+            return;
+        };
+        if let Some((typed, dirs_only)) = palette.path_argument() {
+            let completions = self.path_completions(typed, dirs_only);
+            palette.set_completions(completions);
+        }
+        self.palette = Some(palette);
+    }
+
+    /// What `typed` could be completed to, as whole paths.
+    ///
+    /// The same rules the location bar completes by: a bare name resolves
+    /// against the directory on screen, and a dotfile is only a candidate once
+    /// the dot has been typed. The read is synchronous — one directory, on a
+    /// keystroke somebody is waiting on.
+    fn path_completions(&self, typed: &str, dirs_only: bool) -> Vec<palette::Completion> {
+        let (head, prefix) = match typed.rfind('/') {
+            Some(cut) => (&typed[..=cut], &typed[cut + 1..]),
+            None => ("", typed),
+        };
+        let Some(dir) = self.resolve_typed_path(if head.is_empty() { "." } else { head }) else {
+            return Vec::new();
+        };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return Vec::new();
+        };
+        let mut found: Vec<(String, bool)> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let is_dir = entry.file_type().map(|k| k.is_dir()).unwrap_or(false);
+                (name, is_dir)
+            })
+            .filter(|(name, is_dir)| {
+                name.starts_with(prefix)
+                    && (prefix.starts_with('.') || !name.starts_with('.'))
+                    && (!dirs_only || *is_dir)
+            })
+            .collect();
+        found.sort_by(|a, b| model::natural_cmp(&a.0, &b.0));
+        found.truncate(PALETTE_COMPLETION_LIMIT);
+        found
+            .into_iter()
+            .map(|(name, is_dir)| {
+                // A completed directory gains its separator, so Tab walks down
+                // a tree without anyone reaching for `/` between levels.
+                let value = if is_dir {
+                    format!("{head}{name}/")
+                } else {
+                    format!("{head}{name}")
+                };
+                palette::Completion::new(value, name)
+            })
+            .collect()
+    }
+
+    /// The palette's rows as the view wants them, scrolled so the highlight is
+    /// on screen.
+    fn palette_rows(&mut self) -> Vec<PaletteRowData> {
+        let Some(palette) = self.palette.as_mut() else {
+            return Vec::new();
+        };
+        let len = palette.rows().len();
+        let window = view::palette_window(
+            len,
+            palette.highlighted(),
+            palette.scroll(),
+            view::PALETTE_MAX_ROWS,
+        );
+        palette.set_scroll(window.start);
+
+        let palette = self.palette.as_ref().expect("checked above");
+        let highlight = palette.highlighted();
+        let resting = palette.resting();
+        let mut rows: Vec<PaletteRowData> = palette.rows()[window.clone()]
+            .iter()
+            .zip(window)
+            .map(|(row, index)| match row {
+                palette::Row::Heading(group) => PaletteRowData {
+                    kind: view::PaletteRowKind::Heading,
+                    title: group.label(),
+                    badge: None,
+                    subtitle: None,
+                    shortcut: None,
+                    highlighted: false,
+                },
+                palette::Row::Command(command) => {
+                    let command = &palette.commands()[*command];
+                    PaletteRowData {
+                        kind: view::PaletteRowKind::Item,
+                        title: command.title.clone(),
+                        // What the command will go on to ask for, so a row
+                        // that leads somewhere rather than acting says so
+                        // before it is picked.
+                        badge: command.arg.as_ref().map(|arg| format!("› {}", arg.label)),
+                        // The group is a heading when the list is resting, so
+                        // it only becomes a badge once ranking has thrown the
+                        // headings away.
+                        subtitle: (!resting).then(|| command.group.label()),
+                        shortcut: command.shortcut.clone(),
+                        highlighted: highlight == Some(index),
+                    }
+                }
+                palette::Row::Completion(completion) => {
+                    let completion = &palette.completions()[*completion];
+                    PaletteRowData {
+                        kind: view::PaletteRowKind::Item,
+                        title: completion.title.clone(),
+                        badge: None,
+                        subtitle: completion.subtitle.clone(),
+                        shortcut: None,
+                        highlighted: highlight == Some(index),
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        // A group named with nothing under it reads as broken rather than as
+        // scrolled, so the window never ends on a heading.
+        while rows
+            .last()
+            .is_some_and(|row| row.kind == view::PaletteRowKind::Heading)
+        {
+            rows.pop();
+        }
+        rows
+    }
+
+    /// What to show in place of the list: a refusal, or that nothing matches.
+    fn palette_message(&self) -> Option<String> {
+        let palette = self.palette.as_ref()?;
+        if let Some(error) = palette.error() {
+            return Some(error.to_string());
+        }
+        (palette.rows().is_empty() && !palette.resting())
+            .then(|| otto_kit::t_owned!("files-palette-no-matches"))
+    }
+
+    /// Act on what the palette made of an event, whether it came from a key or
+    /// from a click on a row.
+    ///
+    /// The one place a palette outcome is turned into something happening, so
+    /// the pointer and the keyboard cannot drift apart over what picking a row
+    /// means.
+    fn settle_palette(&mut self, outcome: palette::Outcome, serial: u32) {
+        match outcome {
+            palette::Outcome::Close => {
+                self.close_palette();
+            }
+            palette::Outcome::Clipboard(text) => {
+                clipboard::set_text(&text, serial);
+                self.dirty = true;
+            }
+            palette::Outcome::Run(request) => match self.run_request(&request, serial) {
+                Ok(followup) => {
+                    // Closed only once the command was carried out: a refusal
+                    // keeps the panel up with the text still there to fix.
+                    self.close_palette();
+                    self.palette_quickview = followup == Followup::QuickView;
+                }
+                Err(error) => {
+                    if let Some(palette) = self.palette.as_mut() {
+                        palette.set_error(error);
+                    }
+                    self.dirty = true;
+                }
+            },
+            palette::Outcome::Changed => {
+                self.refresh_palette_completions();
+                self.dirty = true;
+            }
+            palette::Outcome::Ignored => {}
+        }
+    }
+
+    /// Whether a palette command asked for Quick View. Drained by the host,
+    /// which owns the decode — see [`FilesApp::follow_quickview`].
+    fn take_palette_quickview(&mut self) -> bool {
+        std::mem::take(&mut self.palette_quickview)
+    }
+
+    /// Carry out a request the palette produced.
+    ///
+    /// The host answers for its own namespace because it is the only thing
+    /// holding the window; anything else goes to the provider that owns it.
+    /// An `Err` keeps the palette open with the reason shown, so the text is
+    /// still there to fix.
+    fn run_request(&mut self, request: &command::Request, serial: u32) -> Result<Followup, String> {
+        use command::id;
+
+        if let Some(result) = self.commands.run(request) {
+            return result.map(|()| Followup::Nothing);
+        }
+
+        let arg = request.arg.as_deref().unwrap_or_default().trim();
+        match request.id.as_str() {
+            id::GO_BACK => self.go_back(),
+            id::GO_FORWARD => self.go_forward(),
+            id::GO_UP => self.go_up(),
+            id::GO_HOME => {
+                let home = model::home_dir()
+                    .ok_or_else(|| otto_kit::t_owned!("files-no-such-folder", path = "~"))?;
+                self.navigate_to(&home);
+            }
+            id::GO_TO_PATH => {
+                let path = self
+                    .resolve_typed_path(arg)
+                    .filter(|path| path.exists())
+                    .ok_or_else(|| otto_kit::t_owned!("files-no-such-folder", path = arg))?;
+                if path.is_dir() {
+                    self.navigate_to(&path);
+                } else if let Some(parent) = path.parent() {
+                    let name = path.file_name().map(|n| n.to_string_lossy().into_owned());
+                    self.navigate_to(parent);
+                    self.pending_pick = Some((0, name));
+                }
+            }
+            id::GO_TO_PLACE => {
+                let path = PathBuf::from(arg);
+                if !path.is_dir() {
+                    return Err(otto_kit::t_owned!("files-no-such-folder", path = arg));
+                }
+                self.navigate_to(&path);
+            }
+            id::OPEN => self.open_cursor_entry(),
+            id::GET_INFO => self.open_info(),
+            id::RENAME => self.rename_cursor_to(arg)?,
+            id::NEW_FOLDER => self.new_folder_named(arg)?,
+            id::TRASH => self.move_selected_to_trash(),
+            id::PUT_BACK => self.put_back_selection(),
+            id::DELETE_FOREVER => self.ask_delete_forever(),
+            id::EMPTY_TRASH => self.ask_empty_trash(),
+            id::CUT => self.copy_selection(true, serial),
+            id::COPY => self.copy_selection(false, serial),
+            id::PASTE => self.paste(),
+            id::SELECT_ALL => self.select_all(),
+            id::UNDO => self.undo_last(),
+            // The three views by name share their ids with the values Change
+            // View takes, so one arm answers for both.
+            id::VIEW_LIST | id::VIEW_GRID | id::VIEW_COLUMNS => {
+                let mode = view_from_id(&request.id)
+                    .ok_or_else(|| otto_kit::t_owned!("files-palette-no-matches"))?;
+                self.set_mode(mode);
+            }
+            id::CHANGE_VIEW => {
+                let mode = view_from_id(arg)
+                    .ok_or_else(|| otto_kit::t_owned!("files-palette-no-matches"))?;
+                self.set_mode(mode);
+            }
+            id::SORT_BY => {
+                let key = sort_from_id(arg)
+                    .ok_or_else(|| otto_kit::t_owned!("files-palette-no-matches"))?;
+                self.set_sort(key);
+            }
+            id::TOGGLE_HIDDEN => {
+                self.show_hidden = !self.show_hidden;
+                self.dirty = true;
+            }
+            // The preview is the host window's, not the browser's: it owns the
+            // decode. Handed back rather than run here.
+            id::QUICK_LOOK => return Ok(Followup::QuickView),
+            // The strip is opened either way; a query given with the command
+            // is typed into it, so one keystroke can start a search outright.
+            id::SEARCH => {
+                self.toggle_search();
+                if !arg.is_empty() {
+                    if let Some(input) = self.search.as_mut() {
+                        input.set_value(arg);
+                    }
+                    // Typing into the strip does not search — Return does —
+                    // and a query given with the command is a Return already
+                    // pressed.
+                    self.run_search();
+                }
+            }
+            id::RECENT => self.show_recent(),
+            other => return Err(format!("Unknown command: {other}")),
+        }
+        Ok(Followup::Nothing)
+    }
+
+    /// Sort by `key`, in the direction that key reads best in — and remember
+    /// that the choice was the user's, so a view change does not overwrite it.
+    fn set_sort(&mut self, key: SortKey) {
+        if self.sort == key {
+            self.ascending = !self.ascending;
+        } else {
+            self.sort = key;
+            self.ascending = key != SortKey::Modified;
+        }
+        self.sort_pinned = true;
+        self.dirty = true;
+    }
+
+    /// Rename the cursor entry outright, without the in-place field. Takes the
+    /// same undo entry an in-place rename does.
+    fn rename_cursor_to(&mut self, name: &str) -> Result<(), String> {
+        if self.trash {
+            return Err(otto_kit::t_owned!("files-trash-cant-rename"));
+        }
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let index = self.columns[depth]
+            .cursor
+            .ok_or_else(|| otto_kit::t_owned!("files-palette-no-matches"))?;
+        let original = self
+            .visible(depth)
+            .get(index)
+            .map(|entry| entry.path.clone())
+            .ok_or_else(|| otto_kit::t_owned!("files-palette-no-matches"))?;
+        self.rename_path(depth, &original, name)
+    }
+
+    /// Create a folder with the name the user gave, or — given nothing — the
+    /// default name the toolbar's New Folder uses, which lands in rename.
+    fn new_folder_named(&mut self, name: &str) -> Result<(), String> {
+        if name.is_empty() {
+            self.new_folder();
+            return Ok(());
+        }
+        let dest = self.current_directory();
+        let created = model::create_folder_named(&dest, name)?;
+        let name = created
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.status = Some(otto_kit::t_owned!(
+            "files-new-folder-created",
+            name = name.as_str()
+        ));
+        self.record_undo(
+            otto_kit::t!("files-new-folder"),
+            vec![model::Change::Created { path: created }],
+        );
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        self.pending_pick = Some((depth, Some(name)));
+        self.reload_all();
+        self.dirty = true;
+        Ok(())
     }
 
     /// How far one Up/Down press moves. In the grid that is a whole row of
@@ -5426,6 +5954,7 @@ impl App for FilesApp {
             let mut path_caret = None;
             let mut search_caret = None;
             let mut save_caret = None;
+            let mut palette_caret = None;
 
             if let Some(session) = browser.rename.as_ref() {
                 let (depth, index) = (session.depth, session.index);
@@ -5505,6 +6034,68 @@ impl App for FilesApp {
                 save_caret = caret_in_window(input, (rect.left, rect.top));
             }
 
+            // The palette, over the finished window and under the modal
+            // sheet. Its card is drawn from rows gathered first, then the
+            // field's text over the box the card left for it — the same
+            // two-step the rename and path fields take.
+            if browser.palette.is_some() {
+                let width = browser.size.0;
+                let rows = browser.palette_rows();
+                let message = browser.palette_message();
+                let prompt = browser.palette.as_ref().and_then(|p| p.prompt());
+                let view_rows: Vec<view::PaletteRow<'_>> = rows
+                    .iter()
+                    .map(|row| view::PaletteRow {
+                        kind: row.kind,
+                        title: &row.title,
+                        badge: row.badge.as_deref(),
+                        subtitle: row.subtitle.as_deref(),
+                        shortcut: row.shortcut.as_deref(),
+                        highlighted: row.highlighted,
+                    })
+                    .collect();
+                view::draw_palette(
+                    canvas,
+                    &theme,
+                    width,
+                    &view::PaletteData {
+                        prompt: prompt.as_deref(),
+                        rows: view_rows,
+                        message: message.as_deref(),
+                    },
+                );
+
+                // The prompt is not part of the field, so the field starts
+                // after it: what is typed is the argument, and the prefix
+                // cannot be edited or selected.
+                let field = view::palette_field_rect(width);
+                let lead = prompt
+                    .as_deref()
+                    .map(|prompt| {
+                        otto_kit::typography::styles::BODY_EMPHASIZED
+                            .font()
+                            .measure_str(prompt, None)
+                            .0
+                            + 8.0
+                    })
+                    .unwrap_or(0.0);
+                let placeholder = browser
+                    .palette
+                    .as_ref()
+                    .map(|p| p.placeholder())
+                    .unwrap_or_default();
+                if let Some(palette) = browser.palette.as_mut() {
+                    let input = palette.input_mut();
+                    input.state.placeholder = placeholder;
+                    input.set_size(field.width() - lead, field.height());
+                    canvas.save();
+                    canvas.translate((field.left + lead, field.top));
+                    input.render_at(canvas, field.width() - lead, field.height());
+                    canvas.restore();
+                    palette_caret = caret_in_window(input, (field.left + lead, field.top));
+                }
+            }
+
             // Tell the compositor where the text is, so an input method — or
             // the emoji picker, or anything else watching
             // `otto_text_cursor_manager_v1` — can put itself beside the word
@@ -5514,7 +6105,11 @@ impl App for FilesApp {
             // than the order the fields are painted in: the caret to report is
             // the one the keys are going to.
             otto_kit::AppContext::report_text_cursor(
-                rename_caret.or(path_caret).or(save_caret).or(search_caret),
+                palette_caret
+                    .or(rename_caret)
+                    .or(path_caret)
+                    .or(save_caret)
+                    .or(search_caret),
             );
 
             // Last of all, because it is modal and dims everything above.
@@ -5813,6 +6408,7 @@ impl App for FilesApp {
             self.start_quickview(&mut browser);
         }
         self.follow_quickview();
+        self.auto_palette();
 
         // With the columns in their own surfaces, a scroll is repainted there
         // and the window is left alone — which is the whole point, so the
@@ -5954,7 +6550,12 @@ impl App for FilesApp {
         if !ours {
             return;
         }
-        if self.state.lock().unwrap().close_quickview() {
+        // Both go with the keyboard: a panel that is nothing but a place to
+        // type has no reason to stay up once the typing would land elsewhere.
+        let mut browser = self.state.lock().unwrap();
+        let changed = browser.close_quickview() | browser.close_palette();
+        drop(browser);
+        if changed {
             self.render();
         }
     }
@@ -6000,6 +6601,57 @@ impl App for FilesApp {
                     Keysym::Return | Keysym::KP_Enter => browser.confirm_accept(),
                     Keysym::Escape => browser.confirm_dismiss(),
                     _ => {}
+                }
+                drop(browser);
+                self.render();
+                return;
+            }
+
+            // The palette takes the keyboard whole while it is up. It is not
+            // modal over the compositor — the window can still be moved,
+            // resized and closed — but no key reaches the listing behind it.
+            if browser.palette.is_some() {
+                // A second Ctrl+P closes it, the way the chord that opens Get
+                // Info closes it again.
+                if event.keysym == Keysym::p && ctrl {
+                    browser.close_palette();
+                    drop(browser);
+                    self.render();
+                    return;
+                }
+                let key = match event.keysym {
+                    Keysym::Escape => Some(palette::Key::Escape),
+                    Keysym::Return | Keysym::KP_Enter => Some(palette::Key::Enter),
+                    Keysym::Tab | Keysym::ISO_Left_Tab => Some(palette::Key::Tab),
+                    Keysym::Up => Some(palette::Key::Up),
+                    Keysym::Down => Some(palette::Key::Down),
+                    Keysym::Home => Some(palette::Key::Home),
+                    Keysym::End => Some(palette::Key::End),
+                    Keysym::Left => Some(palette::Key::Edit(TextInputKey::Left)),
+                    Keysym::Right => Some(palette::Key::Edit(TextInputKey::Right)),
+                    Keysym::BackSpace => Some(palette::Key::Edit(TextInputKey::Backspace)),
+                    Keysym::Delete => Some(palette::Key::Edit(TextInputKey::Delete)),
+                    Keysym::a if ctrl => Some(palette::Key::Edit(TextInputKey::SelectAll)),
+                    Keysym::c if ctrl => Some(palette::Key::Edit(TextInputKey::Copy)),
+                    Keysym::x if ctrl => Some(palette::Key::Edit(TextInputKey::Cut)),
+                    Keysym::v if ctrl => {
+                        clipboard::text().map(|text| palette::Key::Edit(TextInputKey::Paste(text)))
+                    }
+                    _ => event
+                        .utf8
+                        .as_ref()
+                        .and_then(|s| s.chars().next())
+                        .map(|ch| palette::Key::Edit(TextInputKey::Char(ch))),
+                };
+                if let Some(key) = key {
+                    let mods = KeyMods { shift, ctrl };
+                    if let Some(outcome) = browser
+                        .palette
+                        .as_mut()
+                        .map(|palette| palette.on_key(key, mods))
+                    {
+                        browser.settle_palette(outcome, serial);
+                    }
                 }
                 drop(browser);
                 self.render();
@@ -6432,6 +7084,10 @@ impl App for FilesApp {
                     browser.dirty = true;
                 }
                 Keysym::n if ctrl => browser.open_new_window(),
+                // Every command the window has, by name — Ctrl+P everywhere
+                // but the picker, which is answering a request rather than
+                // managing files and has none of them.
+                Keysym::p if ctrl && browser.picker.is_none() => browser.open_palette(),
                 // The location, made editable — Ctrl+L everywhere but the
                 // picker, whose header is a toolbar with no title to replace.
                 Keysym::l if ctrl && browser.picker.is_none() => browser.open_path_entry(),
@@ -6498,6 +7154,40 @@ impl App for FilesApp {
 }
 
 impl FilesApp {
+    /// Open the palette on its own, for looking at. See
+    /// [`Browser::palette_auto`] — never on in a real session.
+    fn auto_palette(&self) {
+        let mut browser = self.state.lock().unwrap();
+        let depth = browser.active;
+        if browser.palette_auto.is_none() || browser.visible(depth).is_empty() {
+            return;
+        }
+        let query = browser.palette_auto.take().unwrap_or_default();
+        browser.columns[depth].cursor = Some(0);
+        browser.open_palette();
+        // A value other than a bare "1" is typed in, so a screenshot can be
+        // taken of the palette part-way through a query rather than at rest.
+        if query != "1" && !query.is_empty() {
+            let mods = KeyMods {
+                shift: false,
+                ctrl: false,
+            };
+            // A tab in the value is a Tab press, so argument mode can be
+            // looked at too: `OTTO_FILES_PALETTE_AUTO=$'go to path\t/usr/'`.
+            for ch in query.chars() {
+                let key = match ch {
+                    '\t' => palette::Key::Tab,
+                    ch => palette::Key::Edit(TextInputKey::Char(ch)),
+                };
+                if let Some(palette) = browser.palette.as_mut() {
+                    palette.on_key(key, mods);
+                }
+                browser.refresh_palette_completions();
+            }
+        }
+        browser.dirty = true;
+    }
+
     /// Move the picker on when its request is done with, and notice when the
     /// portal withdraws the one on screen.
     ///
@@ -6603,6 +7293,12 @@ impl FilesApp {
     /// file that is now in the Trash.
     fn follow_quickview(&self) {
         let mut browser = self.state.lock().unwrap();
+        // Quick View asked for by name, from the palette. Its command ran in
+        // the browser, which does not own the decode.
+        if browser.take_palette_quickview() {
+            self.start_quickview(&mut browser);
+            return;
+        }
         if browser.take_quickview_follow() {
             self.start_quickview(&mut browser);
         }
@@ -7717,6 +8413,62 @@ impl FilesApp {
                         continue;
                     }
                     PointerEventKind::Press { serial, .. } => {
+                        // The palette is over everything, so it is asked
+                        // first. A click on a row picks it; a click anywhere
+                        // outside the card dismisses the palette and stops
+                        // there, rather than also selecting whatever file
+                        // happened to be underneath.
+                        if browser.palette.is_some() {
+                            let rows = browser.palette_rows();
+                            let view_rows: Vec<view::PaletteRow<'_>> = rows
+                                .iter()
+                                .map(|row| view::PaletteRow {
+                                    kind: row.kind,
+                                    title: &row.title,
+                                    badge: None,
+                                    subtitle: None,
+                                    shortcut: None,
+                                    highlighted: row.highlighted,
+                                })
+                                .collect();
+                            let hit = view::palette_row_at(x, y, width, &view_rows);
+                            let inside = view::palette_rect(
+                                width,
+                                &view_rows,
+                                browser.palette_message().is_some(),
+                            )
+                            .contains(skia_safe::Point::new(x, y));
+                            drop(view_rows);
+                            drop(rows);
+                            match hit {
+                                Some(row) => {
+                                    let picked = browser
+                                        .palette
+                                        .as_mut()
+                                        .is_some_and(|palette| palette.highlight_row(row));
+                                    if picked {
+                                        let mods = KeyMods {
+                                            shift: false,
+                                            ctrl: false,
+                                        };
+                                        if let Some(outcome) = browser
+                                            .palette
+                                            .as_mut()
+                                            .map(|palette| palette.on_key(palette::Key::Enter, mods))
+                                        {
+                                            browser.settle_palette(outcome, serial);
+                                        }
+                                    }
+                                }
+                                None if !inside => {
+                                    browser.close_palette();
+                                }
+                                None => {}
+                            }
+                            browser.dirty = true;
+                            return;
+                        }
+
                         // The whole window, not the file area: the border being
                         // grabbed is the window's, and in the picker the file
                         // area stops short of the bottom by the action row.
@@ -8310,10 +9062,10 @@ mod typeahead_tests {
     ///
     /// The listing comes off a worker thread reading the filesystem, so
     /// type-ahead can only be exercised against something actually on disk.
-    struct TempDir(PathBuf);
+    pub(super) struct TempDir(pub(super) PathBuf);
 
     impl TempDir {
-        fn holding(names: &[&str]) -> Self {
+        pub(super) fn holding(names: &[&str]) -> Self {
             use std::sync::atomic::{AtomicU32, Ordering};
             static COUNTER: AtomicU32 = AtomicU32::new(0);
 
@@ -8337,7 +9089,7 @@ mod typeahead_tests {
     }
 
     /// A browser over `names`, with the first listing already in.
-    fn browser_over(names: &[&str]) -> (Browser, TempDir) {
+    pub(super) fn browser_over(names: &[&str]) -> (Browser, TempDir) {
         let dir = TempDir::holding(names);
         let mut browser = Browser::new(dir.0.clone());
         // The frame loop is what normally polls the loader; a test has to.
@@ -8572,6 +9324,208 @@ mod typeahead_tests {
         let (mut browser, _dir) = browser_over(&[]);
         browser.typeahead('a');
         assert_eq!(at_cursor(&browser), None);
+    }
+}
+
+#[cfg(test)]
+/// The command palette — see `specs/file-command-palette.md`.
+mod palette_tests {
+    use super::typeahead_tests::browser_over;
+    use super::*;
+
+    fn open_and_type(browser: &mut Browser, text: &str) {
+        browser.open_palette();
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        for ch in text.chars() {
+            let palette = browser.palette.as_mut().expect("palette is open");
+            palette.on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+        }
+    }
+
+    fn press(browser: &mut Browser, key: palette::Key) -> palette::Outcome {
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        let outcome = browser
+            .palette
+            .as_mut()
+            .expect("palette is open")
+            .on_key(key, mods);
+        if outcome == palette::Outcome::Changed {
+            browser.refresh_palette_completions();
+        }
+        outcome
+    }
+
+    /// Running a command through the palette is running it: the same rename
+    /// the in-place field does, on the same undo stack.
+    #[test]
+    fn a_command_run_from_the_palette_does_what_the_menu_does() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        browser.select(0, 0);
+        open_and_type(&mut browser, "rename");
+        assert_eq!(
+            press(&mut browser, palette::Key::Tab),
+            palette::Outcome::Changed
+        );
+        // The field starts on the name the file already has.
+        assert_eq!(browser.palette.as_ref().unwrap().input().value(), "a.txt");
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .input_mut()
+            .set_value("b.txt");
+        let palette::Outcome::Run(request) = press(&mut browser, palette::Key::Enter) else {
+            panic!("Return should run the rename");
+        };
+        browser.run_request(&request, 0).expect("the rename works");
+        assert!(dir.0.join("b.txt").exists());
+        assert!(!dir.0.join("a.txt").exists());
+        assert_eq!(browser.undo.len(), 1);
+    }
+
+    /// A command that cannot run is not on the list at all, so nothing has to
+    /// be greyed out and the arrow keys have nothing to skip.
+    #[test]
+    fn the_palette_offers_only_what_can_run_now() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.open_palette();
+        let offered: Vec<&str> = browser
+            .palette
+            .as_ref()
+            .unwrap()
+            .commands()
+            .iter()
+            .map(|command| command.id.as_str())
+            .collect();
+        assert!(!offered.contains(&command::id::UNDO));
+        assert!(!offered.contains(&command::id::GO_BACK));
+        assert!(offered.contains(&command::id::NEW_FOLDER));
+    }
+
+    /// The whole point of the path argument: type a fragment, Tab, arrive.
+    #[test]
+    fn go_to_path_navigates_where_the_argument_says() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        std::fs::create_dir(dir.0.join("inner")).unwrap();
+        open_and_type(&mut browser, "go to path");
+        press(&mut browser, palette::Key::Tab);
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .input_mut()
+            .set_value("inner");
+        let palette::Outcome::Run(request) = press(&mut browser, palette::Key::Enter) else {
+            panic!("Return should go there");
+        };
+        browser
+            .run_request(&request, 0)
+            .expect("the folder is there");
+        assert_eq!(browser.current_path(), dir.0.join("inner"));
+    }
+
+    /// A path that is not there is a refusal, not a navigation — and the
+    /// palette stays open around it.
+    #[test]
+    fn a_path_that_is_not_there_is_refused() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        open_and_type(&mut browser, "go to path");
+        press(&mut browser, palette::Key::Tab);
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .input_mut()
+            .set_value("nowhere");
+        let palette::Outcome::Run(request) = press(&mut browser, palette::Key::Enter) else {
+            panic!("Return should try");
+        };
+        let error = browser
+            .run_request(&request, 0)
+            .expect_err("no such folder");
+        browser.palette.as_mut().unwrap().set_error(error);
+        assert!(browser.palette.as_ref().unwrap().error().is_some());
+        assert_eq!(browser.current_path(), dir.0);
+    }
+
+    /// The host completes a path against the disk, since the palette may not.
+    #[test]
+    fn the_host_completes_a_path_against_the_disk() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        std::fs::create_dir(dir.0.join("shared")).unwrap();
+        std::fs::create_dir(dir.0.join("shrunk")).unwrap();
+        open_and_type(&mut browser, "go to path");
+        press(&mut browser, palette::Key::Tab);
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .input_mut()
+            .set_value("sh");
+        browser.refresh_palette_completions();
+        assert_eq!(browser.palette.as_ref().unwrap().completions().len(), 2);
+        // Tab extends as far as both answers agree.
+        press(&mut browser, palette::Key::Tab);
+        assert_eq!(browser.palette.as_ref().unwrap().input().value(), "sh");
+        press(&mut browser, palette::Key::Down);
+        press(&mut browser, palette::Key::Tab);
+        assert_eq!(browser.palette.as_ref().unwrap().input().value(), "shared/");
+    }
+
+    /// A view is a choice, so it is answered with an arrow key rather than by
+    /// typing the name of one.
+    #[test]
+    fn change_view_is_answered_from_a_list() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.set_mode(ViewMode::List);
+        open_and_type(&mut browser, "change view");
+        press(&mut browser, palette::Key::Tab);
+        // Opens on the view that is already current.
+        let palette::Outcome::Run(request) = press(&mut browser, palette::Key::Enter) else {
+            panic!("Return should take the highlighted view");
+        };
+        assert_eq!(request.arg.as_deref(), Some("list"));
+        browser.run_request(&request, 0).unwrap();
+        assert_eq!(browser.mode, ViewMode::List);
+    }
+
+    /// Named folders come through the palette; the toolbar's unnamed one still
+    /// lands in rename.
+    #[test]
+    fn new_folder_takes_the_name_it_was_given() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        browser
+            .new_folder_named("reports")
+            .expect("the name is free");
+        assert!(dir.0.join("reports").is_dir());
+        // A second one with the same name is an error, not a "reports 2".
+        assert!(browser.new_folder_named("reports").is_err());
+    }
+
+    /// Opening the palette changes nothing underneath it, and closing it
+    /// leaves the browser exactly as it was.
+    #[test]
+    fn the_palette_leaves_the_browser_alone() {
+        let (mut browser, _dir) = browser_over(&["a.txt", "b.txt"]);
+        browser.select(0, 1);
+        let before = (browser.active, browser.columns[0].cursor, browser.mode);
+        open_and_type(&mut browser, "trash");
+        press(&mut browser, palette::Key::Down);
+        assert_eq!(
+            press(&mut browser, palette::Key::Escape),
+            palette::Outcome::Close
+        );
+        browser.close_palette();
+        assert_eq!(
+            (browser.active, browser.columns[0].cursor, browser.mode),
+            before
+        );
     }
 }
 

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -6779,8 +6779,8 @@ impl App for FilesApp {
         // blur at all (see `otto_kit::backdrop`). The panels are filled in
         // rather than left translucent in both cases, so what that isolates is
         // the compositor's blur work and not the window's legibility.
-        let blur =
-            otto_kit::backdrop::blur_available() && std::env::var_os("OTTO_FILES_NO_BLUR").is_none();
+        let blur = otto_kit::backdrop::blur_available()
+            && std::env::var_os("OTTO_FILES_NO_BLUR").is_none();
         window.set_background_blur(blur);
         self.state.lock().unwrap().blur_available = blur;
 

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3597,6 +3597,41 @@ impl Browser {
         }
     }
 
+    /// The situation a palette command is previewed and run against: the
+    /// window's, less whatever the dry run's lines were toggled out of it.
+    fn palette_situation(&self) -> command::Situation {
+        let mut situation = self.situation();
+        let excluded = self
+            .palette
+            .as_ref()
+            .map(|palette| palette.excluded())
+            .unwrap_or_default();
+        if !excluded.is_empty() {
+            situation.selection.retain(|path| {
+                !path
+                    .file_name()
+                    .is_some_and(|name| excluded.contains(&*name.to_string_lossy()))
+            });
+        }
+        situation
+    }
+
+    /// What a palette command would act on, by name and in order: the
+    /// selection, or the cursor's entry when nothing is selected. The list
+    /// a dry run's lines are threaded onto.
+    fn palette_targets(&self) -> Vec<String> {
+        let situation = self.situation();
+        if situation.selection.is_empty() {
+            return situation.cursor_name.into_iter().collect();
+        }
+        situation
+            .selection
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .collect()
+    }
+
     /// Ctrl+P. Asks every provider what it can offer *now* and opens onto the
     /// answer; nothing re-gathers while the palette is up.
     fn open_palette(&mut self) {
@@ -3684,21 +3719,26 @@ impl Browser {
             self.dirty = true;
             return;
         }
-        // A provider's command: ask it for the dry run and show that.
+        // A provider's command: ask it for the dry run — without whatever
+        // has been toggled out — and thread its lines back among the names
+        // left out, so those can be brought back.
         if command::Request::new(id.clone(), None)
             .namespace()
             .is_some()
         {
-            let situation = self.situation();
+            let situation = self.palette_situation();
+            let targets = self.palette_targets();
             let request = command::Request::new(id, Some(typed));
             let preview = self.commands.preview(&request, &situation);
             if let Some(palette) = self.palette.as_mut() {
-                match preview {
-                    Some(preview) => {
-                        palette.set_preview(preview.rows);
-                        palette.set_note(preview.note);
-                    }
-                    None => palette.set_preview(Vec::new()),
+                let excluded = palette.excluded();
+                let (rows, note) = match preview {
+                    Some(preview) => (preview.rows, preview.note),
+                    None => (Vec::new(), None),
+                };
+                palette.set_preview(palette::PreviewLine::merge(&targets, &excluded, rows));
+                if note.is_some() {
+                    palette.set_note(note);
                 }
             }
             self.dirty = true;
@@ -3825,6 +3865,17 @@ impl Browser {
             return;
         }
         if let Some(row) = self.palette_row_under(x, y) {
+            // A dry-run line is toggled, not picked: the file leaves the run
+            // or comes back, and the dry run is made again without it.
+            let toggled = self
+                .palette
+                .as_mut()
+                .is_some_and(|palette| palette.toggle_row(row));
+            if toggled {
+                self.preview_palette_argument();
+                self.dirty = true;
+                return;
+            }
             let picked = self
                 .palette
                 .as_mut()
@@ -4102,12 +4153,13 @@ impl Browser {
                     PaletteRowData {
                         kind: view::PaletteRowKind::Preview {
                             conflict: line.conflict,
+                            excluded: line.excluded,
                         },
                         title: line.to.clone(),
                         badge: None,
                         subtitle: Some(line.from.clone()),
                         shortcut: None,
-                        highlighted: false,
+                        highlighted: highlight == Some(index),
                     }
                 }
             })
@@ -4271,7 +4323,7 @@ impl Browser {
         use command::id;
 
         if request.namespace().is_some() {
-            let situation = self.situation();
+            let situation = self.palette_situation();
             let effect = self
                 .commands
                 .run(request, &situation)
@@ -10511,11 +10563,17 @@ mod palette_tests {
         assert_eq!(rows[0].subtitle.as_deref(), Some("IMG_001.jpg"));
         assert_eq!(
             rows[0].kind,
-            view::PaletteRowKind::Preview { conflict: false }
+            view::PaletteRowKind::Preview {
+                conflict: false,
+                excluded: false
+            }
         );
         assert_eq!(
             rows[1].kind,
-            view::PaletteRowKind::Preview { conflict: true },
+            view::PaletteRowKind::Preview {
+                conflict: true,
+                excluded: false
+            },
             "Holiday 2.jpg is already in the folder"
         );
         assert_eq!(
@@ -10561,6 +10619,105 @@ mod palette_tests {
         assert_eq!(browser.undo.len(), undos - 1);
         assert!(dir.0.join("IMG_001.jpg").exists());
         assert!(dir.0.join("IMG_002.jpg").exists());
+    }
+
+    /// Down into the dry run and Space leaves a file out; the dry run is
+    /// made again without it, and so is the run. A click on a line does the
+    /// same, and a space typed in the field is still a space.
+    #[test]
+    fn a_dry_run_line_can_be_toggled_out_of_the_run_and_back() {
+        let (mut browser, dir) = browser_over(&["a.jpg", "b.jpg", "c.jpg"]);
+        browser.clear_selection();
+        browser.select_matching("*.jpg").unwrap();
+        browser.open_palette();
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        let press = |browser: &mut Browser, key: palette::Key| {
+            let outcome = browser.palette.as_mut().unwrap().on_key(key, mods);
+            browser.settle_palette(outcome, 0);
+        };
+        let type_in = |browser: &mut Browser, text: &str| {
+            for ch in text.chars() {
+                press(browser, palette::Key::Edit(TextInputKey::Char(ch)));
+            }
+        };
+        type_in(&mut browser, "rename 3");
+        press(&mut browser, palette::Key::Tab);
+        type_in(&mut browser, "Pic {n}");
+        let titles = |browser: &Browser| -> Vec<(String, String, bool)> {
+            browser
+                .palette_rows()
+                .into_iter()
+                .map(|row| {
+                    let excluded = matches!(
+                        row.kind,
+                        view::PaletteRowKind::Preview { excluded: true, .. }
+                    );
+                    (row.subtitle.unwrap_or_default(), row.title, excluded)
+                })
+                .collect()
+        };
+        assert_eq!(
+            titles(&browser),
+            vec![
+                ("a.jpg".into(), "Pic 1.jpg".into(), false),
+                ("b.jpg".into(), "Pic 2.jpg".into(), false),
+                ("c.jpg".into(), "Pic 3.jpg".into(), false),
+            ]
+        );
+
+        // Down onto the first line, down again, Space: b is out and c takes
+        // its number.
+        press(&mut browser, palette::Key::Down);
+        press(&mut browser, palette::Key::Down);
+        assert_eq!(browser.palette.as_ref().unwrap().highlighted(), Some(1));
+        press(&mut browser, palette::Key::Edit(TextInputKey::Char(' ')));
+        assert_eq!(
+            titles(&browser),
+            vec![
+                ("a.jpg".into(), "Pic 1.jpg".into(), false),
+                ("b.jpg".into(), String::new(), true),
+                ("c.jpg".into(), "Pic 2.jpg".into(), false),
+            ]
+        );
+        assert!(
+            browser.palette_rows()[1].highlighted,
+            "the highlight stays put"
+        );
+        assert_eq!(
+            browser.palette_message().as_deref(),
+            Some(otto_kit::t_owned!("files-rename-preview", count = 2, total = 2).as_str())
+        );
+
+        // Space again brings it back; a click on the third line takes that
+        // one out instead.
+        press(&mut browser, palette::Key::Edit(TextInputKey::Char(' ')));
+        assert!(!titles(&browser)[1].2);
+        assert!(browser.palette.as_mut().unwrap().toggle_row(2));
+        browser.preview_palette_argument();
+        assert_eq!(titles(&browser)[2], ("c.jpg".into(), String::new(), true));
+
+        // Typing goes back to the field, where a space is a space.
+        press(&mut browser, palette::Key::Edit(TextInputKey::Char('s')));
+        press(&mut browser, palette::Key::Edit(TextInputKey::Char(' ')));
+        assert_eq!(
+            browser.palette.as_ref().unwrap().input().value(),
+            "Pic {n}s "
+        );
+        assert!(titles(&browser)[2].2, "what was toggled out stays out");
+
+        // Return renames the two that are in, and c is untouched.
+        for _ in 0..2 {
+            press(&mut browser, palette::Key::Edit(TextInputKey::Backspace));
+        }
+        press(&mut browser, palette::Key::Enter);
+        assert!(browser.palette.is_none());
+        assert!(dir.0.join("Pic 1.jpg").exists());
+        assert!(dir.0.join("Pic 2.jpg").exists());
+        assert!(dir.0.join("c.jpg").exists());
+        assert!(!dir.0.join("Pic 3.jpg").exists());
     }
 
     #[test]

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -6775,12 +6775,12 @@ impl App for FilesApp {
         // for a window nobody is looking at.
         //
         // `OTTO_FILES_NO_BLUR=1` drops the frosted backdrop entirely, to test
-        // what it costs — as does running under a compositor that carries no
-        // surface style at all. The panels are filled in rather than left
-        // translucent in both cases, so what that isolates is the compositor's
-        // blur work and not the window's legibility.
+        // what it costs — as does running under a compositor that offers no
+        // blur at all (see `otto_kit::backdrop`). The panels are filled in
+        // rather than left translucent in both cases, so what that isolates is
+        // the compositor's blur work and not the window's legibility.
         let blur =
-            window.surface_style().is_some() && std::env::var_os("OTTO_FILES_NO_BLUR").is_none();
+            otto_kit::backdrop::blur_available() && std::env::var_os("OTTO_FILES_NO_BLUR").is_none();
         window.set_background_blur(blur);
         self.state.lock().unwrap().blur_available = blur;
 

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -442,6 +442,12 @@ struct Browser {
     /// would be a placement the user has to undo before they can read the
     /// window under it.
     palette_offset: (f32, f32),
+    /// When the caret was last advanced, so the blink runs on real time.
+    /// The update loop runs as often as anything asks it to — a surface
+    /// repainting, a pointer callback waking it — and a blink that counted
+    /// passes rather than seconds sped up whenever the loop did, which read
+    /// as a nervous caret in the palette.
+    caret_clock: Option<std::time::Instant>,
     /// The palette's list, scrolling under its field: momentum, the band past
     /// either end and the fading bar, the same view the columns run on. Owned
     /// here rather than by the palette because the palette is I/O-free and
@@ -902,6 +908,7 @@ impl Browser {
             palette: None,
             palette_selection: None,
             palette_offset: (0.0, 0.0),
+            caret_clock: None,
             palette_memory: None,
             palette_memory_on_disk: false,
             palette_scroll: ScrollView::new(Rect::new_empty()),
@@ -2062,6 +2069,17 @@ impl Browser {
                 was != input.caret_visible()
             }
             None => false,
+        }
+    }
+
+    /// Seconds since the caret was last advanced — real time, not a count of
+    /// passes through the loop. Capped so a stall does not land as one long
+    /// step, and one idle tick's worth on the first call.
+    fn caret_elapsed(&mut self) -> f32 {
+        let now = std::time::Instant::now();
+        match self.caret_clock.replace(now) {
+            Some(last) => now.duration_since(last).as_secs_f32().min(0.25),
+            None => IDLE_TICK.as_secs_f32(),
         }
     }
 
@@ -7102,7 +7120,8 @@ impl App for FilesApp {
             // advance here rather than on input, since they keep running after
             // the gesture ends.
             let scrolled = browser.tick_scroll();
-            let blinking = browser.tick_caret(IDLE_TICK.as_secs_f32());
+            let elapsed = browser.caret_elapsed();
+            let blinking = browser.tick_caret(elapsed);
             let animating = blinking
                 | browser.quickview_animating()
                 | browser.tick_quickview_exit()
@@ -7944,6 +7963,7 @@ impl FilesApp {
                 let key = match ch {
                     '\t' => palette::Key::Tab,
                     '\n' => palette::Key::Enter,
+                    '\u{1b}' => palette::Key::Escape,
                     '\u{2193}' => palette::Key::Down,
                     '\u{2191}' => palette::Key::Up,
                     ch => palette::Key::Edit(TextInputKey::Char(ch)),

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -437,6 +437,14 @@ struct Browser {
     /// start each keystroke's answer from, since a pattern narrowed by one
     /// character is a fresh question rather than a refinement of the last one.
     palette_selection: Option<SelectionMark>,
+    /// How far the palette has been dragged from where it opens, in points.
+    /// Reset every time it opens: a panel that came back where it was left
+    /// would be a placement the user has to undo before they can read the
+    /// window under it.
+    palette_offset: (f32, f32),
+    /// A drag of the palette in progress: where in the card the pointer took
+    /// hold, so the card follows the pointer without jumping to centre on it.
+    palette_drag: Option<(f32, f32)>,
     /// A palette command asked for Quick View. The panel and its decode belong
     /// to the window around the browser, so the request is left here for it.
     palette_quickview: bool,
@@ -874,6 +882,8 @@ impl Browser {
             pending_rename: None,
             palette: None,
             palette_selection: None,
+            palette_offset: (0.0, 0.0),
+            palette_drag: None,
             palette_quickview: false,
             commands: command::Registry::builtin(),
             path_entry: None,
@@ -3534,6 +3544,8 @@ impl Browser {
             commands,
             view::palette_field_style(AppContext::current_theme()),
         ));
+        self.palette_offset = (0.0, 0.0);
+        self.palette_drag = None;
         self.dirty = true;
     }
 
@@ -3662,6 +3674,71 @@ impl Browser {
                 palette::Completion::new(value, name)
             })
             .collect()
+    }
+
+    /// The card, where it is now — the resting rect moved by whatever drag has
+    /// been applied to it.
+    fn palette_card(&mut self) -> Rect {
+        let rows = self.palette_rows();
+        let view_rows: Vec<view::PaletteRow<'_>> = rows
+            .iter()
+            .map(|row| view::PaletteRow {
+                kind: row.kind,
+                title: &row.title,
+                badge: None,
+                subtitle: None,
+                shortcut: None,
+                highlighted: row.highlighted,
+            })
+            .collect();
+        let message = self
+            .palette
+            .as_ref()
+            .map(|_| ())
+            .and(self.palette_message())
+            .is_some();
+        view::palette_rect(self.size.0, &view_rows, message).with_offset(self.palette_offset)
+    }
+
+    /// The band a drag takes hold of: the card's top, where the field is.
+    ///
+    /// The field rather than a bar of its own — the palette is one card with a
+    /// line of text across the top of it, and a strip above that line would be
+    /// chrome for its own sake.
+    fn palette_grip_at(&mut self, x: f32, y: f32) -> bool {
+        let card = self.palette_card();
+        let grip = Rect::from_ltrb(
+            card.left,
+            card.top,
+            card.right,
+            card.top + view::PALETTE_FIELD_H,
+        );
+        grip.contains(skia_safe::Point::new(x, y))
+    }
+
+    /// Follow the pointer, keeping the card on screen.
+    ///
+    /// Clamped against the window rather than let go: a panel dragged off the
+    /// edge is one the user has to guess the way back to, and it holds the
+    /// keyboard while it is gone.
+    fn drag_palette_to(&mut self, x: f32, y: f32) {
+        let Some((grab_x, grab_y)) = self.palette_drag else {
+            return;
+        };
+        let card = self.palette_card();
+        // Where the card would be with no drag applied — the offset is
+        // measured from there, so it has to be taken back out first.
+        let resting = (
+            card.left - self.palette_offset.0,
+            card.top - self.palette_offset.1,
+        );
+        let left = (x - grab_x).clamp(0.0, (self.size.0 - card.width()).max(0.0));
+        // Never above the window, and never so far down that the field is off
+        // the bottom: the list can hang past the edge, but the line being
+        // typed may not.
+        let top = (y - grab_y).clamp(0.0, (self.size.1 - view::PALETTE_FIELD_H).max(0.0));
+        self.palette_offset = (left - resting.0, top - resting.1);
+        self.dirty = true;
     }
 
     /// The palette's rows as the view wants them, scrolled so the highlight is
@@ -3850,6 +3927,7 @@ impl Browser {
             id::SELECT_ALL => self.select_all(),
             id::SELECT_MATCHING => self.select_matching(arg)?,
             id::MOVE_TO => self.move_selection_to(arg)?,
+            id::NEW_FOLDER_WITH_SELECTION => self.new_folder_with_selection(arg)?,
             id::UNDO => self.undo_last(),
             // The three views by name share their ids with the values Change
             // View takes, so one arm answers for both.
@@ -3947,6 +4025,81 @@ impl Browser {
             "files-selected-count",
             count = count as f64
         ));
+        self.dirty = true;
+        Ok(())
+    }
+
+    /// Put the selection into a folder of its own, made for it.
+    ///
+    /// One undo entry covers both halves, and the folder is recorded *before*
+    /// the moves so that taking it back walks them in the right order: the
+    /// files come out first, and the folder — empty again — goes last.
+    ///
+    /// Given no name the folder takes the default one and lands in rename, the
+    /// way New Folder does; given one it is created with it.
+    fn new_folder_with_selection(&mut self, name: &str) -> Result<(), String> {
+        if self.trash {
+            return Err(otto_kit::t_owned!("files-trash-cant-rename"));
+        }
+        if self.is_synthetic() {
+            return Err(otto_kit::t_owned!("files-recent-not-a-folder"));
+        }
+        let paths: Vec<PathBuf> = self
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect();
+        if paths.is_empty() {
+            return Err(otto_kit::t_owned!("files-nothing-selected"));
+        }
+
+        let name = name.trim();
+        let dest = self.current_directory();
+        let folder = if name.is_empty() {
+            model::create_folder(&dest)?
+        } else {
+            model::create_folder_named(&dest, name)?
+        };
+
+        let clip = model::Clipboard { paths, cut: true };
+        let result = model::paste(&clip, &folder, model::OnConflict::KeepBoth);
+
+        // Nothing made it in: take the folder away again rather than leaving
+        // an empty one behind as the only trace of a command that failed.
+        if result.changes.is_empty() {
+            let _ = std::fs::remove_dir(&folder);
+            return Err(result
+                .errors
+                .first()
+                .cloned()
+                .unwrap_or_else(|| otto_kit::t_owned!("files-nothing-selected")));
+        }
+
+        let mut changes = vec![model::Change::Created {
+            path: folder.clone(),
+        }];
+        changes.extend(result.changes.iter().cloned());
+        self.report(&result);
+        self.record_undo(
+            otto_kit::t!("files-undo-new-folder-with-selection"),
+            changes,
+        );
+
+        let folder_name = folder
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        // The re-read is off-thread, so the folder is not in the listing yet.
+        // Named without a name of its own goes into rename, the way the
+        // toolbar's New Folder does; named outright is already what was asked
+        // for, and is only selected.
+        if name.is_empty() {
+            self.pending_rename = Some((depth, folder_name));
+        } else {
+            self.pending_pick = Some((depth, Some(folder_name)));
+        }
+        self.reload_all();
         self.dirty = true;
         Ok(())
     }
@@ -4826,6 +4979,13 @@ impl Browser {
             if !items.is_empty() {
                 items.push(MenuItem::separator());
             }
+            let folder_label = if entries.len() == 1 {
+                otto_kit::t_owned!("files-new-folder-with-selection")
+            } else {
+                otto_kit::t_owned!("files-new-folder-with-count", count = entries.len() as f64)
+            };
+            items.push(MenuItem::action(folder_label).with_action_id("new_folder_with_selection"));
+            items.push(MenuItem::separator());
             items.push(MenuItem::action(otto_kit::t!("common-cut")).with_action_id("cut"));
             items.push(MenuItem::action(otto_kit::t!("common-copy")).with_action_id("copy"));
             items.push(MenuItem::separator());
@@ -6234,6 +6394,12 @@ impl App for FilesApp {
                         highlighted: row.highlighted,
                     })
                     .collect();
+                // The whole card moves together: drawn through the drag
+                // offset, hit-tested through the same one, so a dragged panel
+                // cannot end up clickable where it is not painted.
+                let offset = browser.palette_offset;
+                canvas.save();
+                canvas.translate(offset);
                 view::draw_palette(
                     canvas,
                     &theme,
@@ -6244,6 +6410,7 @@ impl App for FilesApp {
                         message: message.as_deref(),
                     },
                 );
+                canvas.restore();
 
                 // The prompt is not part of the field, so the field starts
                 // after it: what is typed is the argument, and the prefix
@@ -6268,11 +6435,12 @@ impl App for FilesApp {
                     let input = palette.input_mut();
                     input.state.placeholder = placeholder;
                     input.set_size(field.width() - lead, field.height());
+                    let origin = (field.left + lead + offset.0, field.top + offset.1);
                     canvas.save();
-                    canvas.translate((field.left + lead, field.top));
+                    canvas.translate(origin);
                     input.render_at(canvas, field.width() - lead, field.height());
                     canvas.restore();
-                    palette_caret = caret_in_window(input, (field.left + lead, field.top));
+                    palette_caret = caret_in_window(input, origin);
                 }
             }
 
@@ -8352,6 +8520,15 @@ impl FilesApp {
 
                 match event.kind {
                     PointerEventKind::Motion { .. } => {
+                        // The palette being dragged owns the pointer outright,
+                        // the same way a divider does.
+                        if browser.palette_drag.is_some() {
+                            browser.drag_palette_to(x, y);
+                            AppContext::set_cursor_shape(CursorShape::Grabbing);
+                            drop(browser);
+                            window_for_events.request_frame();
+                            continue;
+                        }
                         // A column divider being dragged owns the pointer
                         // outright — nothing else on this move should react.
                         if let Some((boundary, start_x, start_w)) = browser.column_resize {
@@ -8464,6 +8641,12 @@ impl FilesApp {
                         browser.dirty |= browser.controls.on_motion(control);
                     }
                     PointerEventKind::Release { .. } => {
+                        // The palette stays where it was let go of.
+                        if browser.palette_drag.take().is_some() {
+                            drop(browser);
+                            window_for_events.request_frame();
+                            continue;
+                        }
                         // A press that came up without travelling was a click —
                         // including one that left its narrowing until now.
                         browser.drag_armed = None;
@@ -8585,6 +8768,15 @@ impl FilesApp {
                                 "delete_forever" => browser.ask_delete_forever(),
                                 "empty_trash" => browser.ask_empty_trash(),
                                 "new_folder" => browser.new_folder(),
+                                "new_folder_with_selection" => {
+                                    // No name from a menu: the folder takes the
+                                    // default one and lands in rename, ready to
+                                    // be typed over.
+                                    if let Err(error) = browser.new_folder_with_selection("") {
+                                        browser.status = Some(error);
+                                        browser.dirty = true;
+                                    }
+                                }
                                 _ => {}
                             }
                             drop(browser);
@@ -8601,6 +8793,17 @@ impl FilesApp {
                         // there, rather than also selecting whatever file
                         // happened to be underneath.
                         if browser.palette.is_some() {
+                            // The top band is the handle, so a press there is
+                            // a drag rather than a pick.
+                            if browser.palette_grip_at(x, y) {
+                                let card = browser.palette_card();
+                                browser.palette_drag = Some((x - card.left, y - card.top));
+                                return;
+                            }
+                            let (x, y) = (
+                                x - browser.palette_offset.0,
+                                y - browser.palette_offset.1,
+                            );
                             let rows = browser.palette_rows();
                             let view_rows: Vec<view::PaletteRow<'_>> = rows
                                 .iter()
@@ -9897,6 +10100,94 @@ mod palette_tests {
         browser.close_palette();
         open_and_type(&mut browser, "zzzz");
         assert!(browser.palette_message().is_some());
+    }
+
+    /// The selection goes into a folder made for it, and one undo takes both
+    /// halves back — the files first, the folder after.
+    #[test]
+    fn new_folder_with_selection_gathers_the_files() {
+        let (mut browser, dir) = browser_over(&["a.txt", "b.txt", "c.txt"]);
+        browser.select(0, 0);
+        let second = browser.visible(0)[1].selection_key();
+        browser.columns[0].selection.insert(second);
+        browser
+            .new_folder_with_selection("reports")
+            .expect("the name is free");
+
+        assert!(dir.0.join("reports/a.txt").is_file());
+        assert!(dir.0.join("reports/b.txt").is_file());
+        assert!(dir.0.join("c.txt").is_file());
+        assert!(!dir.0.join("a.txt").exists());
+        assert_eq!(browser.undo.len(), 1);
+
+        browser.undo_last();
+        assert!(dir.0.join("a.txt").is_file());
+        assert!(dir.0.join("b.txt").is_file());
+        assert!(!dir.0.join("reports").exists(), "the empty folder goes too");
+    }
+
+    /// With nothing selected there is nothing to gather, and no folder is left
+    /// behind by the attempt.
+    #[test]
+    fn new_folder_with_selection_needs_a_selection() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        browser.clear_selection();
+        assert!(browser.new_folder_with_selection("reports").is_err());
+        assert!(!dir.0.join("reports").exists());
+    }
+
+    /// The card follows the pointer, and stays where it is let go of.
+    #[test]
+    fn the_palette_is_dragged_by_its_top_band() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        let card = browser.palette_card();
+        assert!(browser.palette_grip_at(card.center_x(), card.top + 4.0));
+        assert!(!browser.palette_grip_at(card.center_x(), card.bottom - 4.0));
+
+        browser.palette_drag = Some((10.0, 10.0));
+        browser.drag_palette_to(400.0, 300.0);
+        let moved = browser.palette_card();
+        assert_eq!(moved.left, 390.0);
+        assert_eq!(moved.top, 290.0);
+    }
+
+    /// And cannot be dragged off the window, where it would hold the keyboard
+    /// from somewhere the user cannot see.
+    #[test]
+    fn the_palette_cannot_be_dragged_off_the_window() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        browser.palette_drag = Some((10.0, 10.0));
+
+        browser.drag_palette_to(-500.0, -500.0);
+        let card = browser.palette_card();
+        assert!(card.left >= 0.0 && card.top >= 0.0);
+
+        browser.drag_palette_to(5000.0, 5000.0);
+        let card = browser.palette_card();
+        assert!(card.left <= 1200.0 - card.width() + 0.5);
+        assert!(card.top <= 800.0 - view::PALETTE_FIELD_H + 0.5);
+    }
+
+    /// A fresh open puts it back where it belongs: a panel that reappeared
+    /// wherever it was last left is a placement to undo before the window can
+    /// be read.
+    #[test]
+    fn the_palette_opens_where_it_belongs_however_it_was_left() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        let resting = browser.palette_card();
+        browser.palette_drag = Some((10.0, 10.0));
+        browser.drag_palette_to(400.0, 300.0);
+        browser.close_palette();
+
+        browser.open_palette();
+        assert_eq!(browser.palette_card().left, resting.left);
+        assert_eq!(browser.palette_card().top, resting.top);
     }
 
     /// Opening the palette changes nothing underneath it, and closing it

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -6084,14 +6084,6 @@ impl App for FilesApp {
                     .as_ref()
                     .map(|p| p.placeholder())
                     .unwrap_or_default();
-                // The rest of the best answer, shown ahead of the caret in
-                // the field's own size — taking it is the same as having typed
-                // it. Read before the field is borrowed to draw.
-                let suggestion = browser
-                    .palette
-                    .as_ref()
-                    .and_then(|palette| palette.suggestion_tail())
-                    .map(str::to_string);
                 if let Some(palette) = browser.palette.as_mut() {
                     let input = palette.input_mut();
                     input.state.placeholder = placeholder;
@@ -6099,17 +6091,6 @@ impl App for FilesApp {
                     canvas.save();
                     canvas.translate((field.left + lead, field.top));
                     input.render_at(canvas, field.width() - lead, field.height());
-                    if let Some(tail) = suggestion {
-                        // From the caret, in the field's own style: the two
-                        // runs have to read as one line of text, one half of
-                        // it already typed.
-                        let caret = input.caret_rect();
-                        Label::new(tail)
-                            .with_style(input.style.text_style.clone())
-                            .with_color(theme.text_tertiary)
-                            .centered_on(caret.left, field.height() / 2.0)
-                            .render(canvas);
-                    }
                     canvas.restore();
                     palette_caret = caret_in_window(input, (field.left + lead, field.top));
                 }

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3287,6 +3287,12 @@ impl Browser {
 
     /// Go to the parent directory.
     fn go_up(&mut self) {
+        // A synthetic listing has no parent: the sentinel's is a path nobody
+        // asked for, and going there would carry Recent's flag along with it.
+        if self.is_synthetic() {
+            self.refuse(otto_kit::t_owned!("files-recent-no-location"));
+            return;
+        }
         if self.columns.len() > 1 {
             self.record_location();
             self.columns.truncate(self.columns.len() - 1);
@@ -3307,8 +3313,24 @@ impl Browser {
     }
 
     /// Replace the whole stack, as clicking a place does.
+    ///
+    /// Whatever synthetic listing is up — Recent, or search results — comes
+    /// down with the pane it was in. The two are one state and have to leave
+    /// together: the pane's search dies with it (see [`crate::search::Search`]'s
+    /// `Drop`), so no stale batch can land, but a `recent` or `searching`
+    /// flag left standing would dress the folder up as the listing it
+    /// replaced the moment its read arrives — Recent's title, day headings
+    /// and locked grid over a home directory, and every place-bound command
+    /// still refusing for want of a location. Every route into a folder goes
+    /// through here, so every one of them gets that right.
     fn navigate_to(&mut self, path: &Path) {
+        // Recorded first: once the listing is down there is nothing left to
+        // record but the sentinel standing in for its directory.
         self.record_location();
+        if self.is_synthetic() {
+            self.close_search();
+            self.leave_recent();
+        }
         self.go_to(path);
     }
 
@@ -3327,15 +3349,11 @@ impl Browser {
 
     /// Leave whatever synthetic listing is up and go to `path`, with the
     /// listing left behind Back.
+    ///
+    /// The same as [`Self::navigate_to`] — every navigation leaves a
+    /// synthetic listing now — kept for the callers that say what they mean.
     fn leave_synthetic_to(&mut self, path: &Path) {
-        if self.is_synthetic() {
-            self.record_location();
-            self.close_search();
-            self.leave_recent();
-            self.go_to(path);
-        } else {
-            self.navigate_to(path);
-        }
+        self.navigate_to(path);
     }
 
     /// Open the path entry on the directory being shown, with the whole path
@@ -12701,6 +12719,120 @@ mod search_tests {
         let _ = std::fs::remove_dir_all(&root);
         assert_eq!(selected.len(), 1, "one row, not three: {selected:?}");
         assert!(selected[0].contains("two"), "and the one clicked");
+    }
+
+    /// Poll until the pane in front has its listing, so a test can look at
+    /// what a navigation *settled* into rather than what it started as.
+    fn settle_listing(browser: &mut Browser) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while browser.columns[0].loading() && std::time::Instant::now() < deadline {
+            browser.poll();
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        browser.poll();
+        browser.rebuild_recent_sections();
+    }
+
+    /// Opening Recent and, before its scan has answered, being sent to a
+    /// folder — the palette's Home, or any other place — must leave Recent
+    /// entirely. The pane was replaced; the flag it hid behind must go with
+    /// it, or the folder arrives under Recent's title, day headings and
+    /// locked grid, and every place-bound command still says there is no
+    /// location.
+    #[test]
+    fn going_to_a_place_while_recent_is_loading_leaves_recent_behind() {
+        let root =
+            std::env::temp_dir().join(format!("otto-files-recent-race-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("note.txt"), "x").unwrap();
+
+        let mut browser = browser_at(&root);
+        browser.show_recent();
+        assert!(browser.recent, "Recent is up");
+        assert!(browser.columns[0].loading(), "and still scanning");
+
+        let request = command::Request {
+            id: command::id::GO_TO_PLACE.to_string(),
+            arg: Some(root.to_string_lossy().into_owned()),
+        };
+        browser.run_request(&request, 0).expect("the folder exists");
+        settle_listing(&mut browser);
+
+        let landed = browser.current_path();
+        let recent = browser.recent;
+        let synthetic = browser.is_synthetic();
+        let flat = browser.recent_sections.is_flat();
+        let names: Vec<String> = browser.columns[0]
+            .snapshot
+            .entries
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+        let back_to_recent = matches!(
+            browser.back.last().map(|l| &l.synthetic),
+            Some(Some(Synthetic::Recent))
+        );
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(landed, root, "the window is on the folder it was sent to");
+        assert!(!recent, "and Recent is no longer up");
+        assert!(!synthetic, "the folder is a real location");
+        assert!(flat, "no day headings over a directory listing");
+        assert_eq!(names, vec!["note.txt".to_string()], "showing the folder");
+        assert!(back_to_recent, "with Recent left behind Back");
+    }
+
+    /// The same race for a search: sent somewhere while the results are
+    /// still coming, the window must show the folder and not a search.
+    #[test]
+    fn going_to_a_place_while_a_search_is_running_closes_the_search() {
+        let root =
+            std::env::temp_dir().join(format!("otto-files-search-race-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("note.txt"), "x").unwrap();
+
+        let mut browser = browser_at(&root);
+        type_query(&mut browser, "invoice");
+        assert!(browser.searching, "results are on their way");
+        assert!(browser.columns[0].loading(), "and not here yet");
+
+        let request = command::Request {
+            id: command::id::GO_TO_PLACE.to_string(),
+            arg: Some(root.to_string_lossy().into_owned()),
+        };
+        browser.run_request(&request, 0).expect("the folder exists");
+        settle_listing(&mut browser);
+
+        let landed = browser.current_path();
+        let searching = browser.searching;
+        let field_open = browser.search.is_some();
+        let names: Vec<String> = browser.columns[0]
+            .snapshot
+            .entries
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(landed, root, "the window is on the folder it was sent to");
+        assert!(!searching, "and no longer searching");
+        assert!(!field_open, "the strip went with it");
+        assert_eq!(names, vec!["note.txt".to_string()], "showing the folder");
+    }
+
+    /// Up from Recent has nowhere to go: the sentinel's parent is not a
+    /// folder anyone asked for.
+    #[test]
+    fn up_from_recent_stays_put() {
+        let mut browser = browser_at(&std::env::temp_dir());
+        browser.show_recent();
+        browser.go_up();
+        assert!(browser.recent, "still Recent");
+        assert!(
+            crate::recent::is_sentinel(&browser.columns[0].path),
+            "not the sentinel's parent: {}",
+            browser.columns[0].path.display()
+        );
     }
 }
 

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -429,6 +429,14 @@ struct Browser {
     /// keyboard whole; the browser underneath is untouched until a command
     /// actually runs. See `specs/file-command-palette.md`.
     palette: Option<palette::Palette>,
+    /// What was selected when the palette opened: the pane, its selection, its
+    /// cursor and its anchor.
+    ///
+    /// A previewed argument selects as it is typed, so there has to be
+    /// something to put back when the palette is abandoned — and something to
+    /// start each keystroke's answer from, since a pattern narrowed by one
+    /// character is a fresh question rather than a refinement of the last one.
+    palette_selection: Option<SelectionMark>,
     /// A palette command asked for Quick View. The panel and its decode belong
     /// to the window around the browser, so the request is left here for it.
     palette_quickview: bool,
@@ -530,6 +538,19 @@ struct Browser {
     /// asking for is this times that — and applying it incrementally instead
     /// would compound rounding across a gesture that can run for seconds.
     quickview_pinch: Option<f32>,
+}
+
+/// A pane's selection as it stood at some moment, so it can be put back.
+///
+/// Held while the palette is open: a previewed argument selects as it is
+/// typed, and every keystroke answers afresh from here rather than refining
+/// the last answer.
+#[derive(Clone)]
+struct SelectionMark {
+    depth: usize,
+    selection: std::collections::BTreeSet<String>,
+    cursor: Option<usize>,
+    anchor: Option<usize>,
 }
 
 /// One of the palette's rows, with its text owned.
@@ -852,6 +873,7 @@ impl Browser {
             rename: None,
             pending_rename: None,
             palette: None,
+            palette_selection: None,
             palette_quickview: false,
             commands: command::Registry::builtin(),
             path_entry: None,
@@ -3500,6 +3522,14 @@ impl Browser {
     fn open_palette(&mut self) {
         let situation = self.situation();
         let commands = self.commands.commands(&situation);
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let column = &self.columns[depth];
+        self.palette_selection = Some(SelectionMark {
+            depth,
+            selection: column.selection.clone(),
+            cursor: column.cursor,
+            anchor: column.anchor,
+        });
         self.palette = Some(palette::Palette::open(
             commands,
             view::palette_field_style(AppContext::current_theme()),
@@ -3511,10 +3541,64 @@ impl Browser {
     /// it was — the palette never changed it by being open.
     fn close_palette(&mut self) -> bool {
         let was_open = self.palette.take().is_some();
+        // Whatever a previewed argument selected along the way is not what the
+        // user asked for: they backed out.
+        self.restore_palette_selection();
+        self.palette_selection = None;
         if was_open {
             self.dirty = true;
         }
         was_open
+    }
+
+    /// Close the palette with what it did left standing — the way out after a
+    /// command actually ran.
+    fn finish_palette(&mut self) -> bool {
+        let was_open = self.palette.take().is_some();
+        self.palette_selection = None;
+        if was_open {
+            self.dirty = true;
+        }
+        was_open
+    }
+
+    /// Put the selection back to what it was when the palette opened.
+    fn restore_palette_selection(&mut self) {
+        let Some(mark) = self.palette_selection.clone() else {
+            return;
+        };
+        if let Some(column) = self.columns.get_mut(mark.depth) {
+            column.selection = mark.selection;
+            column.cursor = mark.cursor;
+            column.anchor = mark.anchor;
+        }
+    }
+
+    /// Show a previewed argument as it is typed.
+    ///
+    /// Every keystroke answers afresh from the selection the palette opened
+    /// on, so deleting a character widens the selection again rather than
+    /// leaving the last narrower answer standing.
+    fn preview_palette_argument(&mut self) {
+        let Some((id, typed)) = self
+            .palette
+            .as_ref()
+            .and_then(|palette| palette.previewed_argument())
+            .map(|(id, typed)| (id.to_string(), typed.to_string()))
+        else {
+            return;
+        };
+        self.restore_palette_selection();
+        if typed.trim().is_empty() {
+            self.dirty = true;
+            return;
+        }
+        if id == command::id::SELECT_MATCHING {
+            // A pattern that matches nothing leaves the restored selection
+            // standing and says nothing: it is half-typed, not wrong.
+            let _ = self.select_matching(&typed);
+        }
+        self.dirty = true;
     }
 
     /// Fill in what a half-typed path could be completed to.
@@ -3657,7 +3741,11 @@ impl Browser {
         if let Some(error) = palette.error() {
             return Some(error.to_string());
         }
-        (palette.rows().is_empty() && !palette.resting())
+        // Only about the *command* list. An argument with nothing under it —
+        // a name, a pattern, anything free-text — has no completions by
+        // nature, and saying "no command matches" about it is both wrong and
+        // alarming.
+        (palette.prompt().is_none() && palette.rows().is_empty() && !palette.resting())
             .then(|| otto_kit::t_owned!("files-palette-no-matches"))
     }
 
@@ -3680,7 +3768,7 @@ impl Browser {
                 Ok(followup) => {
                     // Closed only once the command was carried out: a refusal
                     // keeps the panel up with the text still there to fix.
-                    self.close_palette();
+                    self.finish_palette();
                     self.palette_quickview = followup == Followup::QuickView;
                 }
                 Err(error) => {
@@ -3692,6 +3780,7 @@ impl Browser {
             },
             palette::Outcome::Changed => {
                 self.refresh_palette_completions();
+                self.preview_palette_argument();
                 self.dirty = true;
             }
             palette::Outcome::Ignored => {}
@@ -9672,6 +9761,142 @@ mod palette_tests {
         browser.select(0, outer);
         assert!(browser.move_selection_to("outer/inner").is_err());
         assert!(dir.0.join("outer/inner").is_dir());
+    }
+
+    /// A previewed pattern selects as it is typed.
+    #[test]
+    fn select_matching_shows_its_answer_while_it_is_typed() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt"]);
+        open_and_type(&mut browser, "select matching");
+        press(&mut browser, palette::Key::Tab);
+
+        for ch in "*.png".chars() {
+            browser.palette.as_mut().unwrap().on_key(
+                palette::Key::Edit(TextInputKey::Char(ch)),
+                KeyMods {
+                    shift: false,
+                    ctrl: false,
+                },
+            );
+            browser.preview_palette_argument();
+        }
+        let selected: Vec<String> = browser
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        assert_eq!(selected, vec!["a.png", "b.png"]);
+    }
+
+    /// Deleting back through the pattern widens the answer again, rather than
+    /// leaving the narrower one standing.
+    #[test]
+    fn deleting_through_a_pattern_gives_the_selection_back() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.txt"]);
+        open_and_type(&mut browser, "select matching");
+        press(&mut browser, palette::Key::Tab);
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        for ch in "*.png".chars() {
+            browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+            browser.preview_palette_argument();
+        }
+        assert_eq!(browser.selected_entries().len(), 1);
+
+        // All the way back to an empty pattern: nothing is selected again.
+        for _ in 0..5 {
+            browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Backspace), mods);
+            browser.preview_palette_argument();
+        }
+        assert_eq!(browser.selected_entries().len(), 0);
+    }
+
+    /// And abandoning the palette puts back whatever was selected before it
+    /// opened — the preview was shown, not done.
+    #[test]
+    fn abandoning_a_preview_puts_the_selection_back() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt"]);
+        browser.select(0, 2);
+        let before: Vec<String> = browser
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+
+        open_and_type(&mut browser, "select matching");
+        press(&mut browser, palette::Key::Tab);
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        for ch in "*.png".chars() {
+            browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Edit(TextInputKey::Char(ch)), mods);
+            browser.preview_palette_argument();
+        }
+        assert_eq!(browser.selected_entries().len(), 2);
+
+        browser.close_palette();
+        let after: Vec<String> = browser
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        assert_eq!(after, before);
+    }
+
+    /// Running it keeps what it selected.
+    #[test]
+    fn running_a_preview_keeps_its_answer() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt"]);
+        open_and_type(&mut browser, "select matching");
+        press(&mut browser, palette::Key::Tab);
+        browser
+            .palette
+            .as_mut()
+            .unwrap()
+            .input_mut()
+            .set_value("*.png");
+        let palette::Outcome::Run(request) = press(&mut browser, palette::Key::Enter) else {
+            panic!("Return should run it");
+        };
+        browser.run_request(&request, 0).expect("two match");
+        browser.finish_palette();
+        assert_eq!(browser.selected_entries().len(), 2);
+    }
+
+    /// A free-text argument has no completions, and that is not a failure to
+    /// find anything: the panel must not say "no command matches" about a
+    /// pattern being typed.
+    #[test]
+    fn a_text_argument_is_not_reported_as_matching_nothing() {
+        let (mut browser, _dir) = browser_over(&["a.png"]);
+        open_and_type(&mut browser, "select matching");
+        assert!(browser.palette_message().is_none());
+        press(&mut browser, palette::Key::Tab);
+        assert!(browser.palette.as_ref().unwrap().prompt().is_some());
+        assert!(
+            browser.palette_message().is_none(),
+            "an argument with no completions says nothing"
+        );
+
+        // A query that really matches no command still says so.
+        browser.close_palette();
+        open_and_type(&mut browser, "zzzz");
+        assert!(browser.palette_message().is_some());
     }
 
     /// Opening the palette changes nothing underneath it, and closing it

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -442,6 +442,11 @@ struct Browser {
     /// would be a placement the user has to undo before they can read the
     /// window under it.
     palette_offset: (f32, f32),
+    /// The palette's list, scrolling under its field: momentum, the band past
+    /// either end and the fading bar, the same view the columns run on. Owned
+    /// here rather than by the palette because the palette is I/O-free and
+    /// clock-free, and a scroll view keeps time.
+    palette_scroll: ScrollView,
     /// The display the palette may be dragged around, in window points, as the
     /// compositor last answered. `None` until it has, and the drag then falls
     /// back to the window's own edges.
@@ -890,6 +895,7 @@ impl Browser {
             palette: None,
             palette_selection: None,
             palette_offset: (0.0, 0.0),
+            palette_scroll: ScrollView::new(Rect::new_empty()),
             palette_display: None,
             palette_caret: None,
             palette_drag: None,
@@ -2051,6 +2057,7 @@ impl Browser {
     fn scroll_animating(&self) -> bool {
         self.pan.is_animating()
             || self.columns.iter().any(|c| c.scroll.is_animating())
+            || self.palette_scroll.is_animating()
             || self.quickview_pan_animating()
     }
 
@@ -2065,6 +2072,9 @@ impl Browser {
             if column.scroll.is_animating() {
                 moved |= column.scroll.tick();
             }
+        }
+        if self.palette_scroll.is_animating() {
+            moved |= self.palette_scroll.tick();
         }
         // The open preview's picture pans on scroll views of its own, and
         // they fling and spring like any other.
@@ -3572,6 +3582,7 @@ impl Browser {
             view::palette_field_style(AppContext::current_theme()),
         ));
         self.palette_offset = (0.0, 0.0);
+        self.palette_scroll = ScrollView::new(Rect::new_empty());
         self.palette_display = None;
         self.palette_caret = None;
         self.palette_drag = None;
@@ -3715,49 +3726,105 @@ impl Browser {
     /// The card, where it is now — the resting rect moved by whatever drag has
     /// been applied to it.
     fn palette_card(&mut self) -> Rect {
-        let rows = self.palette_rows();
-        let view_rows: Vec<view::PaletteRow<'_>> = rows
-            .iter()
-            .map(|row| view::PaletteRow {
-                kind: row.kind,
-                title: &row.title,
-                badge: None,
-                subtitle: None,
-                shortcut: None,
-                highlighted: row.highlighted,
-            })
-            .collect();
-        let message = self
-            .palette
-            .as_ref()
-            .map(|_| ())
-            .and(self.palette_message())
-            .is_some();
+        let rows = self.palette_layout();
+        let view_rows = Self::palette_view_rows(&rows);
+        let message = self.palette_message().is_some();
         view::palette_rect(self.size.0, &view_rows, message).with_offset(self.palette_offset)
+    }
+
+    /// The band a drag takes hold of: the card's top, where the field is.
+    ///
+    /// The field rather than a bar of its own — the palette is one card with a
+    /// line of text across the top of it, and a strip above that line would be
+    /// chrome for its own sake. The rows below it are for picking.
+    fn palette_grip_at(&mut self, x: f32, y: f32) -> bool {
+        let card = self.palette_card();
+        Rect::from_ltrb(
+            card.left,
+            card.top,
+            card.right,
+            card.top + view::PALETTE_FIELD_H,
+        )
+        .contains(skia_safe::Point::new(x, y))
     }
 
     /// A press at `(x, y)` in window points, while the palette is up.
     ///
-    /// The card is a handle and nothing else: a press anywhere on it takes
-    /// hold of it, and a press anywhere else lets the palette go. Rows are not
-    /// clicked — picking is the keyboard's, and a card that is all handle can
-    /// be dragged from wherever it was caught, which is what a card that
-    /// wanders off the window needs.
+    /// The top band takes hold of the card; a row is picked, the way Return
+    /// picks the highlighted one; the rest of the card is inert; and a press
+    /// anywhere else lets the palette go, spending the click on that rather
+    /// than on whatever file was underneath.
     ///
-    /// One method rather than two because the press reaches the browser two
-    /// ways — through the palette's own catcher surface when the card has one,
-    /// and through the toplevel when it is painted into the window — and both
-    /// arrive here in the same coordinates.
-    fn palette_press(&mut self, x: f32, y: f32) {
-        let card = self.palette_card();
-        if card.contains(skia_safe::Point::new(x, y)) {
+    /// One method for both doors the press can come through — the palette's
+    /// own catcher surface, and the toplevel when the card is painted into the
+    /// window — since both arrive in the same coordinates.
+    fn palette_press(&mut self, x: f32, y: f32, serial: u32) {
+        if self.palette_grip_at(x, y) {
+            let card = self.palette_card();
             self.palette_drag = Some((x - card.left, y - card.top));
-        } else {
-            // A click outside the card dismisses the palette and stops there,
-            // rather than also selecting whatever file was underneath.
+            self.dirty = true;
+            return;
+        }
+        if let Some(row) = self.palette_row_under(x, y) {
+            let picked = self
+                .palette
+                .as_mut()
+                .is_some_and(|palette| palette.highlight_row(row));
+            if picked {
+                let mods = KeyMods {
+                    shift: false,
+                    ctrl: false,
+                };
+                if let Some(outcome) = self
+                    .palette
+                    .as_mut()
+                    .map(|palette| palette.on_key(palette::Key::Enter, mods))
+                {
+                    self.settle_palette(outcome, serial);
+                }
+            }
+            self.dirty = true;
+            return;
+        }
+        let card = self.palette_card();
+        if !card.contains(skia_safe::Point::new(x, y)) {
             self.close_palette();
         }
         self.dirty = true;
+    }
+
+    /// The pointer moving over the list, with no button down: the row under it
+    /// takes the highlight, so what Return would do is always what the pointer
+    /// is resting on.
+    fn palette_hover(&mut self, x: f32, y: f32) {
+        let Some(row) = self.palette_row_under(x, y) else {
+            return;
+        };
+        let moved = self.palette.as_mut().is_some_and(|palette| {
+            palette.highlighted() != Some(row) && palette.highlight_row(row)
+        });
+        self.dirty |= moved;
+    }
+
+    /// A scroll over the card. The list flings and springs like a column's:
+    /// a touchpad's stream carries momentum and stretches past the ends, a
+    /// notched wheel steps.
+    fn palette_wheel(&mut self, x: f32, y: f32, dy: f32, stop: bool, discrete: bool) {
+        let card = self.palette_card();
+        if !card.contains(skia_safe::Point::new(x, y)) {
+            return;
+        }
+        let _ = self.palette_layout();
+        let scroll = &mut self.palette_scroll;
+        let moved = if stop {
+            scroll.on_wheel_end();
+            true
+        } else if discrete {
+            scroll.on_wheel_discrete(dy)
+        } else {
+            scroll.on_wheel(dy)
+        };
+        self.dirty |= moved;
     }
 
     /// Everything the palette's own surface needs, with its text owned.
@@ -3766,20 +3833,10 @@ impl Browser {
     /// palette back, mutably, to render its text field into the same canvas.
     fn palette_frame(&mut self) -> Option<pane_surfaces::PaletteFrame> {
         self.palette.as_ref()?;
-        let rows = self.palette_rows();
+        let rows = self.palette_layout();
         let message = self.palette_message();
         let prompt = self.palette.as_ref().and_then(|p| p.prompt());
-        let view_rows: Vec<view::PaletteRow<'_>> = rows
-            .iter()
-            .map(|row| view::PaletteRow {
-                kind: row.kind,
-                title: &row.title,
-                badge: row.badge.as_deref(),
-                subtitle: row.subtitle.as_deref(),
-                shortcut: row.shortcut.as_deref(),
-                highlighted: row.highlighted,
-            })
-            .collect();
+        let view_rows = Self::palette_view_rows(&rows);
         let resting = view::palette_rect(self.size.0, &view_rows, message.is_some());
         drop(view_rows);
         Some(pane_surfaces::PaletteFrame {
@@ -3788,6 +3845,7 @@ impl Browser {
             prompt,
             message,
             rows,
+            scroll: self.palette_scroll.state,
         })
     }
 
@@ -3886,26 +3944,17 @@ impl Browser {
 
     /// The palette's rows as the view wants them, scrolled so the highlight is
     /// on screen.
-    fn palette_rows(&mut self) -> Vec<PaletteRowData> {
-        let Some(palette) = self.palette.as_mut() else {
+    fn palette_rows(&self) -> Vec<PaletteRowData> {
+        let Some(palette) = self.palette.as_ref() else {
             return Vec::new();
         };
-        let len = palette.rows().len();
-        let window = view::palette_window(
-            len,
-            palette.highlighted(),
-            palette.scroll(),
-            view::PALETTE_MAX_ROWS,
-        );
-        palette.set_scroll(window.start);
-
-        let palette = self.palette.as_ref().expect("checked above");
         let highlight = palette.highlighted();
         let resting = palette.resting();
-        let mut rows: Vec<PaletteRowData> = palette.rows()[window.clone()]
+        palette
+            .rows()
             .iter()
-            .zip(window)
-            .map(|(row, index)| match row {
+            .enumerate()
+            .map(|(index, row)| match row {
                 palette::Row::Heading(group) => PaletteRowData {
                     kind: view::PaletteRowKind::Heading,
                     title: group.label(),
@@ -3943,16 +3992,73 @@ impl Browser {
                     }
                 }
             })
-            .collect::<Vec<_>>();
-        // A group named with nothing under it reads as broken rather than as
-        // scrolled, so the window never ends on a heading.
-        while rows
-            .last()
-            .is_some_and(|row| row.kind == view::PaletteRowKind::Heading)
-        {
-            rows.pop();
+            .collect()
+    }
+
+    /// Size the list's scroll view to the rows it holds, and return those
+    /// rows. Everything that measures the list — painting, hit-testing,
+    /// revealing the highlight — goes through here, so they cannot disagree.
+    fn palette_layout(&mut self) -> Vec<PaletteRowData> {
+        let rows = self.palette_rows();
+        let message = self.palette_message().is_some();
+        let view_rows = Self::palette_view_rows(&rows);
+        let viewport = view::palette_list_rect(self.size.0, &view_rows, message);
+        let content = view::palette_content_h(&view_rows);
+        drop(view_rows);
+        if self.palette_scroll.state.viewport() != viewport {
+            self.palette_scroll.set_viewport(viewport);
+        }
+        if self.palette_scroll.state.content_length() != content {
+            self.palette_scroll.set_content_length(content);
         }
         rows
+    }
+
+    /// The rows as the view measures them — text borrowed, nothing else.
+    fn palette_view_rows(rows: &[PaletteRowData]) -> Vec<view::PaletteRow<'_>> {
+        rows.iter()
+            .map(|row| view::PaletteRow {
+                kind: row.kind,
+                title: &row.title,
+                badge: row.badge.as_deref(),
+                subtitle: row.subtitle.as_deref(),
+                shortcut: row.shortcut.as_deref(),
+                highlighted: row.highlighted,
+            })
+            .collect()
+    }
+
+    /// Scroll the list by the least that brings the highlighted row into
+    /// view. After every key, so the arrows walk a long list a row at a time.
+    fn palette_reveal_highlight(&mut self) {
+        let Some(highlight) = self.palette.as_ref().and_then(|p| p.highlighted()) else {
+            return;
+        };
+        let rows = self.palette_layout();
+        let view_rows = Self::palette_view_rows(&rows);
+        if highlight >= view_rows.len() {
+            return;
+        }
+        let row = view::palette_row_rect(self.size.0, &view_rows, highlight);
+        let viewport = self.palette_scroll.state.viewport();
+        let offset = view::palette_reveal(row, viewport, self.palette_scroll.offset());
+        if offset != self.palette_scroll.offset() {
+            self.palette_scroll.scroll_to(offset);
+        }
+    }
+
+    /// Which row of the list is under `(x, y)` in window points, through the
+    /// list's scroll: the rows are hit-tested where they lie, shifted by how
+    /// far they have been scrolled.
+    fn palette_row_under(&mut self, x: f32, y: f32) -> Option<usize> {
+        let rows = self.palette_layout();
+        let view_rows = Self::palette_view_rows(&rows);
+        let (x, y) = (x - self.palette_offset.0, y - self.palette_offset.1);
+        let viewport = self.palette_scroll.state.viewport();
+        if !viewport.contains(skia_safe::Point::new(x, y)) {
+            return None;
+        }
+        view::palette_row_at(x, y + self.palette_scroll.offset(), self.size.0, &view_rows)
     }
 
     /// What to show in place of the list: a refusal, or that nothing matches.
@@ -4006,6 +4112,7 @@ impl Browser {
             palette::Outcome::Changed => {
                 self.refresh_palette_completions();
                 self.preview_palette_argument();
+                self.palette_reveal_highlight();
                 self.dirty = true;
             }
             palette::Outcome::Ignored => {}
@@ -6551,7 +6658,7 @@ impl App for FilesApp {
             // two-step the rename and path fields take.
             if browser.palette.is_some() && !pane_surfaces::palette_on_surface() {
                 let width = browser.size.0;
-                let rows = browser.palette_rows();
+                let rows = browser.palette_layout();
                 let message = browser.palette_message();
                 let prompt = browser.palette.as_ref().and_then(|p| p.prompt());
                 let view_rows: Vec<view::PaletteRow<'_>> = rows
@@ -6580,6 +6687,7 @@ impl App for FilesApp {
                         rows: view_rows,
                         message: message.as_deref(),
                         on_surface: false,
+                        scroll: Some(browser.palette_scroll.state),
                     },
                 );
                 canvas.restore();
@@ -8050,15 +8158,27 @@ impl FilesApp {
                     continue;
                 }
                 match event.kind {
-                    PointerEventKind::Press { .. } => {
-                        browser.palette_press(x, y);
+                    PointerEventKind::Press { serial, .. } => {
+                        browser.palette_press(x, y, serial);
                     }
                     PointerEventKind::Motion { .. } if browser.palette_drag.is_some() => {
                         browser.drag_palette_to(x, y);
                     }
+                    PointerEventKind::Motion { .. } => {
+                        browser.palette_hover(x, y);
+                    }
                     // The card stays where it was let go of.
                     PointerEventKind::Release { .. } => {
                         browser.dirty |= browser.palette_drag.take().is_some();
+                    }
+                    PointerEventKind::Axis { vertical, .. } => {
+                        browser.palette_wheel(
+                            x,
+                            y,
+                            vertical.absolute as f32,
+                            vertical.stop,
+                            vertical.discrete != 0,
+                        );
                     }
                     _ => {}
                 }
@@ -9071,7 +9191,7 @@ impl FilesApp {
                         // there, rather than also selecting whatever file
                         // happened to be underneath.
                         if browser.palette.is_some() {
-                            browser.palette_press(x, y);
+                            browser.palette_press(x, y, serial);
                             return;
                         }
 
@@ -10421,41 +10541,119 @@ mod palette_tests {
         assert!(!dir.0.join("reports").exists());
     }
 
-    /// The whole card is a handle: a press anywhere on it — the field, a row,
-    /// the bottom edge — takes hold, and the card then follows the pointer and
-    /// stays where it is let go of. Nothing on it is clicked.
+    /// The top band takes hold of the card; a row is picked, not grabbed.
     #[test]
-    fn the_palette_is_a_handle_all_over() {
+    fn the_top_band_drags_and_the_rows_pick() {
         let (mut browser, _dir) = browser_over(&["a.txt"]);
         browser.size = (1200.0, 800.0);
         browser.open_palette();
         let card = browser.palette_card();
-        let rows = browser
-            .palette
-            .as_ref()
-            .map(|p| p.rows().len())
-            .unwrap_or(0);
-        assert!(rows > 1, "the resting list should offer something");
 
-        // A press on a row is a grab, not a pick: the highlight does not move
-        // and nothing runs.
-        let before = browser.palette.as_ref().and_then(|p| p.highlighted());
-        browser.palette_press(card.center_x(), card.bottom - 4.0);
-        assert!(browser.palette_drag.is_some());
+        browser.palette_press(card.center_x(), card.top + 4.0, 0);
         assert!(
-            browser.palette.is_some(),
-            "a press on the card must not close it"
+            browser.palette_drag.is_some(),
+            "the field band is the handle"
         );
-        assert_eq!(
-            browser.palette.as_ref().and_then(|p| p.highlighted()),
-            before
-        );
+        browser.palette_drag = None;
+
+        // The first row that asks for an argument: pressing it enters
+        // argument mode, the same as Return on it would.
+        let rows = browser.palette_layout();
+        let view_rows = Browser::palette_view_rows(&rows);
+        let target = rows
+            .iter()
+            .position(|row| row.badge.is_some())
+            .expect("a command with an argument");
+        let rect = view::palette_row_rect(1200.0, &view_rows, target);
+        drop(view_rows);
+        browser.palette_press(rect.center_x(), rect.center_y(), 0);
+        assert!(browser.palette_drag.is_none(), "a row is not a handle");
+        assert!(browser.palette.as_ref().unwrap().prompt().is_some());
 
         browser.palette_drag = Some((10.0, 10.0));
         browser.drag_palette_to(400.0, 300.0);
         let moved = browser.palette_card();
         assert_eq!(moved.left, 390.0);
         assert_eq!(moved.top, 290.0);
+    }
+
+    /// The row under the pointer is the highlighted one, so Return always does
+    /// what the pointer is resting on.
+    #[test]
+    fn hovering_a_row_highlights_it() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        let rows = browser.palette_layout();
+        let view_rows = Browser::palette_view_rows(&rows);
+        let items: Vec<usize> = (0..rows.len())
+            .filter(|&i| rows[i].kind == view::PaletteRowKind::Item)
+            .collect();
+        assert!(items.len() >= 2);
+        let second = view::palette_row_rect(1200.0, &view_rows, items[1]);
+        drop(view_rows);
+        browser.palette_hover(second.center_x(), second.center_y());
+        assert_eq!(
+            browser.palette.as_ref().unwrap().highlighted(),
+            Some(items[1])
+        );
+        // A heading is read, not hovered.
+        if let Some(heading) = rows
+            .iter()
+            .position(|r| r.kind == view::PaletteRowKind::Heading)
+        {
+            let rows2 = browser.palette_layout();
+            let view_rows = Browser::palette_view_rows(&rows2);
+            let rect = view::palette_row_rect(1200.0, &view_rows, heading);
+            drop(view_rows);
+            browser.palette_hover(rect.center_x(), rect.center_y());
+            assert_eq!(
+                browser.palette.as_ref().unwrap().highlighted(),
+                Some(items[1])
+            );
+        }
+    }
+
+    /// The list is a scroll view: a wheel over it moves the rows, and the
+    /// arrows keep the highlight in view by the least that shows it.
+    #[test]
+    fn the_list_scrolls_under_the_wheel_and_the_arrows() {
+        let (mut browser, _dir) = browser_over(&["a.txt", "b.txt"]);
+        browser.size = (1200.0, 800.0);
+        browser.open_palette();
+        let rows = browser.palette_layout();
+        assert!(
+            rows.len() > view::PALETTE_MAX_ROWS,
+            "the resting list should be longer than the viewport"
+        );
+        let content = browser.palette_scroll.state.content_length();
+        let viewport = browser.palette_scroll.state.viewport();
+        assert!(content > viewport.height());
+
+        let card = browser.palette_card();
+        browser.palette_wheel(card.center_x(), card.center_y(), 3.0, false, true);
+        assert!(
+            browser.palette_scroll.offset() > 0.0,
+            "a notch scrolls the list"
+        );
+        browser.palette_scroll.scroll_to(0.0);
+
+        // Arrow down past the bottom of the viewport: the list follows.
+        let mods = KeyMods {
+            shift: false,
+            ctrl: false,
+        };
+        for _ in 0..rows.len() {
+            let outcome = browser
+                .palette
+                .as_mut()
+                .unwrap()
+                .on_key(palette::Key::Down, mods);
+            browser.settle_palette(outcome, 0);
+        }
+        let offset = browser.palette_scroll.offset();
+        assert!(offset > 0.0, "the highlight at the end pulls the list down");
+        assert!(offset <= content - viewport.height() + 0.5);
     }
 
     /// A press anywhere else lets the palette go, and the click is spent on
@@ -10466,7 +10664,7 @@ mod palette_tests {
         browser.size = (1200.0, 800.0);
         let selection = browser.columns[0].selection.clone();
         browser.open_palette();
-        browser.palette_press(20.0, 700.0);
+        browser.palette_press(20.0, 700.0, 0);
         assert!(browser.palette.is_none());
         assert!(browser.palette_drag.is_none());
         assert_eq!(browser.columns[0].selection, selection);

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
     command, model, palette, pane_surfaces, perf, picker, quickview, remembered, rename, scene,
-    thumbcache, thumbnails, view,
+    scripts, thumbcache, thumbnails, view,
 };
 
 use std::cell::RefCell;
@@ -919,6 +919,7 @@ impl Browser {
             commands: {
                 let mut registry = command::Registry::builtin();
                 registry.add(Box::new(rename::RenameProvider));
+                registry.add(Box::new(scripts::ScriptProvider::new()));
                 registry
             },
             path_entry: None,
@@ -6145,6 +6146,15 @@ impl Browser {
         }
         if let Some(depth) = vanished {
             self.follow_vanished(depth);
+            changed = true;
+        }
+        // What a provider's earlier runs — a script, most likely — have
+        // finished with, applied the same way as a run that answered at once.
+        for landed in self.commands.poll() {
+            match landed {
+                Ok(effect) => self.apply_effect(effect),
+                Err(reason) => self.status = Some(reason),
+            }
             changed = true;
         }
         changed

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -3759,6 +3759,8 @@ impl Browser {
             id::COPY => self.copy_selection(false, serial),
             id::PASTE => self.paste(),
             id::SELECT_ALL => self.select_all(),
+            id::SELECT_MATCHING => self.select_matching(arg)?,
+            id::MOVE_TO => self.move_selection_to(arg)?,
             id::UNDO => self.undo_last(),
             // The three views by name share their ids with the values Change
             // View takes, so one arm answers for both.
@@ -3802,6 +3804,95 @@ impl Browser {
             other => return Err(format!("Unknown command: {other}")),
         }
         Ok(Followup::Nothing)
+    }
+
+    /// Select every entry in the active pane whose name matches `pattern`.
+    ///
+    /// Matched against the *visible* listing rather than the directory, so a
+    /// pattern selects what is on screen: hidden files stay out of it unless
+    /// they are being shown, and a filtered listing narrows what can be
+    /// picked. That is what someone typing at a listing means by it.
+    fn select_matching(&mut self, pattern: &str) -> Result<(), String> {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            return Err(otto_kit::t_owned!("files-no-pattern"));
+        }
+        let depth = self.active.min(self.columns.len().saturating_sub(1));
+        let matched: Vec<(usize, String)> = self
+            .visible(depth)
+            .into_iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                // Case-sensitive when the pattern carries case, the way the
+                // picker's filters read: `*.png` finds `PHOTO.PNG`, and
+                // `*.PNG` means the shouty one.
+                if pattern.chars().any(|c| c.is_ascii_uppercase()) {
+                    otto_kit::filetype::glob::matches(pattern, &entry.name)
+                } else {
+                    otto_kit::filetype::glob::matches_ignore_case(pattern, &entry.name)
+                }
+            })
+            .map(|(index, entry)| (index, entry.selection_key()))
+            .collect();
+
+        if matched.is_empty() {
+            return Err(otto_kit::t_owned!(
+                "files-nothing-matches",
+                pattern = pattern
+            ));
+        }
+        let count = matched.len();
+        let first = matched[0].0;
+        let column = &mut self.columns[depth];
+        column.selection.clear();
+        for (_, key) in matched {
+            column.selection.insert(key);
+        }
+        // The cursor goes to the first match so the selection can be walked
+        // from somewhere, and the anchor with it so a following Shift+Arrow
+        // extends from there rather than from wherever the cursor last was.
+        column.cursor = Some(first);
+        column.anchor = Some(first);
+        self.reveal_cursor();
+        self.status = Some(otto_kit::t_owned!(
+            "files-selected-count",
+            count = count as f64
+        ));
+        self.dirty = true;
+        Ok(())
+    }
+
+    /// Move the selection into `path`.
+    ///
+    /// The move a cut and paste would make, said in one go: the same
+    /// conflict rule, the same sound, the same undo entry.
+    fn move_selection_to(&mut self, path: &str) -> Result<(), String> {
+        let paths: Vec<PathBuf> = self
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect();
+        if paths.is_empty() {
+            return Err(otto_kit::t_owned!("files-nothing-selected"));
+        }
+        let dest = self
+            .resolve_typed_path(path)
+            .filter(|dest| dest.is_dir())
+            .ok_or_else(|| otto_kit::t_owned!("files-no-such-folder", path = path.trim()))?;
+        // Moving a folder into itself, or into its own child, would take the
+        // whole subtree somewhere it cannot be reached from.
+        if paths.iter().any(|from| dest.starts_with(from)) {
+            return Err(otto_kit::t_owned!("files-cant-move-into-itself"));
+        }
+
+        let clip = model::Clipboard { paths, cut: true };
+        // Keep Both, like a paste with no sheet to ask with: the only default
+        // that cannot destroy anything.
+        let result = model::paste(&clip, &dest, model::OnConflict::KeepBoth);
+        self.report(&result);
+        self.record_undo(otto_kit::t!("files-undo-move"), result.changes);
+        self.reload_all();
+        Ok(())
     }
 
     /// Sort by `key`, in the direction that key reads best in — and remember
@@ -9508,6 +9599,79 @@ mod palette_tests {
         assert!(dir.0.join("reports").is_dir());
         // A second one with the same name is an error, not a "reports 2".
         assert!(browser.new_folder_named("reports").is_err());
+    }
+
+    /// A pattern selects what is on screen, and nothing else.
+    #[test]
+    fn select_matching_picks_the_files_the_pattern_names() {
+        let (mut browser, _dir) = browser_over(&["a.png", "b.png", "c.txt", "D.PNG"]);
+        browser.select_matching("*.png").expect("three match");
+        let selected: Vec<String> = browser
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        // A lowercase pattern also takes the shouty extension.
+        assert_eq!(selected, vec!["a.png", "b.png", "D.PNG"]);
+    }
+
+    /// A pattern carrying case means that case.
+    #[test]
+    fn a_pattern_with_case_in_it_is_matched_with_case() {
+        let (mut browser, _dir) = browser_over(&["a.png", "D.PNG"]);
+        browser.select_matching("*.PNG").expect("one matches");
+        let selected: Vec<String> = browser
+            .selected_entries()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        assert_eq!(selected, vec!["D.PNG"]);
+    }
+
+    /// A pattern matching nothing is a refusal, and leaves the selection be.
+    #[test]
+    fn a_pattern_matching_nothing_is_refused() {
+        let (mut browser, _dir) = browser_over(&["a.txt"]);
+        browser.select(0, 0);
+        assert!(browser.select_matching("*.png").is_err());
+        assert_eq!(browser.selected_entries().len(), 1);
+    }
+
+    /// Moving the selection is the move a cut and paste would make.
+    #[test]
+    fn move_to_folder_moves_the_selection() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        std::fs::create_dir(dir.0.join("inbox")).unwrap();
+        browser.select(0, 0);
+        browser
+            .move_selection_to("inbox")
+            .expect("the folder is there");
+        assert!(dir.0.join("inbox/a.txt").is_file());
+        assert!(!dir.0.join("a.txt").exists());
+        assert_eq!(browser.undo.len(), 1);
+    }
+
+    /// A folder cannot be moved inside itself: the subtree would go somewhere
+    /// it can no longer be reached from.
+    #[test]
+    fn a_folder_is_not_moved_into_itself() {
+        let (mut browser, dir) = browser_over(&["a.txt"]);
+        std::fs::create_dir_all(dir.0.join("outer/inner")).unwrap();
+        browser.reload_all();
+        for _ in 0..500 {
+            if browser.columns[0].poll() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        let outer = browser
+            .visible(0)
+            .iter()
+            .position(|entry| entry.name == "outer")
+            .expect("outer is listed");
+        browser.select(0, outer);
+        assert!(browser.move_selection_to("outer/inner").is_err());
+        assert!(dir.0.join("outer/inner").is_dir());
     }
 
     /// Opening the palette changes nothing underneath it, and closing it

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -5453,7 +5453,65 @@ impl Browser {
             items.push(MenuItem::action(label).with_action_id("trash"));
         }
 
+        // What the providers offer for this situation — scripts, the pattern
+        // rename — after the window's own items. The menu asks the same
+        // registry the palette does, so a script that shows up in one shows
+        // up in the other; picking one goes through the palette, which is
+        // where a command's argument and its dry run live.
+        let situation = self.situation();
+        let provided: Vec<command::Command> = self
+            .commands
+            .commands(&situation)
+            .into_iter()
+            .filter(|command| command.namespace().is_some())
+            .collect();
+        if !provided.is_empty() {
+            if !items.is_empty() {
+                items.push(MenuItem::separator());
+            }
+            for command in provided {
+                let label = if command.arg.is_some() {
+                    format!("{}…", command.title)
+                } else {
+                    command.title.clone()
+                };
+                items.push(MenuItem::action(label).with_action_id(command.id));
+            }
+        }
+
         items
+    }
+
+    /// Carry out a provider command picked from a menu.
+    ///
+    /// One that takes an argument opens the palette in its field, initial
+    /// value and dry run included, so the menu is a shortcut into the same
+    /// interaction rather than a second one; one that does not runs at once.
+    fn run_menu_command(&mut self, id: &str, serial: u32) {
+        let takes_arg = self
+            .commands
+            .commands(&self.situation())
+            .iter()
+            .any(|command| command.id == id && command.arg.is_some());
+        if takes_arg {
+            self.open_palette();
+            let opened = self
+                .palette
+                .as_mut()
+                .is_some_and(|palette| palette.open_on(id));
+            if opened {
+                self.preview_palette_argument();
+                self.palette_reveal_highlight();
+            } else {
+                self.close_palette();
+            }
+            return;
+        }
+        match self.run_request(&command::Request::new(id, None), serial) {
+            Ok(_) => {}
+            Err(error) => self.status = Some(error),
+        }
+        self.dirty = true;
     }
 
     /// Say out loud what an operation did.
@@ -9414,6 +9472,8 @@ impl FilesApp {
                                         browser.dirty = true;
                                     }
                                 }
+                                // A provider's command, by its namespaced id.
+                                id if id.contains(':') => browser.run_menu_command(id, serial),
                                 _ => {}
                             }
                             drop(browser);
@@ -10638,6 +10698,35 @@ mod palette_tests {
         assert_eq!(browser.undo.len(), undos - 1);
         assert!(dir.0.join("IMG_001.jpg").exists());
         assert!(dir.0.join("IMG_002.jpg").exists());
+    }
+
+    /// The right-click menu lists what the providers offer, and picking one
+    /// that takes an argument lands in the palette's field with the dry run
+    /// already showing.
+    #[test]
+    fn the_context_menu_offers_provider_commands_through_the_palette() {
+        let (mut browser, _dir) = browser_over(&["a.jpg", "b.jpg"]);
+        browser.clear_selection();
+        browser.select_matching("*.jpg").unwrap();
+        let items = browser.context_menu_items(-1.0, -1.0);
+        let labels: Vec<String> = items
+            .iter()
+            .filter_map(|item| match &item.kind {
+                otto_kit::prelude::MenuItemKind::Action { label, .. } => Some(label.clone()),
+                _ => None,
+            })
+            .collect();
+        let rename = otto_kit::t_owned!("files-rename-many", count = 2);
+        assert!(
+            labels.iter().any(|l| l == &format!("{rename}…")),
+            "{labels:?}"
+        );
+
+        browser.run_menu_command(rename::RENAME_MANY, 0);
+        let palette = browser.palette.as_ref().expect("the palette opened");
+        assert!(palette.prompt().is_some(), "in the argument field");
+        assert_eq!(palette.input().value(), "{name}");
+        assert_eq!(browser.palette_rows().len(), 2, "the dry run is showing");
     }
 
     /// Down into the dry run and Space leaves a file out; the dry run is

--- a/components/otto-files/src/app.rs
+++ b/components/otto-files/src/app.rs
@@ -1080,6 +1080,19 @@ impl Browser {
         self.dirty = true;
     }
 
+    /// Go to Recent from wherever the window is, as a navigation: the place
+    /// being left is recorded behind Back, and a search that was up comes
+    /// down — results are not somewhere Recent can sit on top of. The one
+    /// way in for the sidebar and the palette alike.
+    fn enter_recent(&mut self) {
+        if self.recent {
+            return;
+        }
+        self.record_location();
+        self.close_search();
+        self.show_recent();
+    }
+
     /// Leave the Recent listing, on the way to somewhere real.
     ///
     /// Clears the flag without navigating: the caller is about to, and doing
@@ -4364,6 +4377,11 @@ impl Browser {
             }
             id::GO_TO_PLACE => {
                 let path = PathBuf::from(arg);
+                // The Recent place is a sentinel, not a folder.
+                if crate::recent::is_sentinel(&path) {
+                    self.enter_recent();
+                    return Ok(Followup::Nothing);
+                }
                 if !path.is_dir() {
                     return Err(otto_kit::t_owned!("files-no-such-folder", path = arg));
                 }
@@ -4423,7 +4441,7 @@ impl Browser {
                     self.run_search();
                 }
             }
-            id::RECENT => self.show_recent(),
+            id::RECENT => self.enter_recent(),
             other => return Err(format!("Unknown command: {other}")),
         }
         Ok(Followup::Nothing)
@@ -4771,7 +4789,8 @@ impl Browser {
         if viewport.is_empty() {
             return;
         }
-        let (top, item_h) = view::item_span(width, height, self.mode, index);
+        let (top, item_h) =
+            view::item_span_in(width, height, self.mode, &self.recent_sections, index);
 
         let scroll = &mut self.columns[depth].scroll;
         let offset = scroll.offset();
@@ -9584,9 +9603,7 @@ impl FilesApp {
                             // showing a folder refuses half its own menu.
                             browser.active_place = Some(index);
                             if browser.places[index].recent {
-                                browser.record_location();
-                                browser.close_search();
-                                browser.show_recent();
+                                browser.enter_recent();
                             } else {
                                 let path = browser.places[index].path.clone();
                                 browser.leave_synthetic_to(&path);
@@ -10698,6 +10715,25 @@ mod palette_tests {
         assert_eq!(browser.undo.len(), undos - 1);
         assert!(dir.0.join("IMG_001.jpg").exists());
         assert!(dir.0.join("IMG_002.jpg").exists());
+    }
+
+    /// Recent reached from the palette — by name or as the place — takes a
+    /// search down with it, the way the sidebar already did.
+    #[test]
+    fn going_to_recent_from_the_palette_closes_the_search() {
+        for id in [command::id::RECENT, command::id::GO_TO_PLACE] {
+            let (mut browser, _dir) = browser_over(&["a.txt"]);
+            browser.searching = true;
+            view::set_search_band(true);
+            let arg = (id == command::id::GO_TO_PLACE).then(|| crate::recent::SENTINEL.to_string());
+            browser
+                .run_request(&command::Request::new(id, arg), 0)
+                .unwrap();
+            assert!(browser.recent, "{id}: in Recent");
+            assert!(!browser.searching, "{id}: the search came down");
+            assert!(browser.search.is_none(), "{id}: no search field either");
+            assert!(!browser.back.is_empty(), "{id}: the search is behind Back");
+        }
     }
 
     /// The right-click menu lists what the providers offer, and picking one

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -103,6 +103,13 @@ pub struct ArgSpec {
     pub placeholder: Option<String>,
     /// What the field starts out holding — the current name, for a rename.
     pub initial: Option<String>,
+    /// Whether a half-typed argument can be applied as you type.
+    ///
+    /// Only for a command whose effect is *shown* rather than done — a
+    /// selection, a filter, a highlight — and which the window can therefore
+    /// take back when the palette is abandoned. A command that touches files
+    /// must never set this: there is no half-typed rename.
+    pub preview: bool,
     pub kind: ArgKind,
 }
 
@@ -113,6 +120,7 @@ impl ArgSpec {
             label: label.into(),
             placeholder: None,
             initial: None,
+            preview: false,
             kind,
         }
     }
@@ -124,6 +132,13 @@ impl ArgSpec {
 
     pub fn with_initial(mut self, initial: impl Into<String>) -> Self {
         self.initial = Some(initial.into());
+        self
+    }
+
+    /// Mark the argument as one that can be applied while it is being typed.
+    /// See [`Self::preview`] for what may claim this.
+    pub fn previewed(mut self) -> Self {
+        self.preview = true;
         self
     }
 
@@ -750,7 +765,11 @@ impl CommandProvider for Builtin {
                         otto_kit::t_owned!("files-command-arg-pattern"),
                         ArgKind::Text,
                     )
-                    .with_placeholder("*.png"),
+                    .with_placeholder("*.png")
+                    // The selection is shown, not done: every keystroke can
+                    // narrow it in place, and abandoning the palette puts back
+                    // whatever was selected before.
+                    .previewed(),
                 ),
             );
             out.push(

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -304,6 +304,14 @@ pub trait CommandProvider: Send {
     /// the disk or the network: a provider offers what it already knows.
     fn commands(&self, situation: &Situation) -> Vec<Command>;
 
+    /// Whether this provider knows everything it is going to offer. A
+    /// provider that finds its commands in the background says `false`
+    /// until they have landed. Only the palette's test driver waits on it —
+    /// a person opening the palette gets whatever has answered by then.
+    fn settled(&self) -> bool {
+        true
+    }
+
     /// What one of this provider's commands *would* do with the argument as
     /// typed so far — shown in the palette after every keystroke, for a
     /// command whose argument is [previewed](ArgSpec::previewed).
@@ -402,6 +410,11 @@ impl Registry {
             .iter()
             .flat_map(|provider| provider.commands(situation))
             .collect()
+    }
+
+    /// Whether every provider has finished finding what it offers.
+    pub fn settled(&self) -> bool {
+        self.providers.iter().all(|provider| provider.settled())
     }
 
     /// Hand a request to the provider whose namespace it names. `None` when

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -239,6 +239,9 @@ pub struct Situation {
     pub path: PathBuf,
     /// What is selected, deepest pane only.
     pub selection: Vec<PathBuf>,
+    /// Every name in the listing the selection was made from — what a new
+    /// name would have to avoid. Already in memory, so no I/O to gather.
+    pub siblings: Vec<String>,
     /// The name under the cursor, selected or not.
     pub cursor_name: Option<String>,
     /// Whether the cursor is on a directory.
@@ -300,15 +303,68 @@ pub trait CommandProvider: Send {
     /// the disk or the network: a provider offers what it already knows.
     fn commands(&self, situation: &Situation) -> Vec<Command>;
 
+    /// What one of this provider's commands *would* do with the argument as
+    /// typed so far — shown in the palette after every keystroke, for a
+    /// command whose argument is [previewed](ArgSpec::previewed).
+    ///
+    /// A dry run: it must change nothing. Called from the keyboard, so it
+    /// should be quick, and it answers from the situation the palette opened
+    /// on rather than looking again. The default has nothing to show.
+    fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
+        let _ = (request, situation);
+        None
+    }
+
     /// Carry out one of this provider's commands.
     ///
     /// The host never calls this for its own namespace — it is the only thing
     /// holding the window, so it routes its own commands internally. A
     /// provider that lives elsewhere implements this; the default refuses,
     /// which is the right answer for one that only describes.
-    fn run(&mut self, request: &Request) -> Result<(), String> {
+    ///
+    /// What came of it is handed back as data — a status line, and the moves
+    /// and creations the host records for undo — rather than done to the
+    /// window directly, since a provider in another process could not.
+    fn run(&mut self, request: &Request, situation: &Situation) -> Result<Effect, String> {
+        let _ = situation;
         Err(format!("{} cannot be run here", request.id))
     }
+}
+
+/// A dry run of an argument as typed, for the palette to show.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Preview {
+    /// One line per thing the command would touch: what it is, and what it
+    /// would become.
+    pub rows: Vec<PreviewRow>,
+    /// A summary under the rows — "3 of 5 renamed, 1 name collides".
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewRow {
+    pub from: String,
+    pub to: String,
+    /// The outcome is not possible as things stand — a name already taken,
+    /// say — and the row is drawn to say so.
+    pub conflict: bool,
+}
+
+/// What running a command did, for the host to record.
+///
+/// Data rather than side effects on the window: the same shape works for a
+/// provider in this process and for a script in another. `changes` are what
+/// undo needs — files moved, files created — in the order they happened, so
+/// undoing walks them backwards.
+#[derive(Debug, Clone, Default)]
+pub struct Effect {
+    /// The status line, if the command has something to say.
+    pub status: Option<String>,
+    /// What to call this in the undo history — "Undid Rename".
+    pub undo_label: Option<&'static str>,
+    pub changes: Vec<crate::model::Change>,
+    /// Whether the listing has to be re-read to show the outcome.
+    pub reload: bool,
 }
 
 /// Every provider, asked together.
@@ -342,13 +398,27 @@ impl Registry {
     /// Hand a request to the provider whose namespace it names. `None` when
     /// the request belongs to the host's own namespace, which the host runs
     /// itself.
-    pub fn run(&mut self, request: &Request) -> Option<Result<(), String>> {
+    pub fn run(
+        &mut self,
+        request: &Request,
+        situation: &Situation,
+    ) -> Option<Result<Effect, String>> {
         let namespace = request.namespace()?;
         let provider = self
             .providers
             .iter_mut()
             .find(|provider| provider.namespace() == namespace)?;
-        Some(provider.run(request))
+        Some(provider.run(request, situation))
+    }
+
+    /// Ask the provider a request names what it would do. `None` for the
+    /// host's own namespace, and for a provider with nothing to show.
+    pub fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
+        let namespace = request.namespace()?;
+        self.providers
+            .iter()
+            .find(|provider| provider.namespace() == namespace)?
+            .preview(request, situation)
     }
 }
 
@@ -1057,6 +1127,37 @@ mod tests {
     #[test]
     fn the_registry_leaves_the_hosts_own_requests_to_the_host() {
         let mut registry = Registry::builtin();
-        assert!(registry.run(&Request::new(id::GO_UP, None)).is_none());
+        let situation = browsing();
+        assert!(registry
+            .run(&Request::new(id::GO_UP, None), &situation)
+            .is_none());
+        assert!(registry
+            .preview(&Request::new(id::GO_UP, Some("x".into())), &situation)
+            .is_none());
+    }
+
+    /// A provider that describes but neither previews nor runs gets the
+    /// defaults: nothing to show, and a refusal.
+    #[test]
+    fn a_provider_that_only_describes_refuses_to_run() {
+        struct Quiet;
+        impl CommandProvider for Quiet {
+            fn namespace(&self) -> &'static str {
+                "quiet"
+            }
+            fn commands(&self, _: &Situation) -> Vec<Command> {
+                vec![Command::new("quiet:one", "One", Group::File)]
+            }
+        }
+        let mut registry = Registry::builtin();
+        registry.add(Box::new(Quiet));
+        let situation = browsing();
+        let request = Request::new("quiet:one", None);
+        assert!(registry.preview(&request, &situation).is_none());
+        assert!(matches!(registry.run(&request, &situation), Some(Err(_))));
+        assert!(registry
+            .commands(&situation)
+            .iter()
+            .any(|c| c.id == "quiet:one"));
     }
 }

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -453,6 +453,7 @@ pub mod id {
     pub const SELECT_ALL: &str = "select_all";
     pub const SELECT_MATCHING: &str = "select_matching";
     pub const MOVE_TO: &str = "move_to";
+    pub const NEW_FOLDER_WITH_SELECTION: &str = "new_folder_with_selection";
     pub const UNDO: &str = "undo";
     /// The three views, by name. Their ids double as the values
     /// [`CHANGE_VIEW`] takes, so there is one spelling of "grid".
@@ -655,6 +656,26 @@ impl CommandProvider for Builtin {
                 } else {
                     otto_kit::t_owned!("files-move-count-to-trash", count = s.target_count() as f64)
                 };
+                let folder_title = if s.target_count() == 1 {
+                    otto_kit::t_owned!("files-new-folder-with-selection")
+                } else {
+                    otto_kit::t_owned!(
+                        "files-new-folder-with-count",
+                        count = s.target_count() as f64
+                    )
+                };
+                out.push(
+                    Command::new(id::NEW_FOLDER_WITH_SELECTION, folder_title, Group::File)
+                        .with_keywords(["group", "gather", "collect", "into folder"])
+                        .with_arg(
+                            ArgSpec::new(
+                                otto_kit::t_owned!("files-command-new-folder-prompt"),
+                                otto_kit::t_owned!("files-command-arg-name"),
+                                ArgKind::Text,
+                            )
+                            .with_placeholder("untitled folder"),
+                        ),
+                );
                 out.push(
                     Command::new(
                         id::MOVE_TO,

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -436,6 +436,8 @@ pub mod id {
     pub const COPY: &str = "copy";
     pub const PASTE: &str = "paste";
     pub const SELECT_ALL: &str = "select_all";
+    pub const SELECT_MATCHING: &str = "select_matching";
+    pub const MOVE_TO: &str = "move_to";
     pub const UNDO: &str = "undo";
     /// The three views, by name. Their ids double as the values
     /// [`CHANGE_VIEW`] takes, so there is one spelling of "grid".
@@ -639,6 +641,24 @@ impl CommandProvider for Builtin {
                     otto_kit::t_owned!("files-move-count-to-trash", count = s.target_count() as f64)
                 };
                 out.push(
+                    Command::new(
+                        id::MOVE_TO,
+                        otto_kit::t_owned!("files-command-move-to"),
+                        Group::File,
+                    )
+                    .with_keywords(["move", "put", "file away", "relocate"])
+                    .with_arg(
+                        ArgSpec::new(
+                            otto_kit::t_owned!("files-command-move-to-prompt"),
+                            otto_kit::t_owned!("files-command-arg-path"),
+                            // Only a folder can be moved into, so only folders
+                            // are offered.
+                            ArgKind::Path { dirs_only: true },
+                        )
+                        .with_placeholder("~/Documents"),
+                    ),
+                );
+                out.push(
                     Command::new(id::TRASH, title, Group::File)
                         .with_keywords(["delete", "remove", "bin"])
                         .with_shortcut("Delete"),
@@ -717,6 +737,22 @@ impl CommandProvider for Builtin {
             }
         }
         if s.has_entries {
+            out.push(
+                Command::new(
+                    id::SELECT_MATCHING,
+                    otto_kit::t_owned!("files-command-select-matching"),
+                    Group::Edit,
+                )
+                .with_keywords(["glob", "wildcard", "pattern", "extension"])
+                .with_arg(
+                    ArgSpec::new(
+                        otto_kit::t_owned!("files-command-select-matching-prompt"),
+                        otto_kit::t_owned!("files-command-arg-pattern"),
+                        ArgKind::Text,
+                    )
+                    .with_placeholder("*.png"),
+                ),
+            );
             out.push(
                 Command::new(
                     id::SELECT_ALL,

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -1,0 +1,986 @@
+//! What the file browser can be asked to do, as data.
+//!
+//! See `specs/file-command-palette.md`. The palette does not know what any
+//! command *is*: it asks providers what is available given the situation the
+//! window is in, ranks the answers against what is being typed, and hands back
+//! a [`Request`] — an id and, where the command asked for one, a line of text.
+//!
+//! Everything crossing that seam is plain data. No closure over the browser,
+//! no borrow, nothing that could not be written down and sent somewhere else.
+//! That is deliberate and load-bearing: the extension system this is meant to
+//! grow into will put a provider in another process, and the difference
+//! between reusing this seam and rebuilding it is whether anything in it is a
+//! Rust type in disguise.
+//!
+//! The built-in commands are one provider, [`Builtin`]. It has no privileges
+//! the seam does not give everybody — it describes commands and nothing more.
+//! Carrying one out is the host's job, because the host is the only thing
+//! holding the window.
+
+use std::path::PathBuf;
+
+use otto_kit::matching;
+
+// ---------------------------------------------------------------------------
+// The vocabulary
+// ---------------------------------------------------------------------------
+
+/// Which part of the window a command belongs to. Fixed, and ordered the way
+/// the resting list reads: where you are, then what you do to files, then the
+/// clipboard, then how it all looks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Group {
+    Go,
+    File,
+    Edit,
+    View,
+}
+
+impl Group {
+    pub const ALL: [Group; 4] = [Group::Go, Group::File, Group::Edit, Group::View];
+
+    /// The heading the resting list puts this group under, and the badge a
+    /// ranked row carries.
+    pub fn label(self) -> String {
+        match self {
+            Group::Go => otto_kit::t_owned!("files-command-group-go"),
+            Group::File => otto_kit::t_owned!("files-command-group-file"),
+            Group::Edit => otto_kit::t_owned!("files-command-group-edit"),
+            Group::View => otto_kit::t_owned!("files-command-group-view"),
+        }
+    }
+}
+
+/// One of a fixed set of answers to an argument.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Choice {
+    /// What the command receives.
+    pub value: String,
+    /// What the user reads.
+    pub title: String,
+    /// The dimmer second line — a place's path, a sort key's direction.
+    pub subtitle: Option<String>,
+}
+
+impl Choice {
+    pub fn new(value: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            title: title.into(),
+            subtitle: None,
+        }
+    }
+
+    pub fn with_subtitle(mut self, subtitle: impl Into<String>) -> Self {
+        self.subtitle = Some(subtitle.into());
+        self
+    }
+}
+
+/// What kind of answer an argument wants, which is what decides where its
+/// completions come from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArgKind {
+    /// A filesystem path, completed against the disk by the host — the palette
+    /// itself never does I/O.
+    Path { dirs_only: bool },
+    /// Free text, with no completions.
+    Text,
+    /// One of a fixed set, completed by the palette itself.
+    Choice(Vec<Choice>),
+}
+
+/// The something-more a command needs said about it before it can run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArgSpec {
+    /// The non-editable prefix the field wears while the argument is being
+    /// typed, without its colon: "Go to path".
+    pub prompt: String,
+    /// The one-word name of what is being asked for, shown dimmed after the
+    /// command's title in the list: `Go to Path  ›  path`.
+    pub label: String,
+    /// Dim text standing in for an empty argument.
+    pub placeholder: Option<String>,
+    /// What the field starts out holding — the current name, for a rename.
+    pub initial: Option<String>,
+    pub kind: ArgKind,
+}
+
+impl ArgSpec {
+    pub fn new(prompt: impl Into<String>, label: impl Into<String>, kind: ArgKind) -> Self {
+        Self {
+            prompt: prompt.into(),
+            label: label.into(),
+            placeholder: None,
+            initial: None,
+            kind,
+        }
+    }
+
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
+    }
+
+    pub fn with_initial(mut self, initial: impl Into<String>) -> Self {
+        self.initial = Some(initial.into());
+        self
+    }
+
+    /// The choices this argument offers, if it is a choice at all.
+    pub fn choices(&self) -> Option<&[Choice]> {
+        match &self.kind {
+            ArgKind::Choice(choices) => Some(choices),
+            _ => None,
+        }
+    }
+}
+
+/// One thing the window can be asked to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Command {
+    /// Stable across releases and across locales — this is what a [`Request`]
+    /// carries, so it is the one part of a command nothing may translate.
+    /// Namespaced `provider:id` for everything but the built-ins.
+    pub id: String,
+    /// The localised line someone reads and types against.
+    pub title: String,
+    pub group: Group,
+    /// Extra words that match but are never shown — the other name for the
+    /// same thing, the term another file manager uses.
+    pub keywords: Vec<String>,
+    /// The chord this is also bound to, written the way the menus write it.
+    /// Shown right-aligned; purely informational.
+    pub shortcut: Option<String>,
+    /// What the command needs said about it, if anything.
+    pub arg: Option<ArgSpec>,
+}
+
+impl Command {
+    pub fn new(id: impl Into<String>, title: impl Into<String>, group: Group) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            group,
+            keywords: Vec::new(),
+            shortcut: None,
+            arg: None,
+        }
+    }
+
+    pub fn with_keywords<S: Into<String>>(mut self, keywords: impl IntoIterator<Item = S>) -> Self {
+        self.keywords = keywords.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_shortcut(mut self, shortcut: impl Into<String>) -> Self {
+        self.shortcut = Some(shortcut.into());
+        self
+    }
+
+    pub fn with_arg(mut self, arg: ArgSpec) -> Self {
+        self.arg = Some(arg);
+        self
+    }
+
+    /// Which provider this came from. The built-ins have no namespace, and the
+    /// host answers for those itself.
+    pub fn namespace(&self) -> Option<&str> {
+        self.id.split_once(':').map(|(namespace, _)| namespace)
+    }
+}
+
+/// A command, said in full: what to run and what to run it on.
+///
+/// The whole of what crosses back over the seam. An argument is text because
+/// text is what was typed and text is what survives a trip out of the process;
+/// making sense of it is the runner's job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    pub id: String,
+    pub arg: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// The situation
+// ---------------------------------------------------------------------------
+
+/// A place the window can be sent, as a provider sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaceRef {
+    pub label: String,
+    pub path: PathBuf,
+}
+
+/// Everything a provider is allowed to know about the window when it is asked
+/// what it can offer.
+///
+/// Deliberately a description rather than a handle. A provider that does not
+/// live in this process must be able to answer the same question from the same
+/// facts, so there is nothing here it could not be sent.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Situation {
+    /// The directory the active pane is showing.
+    pub path: PathBuf,
+    /// What is selected, deepest pane only.
+    pub selection: Vec<PathBuf>,
+    /// The name under the cursor, selected or not.
+    pub cursor_name: Option<String>,
+    /// Whether the cursor is on a directory.
+    pub cursor_is_dir: bool,
+    /// This window is the Trash — a shell where most commands mean nothing.
+    pub trash: bool,
+    /// This window is showing Recent: a listing with no directory behind it,
+    /// so nothing that needs a location applies.
+    pub recent: bool,
+    /// Something has been cut or copied and could be pasted.
+    pub can_paste: bool,
+    pub can_undo: bool,
+    pub can_go_back: bool,
+    pub can_go_forward: bool,
+    pub can_go_up: bool,
+    /// The listing has at least one entry.
+    pub has_entries: bool,
+    pub show_hidden: bool,
+    /// The current view, as one of the ids [`view_choices`] offers.
+    pub view: String,
+    /// The current sort key, as one of the ids [`sort_choices`] offers.
+    pub sort: String,
+    /// The sidebar's places, in sidebar order.
+    pub places: Vec<PlaceRef>,
+}
+
+impl Situation {
+    /// How many files a command would act on: the selection, or the cursor
+    /// entry when nothing is selected.
+    pub fn target_count(&self) -> usize {
+        if self.selection.is_empty() {
+            usize::from(self.cursor_name.is_some())
+        } else {
+            self.selection.len()
+        }
+    }
+
+    fn has_target(&self) -> bool {
+        self.target_count() > 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+/// Somewhere commands come from.
+///
+/// `Send` because the browser's state is shared with the threads that read
+/// directories and decode previews; a provider rides along in it.
+pub trait CommandProvider: Send {
+    /// The prefix on this provider's command ids, and the name it is known by.
+    /// Empty for the built-ins, which own the unprefixed namespace.
+    fn namespace(&self) -> &'static str;
+
+    /// What this provider can offer, here and now.
+    ///
+    /// Called on the keystroke that opens the palette, so it must not touch
+    /// the disk or the network: a provider offers what it already knows.
+    fn commands(&self, situation: &Situation) -> Vec<Command>;
+
+    /// Carry out one of this provider's commands.
+    ///
+    /// The host never calls this for its own namespace — it is the only thing
+    /// holding the window, so it routes its own commands internally. A
+    /// provider that lives elsewhere implements this; the default refuses,
+    /// which is the right answer for one that only describes.
+    fn run(&mut self, request: &Request) -> Result<(), String> {
+        Err(format!("{} cannot be run here", request.id))
+    }
+}
+
+/// Every provider, asked together.
+#[derive(Default)]
+pub struct Registry {
+    providers: Vec<Box<dyn CommandProvider>>,
+}
+
+impl Registry {
+    /// The registry the browser runs with: the built-ins, and nothing else
+    /// yet.
+    pub fn builtin() -> Self {
+        let mut registry = Self::default();
+        registry.add(Box::new(Builtin));
+        registry
+    }
+
+    pub fn add(&mut self, provider: Box<dyn CommandProvider>) {
+        self.providers.push(provider);
+    }
+
+    /// Everything on offer, in provider order — the built-ins first, so a
+    /// later provider can never push a window command down the resting list.
+    pub fn commands(&self, situation: &Situation) -> Vec<Command> {
+        self.providers
+            .iter()
+            .flat_map(|provider| provider.commands(situation))
+            .collect()
+    }
+
+    /// Hand a request to the provider whose namespace it names. `None` when
+    /// the request belongs to the host's own namespace, which the host runs
+    /// itself.
+    pub fn run(&mut self, request: &Request) -> Option<Result<(), String>> {
+        let namespace = request.namespace()?;
+        let provider = self
+            .providers
+            .iter_mut()
+            .find(|provider| provider.namespace() == namespace)?;
+        Some(provider.run(request))
+    }
+}
+
+impl Request {
+    pub fn new(id: impl Into<String>, arg: Option<String>) -> Self {
+        Self { id: id.into(), arg }
+    }
+
+    /// The provider this is addressed to, or `None` for the host's own.
+    pub fn namespace(&self) -> Option<&str> {
+        self.id
+            .split_once(':')
+            .map(|(namespace, _)| namespace)
+            .filter(|namespace| !namespace.is_empty())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+/// A matched command, with the score that ordered it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Match {
+    pub index: usize,
+    pub score: i32,
+}
+
+/// Rank `commands` against `query`, best first.
+///
+/// An empty query keeps every command in the order the providers gave it,
+/// which is the order the resting list groups.
+pub fn rank(commands: &[Command], query: &str) -> Vec<Match> {
+    let query = query.trim();
+    if query.is_empty() {
+        return commands
+            .iter()
+            .enumerate()
+            .map(|(index, _)| Match { index, score: 0 })
+            .collect();
+    }
+
+    let mut matches: Vec<Match> = commands
+        .iter()
+        .enumerate()
+        .filter_map(|(index, command)| {
+            // The title is what someone is aiming at. A keyword or a group
+            // name is a way of still finding the command when they aimed at
+            // something adjacent, so it scores lower and can never outrank a
+            // title hit.
+            let title = matching::score(&command.title, query);
+            let group = command.group.label();
+            let secondary = command
+                .keywords
+                .iter()
+                .map(String::as_str)
+                .chain(std::iter::once(group.as_str()))
+                .filter_map(|text| matching::score(text, query))
+                .max()
+                .map(|score| score / 2 - 20);
+
+            let best = match (title, secondary) {
+                (Some(a), Some(b)) => a.max(b),
+                (Some(a), None) => a,
+                (None, Some(b)) => b,
+                (None, None) => return None,
+            };
+            Some(Match { index, score: best })
+        })
+        .collect();
+
+    // Ties keep provider order — a stable sort, so a fully tied query looks
+    // like the resting list.
+    matches.sort_by_key(|m| std::cmp::Reverse(m.score));
+    matches
+}
+
+// ---------------------------------------------------------------------------
+// The built-in commands
+// ---------------------------------------------------------------------------
+
+/// The ids the host answers for. Public so the host's routing and these
+/// descriptions cannot drift apart.
+pub mod id {
+    pub const GO_BACK: &str = "go_back";
+    pub const GO_FORWARD: &str = "go_forward";
+    pub const GO_UP: &str = "go_up";
+    pub const GO_HOME: &str = "go_home";
+    pub const GO_TO_PATH: &str = "go_to_path";
+    pub const GO_TO_PLACE: &str = "go_to_place";
+    pub const OPEN: &str = "open";
+    pub const GET_INFO: &str = "get_info";
+    pub const RENAME: &str = "rename";
+    pub const NEW_FOLDER: &str = "new_folder";
+    pub const TRASH: &str = "trash";
+    pub const PUT_BACK: &str = "put_back";
+    pub const DELETE_FOREVER: &str = "delete_forever";
+    pub const EMPTY_TRASH: &str = "empty_trash";
+    pub const CUT: &str = "cut";
+    pub const COPY: &str = "copy";
+    pub const PASTE: &str = "paste";
+    pub const SELECT_ALL: &str = "select_all";
+    pub const UNDO: &str = "undo";
+    /// The three views, by name. Their ids double as the values
+    /// [`CHANGE_VIEW`] takes, so there is one spelling of "grid".
+    pub const VIEW_LIST: &str = "list";
+    pub const VIEW_GRID: &str = "grid";
+    pub const VIEW_COLUMNS: &str = "columns";
+    pub const CHANGE_VIEW: &str = "change_view";
+    pub const SORT_BY: &str = "sort_by";
+    pub const TOGGLE_HIDDEN: &str = "toggle_hidden";
+    pub const QUICK_LOOK: &str = "quick_look";
+    pub const SEARCH: &str = "search";
+    pub const RECENT: &str = "recent";
+}
+
+/// The views [`id::CHANGE_VIEW`] can be given.
+pub fn view_choices() -> Vec<Choice> {
+    vec![
+        Choice::new("list", otto_kit::t_owned!("files-view-list")),
+        Choice::new("grid", otto_kit::t_owned!("files-view-grid")),
+        Choice::new("columns", otto_kit::t_owned!("files-view-columns")),
+    ]
+}
+
+/// The keys [`id::SORT_BY`] can be given.
+pub fn sort_choices() -> Vec<Choice> {
+    vec![
+        Choice::new("name", otto_kit::t_owned!("files-column-name")),
+        Choice::new("size", otto_kit::t_owned!("files-column-size")),
+        Choice::new("kind", otto_kit::t_owned!("files-column-kind")),
+        Choice::new("modified", otto_kit::t_owned!("files-column-date-modified")),
+    ]
+}
+
+/// The window's own commands.
+pub struct Builtin;
+
+impl CommandProvider for Builtin {
+    fn namespace(&self) -> &'static str {
+        ""
+    }
+
+    fn commands(&self, s: &Situation) -> Vec<Command> {
+        let mut out = Vec::new();
+
+        // --- Go -------------------------------------------------------------
+        if s.can_go_back {
+            out.push(
+                Command::new(
+                    id::GO_BACK,
+                    otto_kit::t_owned!("files-command-back"),
+                    Group::Go,
+                )
+                .with_keywords(["previous", "history"])
+                .with_shortcut("Alt+←"),
+            );
+        }
+        if s.can_go_forward {
+            out.push(
+                Command::new(
+                    id::GO_FORWARD,
+                    otto_kit::t_owned!("files-command-forward"),
+                    Group::Go,
+                )
+                .with_keywords(["next", "history"])
+                .with_shortcut("Alt+→"),
+            );
+        }
+        if s.can_go_up {
+            out.push(
+                Command::new(id::GO_UP, otto_kit::t_owned!("files-command-up"), Group::Go)
+                    .with_keywords(["parent", "enclosing folder"])
+                    .with_shortcut("Alt+↑"),
+            );
+        }
+        if !s.trash {
+            out.push(
+                Command::new(id::GO_HOME, otto_kit::t_owned!("files-home"), Group::Go)
+                    .with_keywords(["home folder"])
+                    .with_shortcut("Alt+Home"),
+            );
+            out.push(
+                Command::new(
+                    id::GO_TO_PATH,
+                    otto_kit::t_owned!("files-command-go-to-path"),
+                    Group::Go,
+                )
+                .with_keywords(["location", "directory", "cd"])
+                .with_shortcut("Ctrl+L")
+                .with_arg(
+                    ArgSpec::new(
+                        otto_kit::t_owned!("files-command-go-to-path-prompt"),
+                        otto_kit::t_owned!("files-command-arg-path"),
+                        ArgKind::Path { dirs_only: false },
+                    )
+                    .with_placeholder("~/Documents"),
+                ),
+            );
+            if !s.places.is_empty() {
+                out.push(
+                    Command::new(
+                        id::GO_TO_PLACE,
+                        otto_kit::t_owned!("files-command-go-to-place"),
+                        Group::Go,
+                    )
+                    .with_keywords(["sidebar", "shortcut", "bookmark"])
+                    .with_arg(ArgSpec::new(
+                        otto_kit::t_owned!("files-command-go-to-place-prompt"),
+                        otto_kit::t_owned!("files-command-arg-place"),
+                        ArgKind::Choice(
+                            s.places
+                                .iter()
+                                .map(|place| {
+                                    Choice::new(
+                                        place.path.to_string_lossy().into_owned(),
+                                        place.label.clone(),
+                                    )
+                                    .with_subtitle(crate::model::abbreviate_home(&place.path))
+                                })
+                                .collect(),
+                        ),
+                    )),
+                );
+            }
+            out.push(
+                Command::new(
+                    id::SEARCH,
+                    otto_kit::t_owned!("files-command-search"),
+                    Group::Go,
+                )
+                .with_keywords(["find", "filter", "look for"])
+                .with_shortcut("Ctrl+F")
+                .with_arg(ArgSpec::new(
+                    otto_kit::t_owned!("files-command-search-prompt"),
+                    otto_kit::t_owned!("files-command-arg-query"),
+                    ArgKind::Text,
+                )),
+            );
+            if !s.recent {
+                out.push(
+                    Command::new(id::RECENT, otto_kit::t_owned!("files-recent"), Group::Go)
+                        .with_keywords(["latest", "newest", "lately"]),
+                );
+            }
+            if s.cursor_is_dir || s.cursor_name.is_some() {
+                out.push(
+                    Command::new(id::OPEN, otto_kit::t_owned!("common-open"), Group::Go)
+                        .with_keywords(["launch", "enter"])
+                        .with_shortcut("Ctrl+O"),
+                );
+            }
+        }
+
+        // --- File -----------------------------------------------------------
+        if s.has_target() {
+            out.push(
+                Command::new(
+                    id::GET_INFO,
+                    otto_kit::t_owned!("files-get-info"),
+                    Group::File,
+                )
+                .with_keywords(["properties", "permissions", "size"])
+                .with_shortcut("Ctrl+I"),
+            );
+        }
+        if !s.trash {
+            if s.target_count() == 1 {
+                out.push(
+                    Command::new(id::RENAME, otto_kit::t_owned!("common-rename"), Group::File)
+                        .with_keywords(["name"])
+                        .with_shortcut("F2")
+                        .with_arg(
+                            ArgSpec::new(
+                                otto_kit::t_owned!("files-command-rename-prompt"),
+                                otto_kit::t_owned!("files-command-arg-name"),
+                                ArgKind::Text,
+                            )
+                            .with_initial(s.cursor_name.clone().unwrap_or_default()),
+                        ),
+                );
+            }
+            out.push(
+                Command::new(
+                    id::NEW_FOLDER,
+                    otto_kit::t_owned!("files-new-folder"),
+                    Group::File,
+                )
+                .with_keywords(["create", "directory", "mkdir"])
+                .with_arg(
+                    ArgSpec::new(
+                        otto_kit::t_owned!("files-command-new-folder-prompt"),
+                        otto_kit::t_owned!("files-command-arg-name"),
+                        ArgKind::Text,
+                    )
+                    .with_placeholder("untitled folder"),
+                ),
+            );
+            if s.has_target() {
+                let title = if s.target_count() == 1 {
+                    otto_kit::t_owned!("files-move-to-trash")
+                } else {
+                    otto_kit::t_owned!("files-move-count-to-trash", count = s.target_count() as f64)
+                };
+                out.push(
+                    Command::new(id::TRASH, title, Group::File)
+                        .with_keywords(["delete", "remove", "bin"])
+                        .with_shortcut("Delete"),
+                );
+            }
+        }
+        if s.trash {
+            if s.has_target() {
+                out.push(
+                    Command::new(
+                        id::PUT_BACK,
+                        otto_kit::t_owned!("files-put-back"),
+                        Group::File,
+                    )
+                    .with_keywords(["restore", "undelete"]),
+                );
+                let title = if s.target_count() == 1 {
+                    otto_kit::t_owned!("files-delete-immediately")
+                } else {
+                    otto_kit::t_owned!(
+                        "files-delete-count-immediately",
+                        count = s.target_count() as f64
+                    )
+                };
+                out.push(
+                    Command::new(id::DELETE_FOREVER, title, Group::File).with_keywords([
+                        "destroy",
+                        "erase",
+                        "permanently",
+                    ]),
+                );
+            }
+            if s.has_entries {
+                out.push(
+                    Command::new(
+                        id::EMPTY_TRASH,
+                        otto_kit::t_owned!("files-empty-trash"),
+                        Group::File,
+                    )
+                    .with_keywords(["destroy", "erase all"]),
+                );
+            }
+        }
+
+        // --- Edit -----------------------------------------------------------
+        if !s.trash {
+            if s.has_target() {
+                out.push(
+                    Command::new(id::CUT, otto_kit::t_owned!("common-cut"), Group::Edit)
+                        .with_keywords(["move"])
+                        .with_shortcut("Ctrl+X"),
+                );
+                out.push(
+                    Command::new(id::COPY, otto_kit::t_owned!("common-copy"), Group::Edit)
+                        .with_keywords(["duplicate", "clipboard"])
+                        .with_shortcut("Ctrl+C"),
+                );
+            }
+            if s.can_paste {
+                out.push(
+                    Command::new(id::PASTE, otto_kit::t_owned!("common-paste"), Group::Edit)
+                        .with_keywords(["clipboard"])
+                        .with_shortcut("Ctrl+V"),
+                );
+            }
+            if s.can_undo {
+                out.push(
+                    Command::new(
+                        id::UNDO,
+                        otto_kit::t_owned!("files-command-undo"),
+                        Group::Edit,
+                    )
+                    .with_keywords(["take back", "revert"])
+                    .with_shortcut("Ctrl+Z"),
+                );
+            }
+        }
+        if s.has_entries {
+            out.push(
+                Command::new(
+                    id::SELECT_ALL,
+                    otto_kit::t_owned!("files-command-select-all"),
+                    Group::Edit,
+                )
+                .with_shortcut("Ctrl+A"),
+            );
+        }
+
+        // --- View -----------------------------------------------------------
+        if !s.trash {
+            // The three views by name as well as behind Change View: typing
+            // "grid" should land on the grid, not on a question about which
+            // view you meant. The one that is already on is not offered —
+            // switching to where you are is not a command.
+            for (view, title, shortcut) in [
+                (
+                    id::VIEW_LIST,
+                    otto_kit::t_owned!("files-view-list"),
+                    "Ctrl+1",
+                ),
+                (
+                    id::VIEW_GRID,
+                    otto_kit::t_owned!("files-view-grid"),
+                    "Ctrl+2",
+                ),
+                (
+                    id::VIEW_COLUMNS,
+                    otto_kit::t_owned!("files-view-columns"),
+                    "Ctrl+3",
+                ),
+            ] {
+                if s.view == view {
+                    continue;
+                }
+                out.push(
+                    Command::new(view, title, Group::View)
+                        .with_keywords(["view", "layout"])
+                        .with_shortcut(shortcut),
+                );
+            }
+            out.push(
+                Command::new(
+                    id::CHANGE_VIEW,
+                    otto_kit::t_owned!("files-command-change-view"),
+                    Group::View,
+                )
+                .with_keywords(["list", "grid", "icons", "columns", "layout"])
+                .with_arg(
+                    ArgSpec::new(
+                        otto_kit::t_owned!("files-command-change-view-prompt"),
+                        otto_kit::t_owned!("files-command-arg-view"),
+                        ArgKind::Choice(view_choices()),
+                    )
+                    // The view that is already on, so the list opens on it.
+                    .with_initial(s.view.clone()),
+                ),
+            );
+        }
+        out.push(
+            Command::new(
+                id::SORT_BY,
+                otto_kit::t_owned!("files-command-sort-by"),
+                Group::View,
+            )
+            .with_keywords(["order", "arrange"])
+            .with_arg(
+                ArgSpec::new(
+                    otto_kit::t_owned!("files-command-sort-by-prompt"),
+                    otto_kit::t_owned!("files-command-arg-sort"),
+                    ArgKind::Choice(sort_choices()),
+                )
+                .with_initial(s.sort.clone()),
+            ),
+        );
+        let hidden = if s.show_hidden {
+            otto_kit::t_owned!("files-command-hide-hidden")
+        } else {
+            otto_kit::t_owned!("files-command-show-hidden")
+        };
+        out.push(
+            Command::new(id::TOGGLE_HIDDEN, hidden, Group::View)
+                .with_keywords(["dotfiles", "invisible"])
+                .with_shortcut("Ctrl+H"),
+        );
+        if s.has_target() {
+            out.push(
+                Command::new(
+                    id::QUICK_LOOK,
+                    otto_kit::t_owned!("files-command-quick-look"),
+                    Group::View,
+                )
+                .with_keywords(["preview", "peek"])
+                .with_shortcut("Space"),
+            );
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn browsing() -> Situation {
+        Situation {
+            path: PathBuf::from("/home/someone"),
+            cursor_name: Some("notes.txt".into()),
+            has_entries: true,
+            can_go_up: true,
+            view: "list".into(),
+            sort: "name".into(),
+            ..Situation::default()
+        }
+    }
+
+    fn ids(situation: &Situation) -> Vec<String> {
+        Builtin
+            .commands(situation)
+            .into_iter()
+            .map(|command| command.id)
+            .collect()
+    }
+
+    #[test]
+    fn a_command_whose_preconditions_are_unmet_is_not_offered() {
+        let quiet = Situation {
+            can_paste: false,
+            can_undo: false,
+            ..browsing()
+        };
+        let offered = ids(&quiet);
+        assert!(!offered.contains(&id::PASTE.to_string()));
+        assert!(!offered.contains(&id::UNDO.to_string()));
+
+        let ready = Situation {
+            can_paste: true,
+            can_undo: true,
+            ..browsing()
+        };
+        let offered = ids(&ready);
+        assert!(offered.contains(&id::PASTE.to_string()));
+        assert!(offered.contains(&id::UNDO.to_string()));
+    }
+
+    #[test]
+    fn the_trash_offers_its_own_commands_and_not_the_browsers() {
+        let trash = Situation {
+            trash: true,
+            ..browsing()
+        };
+        let offered = ids(&trash);
+        assert!(offered.contains(&id::PUT_BACK.to_string()));
+        assert!(offered.contains(&id::EMPTY_TRASH.to_string()));
+        assert!(!offered.contains(&id::TRASH.to_string()));
+        assert!(!offered.contains(&id::RENAME.to_string()));
+        assert!(!offered.contains(&id::PASTE.to_string()));
+    }
+
+    #[test]
+    fn trashing_names_the_number_of_files_it_would_take() {
+        let many = Situation {
+            selection: vec!["/a".into(), "/b".into(), "/c".into()],
+            ..browsing()
+        };
+        let trash = Builtin
+            .commands(&many)
+            .into_iter()
+            .find(|command| command.id == id::TRASH)
+            .expect("trash is offered");
+        assert!(trash.title.contains('3'), "{}", trash.title);
+    }
+
+    #[test]
+    fn renaming_is_offered_for_one_file_and_not_for_several() {
+        assert!(ids(&browsing()).contains(&id::RENAME.to_string()));
+        let many = Situation {
+            selection: vec!["/a".into(), "/b".into()],
+            ..browsing()
+        };
+        assert!(!ids(&many).contains(&id::RENAME.to_string()));
+    }
+
+    #[test]
+    fn a_rename_starts_from_the_name_the_file_already_has() {
+        let rename = Builtin
+            .commands(&browsing())
+            .into_iter()
+            .find(|command| command.id == id::RENAME)
+            .expect("rename is offered");
+        let arg = rename.arg.expect("rename takes a name");
+        assert_eq!(arg.initial.as_deref(), Some("notes.txt"));
+    }
+
+    #[test]
+    fn the_places_argument_is_built_from_the_sidebar() {
+        let with_places = Situation {
+            places: vec![PlaceRef {
+                label: "Downloads".into(),
+                path: PathBuf::from("/home/someone/Downloads"),
+            }],
+            ..browsing()
+        };
+        let go = Builtin
+            .commands(&with_places)
+            .into_iter()
+            .find(|command| command.id == id::GO_TO_PLACE)
+            .expect("go to place is offered");
+        let choices = go.arg.as_ref().and_then(ArgSpec::choices).expect("choices");
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].value, "/home/someone/Downloads");
+    }
+
+    #[test]
+    fn the_view_already_on_is_not_offered_as_a_command() {
+        let offered = ids(&browsing());
+        assert!(!offered.contains(&id::VIEW_LIST.to_string()));
+        assert!(offered.contains(&id::VIEW_GRID.to_string()));
+        assert!(offered.contains(&id::CHANGE_VIEW.to_string()));
+    }
+
+    #[test]
+    fn an_empty_query_keeps_every_command_in_provider_order() {
+        let commands = Builtin.commands(&browsing());
+        let ranked = rank(&commands, "   ");
+        assert_eq!(ranked.len(), commands.len());
+        assert_eq!(ranked[0].index, 0);
+    }
+
+    #[test]
+    fn a_gapped_query_finds_the_command_it_meant() {
+        let commands = Builtin.commands(&Situation {
+            selection: vec!["/a".into()],
+            ..browsing()
+        });
+        let ranked = rank(&commands, "mo tr");
+        let best = &commands[ranked[0].index];
+        assert_eq!(best.id, id::TRASH);
+    }
+
+    #[test]
+    fn a_title_hit_outranks_a_keyword_hit() {
+        let commands = vec![
+            Command::new("a", "Duplicate", Group::File),
+            Command::new("b", "Copy", Group::Edit).with_keywords(["duplicate"]),
+        ];
+        let ranked = rank(&commands, "duplicate");
+        assert_eq!(commands[ranked[0].index].id, "a");
+    }
+
+    #[test]
+    fn a_request_names_the_provider_it_belongs_to() {
+        assert_eq!(Request::new("go_up", None).namespace(), None);
+        assert_eq!(
+            Request::new("scripts:reveal", None).namespace(),
+            Some("scripts")
+        );
+    }
+
+    #[test]
+    fn the_registry_leaves_the_hosts_own_requests_to_the_host() {
+        let mut registry = Registry::builtin();
+        assert!(registry.run(&Request::new(id::GO_UP, None)).is_none());
+    }
+}

--- a/components/otto-files/src/command.rs
+++ b/components/otto-files/src/command.rs
@@ -20,6 +20,7 @@
 use std::path::PathBuf;
 
 use otto_kit::matching;
+use serde::Serialize;
 
 // ---------------------------------------------------------------------------
 // The vocabulary
@@ -221,7 +222,7 @@ pub struct Request {
 // ---------------------------------------------------------------------------
 
 /// A place the window can be sent, as a provider sees it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PlaceRef {
     pub label: String,
     pub path: PathBuf,
@@ -233,7 +234,7 @@ pub struct PlaceRef {
 /// Deliberately a description rather than a handle. A provider that does not
 /// live in this process must be able to answer the same question from the same
 /// facts, so there is nothing here it could not be sent.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct Situation {
     /// The directory the active pane is showing.
     pub path: PathBuf,
@@ -329,6 +330,14 @@ pub trait CommandProvider: Send {
         let _ = situation;
         Err(format!("{} cannot be run here", request.id))
     }
+
+    /// Anything a run started earlier has finished with. A provider whose
+    /// commands take a while — a script compressing a folder — answers `run`
+    /// at once with what to say meanwhile, and hands the real effect back
+    /// here when it lands. Called on the host's idle tick.
+    fn poll(&mut self) -> Vec<Result<Effect, String>> {
+        Vec::new()
+    }
 }
 
 /// A dry run of an argument as typed, for the palette to show.
@@ -409,6 +418,14 @@ impl Registry {
             .iter_mut()
             .find(|provider| provider.namespace() == namespace)?;
         Some(provider.run(request, situation))
+    }
+
+    /// Collect what every provider's earlier runs have finished with.
+    pub fn poll(&mut self) -> Vec<Result<Effect, String>> {
+        self.providers
+            .iter_mut()
+            .flat_map(|provider| provider.poll())
+            .collect()
     }
 
     /// Ask the provider a request names what it would do. `None` for the

--- a/components/otto-files/src/lib.rs
+++ b/components/otto-files/src/lib.rs
@@ -17,8 +17,10 @@
 mod bench;
 
 pub mod app;
+pub mod command;
 pub mod dbus;
 pub mod model;
+pub mod palette;
 pub mod pane_surfaces;
 pub mod perf;
 pub mod picker;

--- a/components/otto-files/src/lib.rs
+++ b/components/otto-files/src/lib.rs
@@ -30,6 +30,7 @@ pub mod recent;
 pub mod remembered;
 pub mod rename;
 pub mod scene;
+pub mod scripts;
 pub mod search;
 pub mod thumbcache;
 pub mod thumbnails;

--- a/components/otto-files/src/lib.rs
+++ b/components/otto-files/src/lib.rs
@@ -27,6 +27,8 @@ pub mod picker;
 pub mod places_config;
 pub mod quickview;
 pub mod recent;
+pub mod remembered;
+pub mod rename;
 pub mod scene;
 pub mod search;
 pub mod thumbcache;

--- a/components/otto-files/src/main.rs
+++ b/components/otto-files/src/main.rs
@@ -9,7 +9,8 @@ use std::path::PathBuf;
 /// `current_icon_theme()` stays empty. An empty theme name makes every icon
 /// lookup search `hicolor` alone, which ships no `folder` or mimetype icons —
 /// so the whole listing draws without icons. The theme comes from Otto's own
-/// settings, surfaced through the settings portal.
+/// settings, surfaced through the settings portal, or from the desktop's own
+/// setting elsewhere — see `otto_kit::icon_theme`.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // First, before the tokio runtime starts a thread and before anything
     // connects to Wayland. The sandboxed decode worker is *this binary*

--- a/components/otto-files/src/model.rs
+++ b/components/otto-files/src/model.rs
@@ -1697,6 +1697,25 @@ pub fn create_folder(dest: &Path) -> Result<PathBuf, String> {
     Ok(target)
 }
 
+/// Create a folder with the name somebody gave, under `dest`.
+///
+/// Distinct from [`create_folder`], which picks the name itself and so can
+/// never collide: a name that was asked for is either free or an error, and
+/// quietly creating "name 2" instead would be answering a different question.
+pub fn create_folder_named(dest: &Path, name: &str) -> Result<PathBuf, String> {
+    let name = name.trim();
+    if name.is_empty() || name.contains('/') || name == "." || name == ".." {
+        return Err(otto_kit::t_owned!("files-name-invalid"));
+    }
+    let target = dest.join(name);
+    if target.exists() {
+        return Err(otto_kit::t_owned!("files-name-taken", name = name));
+    }
+    std::fs::create_dir(&target)
+        .map_err(|err| otto_kit::t_owned!("files-new-folder-failed", error = err.to_string()))?;
+    Ok(target)
+}
+
 // ---------------------------------------------------------------------------
 // Trash
 // ---------------------------------------------------------------------------

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -262,6 +262,19 @@ impl Palette {
             .map(|session| &self.commands[session.command])
     }
 
+    /// The argument being typed, when its command asked to be shown as it is
+    /// written. The host applies it after each key and takes it back if the
+    /// palette is abandoned.
+    pub fn previewed_argument(&self) -> Option<(&str, &str)> {
+        let session = self.arg.as_ref()?;
+        let command = &self.commands[session.command];
+        command
+            .arg
+            .as_ref()
+            .filter(|spec| spec.preview)
+            .map(|_| (command.id.as_str(), session.input.value()))
+    }
+
     /// The half-typed path the host should complete against, and whether only
     /// directories count. `None` unless a path argument is open — which is the
     /// palette's whole involvement with the disk.

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -130,7 +130,6 @@ pub struct Palette {
     note: Option<String>,
     /// The first row on screen. The list is longer than the card whenever the
     /// query is short, and this is what keeps the highlight in view.
-    scroll: usize,
     /// How the field is drawn. Held rather than looked up, because argument
     /// mode builds a second field and the two must match — and because a test
     /// has no theme to look one up from.
@@ -149,7 +148,6 @@ impl Palette {
             arg: None,
             error: None,
             note: None,
-            scroll: 0,
             style,
         };
         palette.refilter();
@@ -225,15 +223,6 @@ impl Palette {
     /// The live result of the argument being typed, if the host has one.
     pub fn note(&self) -> Option<&str> {
         self.note.as_deref()
-    }
-
-    /// The first row on screen, and where the view puts it after scrolling.
-    pub fn scroll(&self) -> usize {
-        self.scroll
-    }
-
-    pub fn set_scroll(&mut self, first: usize) {
-        self.scroll = first;
     }
 
     /// Put the highlight on `row`, if it is one that can be chosen. What the
@@ -593,7 +582,6 @@ impl Palette {
             .collect();
         self.rebuild_rows();
         // A fresh query is a fresh list: start at the top of it.
-        self.scroll = 0;
         self.highlight = 0;
         self.settle_highlight(1);
     }

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -262,6 +262,66 @@ impl Palette {
             .map(|session| &self.commands[session.command])
     }
 
+    /// What the field would become if the suggestion were taken — the whole
+    /// value, not the part still to be typed.
+    ///
+    /// The terminal's bargain: the best answer is shown ahead of the caret as
+    /// you type, and taking it is the same as having typed it. Only a
+    /// candidate that *starts with* what is typed can be shown this way — a
+    /// fuzzy hit like "mo tr" for "Move to Trash" has no tail to put after the
+    /// caret, so it is left to the list below.
+    pub fn suggestion(&self) -> Option<&str> {
+        let typed = self.input().value();
+        if typed.is_empty() {
+            return None;
+        }
+        let candidate = match &self.arg {
+            Some(session) => {
+                let completion = session.completions.get(session.highlight.unwrap_or(0))?;
+                // A path's value is what gets typed; a choice's is an id
+                // nobody types, so that one is suggested by its title.
+                match self.commands[session.command].arg.as_ref()?.kind {
+                    ArgKind::Path { .. } => completion.value.as_str(),
+                    _ => completion.title.as_str(),
+                }
+            }
+            None => self.commands[*self.order.first()?].title.as_str(),
+        };
+        (candidate.len() > typed.len()
+            && candidate.to_lowercase().starts_with(&typed.to_lowercase()))
+        .then_some(candidate)
+    }
+
+    /// The part of the suggestion still to be typed — what the view draws
+    /// after the caret, in the field's own size.
+    pub fn suggestion_tail(&self) -> Option<&str> {
+        let typed_len = self.input().value().len();
+        self.suggestion().map(|whole| &whole[typed_len..])
+    }
+
+    /// Take the suggestion whole. The field then holds exactly what it would
+    /// hold had it all been typed, which is what makes the two the same.
+    fn accept_suggestion(&mut self) -> bool {
+        let Some(whole) = self.suggestion().map(str::to_string) else {
+            return false;
+        };
+        let input = self.input_mut();
+        input.set_value(whole);
+        input.state.set_caret(usize::MAX, false);
+        self.refilter_choices();
+        if self.arg.is_none() {
+            self.refilter();
+        }
+        true
+    }
+
+    /// Whether the caret is at the end of the text, which is the only place a
+    /// suggestion can be taken from: in the middle, Right means Right.
+    fn caret_at_end(&self) -> bool {
+        let input = self.input();
+        input.state.caret() >= input.value().len()
+    }
+
     /// The half-typed path the host should complete against, and whether only
     /// directories count. `None` unless a path argument is open — which is the
     /// palette's whole involvement with the disk.
@@ -350,6 +410,12 @@ impl Palette {
                 }
                 _ => Outcome::Ignored,
             },
+            // Right at the end of the text takes the suggestion, the way it
+            // does at a shell prompt. Anywhere else in the text it is just
+            // Right.
+            Key::Edit(TextInputKey::Right) if self.caret_at_end() && self.accept_suggestion() => {
+                Outcome::Changed
+            }
             Key::Edit(edit) => {
                 let response = self.query.on_key(edit, mods);
                 if let TextInputResponse::Clipboard(text) = response {
@@ -388,6 +454,9 @@ impl Palette {
             }
             Key::Tab => {
                 self.complete();
+                Outcome::Changed
+            }
+            Key::Edit(TextInputKey::Right) if self.caret_at_end() && self.accept_suggestion() => {
                 Outcome::Changed
             }
             Key::Edit(TextInputKey::Backspace) if self.arg_is_empty() => {
@@ -879,6 +948,84 @@ mod tests {
         palette.on_key(Key::Tab, mods());
         type_text(&mut palette, "/us");
         assert_eq!(palette.path_argument(), Some(("/us", false)));
+    }
+
+    /// The terminal's bargain: the rest of the best answer is shown ahead of
+    /// the caret, and Right takes it.
+    #[test]
+    fn the_rest_of_the_best_answer_is_offered_ahead_of_the_caret() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/usr/sh");
+        palette.set_completions(vec![
+            Completion::new("/usr/share", "share"),
+            Completion::new("/usr/shrunk", "shrunk"),
+        ]);
+        assert_eq!(palette.suggestion(), Some("/usr/share"));
+        assert_eq!(palette.suggestion_tail(), Some("are"));
+
+        palette.on_key(Key::Edit(TextInputKey::Right), mods());
+        assert_eq!(palette.input().value(), "/usr/share");
+    }
+
+    /// And taking it leaves the field exactly as typing it would have.
+    #[test]
+    fn taking_the_suggestion_is_the_same_as_typing_it() {
+        let completions = || {
+            vec![
+                Completion::new("/usr/share", "share"),
+                Completion::new("/usr/shrunk", "shrunk"),
+            ]
+        };
+
+        let mut taken = open(commands());
+        type_text(&mut taken, "go to path");
+        taken.on_key(Key::Tab, mods());
+        type_text(&mut taken, "/usr/sh");
+        taken.set_completions(completions());
+        taken.on_key(Key::Edit(TextInputKey::Right), mods());
+
+        let mut typed = open(commands());
+        type_text(&mut typed, "go to path");
+        typed.on_key(Key::Tab, mods());
+        type_text(&mut typed, "/usr/share");
+        typed.set_completions(completions());
+
+        assert_eq!(taken.input().value(), typed.input().value());
+        assert_eq!(
+            taken.on_key(Key::Enter, mods()),
+            typed.on_key(Key::Enter, mods())
+        );
+    }
+
+    /// A fuzzy hit has no tail to put after the caret — "mo tr" is not a
+    /// prefix of "Move to Trash" — so nothing is offered there.
+    #[test]
+    fn a_gapped_query_offers_no_inline_suggestion() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "mo tr");
+        assert_eq!(palette.suggestion(), None);
+    }
+
+    /// A prefix of a command's name is offered, though.
+    #[test]
+    fn a_prefix_of_a_command_is_offered_in_the_query_too() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to p");
+        assert_eq!(palette.suggestion(), Some("Go to Path"));
+        palette.on_key(Key::Edit(TextInputKey::Right), mods());
+        assert_eq!(palette.input().value(), "Go to Path");
+    }
+
+    /// Right in the middle of the text is just Right.
+    #[test]
+    fn the_suggestion_is_only_taken_from_the_end_of_the_text() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to p");
+        palette.input_mut().state.set_caret(2, false);
+        palette.on_key(Key::Edit(TextInputKey::Right), mods());
+        assert_eq!(palette.input().value(), "go to p");
     }
 
     #[test]

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -682,7 +682,15 @@ impl Palette {
         };
         let mut input = field(&initial, &self.style);
         if !initial.is_empty() {
-            input.state.select_all();
+            // A name is retyped up to its extension — "Archive" in
+            // "Archive.zip" — so the kind of file stays put. Anything else
+            // is replaced whole.
+            let keep_extension = matches!(spec.kind, ArgKind::Text);
+            let stem = initial
+                .rfind('.')
+                .filter(|&dot| keep_extension && dot > 0 && dot + 1 < initial.len())
+                .unwrap_or(initial.len());
+            input.state.select_range(0..stem);
         }
         self.arg = Some(ArgSession {
             command,

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -161,7 +161,19 @@ impl Palette {
     }
 
     /// Which row is highlighted, or `None` when there is nothing to highlight.
+    ///
+    /// Argument mode answers from the argument's own highlight rather than
+    /// from the command list's. The two are separate — backing out of an
+    /// argument has to put the highlight back on the command it came from —
+    /// and reporting the wrong one here draws a bar that Return does not act
+    /// on, which is worse than drawing none. `None` in argument mode means the
+    /// typed text stands on its own, which is the usual state for a path.
     pub fn highlighted(&self) -> Option<usize> {
+        if let Some(session) = self.arg.as_ref() {
+            // Rows are one-to-one with completions here, so the completion's
+            // index is the row's.
+            return session.highlight;
+        }
         self.rows.get(self.highlight).map(|_| self.highlight)
     }
 
@@ -895,6 +907,50 @@ mod tests {
         palette.on_key(Key::Down, mods());
         palette.on_key(Key::Tab, mods());
         assert_eq!(palette.input().value(), "/usr/share");
+    }
+
+    /// The bug this pins: the palette holds a command highlight and an
+    /// argument highlight, and argument mode has to report the second. It once
+    /// reported the first, so the bar sat on whatever row the command had
+    /// occupied and no arrow key moved it.
+    #[test]
+    fn the_arrows_move_the_highlight_through_the_answers() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        palette.set_completions(vec![
+            Completion::new("/usr/bin", "bin"),
+            Completion::new("/usr/lib", "lib"),
+            Completion::new("/usr/src", "src"),
+        ]);
+        // Nothing is highlighted until an arrow key says so: what was typed
+        // stands on its own.
+        assert_eq!(palette.highlighted(), None);
+        palette.on_key(Key::Down, mods());
+        assert_eq!(palette.highlighted(), Some(0));
+        palette.on_key(Key::Down, mods());
+        assert_eq!(palette.highlighted(), Some(1));
+        palette.on_key(Key::Up, mods());
+        assert_eq!(palette.highlighted(), Some(0));
+    }
+
+    /// And what is highlighted is what Return acts on.
+    #[test]
+    fn the_highlight_the_arrows_moved_is_the_one_return_takes() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        palette.set_completions(vec![
+            Completion::new("/usr/bin", "bin"),
+            Completion::new("/usr/lib", "lib"),
+        ]);
+        palette.on_key(Key::Down, mods());
+        palette.on_key(Key::Down, mods());
+        assert_eq!(palette.highlighted(), Some(1));
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::GO_TO_PATH, Some("/usr/lib".into())))
+        );
     }
 
     #[test]

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -123,6 +123,11 @@ pub struct Palette {
     arg: Option<ArgSession>,
     /// Why the last attempt did not work, shown in place of the list.
     error: Option<String>,
+    /// What the argument being typed is doing right now — how many items a
+    /// pattern has picked, say. Set by the host after each preview and shown
+    /// where an error would be; cleared by the next key like an error is,
+    /// since it was about text that is now being changed.
+    note: Option<String>,
     /// The first row on screen. The list is longer than the card whenever the
     /// query is short, and this is what keeps the highlight in view.
     scroll: usize,
@@ -143,6 +148,7 @@ impl Palette {
             highlight: 0,
             arg: None,
             error: None,
+            note: None,
             scroll: 0,
             style,
         };
@@ -214,6 +220,11 @@ impl Palette {
 
     pub fn error(&self) -> Option<&str> {
         self.error.as_deref()
+    }
+
+    /// The live result of the argument being typed, if the host has one.
+    pub fn note(&self) -> Option<&str> {
+        self.note.as_deref()
     }
 
     /// The first row on screen, and where the view puts it after scrolling.
@@ -310,12 +321,19 @@ impl Palette {
         self.error = Some(error.into());
     }
 
+    /// Say what the argument as typed is doing — the answer a previewed
+    /// argument produced. Shown until the next key changes the question.
+    pub fn set_note(&mut self, note: Option<String>) {
+        self.note = note;
+    }
+
     // === Keys ===
 
     pub fn on_key(&mut self, key: Key, mods: KeyMods) -> Outcome {
         // Any key at all clears the last complaint: it was about text that is
         // now being changed.
         let had_error = self.error.take().is_some();
+        self.note = None;
         let outcome = if self.arg.is_some() {
             self.arg_key(key, mods)
         } else {
@@ -995,9 +1013,15 @@ mod tests {
         type_text(&mut palette, "/nowhere");
         palette.set_error("No such folder");
         assert_eq!(palette.error(), Some("No such folder"));
+        palette.set_note(Some("3 of 9 selected".into()));
+        assert_eq!(palette.note(), Some("3 of 9 selected"));
         // The next keystroke is about the text, so the complaint goes.
         palette.on_key(Key::Edit(TextInputKey::Backspace), mods());
         assert!(palette.error().is_none());
+        assert!(
+            palette.note().is_none(),
+            "a note is about text that has now changed"
+        );
         assert_eq!(palette.input().value(), "/nowher");
     }
 }

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -55,6 +55,10 @@ pub enum Row {
     /// An answer to the argument being typed, by its index into the session's
     /// completions.
     Completion(usize),
+    /// One line of a dry run — what the argument as typed would do to one
+    /// thing — by its index into the session's preview. Read, never chosen:
+    /// Return runs the command, not the line.
+    Preview(usize),
 }
 
 /// Something an argument could be completed to.
@@ -105,6 +109,9 @@ struct ArgSession {
     /// The prefix is never edited a character at a time, so this is the only
     /// way back.
     saved_query: String,
+    /// What the argument as typed would do, from the host, when the command
+    /// can say. Shown as the rows while it is not empty.
+    preview: Vec<crate::command::PreviewRow>,
 }
 
 /// The palette.
@@ -316,6 +323,27 @@ impl Palette {
         self.note = note;
     }
 
+    /// Show what the argument as typed would do, line by line, in place of
+    /// the completions. Nothing outside argument mode.
+    pub fn set_preview(&mut self, rows: Vec<crate::command::PreviewRow>) {
+        let Some(session) = self.arg.as_mut() else {
+            return;
+        };
+        if session.preview == rows {
+            return;
+        }
+        session.preview = rows;
+        self.rebuild_rows();
+    }
+
+    /// The dry run on show, if any.
+    pub fn preview(&self) -> &[crate::command::PreviewRow] {
+        match &self.arg {
+            Some(session) => &session.preview,
+            None => &[],
+        }
+    }
+
     // === Keys ===
 
     pub fn on_key(&mut self, key: Key, mods: KeyMods) -> Outcome {
@@ -521,6 +549,7 @@ impl Palette {
             },
             highlight,
             saved_query: self.query.value().to_string(),
+            preview: Vec::new(),
         });
         self.rebuild_rows();
     }
@@ -631,9 +660,17 @@ impl Palette {
 
     fn rebuild_rows(&mut self) {
         self.rows.clear();
-        if self.arg.is_some() {
-            self.rows
-                .extend((0..self.completions().len()).map(Row::Completion));
+        if let Some(session) = self.arg.as_ref() {
+            // A dry run stands in for the completions while there is one: the
+            // two are never both worth showing, and a command that previews
+            // is one whose argument is free text with nothing to complete.
+            if !session.preview.is_empty() {
+                self.rows
+                    .extend((0..session.preview.len()).map(Row::Preview));
+            } else {
+                self.rows
+                    .extend((0..session.completions.len()).map(Row::Completion));
+            }
             return;
         }
         if self.resting() {

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -262,66 +262,6 @@ impl Palette {
             .map(|session| &self.commands[session.command])
     }
 
-    /// What the field would become if the suggestion were taken — the whole
-    /// value, not the part still to be typed.
-    ///
-    /// The terminal's bargain: the best answer is shown ahead of the caret as
-    /// you type, and taking it is the same as having typed it. Only a
-    /// candidate that *starts with* what is typed can be shown this way — a
-    /// fuzzy hit like "mo tr" for "Move to Trash" has no tail to put after the
-    /// caret, so it is left to the list below.
-    pub fn suggestion(&self) -> Option<&str> {
-        let typed = self.input().value();
-        if typed.is_empty() {
-            return None;
-        }
-        let candidate = match &self.arg {
-            Some(session) => {
-                let completion = session.completions.get(session.highlight.unwrap_or(0))?;
-                // A path's value is what gets typed; a choice's is an id
-                // nobody types, so that one is suggested by its title.
-                match self.commands[session.command].arg.as_ref()?.kind {
-                    ArgKind::Path { .. } => completion.value.as_str(),
-                    _ => completion.title.as_str(),
-                }
-            }
-            None => self.commands[*self.order.first()?].title.as_str(),
-        };
-        (candidate.len() > typed.len()
-            && candidate.to_lowercase().starts_with(&typed.to_lowercase()))
-        .then_some(candidate)
-    }
-
-    /// The part of the suggestion still to be typed — what the view draws
-    /// after the caret, in the field's own size.
-    pub fn suggestion_tail(&self) -> Option<&str> {
-        let typed_len = self.input().value().len();
-        self.suggestion().map(|whole| &whole[typed_len..])
-    }
-
-    /// Take the suggestion whole. The field then holds exactly what it would
-    /// hold had it all been typed, which is what makes the two the same.
-    fn accept_suggestion(&mut self) -> bool {
-        let Some(whole) = self.suggestion().map(str::to_string) else {
-            return false;
-        };
-        let input = self.input_mut();
-        input.set_value(whole);
-        input.state.set_caret(usize::MAX, false);
-        self.refilter_choices();
-        if self.arg.is_none() {
-            self.refilter();
-        }
-        true
-    }
-
-    /// Whether the caret is at the end of the text, which is the only place a
-    /// suggestion can be taken from: in the middle, Right means Right.
-    fn caret_at_end(&self) -> bool {
-        let input = self.input();
-        input.state.caret() >= input.value().len()
-    }
-
     /// The half-typed path the host should complete against, and whether only
     /// directories count. `None` unless a path argument is open — which is the
     /// palette's whole involvement with the disk.
@@ -410,12 +350,6 @@ impl Palette {
                 }
                 _ => Outcome::Ignored,
             },
-            // Right at the end of the text takes the suggestion, the way it
-            // does at a shell prompt. Anywhere else in the text it is just
-            // Right.
-            Key::Edit(TextInputKey::Right) if self.caret_at_end() && self.accept_suggestion() => {
-                Outcome::Changed
-            }
             Key::Edit(edit) => {
                 let response = self.query.on_key(edit, mods);
                 if let TextInputResponse::Clipboard(text) = response {
@@ -454,9 +388,6 @@ impl Palette {
             }
             Key::Tab => {
                 self.complete();
-                Outcome::Changed
-            }
-            Key::Edit(TextInputKey::Right) if self.caret_at_end() && self.accept_suggestion() => {
                 Outcome::Changed
             }
             Key::Edit(TextInputKey::Backspace) if self.arg_is_empty() => {
@@ -948,84 +879,6 @@ mod tests {
         palette.on_key(Key::Tab, mods());
         type_text(&mut palette, "/us");
         assert_eq!(palette.path_argument(), Some(("/us", false)));
-    }
-
-    /// The terminal's bargain: the rest of the best answer is shown ahead of
-    /// the caret, and Right takes it.
-    #[test]
-    fn the_rest_of_the_best_answer_is_offered_ahead_of_the_caret() {
-        let mut palette = open(commands());
-        type_text(&mut palette, "go to path");
-        palette.on_key(Key::Tab, mods());
-        type_text(&mut palette, "/usr/sh");
-        palette.set_completions(vec![
-            Completion::new("/usr/share", "share"),
-            Completion::new("/usr/shrunk", "shrunk"),
-        ]);
-        assert_eq!(palette.suggestion(), Some("/usr/share"));
-        assert_eq!(palette.suggestion_tail(), Some("are"));
-
-        palette.on_key(Key::Edit(TextInputKey::Right), mods());
-        assert_eq!(palette.input().value(), "/usr/share");
-    }
-
-    /// And taking it leaves the field exactly as typing it would have.
-    #[test]
-    fn taking_the_suggestion_is_the_same_as_typing_it() {
-        let completions = || {
-            vec![
-                Completion::new("/usr/share", "share"),
-                Completion::new("/usr/shrunk", "shrunk"),
-            ]
-        };
-
-        let mut taken = open(commands());
-        type_text(&mut taken, "go to path");
-        taken.on_key(Key::Tab, mods());
-        type_text(&mut taken, "/usr/sh");
-        taken.set_completions(completions());
-        taken.on_key(Key::Edit(TextInputKey::Right), mods());
-
-        let mut typed = open(commands());
-        type_text(&mut typed, "go to path");
-        typed.on_key(Key::Tab, mods());
-        type_text(&mut typed, "/usr/share");
-        typed.set_completions(completions());
-
-        assert_eq!(taken.input().value(), typed.input().value());
-        assert_eq!(
-            taken.on_key(Key::Enter, mods()),
-            typed.on_key(Key::Enter, mods())
-        );
-    }
-
-    /// A fuzzy hit has no tail to put after the caret — "mo tr" is not a
-    /// prefix of "Move to Trash" — so nothing is offered there.
-    #[test]
-    fn a_gapped_query_offers_no_inline_suggestion() {
-        let mut palette = open(commands());
-        type_text(&mut palette, "mo tr");
-        assert_eq!(palette.suggestion(), None);
-    }
-
-    /// A prefix of a command's name is offered, though.
-    #[test]
-    fn a_prefix_of_a_command_is_offered_in_the_query_too() {
-        let mut palette = open(commands());
-        type_text(&mut palette, "go to p");
-        assert_eq!(palette.suggestion(), Some("Go to Path"));
-        palette.on_key(Key::Edit(TextInputKey::Right), mods());
-        assert_eq!(palette.input().value(), "Go to Path");
-    }
-
-    /// Right in the middle of the text is just Right.
-    #[test]
-    fn the_suggestion_is_only_taken_from_the_end_of_the_text() {
-        let mut palette = open(commands());
-        type_text(&mut palette, "go to p");
-        palette.input_mut().state.set_caret(2, false);
-        palette.on_key(Key::Edit(TextInputKey::Right), mods());
-        assert_eq!(palette.input().value(), "go to p");
     }
 
     #[test]

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -1,0 +1,934 @@
+//! The command palette's state: what is typed, what matches, what is
+//! highlighted, and what an argument is being answered with.
+//!
+//! See `specs/file-command-palette.md`. Everything here is decided without a
+//! window, a font or a disk: the palette is a state machine the host feeds
+//! keys to and reads rows off. The one thing it cannot work out for itself is
+//! what a half-typed path could be completed to — that is I/O, so the host
+//! does it and hands the answers back through [`Palette::set_completions`].
+
+use otto_kit::prelude::{KeyMods, TextInput, TextInputKey, TextInputResponse, TextInputStyle};
+
+use crate::command::{rank, ArgKind, Choice, Command, Group, Request};
+
+/// A key press, as the palette understands it.
+///
+/// Split rather than passed through whole because the same physical key means
+/// different things here than in a plain field: Return runs a command, Tab
+/// commits to one, and Escape unwinds a layer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Key {
+    Up,
+    Down,
+    Home,
+    End,
+    Tab,
+    Enter,
+    Escape,
+    /// Everything the text field itself handles — characters, Backspace,
+    /// caret movement, clipboard.
+    Edit(TextInputKey),
+}
+
+/// What the host should do about a key the palette has just taken.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Outcome {
+    /// Nothing happened; the key was not the palette's.
+    Ignored,
+    /// Something on screen changed.
+    Changed,
+    /// Close the palette without running anything.
+    Close,
+    /// Put this on the clipboard — a copy or cut inside the field.
+    Clipboard(String),
+    /// Run this, then close.
+    Run(Request),
+}
+
+/// One line of the list, as the view draws it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Row {
+    /// A group's name, in the resting list only. Never highlighted.
+    Heading(Group),
+    /// A command, by its index into [`Palette::commands`].
+    Command(usize),
+    /// An answer to the argument being typed, by its index into the session's
+    /// completions.
+    Completion(usize),
+}
+
+/// Something an argument could be completed to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Completion {
+    /// What the argument becomes if this is taken.
+    pub value: String,
+    /// What the user reads.
+    pub title: String,
+    pub subtitle: Option<String>,
+}
+
+impl Completion {
+    pub fn new(value: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            title: title.into(),
+            subtitle: None,
+        }
+    }
+
+    pub fn with_subtitle(mut self, subtitle: impl Into<String>) -> Self {
+        self.subtitle = Some(subtitle.into());
+        self
+    }
+}
+
+impl From<&Choice> for Completion {
+    fn from(choice: &Choice) -> Self {
+        Self {
+            value: choice.value.clone(),
+            title: choice.title.clone(),
+            subtitle: choice.subtitle.clone(),
+        }
+    }
+}
+
+/// An argument being answered.
+struct ArgSession {
+    /// Which command asked, by its index into [`Palette::commands`].
+    command: usize,
+    input: TextInput,
+    completions: Vec<Completion>,
+    /// Which completion is highlighted, if any. `None` means the typed text
+    /// stands on its own — which is the usual state for a path being typed.
+    highlight: Option<usize>,
+    /// The query the search was left on, so backing out restores it whole.
+    /// The prefix is never edited a character at a time, so this is the only
+    /// way back.
+    saved_query: String,
+}
+
+/// The palette.
+pub struct Palette {
+    /// Everything on offer, gathered once when the palette opened. Nothing
+    /// re-gathers while it is up: the window is not changing underneath it.
+    commands: Vec<Command>,
+    query: TextInput,
+    /// The ranked commands, best first. Empty query means all of them, in
+    /// provider order.
+    order: Vec<usize>,
+    rows: Vec<Row>,
+    /// Index into `rows`, always pointing at a highlightable row when there is
+    /// one.
+    highlight: usize,
+    arg: Option<ArgSession>,
+    /// Why the last attempt did not work, shown in place of the list.
+    error: Option<String>,
+    /// The first row on screen. The list is longer than the card whenever the
+    /// query is short, and this is what keeps the highlight in view.
+    scroll: usize,
+    /// How the field is drawn. Held rather than looked up, because argument
+    /// mode builds a second field and the two must match — and because a test
+    /// has no theme to look one up from.
+    style: TextInputStyle,
+}
+
+impl Palette {
+    /// Open onto `commands`, resting: no query, everything grouped.
+    pub fn open(commands: Vec<Command>, style: TextInputStyle) -> Self {
+        let mut palette = Self {
+            commands,
+            query: field("", &style),
+            order: Vec::new(),
+            rows: Vec::new(),
+            highlight: 0,
+            arg: None,
+            error: None,
+            scroll: 0,
+            style,
+        };
+        palette.refilter();
+        palette
+    }
+
+    // === What the view reads ===
+
+    pub fn commands(&self) -> &[Command] {
+        &self.commands
+    }
+
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    /// Which row is highlighted, or `None` when there is nothing to highlight.
+    pub fn highlighted(&self) -> Option<usize> {
+        self.rows.get(self.highlight).map(|_| self.highlight)
+    }
+
+    /// The field the caret is in — the query, or the argument.
+    pub fn input(&self) -> &TextInput {
+        match &self.arg {
+            Some(session) => &session.input,
+            None => &self.query,
+        }
+    }
+
+    pub fn input_mut(&mut self) -> &mut TextInput {
+        match &mut self.arg {
+            Some(session) => &mut session.input,
+            None => &mut self.query,
+        }
+    }
+
+    /// The non-editable prefix in front of the field, with its colon, while an
+    /// argument is being answered. `None` in search mode.
+    pub fn prompt(&self) -> Option<String> {
+        let session = self.arg.as_ref()?;
+        let spec = self.commands[session.command].arg.as_ref()?;
+        Some(format!("{}:", spec.prompt))
+    }
+
+    /// Dim text standing in for an empty field.
+    pub fn placeholder(&self) -> String {
+        match &self.arg {
+            Some(session) => self.commands[session.command]
+                .arg
+                .as_ref()
+                .and_then(|spec| spec.placeholder.clone())
+                .unwrap_or_default(),
+            None => otto_kit::t_owned!("files-palette-placeholder"),
+        }
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    /// The first row on screen, and where the view puts it after scrolling.
+    pub fn scroll(&self) -> usize {
+        self.scroll
+    }
+
+    pub fn set_scroll(&mut self, first: usize) {
+        self.scroll = first;
+    }
+
+    /// Put the highlight on `row`, if it is one that can be chosen. What the
+    /// pointer does when it moves over the list, and the first half of what a
+    /// click on a row does.
+    pub fn highlight_row(&mut self, row: usize) -> bool {
+        match self.rows.get(row) {
+            Some(Row::Command(_)) | Some(Row::Completion(_)) => {
+                self.highlight = row;
+                if let (Some(session), Some(Row::Completion(index))) =
+                    (self.arg.as_mut(), self.rows.get(row))
+                {
+                    session.highlight = Some(*index);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether the list is the grouped resting one rather than a ranked list.
+    pub fn resting(&self) -> bool {
+        self.arg.is_none() && self.query.value().trim().is_empty()
+    }
+
+    pub fn completions(&self) -> &[Completion] {
+        match &self.arg {
+            Some(session) => &session.completions,
+            None => &[],
+        }
+    }
+
+    /// The command an argument is being typed for.
+    pub fn arg_command(&self) -> Option<&Command> {
+        self.arg
+            .as_ref()
+            .map(|session| &self.commands[session.command])
+    }
+
+    /// The half-typed path the host should complete against, and whether only
+    /// directories count. `None` unless a path argument is open — which is the
+    /// palette's whole involvement with the disk.
+    pub fn path_argument(&self) -> Option<(&str, bool)> {
+        let session = self.arg.as_ref()?;
+        match self.commands[session.command].arg.as_ref()?.kind {
+            ArgKind::Path { dirs_only } => Some((session.input.value(), dirs_only)),
+            _ => None,
+        }
+    }
+
+    /// Hand back what a path could be completed to.
+    ///
+    /// Answering with the list that is already there changes nothing — not
+    /// even the highlight. The host re-completes after every key, arrow keys
+    /// included, and an arrow key that moved the highlight must not have it
+    /// taken away again by the refresh that follows.
+    pub fn set_completions(&mut self, completions: Vec<Completion>) {
+        if let Some(session) = self.arg.as_mut() {
+            if session.completions == completions {
+                return;
+            }
+            session.completions = completions;
+            // A different list: the old position in it means nothing.
+            session.highlight = None;
+        }
+        self.rebuild_rows();
+    }
+
+    /// Say why the last attempt did not work. The palette stays open with the
+    /// text still there to fix.
+    pub fn set_error(&mut self, error: impl Into<String>) {
+        self.error = Some(error.into());
+    }
+
+    // === Keys ===
+
+    pub fn on_key(&mut self, key: Key, mods: KeyMods) -> Outcome {
+        // Any key at all clears the last complaint: it was about text that is
+        // now being changed.
+        let had_error = self.error.take().is_some();
+        let outcome = if self.arg.is_some() {
+            self.arg_key(key, mods)
+        } else {
+            self.search_key(key, mods)
+        };
+        match (outcome, had_error) {
+            (Outcome::Ignored, true) => Outcome::Changed,
+            (outcome, _) => outcome,
+        }
+    }
+
+    fn search_key(&mut self, key: Key, mods: KeyMods) -> Outcome {
+        match key {
+            Key::Escape => Outcome::Close,
+            Key::Up => {
+                self.step_highlight(-1);
+                Outcome::Changed
+            }
+            Key::Down => {
+                self.step_highlight(1);
+                Outcome::Changed
+            }
+            // In search mode the list is what Home and End are about — the
+            // query is short and its ends are one Left or Right away.
+            Key::Home => {
+                self.highlight = 0;
+                self.settle_highlight(1);
+                Outcome::Changed
+            }
+            Key::End => {
+                self.highlight = self.rows.len().saturating_sub(1);
+                self.settle_highlight(-1);
+                Outcome::Changed
+            }
+            // Both commit to the highlighted command. They agree deliberately:
+            // a user who only ever presses Return still lands in the field the
+            // command was going to need.
+            Key::Enter | Key::Tab => match self.highlighted_command() {
+                Some(index) if self.commands[index].arg.is_some() => {
+                    self.enter_arg(index);
+                    Outcome::Changed
+                }
+                Some(index) if key == Key::Enter => {
+                    Outcome::Run(Request::new(self.commands[index].id.clone(), None))
+                }
+                _ => Outcome::Ignored,
+            },
+            Key::Edit(edit) => {
+                let response = self.query.on_key(edit, mods);
+                if let TextInputResponse::Clipboard(text) = response {
+                    return Outcome::Clipboard(text);
+                }
+                self.refilter();
+                Outcome::Changed
+            }
+        }
+    }
+
+    fn arg_key(&mut self, key: Key, mods: KeyMods) -> Outcome {
+        match key {
+            // One layer at a time: out of the argument, then out of the
+            // palette. Escape never runs anything.
+            Key::Escape => {
+                self.leave_arg();
+                Outcome::Changed
+            }
+            Key::Up => {
+                self.step_completion(-1);
+                Outcome::Changed
+            }
+            Key::Down => {
+                self.step_completion(1);
+                Outcome::Changed
+            }
+            Key::Enter => {
+                let session = self.arg.as_ref().expect("in argument mode");
+                let command = &self.commands[session.command];
+                let value = match session.highlight.and_then(|i| session.completions.get(i)) {
+                    Some(completion) => completion.value.clone(),
+                    None => session.input.value().to_string(),
+                };
+                Outcome::Run(Request::new(command.id.clone(), Some(value)))
+            }
+            Key::Tab => {
+                self.complete();
+                Outcome::Changed
+            }
+            Key::Edit(TextInputKey::Backspace) if self.arg_is_empty() => {
+                // The prefix is not text and is never eaten a character at a
+                // time: Backspace at the start of an empty argument is the way
+                // back to the query that was typed.
+                self.leave_arg();
+                Outcome::Changed
+            }
+            // Here the field is the point, so Home and End are the caret's.
+            Key::Home => self.edit_arg(TextInputKey::Home, mods),
+            Key::End => self.edit_arg(TextInputKey::End, mods),
+            Key::Edit(edit) => self.edit_arg(edit, mods),
+        }
+    }
+
+    fn edit_arg(&mut self, edit: TextInputKey, mods: KeyMods) -> Outcome {
+        let Some(session) = self.arg.as_mut() else {
+            return Outcome::Ignored;
+        };
+        let response = session.input.on_key(edit, mods);
+        if let TextInputResponse::Clipboard(text) = response {
+            return Outcome::Clipboard(text);
+        }
+        self.refilter_choices();
+        Outcome::Changed
+    }
+
+    // === Moving about ===
+
+    fn highlighted_command(&self) -> Option<usize> {
+        match self.rows.get(self.highlight) {
+            Some(Row::Command(index)) => Some(*index),
+            _ => None,
+        }
+    }
+
+    fn step_highlight(&mut self, direction: isize) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let mut cursor = self.highlight as isize;
+        // Headings are read, not chosen: the arrow keys walk past them.
+        loop {
+            cursor += direction;
+            if cursor < 0 || cursor as usize >= self.rows.len() {
+                return;
+            }
+            if matches!(self.rows[cursor as usize], Row::Command(_)) {
+                self.highlight = cursor as usize;
+                return;
+            }
+        }
+    }
+
+    /// Nudge the highlight onto a choosable row, looking in `direction`.
+    fn settle_highlight(&mut self, direction: isize) {
+        if matches!(self.rows.get(self.highlight), Some(Row::Command(_))) {
+            return;
+        }
+        self.step_highlight(direction);
+    }
+
+    fn step_completion(&mut self, direction: isize) {
+        let Some(session) = self.arg.as_mut() else {
+            return;
+        };
+        if session.completions.is_empty() {
+            return;
+        }
+        let last = session.completions.len() as isize - 1;
+        session.highlight = Some(match session.highlight {
+            // Down out of the field lands on the first answer; up out of it
+            // lands on the last, so both ends are one key away.
+            None if direction > 0 => 0,
+            None => last as usize,
+            Some(current) => (current as isize + direction).clamp(0, last) as usize,
+        });
+        self.rebuild_rows();
+    }
+
+    // === Modes ===
+
+    fn enter_arg(&mut self, command: usize) {
+        let Some(spec) = self.commands[command].arg.clone() else {
+            return;
+        };
+        let (initial, highlight) = match &spec.kind {
+            // A choice's `initial` names the answer that is already true, so
+            // it is highlighted rather than typed: one arrow key and Return
+            // is the whole interaction.
+            ArgKind::Choice(choices) => (
+                String::new(),
+                spec.initial
+                    .as_ref()
+                    .and_then(|value| choices.iter().position(|c| &c.value == value)),
+            ),
+            _ => (spec.initial.clone().unwrap_or_default(), None),
+        };
+        let mut input = field(&initial, &self.style);
+        if !initial.is_empty() {
+            input.state.select_all();
+        }
+        self.arg = Some(ArgSession {
+            command,
+            input,
+            completions: match &spec.kind {
+                ArgKind::Choice(choices) => choices.iter().map(Completion::from).collect(),
+                // A path's answers arrive from the host; free text has none.
+                _ => Vec::new(),
+            },
+            highlight,
+            saved_query: self.query.value().to_string(),
+        });
+        self.rebuild_rows();
+    }
+
+    fn leave_arg(&mut self) {
+        let Some(session) = self.arg.take() else {
+            return;
+        };
+        let command = session.command;
+        self.query = field(&session.saved_query, &self.style);
+        self.query
+            .state
+            .set_caret(session.saved_query.chars().count(), false);
+        self.refilter();
+        // The command that was being answered stays highlighted: backing out
+        // of the argument is not backing out of the choice.
+        if let Some(row) = self
+            .rows
+            .iter()
+            .position(|row| matches!(row, Row::Command(index) if *index == command))
+        {
+            self.highlight = row;
+        }
+    }
+
+    fn arg_is_empty(&self) -> bool {
+        self.arg
+            .as_ref()
+            .is_some_and(|session| session.input.value().is_empty())
+    }
+
+    /// Tab: take the highlighted answer, or extend as far as every answer
+    /// agrees.
+    fn complete(&mut self) {
+        let Some(session) = self.arg.as_mut() else {
+            return;
+        };
+        if let Some(completion) = session.highlight.and_then(|i| session.completions.get(i)) {
+            let value = completion.value.clone();
+            session.input.set_value(value);
+            session.input.state.set_caret(usize::MAX, false);
+            session.highlight = None;
+        } else if let Some(prefix) = common_prefix(&session.completions) {
+            if prefix.chars().count() > session.input.value().chars().count() {
+                session.input.set_value(prefix);
+                session.input.state.set_caret(usize::MAX, false);
+            }
+        }
+        self.refilter_choices();
+    }
+
+    // === Lists ===
+
+    fn refilter(&mut self) {
+        let query = self.query.value().to_string();
+        self.order = rank(&self.commands, &query)
+            .into_iter()
+            .map(|m| m.index)
+            .collect();
+        self.rebuild_rows();
+        // A fresh query is a fresh list: start at the top of it.
+        self.scroll = 0;
+        self.highlight = 0;
+        self.settle_highlight(1);
+    }
+
+    /// A choice argument filters itself — its answers are already in hand, so
+    /// typing at them is ranking, not I/O.
+    fn refilter_choices(&mut self) {
+        let Some(session) = self.arg.as_ref() else {
+            return;
+        };
+        let Some(spec) = self.commands[session.command].arg.as_ref() else {
+            return;
+        };
+        let ArgKind::Choice(choices) = &spec.kind else {
+            return;
+        };
+        let typed = session.input.value().to_string();
+        let filtered: Vec<Completion> = if typed.trim().is_empty() {
+            choices.iter().map(Completion::from).collect()
+        } else {
+            let mut scored: Vec<(i32, Completion)> = choices
+                .iter()
+                .filter_map(|choice| {
+                    otto_kit::matching::score(&choice.title, &typed)
+                        .map(|score| (score, Completion::from(choice)))
+                })
+                .collect();
+            scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+            scored
+                .into_iter()
+                .map(|(_, completion)| completion)
+                .collect()
+        };
+        let session = self.arg.as_mut().expect("checked above");
+        session.completions = filtered;
+        session.highlight =
+            session
+                .highlight
+                .filter(|_| false)
+                .or(if session.completions.is_empty() {
+                    None
+                } else {
+                    Some(0)
+                });
+        self.rebuild_rows();
+    }
+
+    fn rebuild_rows(&mut self) {
+        self.rows.clear();
+        if self.arg.is_some() {
+            self.rows
+                .extend((0..self.completions().len()).map(Row::Completion));
+            return;
+        }
+        if self.resting() {
+            // Grouped, in the fixed order the groups are declared in. A group
+            // nothing is offered from is not named.
+            for group in Group::ALL {
+                let mut named = false;
+                for &index in &self.order {
+                    if self.commands[index].group != group {
+                        continue;
+                    }
+                    if !named {
+                        self.rows.push(Row::Heading(group));
+                        named = true;
+                    }
+                    self.rows.push(Row::Command(index));
+                }
+            }
+        } else {
+            self.rows
+                .extend(self.order.iter().copied().map(Row::Command));
+        }
+    }
+}
+
+fn field(value: &str, style: &TextInputStyle) -> TextInput {
+    let mut input = TextInput::new(value, style.clone());
+    input.state.set_focused(true);
+    input
+}
+
+/// The longest start every completion agrees on, or `None` when there is
+/// nothing to agree about.
+fn common_prefix(completions: &[Completion]) -> Option<String> {
+    let first = completions.first()?;
+    let mut prefix: Vec<char> = first.value.chars().collect();
+    for completion in &completions[1..] {
+        let shared = completion
+            .value
+            .chars()
+            .zip(prefix.iter())
+            .take_while(|(a, b)| a == *b)
+            .count();
+        prefix.truncate(shared);
+        if prefix.is_empty() {
+            return None;
+        }
+    }
+    Some(prefix.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::{id, ArgSpec, Group};
+
+    fn mods() -> KeyMods {
+        KeyMods {
+            shift: false,
+            ctrl: false,
+        }
+    }
+
+    fn type_text(palette: &mut Palette, text: &str) {
+        for ch in text.chars() {
+            palette.on_key(Key::Edit(TextInputKey::Char(ch)), mods());
+        }
+    }
+
+    fn open(commands: Vec<Command>) -> Palette {
+        Palette::open(commands, TextInputStyle::new())
+    }
+
+    fn commands() -> Vec<Command> {
+        vec![
+            Command::new(id::GO_UP, "Up", Group::Go),
+            Command::new(id::GO_TO_PATH, "Go to Path", Group::Go).with_arg(ArgSpec::new(
+                "Go to path",
+                "path",
+                ArgKind::Path { dirs_only: false },
+            )),
+            Command::new(id::TRASH, "Move to Trash", Group::File),
+            Command::new(id::CHANGE_VIEW, "Change View", Group::View).with_arg(
+                ArgSpec::new(
+                    "View",
+                    "view",
+                    ArgKind::Choice(vec![
+                        Choice::new("list", "List"),
+                        Choice::new("grid", "Grid"),
+                        Choice::new("columns", "Columns"),
+                    ]),
+                )
+                .with_initial("grid"),
+            ),
+        ]
+    }
+
+    fn highlighted_id(palette: &Palette) -> Option<&str> {
+        match palette.rows().get(palette.highlighted()?)? {
+            Row::Command(index) => Some(palette.commands()[*index].id.as_str()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn the_resting_list_is_grouped_and_headings_are_not_chosen() {
+        let palette = open(commands());
+        assert!(palette.resting());
+        assert!(matches!(palette.rows()[0], Row::Heading(Group::Go)));
+        // The highlight starts on the first *command*, never on the heading.
+        assert_eq!(highlighted_id(&palette), Some(id::GO_UP));
+    }
+
+    #[test]
+    fn arrowing_down_walks_past_the_headings() {
+        let mut palette = open(commands());
+        let mut seen = vec![highlighted_id(&palette).unwrap().to_string()];
+        for _ in 0..3 {
+            palette.on_key(Key::Down, mods());
+            seen.push(highlighted_id(&palette).unwrap().to_string());
+        }
+        assert_eq!(
+            seen,
+            vec![id::GO_UP, id::GO_TO_PATH, id::TRASH, id::CHANGE_VIEW]
+        );
+    }
+
+    #[test]
+    fn typing_flattens_the_list_and_ranks_it() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "mo tr");
+        assert!(!palette.resting());
+        assert!(palette
+            .rows()
+            .iter()
+            .all(|row| matches!(row, Row::Command(_))));
+        assert_eq!(highlighted_id(&palette), Some(id::TRASH));
+    }
+
+    #[test]
+    fn return_runs_a_command_that_asks_for_nothing() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "up");
+        let outcome = palette.on_key(Key::Enter, mods());
+        assert_eq!(outcome, Outcome::Run(Request::new(id::GO_UP, None)));
+    }
+
+    #[test]
+    fn return_on_a_command_that_wants_an_argument_asks_for_it_instead() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        assert_eq!(palette.on_key(Key::Enter, mods()), Outcome::Changed);
+        assert_eq!(palette.prompt().as_deref(), Some("Go to path:"));
+        assert_eq!(
+            palette.arg_command().map(|c| c.id.as_str()),
+            Some(id::GO_TO_PATH)
+        );
+    }
+
+    #[test]
+    fn tab_asks_for_the_argument_the_same_way_return_does() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        assert_eq!(palette.on_key(Key::Tab, mods()), Outcome::Changed);
+        assert_eq!(palette.prompt().as_deref(), Some("Go to path:"));
+    }
+
+    #[test]
+    fn tab_on_a_command_with_nothing_to_ask_does_nothing() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "up");
+        assert_eq!(palette.on_key(Key::Tab, mods()), Outcome::Ignored);
+        assert!(palette.prompt().is_none());
+    }
+
+    #[test]
+    fn what_is_typed_after_the_prompt_is_the_argument_not_a_query() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/etc");
+        assert_eq!(palette.input().value(), "/etc");
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::GO_TO_PATH, Some("/etc".into())))
+        );
+    }
+
+    #[test]
+    fn backspacing_out_of_an_empty_argument_restores_the_query() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/e");
+        palette.on_key(Key::Edit(TextInputKey::Backspace), mods());
+        palette.on_key(Key::Edit(TextInputKey::Backspace), mods());
+        // Still in the argument: it only just became empty.
+        assert!(palette.prompt().is_some());
+        palette.on_key(Key::Edit(TextInputKey::Backspace), mods());
+        assert!(palette.prompt().is_none());
+        assert_eq!(palette.input().value(), "go to path");
+        assert_eq!(highlighted_id(&palette), Some(id::GO_TO_PATH));
+    }
+
+    #[test]
+    fn escape_leaves_the_argument_before_it_closes_the_palette() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        assert_eq!(palette.on_key(Key::Escape, mods()), Outcome::Changed);
+        assert!(palette.prompt().is_none());
+        assert_eq!(palette.on_key(Key::Escape, mods()), Outcome::Close);
+    }
+
+    #[test]
+    fn a_choice_argument_opens_on_the_answer_that_is_already_true() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "change view");
+        palette.on_key(Key::Tab, mods());
+        assert_eq!(palette.completions().len(), 3);
+        // "grid" was the initial, so it is the one Return would take.
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::CHANGE_VIEW, Some("grid".into())))
+        );
+    }
+
+    #[test]
+    fn one_arrow_key_and_return_answers_a_choice() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "change view");
+        palette.on_key(Key::Tab, mods());
+        palette.on_key(Key::Down, mods());
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::CHANGE_VIEW, Some("columns".into())))
+        );
+    }
+
+    #[test]
+    fn typing_at_a_choice_narrows_it_without_touching_the_disk() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "change view");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "col");
+        assert_eq!(palette.completions().len(), 1);
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::CHANGE_VIEW, Some("columns".into())))
+        );
+    }
+
+    #[test]
+    fn the_host_is_asked_to_complete_a_path_and_nothing_else() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "change view");
+        palette.on_key(Key::Tab, mods());
+        assert!(palette.path_argument().is_none());
+
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/us");
+        assert_eq!(palette.path_argument(), Some(("/us", false)));
+    }
+
+    #[test]
+    fn tab_extends_a_path_as_far_as_every_answer_agrees() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/us");
+        palette.set_completions(vec![
+            Completion::new("/usr/share", "share"),
+            Completion::new("/usr/src", "src"),
+        ]);
+        palette.on_key(Key::Tab, mods());
+        assert_eq!(palette.input().value(), "/usr/s");
+    }
+
+    #[test]
+    fn tab_on_a_highlighted_answer_takes_it_whole() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        palette.set_completions(vec![
+            Completion::new("/usr/share", "share"),
+            Completion::new("/usr/src", "src"),
+        ]);
+        palette.on_key(Key::Down, mods());
+        palette.on_key(Key::Tab, mods());
+        assert_eq!(palette.input().value(), "/usr/share");
+    }
+
+    #[test]
+    fn return_on_a_highlighted_answer_runs_with_it() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        palette.set_completions(vec![Completion::new("/usr/share", "share")]);
+        palette.on_key(Key::Down, mods());
+        assert_eq!(
+            palette.on_key(Key::Enter, mods()),
+            Outcome::Run(Request::new(id::GO_TO_PATH, Some("/usr/share".into())))
+        );
+    }
+
+    #[test]
+    fn a_query_matching_nothing_has_nothing_to_run() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "zzzz");
+        assert!(palette.rows().is_empty());
+        assert_eq!(palette.on_key(Key::Enter, mods()), Outcome::Ignored);
+    }
+
+    #[test]
+    fn a_rejected_argument_leaves_the_text_there_to_fix() {
+        let mut palette = open(commands());
+        type_text(&mut palette, "go to path");
+        palette.on_key(Key::Tab, mods());
+        type_text(&mut palette, "/nowhere");
+        palette.set_error("No such folder");
+        assert_eq!(palette.error(), Some("No such folder"));
+        // The next keystroke is about the text, so the complaint goes.
+        palette.on_key(Key::Edit(TextInputKey::Backspace), mods());
+        assert!(palette.error().is_none());
+        assert_eq!(palette.input().value(), "/nowher");
+    }
+}

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -664,6 +664,27 @@ impl Palette {
 
     // === Modes ===
 
+    /// Open straight onto one command, by id — what a menu item does when it
+    /// stands for a palette command. A command that takes an argument opens
+    /// in its field; one that does not is simply highlighted, ready for
+    /// Return. `false` when no such command is on offer.
+    pub fn open_on(&mut self, id: &str) -> bool {
+        let Some(index) = self.commands.iter().position(|command| command.id == id) else {
+            return false;
+        };
+        if let Some(row) = self
+            .rows
+            .iter()
+            .position(|row| matches!(row, Row::Command(i) if *i == index))
+        {
+            self.highlight = row;
+        }
+        if self.commands[index].arg.is_some() {
+            self.enter_arg(index);
+        }
+        true
+    }
+
     fn enter_arg(&mut self, command: usize) {
         let Some(spec) = self.commands[command].arg.clone() else {
             return;

--- a/components/otto-files/src/palette.rs
+++ b/components/otto-files/src/palette.rs
@@ -7,6 +7,8 @@
 //! what a half-typed path could be completed to — that is I/O, so the host
 //! does it and hands the answers back through [`Palette::set_completions`].
 
+use std::collections::HashSet;
+
 use otto_kit::prelude::{KeyMods, TextInput, TextInputKey, TextInputResponse, TextInputStyle};
 
 use crate::command::{rank, ArgKind, Choice, Command, Group, Request};
@@ -56,9 +58,74 @@ pub enum Row {
     /// completions.
     Completion(usize),
     /// One line of a dry run — what the argument as typed would do to one
-    /// thing — by its index into the session's preview. Read, never chosen:
-    /// Return runs the command, not the line.
+    /// thing — by its index into the session's preview. Never *chosen*:
+    /// Return runs the command, not the line. But a line can be highlighted
+    /// and toggled, which leaves its file out of the run.
     Preview(usize),
+}
+
+/// One line of the dry run on show: what a thing is, what it would become,
+/// and whether it has been left out of the run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewLine {
+    pub from: String,
+    pub to: String,
+    pub conflict: bool,
+    /// Toggled off: the file is named so it can be toggled back, but the
+    /// command will not touch it and the dry run was made without it.
+    pub excluded: bool,
+}
+
+impl PreviewLine {
+    /// Lay a provider's dry run over the full list of targets, so the ones
+    /// left out still have a line to be brought back by.
+    ///
+    /// A provider answers for the targets it was given — the included ones —
+    /// and, when it answers one line per target, its lines are threaded back
+    /// among the excluded names in the targets' order. A provider that says
+    /// something else (one line for the whole batch, say) has its lines shown
+    /// as they are, with the excluded names after them.
+    pub fn merge(
+        targets: &[String],
+        excluded: &HashSet<String>,
+        rows: Vec<crate::command::PreviewRow>,
+    ) -> Vec<PreviewLine> {
+        let left_out = |name: &String| PreviewLine {
+            from: name.clone(),
+            to: String::new(),
+            conflict: false,
+            excluded: true,
+        };
+        let included = targets
+            .iter()
+            .filter(|name| !excluded.contains(*name))
+            .count();
+        let mut rows = rows.into_iter().map(|row| PreviewLine {
+            from: row.from,
+            to: row.to,
+            conflict: row.conflict,
+            excluded: false,
+        });
+        if rows.len() == included {
+            return targets
+                .iter()
+                .map(|name| {
+                    if excluded.contains(name) {
+                        left_out(name)
+                    } else {
+                        rows.next().expect("one row per included target")
+                    }
+                })
+                .collect();
+        }
+        rows.chain(
+            targets
+                .iter()
+                .filter(|name| excluded.contains(*name))
+                .map(left_out),
+        )
+        .collect()
+    }
 }
 
 /// Something an argument could be completed to.
@@ -111,7 +178,10 @@ struct ArgSession {
     saved_query: String,
     /// What the argument as typed would do, from the host, when the command
     /// can say. Shown as the rows while it is not empty.
-    preview: Vec<crate::command::PreviewRow>,
+    preview: Vec<PreviewLine>,
+    /// The names toggled out of the run from the dry run's lines. The host
+    /// leaves these out of what it asks the provider to preview and to do.
+    excluded: HashSet<String>,
 }
 
 /// The palette.
@@ -237,9 +307,9 @@ impl Palette {
     /// click on a row does.
     pub fn highlight_row(&mut self, row: usize) -> bool {
         match self.rows.get(row) {
-            Some(Row::Command(_)) | Some(Row::Completion(_)) => {
+            Some(Row::Command(_)) | Some(Row::Completion(_)) | Some(Row::Preview(_)) => {
                 self.highlight = row;
-                if let (Some(session), Some(Row::Completion(index))) =
+                if let (Some(session), Some(Row::Completion(index) | Row::Preview(index))) =
                     (self.arg.as_mut(), self.rows.get(row))
                 {
                     session.highlight = Some(*index);
@@ -248,6 +318,54 @@ impl Palette {
             }
             _ => false,
         }
+    }
+
+    /// Toggle the dry-run line at `row` in or out of the run — what a click
+    /// on one does. `false` when the row is not a dry-run line.
+    pub fn toggle_row(&mut self, row: usize) -> bool {
+        match self.rows.get(row) {
+            Some(Row::Preview(index)) => {
+                let index = *index;
+                self.highlight_row(row);
+                self.toggle_line(index)
+            }
+            _ => false,
+        }
+    }
+
+    fn toggle_line(&mut self, index: usize) -> bool {
+        let Some(session) = self.arg.as_mut() else {
+            return false;
+        };
+        let Some(line) = session.preview.get_mut(index) else {
+            return false;
+        };
+        line.excluded = !line.excluded;
+        if line.excluded {
+            session.excluded.insert(line.from.clone());
+        } else {
+            session.excluded.remove(&line.from);
+        }
+        true
+    }
+
+    /// Whether a dry-run line has the highlight, which is when Space toggles
+    /// rather than types.
+    fn on_preview_line(&self) -> bool {
+        self.arg.as_ref().is_some_and(|session| {
+            !session.preview.is_empty()
+                && session
+                    .highlight
+                    .is_some_and(|index| index < session.preview.len())
+        })
+    }
+
+    /// The names toggled out of the run. Empty outside argument mode.
+    pub fn excluded(&self) -> HashSet<String> {
+        self.arg
+            .as_ref()
+            .map(|session| session.excluded.clone())
+            .unwrap_or_default()
     }
 
     /// Whether the list is the grouped resting one rather than a ranked list.
@@ -325,19 +443,26 @@ impl Palette {
 
     /// Show what the argument as typed would do, line by line, in place of
     /// the completions. Nothing outside argument mode.
-    pub fn set_preview(&mut self, rows: Vec<crate::command::PreviewRow>) {
+    pub fn set_preview(&mut self, lines: Vec<PreviewLine>) {
         let Some(session) = self.arg.as_mut() else {
             return;
         };
-        if session.preview == rows {
+        if session.preview == lines {
             return;
         }
-        session.preview = rows;
+        session.preview = lines;
+        // A highlight past the end of a shorter list means nothing.
+        if session
+            .highlight
+            .is_some_and(|index| index >= session.preview.len())
+        {
+            session.highlight = None;
+        }
         self.rebuild_rows();
     }
 
     /// The dry run on show, if any.
-    pub fn preview(&self) -> &[crate::command::PreviewRow] {
+    pub fn preview(&self) -> &[PreviewLine] {
         match &self.arg {
             Some(session) => &session.preview,
             None => &[],
@@ -438,6 +563,14 @@ impl Palette {
                 self.complete();
                 Outcome::Changed
             }
+            // Down into the dry run, Space to leave a line out or bring it
+            // back. Only there: in the field, a space is a space.
+            Key::Edit(TextInputKey::Char(' ')) if self.on_preview_line() => {
+                if let Some(index) = self.arg.as_ref().and_then(|session| session.highlight) {
+                    self.toggle_line(index);
+                }
+                Outcome::Changed
+            }
             Key::Edit(TextInputKey::Backspace) if self.arg_is_empty() => {
                 // The prefix is not text and is never eaten a character at a
                 // time: Backspace at the start of an empty argument is the way
@@ -456,6 +589,11 @@ impl Palette {
         let Some(session) = self.arg.as_mut() else {
             return Outcome::Ignored;
         };
+        // Editing is being back in the field: a highlight left on a dry-run
+        // line would make the next Space a toggle instead of a space.
+        if !session.preview.is_empty() {
+            session.highlight = None;
+        }
         let response = session.input.on_key(edit, mods);
         if let TextInputResponse::Clipboard(text) = response {
             return Outcome::Clipboard(text);
@@ -503,10 +641,17 @@ impl Palette {
         let Some(session) = self.arg.as_mut() else {
             return;
         };
-        if session.completions.is_empty() {
+        // The list is the dry run while there is one, the completions
+        // otherwise — whichever the rows are showing.
+        let len = if session.preview.is_empty() {
+            session.completions.len()
+        } else {
+            session.preview.len()
+        };
+        if len == 0 {
             return;
         }
-        let last = session.completions.len() as isize - 1;
+        let last = len as isize - 1;
         session.highlight = Some(match session.highlight {
             // Down out of the field lands on the first answer; up out of it
             // lands on the last, so both ends are one key away.
@@ -550,6 +695,7 @@ impl Palette {
             highlight,
             saved_query: self.query.value().to_string(),
             preview: Vec::new(),
+            excluded: HashSet::new(),
         });
         self.rebuild_rows();
     }

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -1087,6 +1087,20 @@ impl PaneSurfaces {
     }
 }
 
+impl Drop for PaneSurface {
+    /// A surface let go of is torn down, not merely forgotten.
+    ///
+    /// `SubsurfaceSurface` has no `Drop` of its own: dropping one leaves the
+    /// wl_surface mapped, with its buffer and its input region, until the
+    /// process exits. For the palette's catcher that meant a dead,
+    /// display-sized surface still on top after the palette closed — taking
+    /// every press meant for the window, and for the next palette's catcher
+    /// stacked underneath it. So the card could be moved exactly once.
+    fn drop(&mut self) {
+        self.surface.destroy();
+    }
+}
+
 impl PaneSurface {
     /// Returns whether the surface had to be reallocated, which is the
     /// expensive half of a move.

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -124,6 +124,8 @@ pub struct PaletteFrame {
     /// Shown in place of the list.
     pub message: Option<String>,
     pub rows: Vec<crate::app::PaletteRowData>,
+    /// Where the list has scrolled to, and the state of its bar.
+    pub scroll: otto_kit::components::scroll::ScrollState,
 }
 
 impl PaletteFrame {
@@ -145,6 +147,7 @@ impl PaletteFrame {
                 .collect(),
             message: self.message.as_deref(),
             on_surface: true,
+            scroll: Some(self.scroll),
         }
     }
 }

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -178,6 +178,14 @@ struct PaneSurface {
     /// it: a parent-relative position sent after the centring would simply
     /// undo it.
     output_centered: bool,
+    /// A size and position the compositor has not been told about yet.
+    ///
+    /// The style protocol applies a size the moment it arrives, not on the
+    /// next commit, so claiming a new size while the old buffer is still
+    /// attached has the compositor draw the old pixels stretched to the new
+    /// bounds until the paint lands. A resize therefore waits here and is
+    /// claimed by [`PaneSurface::draw`], right after the buffer that fits it.
+    claim: Option<(Rect, f32)>,
 }
 
 /// The per-column subsurfaces, pooled the way the scene pools its pane layers.
@@ -362,7 +370,7 @@ impl PaneSurfaces {
             // the correct half rather than a squeezed whole.
             let width = full.width();
             let origin = (clipped.left, clipped.top);
-            pane.surface.draw(|canvas| {
+            pane.draw(|canvas| {
                 canvas.save();
                 canvas.translate((dx, 0.0));
                 scene::paint_column(canvas, f, depth, width);
@@ -561,7 +569,7 @@ impl PaneSurfaces {
                     PALETTE_MARGIN - palette.resting.top,
                 );
                 let data = palette.data();
-                pane.surface.draw(|canvas| {
+                pane.draw(|canvas| {
                     canvas.clear(skia_safe::Color::TRANSPARENT);
                     canvas.save();
                     canvas.translate(shift);
@@ -653,7 +661,7 @@ impl PaneSurfaces {
         // buffer is not mapped and takes no input.
         if resized || pane.key == 0 {
             pane.key = 1;
-            pane.surface.draw(|canvas| {
+            pane.draw(|canvas| {
                 canvas.clear(skia_safe::Color::TRANSPARENT);
             });
             painted = true;
@@ -784,7 +792,7 @@ impl PaneSurfaces {
         pane.key = key;
         let origin = (rect.left, rect.top);
         let started = qv_trace::now();
-        pane.surface.draw(|canvas| {
+        pane.draw(|canvas| {
             canvas.clear(skia_safe::Color::TRANSPARENT);
             canvas.save();
             canvas.translate((-origin.0, -origin.1));
@@ -878,7 +886,7 @@ impl PaneSurfaces {
             .and_then(otto_kit::preview::Pixels::to_image);
         let theme = f.theme.clone();
         let origin = (rect.left, rect.top);
-        pane.surface.draw(|canvas| {
+        pane.draw(|canvas| {
             canvas.clear(skia_safe::Color::TRANSPARENT);
             canvas.save();
             canvas.translate((-origin.0, -origin.1));
@@ -950,7 +958,7 @@ impl PaneSurfaces {
         pane.bar = bar;
         let origin = (strip.left, strip.top);
         let theme = f.theme;
-        pane.surface.draw(|canvas| {
+        pane.draw(|canvas| {
             canvas.clear(skia_safe::Color::TRANSPARENT);
             canvas.save();
             canvas.translate((-origin.0, -origin.1));
@@ -1086,6 +1094,7 @@ impl PaneSurfaces {
             hidden: false,
             takes_input: false,
             output_centered: false,
+            claim: None,
         })
     }
 }
@@ -1122,19 +1131,46 @@ impl PaneSurface {
         // A move does too, now that the bar is drawn in window coordinates
         // shifted by this rect's origin.
         self.bar = f32::NAN;
+        // The wl position is what the pointer is hit-tested against; it is
+        // parent state and lands with the parent's commit, so it is safe to
+        // send now whatever the buffer is.
         self.surface.set_position(rect.left as i32, rect.top as i32);
-        if let Some(style) = self.surface.layer() {
-            // Claiming the size stops the compositor re-deriving both size and
-            // position from the surface tree — see `ScrollSurfaces`, which
-            // depends on the same rule.
+        if resized || self.claim.is_some() {
+            // Not claimed yet: the buffer on screen is the old size, and the
+            // compositor would stretch it. The draw that follows claims it,
+            // with the new buffer in hand — and a move that lands while a
+            // claim is waiting joins it rather than overtaking it.
+            self.claim = Some((rect, scale));
+            return resized;
+        }
+        Self::claim_bounds(&self.surface, rect, scale);
+        self.surface.commit();
+        resized
+    }
+
+    /// Tell the compositor where this surface is and how big. Claiming the
+    /// size stops it re-deriving both size and position from the surface
+    /// tree — see `ScrollSurfaces`, which depends on the same rule.
+    fn claim_bounds(surface: &SubsurfaceSurface, rect: Rect, scale: f32) {
+        if let Some(style) = surface.layer() {
             style.set_size(
                 (rect.width() * scale) as f64,
                 (rect.height() * scale) as f64,
             );
             style.set_position((rect.left * scale) as f64, (rect.top * scale) as f64);
         }
-        self.surface.commit();
-        resized
+    }
+
+    /// Paint the surface, and claim any size it has been waiting to claim.
+    ///
+    /// The paint attaches and commits a buffer of the current size; the claim
+    /// goes out right behind it, in the same flush, so the compositor never
+    /// holds a new size with an old buffer.
+    fn draw(&mut self, paint: impl FnOnce(&skia_safe::Canvas)) {
+        self.surface.draw(paint);
+        if let Some((rect, scale)) = self.claim.take() {
+            Self::claim_bounds(&self.surface, rect, scale);
+        }
     }
 
     /// Say whether the surface answers for the pointer over its own area.

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -609,7 +609,11 @@ impl PaneSurfaces {
         // shadow follow the corners instead of squaring them off.
         style.set_corner_radius(14.0 * scale);
         style.set_shadow(0.28, 24.0 * scale, 0.0, 8.0 * scale, 0.0, 0.0, 0.0);
-        style.set_blend_mode(otto_kit::protocols::otto_surface_style_v1::BlendMode::BackgroundBlur);
+        style.set_blend_mode(if otto_kit::frosting::enabled() {
+            otto_kit::protocols::otto_surface_style_v1::BlendMode::BackgroundBlur
+        } else {
+            otto_kit::protocols::otto_surface_style_v1::BlendMode::Normal
+        });
     }
 
     /// The surface the palette's pointer arrives on, and where that surface

--- a/components/otto-files/src/pane_surfaces.rs
+++ b/components/otto-files/src/pane_surfaces.rs
@@ -72,10 +72,81 @@ pub fn quickview_on_surface() -> bool {
     enabled() || quickview_centered()
 }
 
+/// Whether the command palette is presented on a surface of its own rather
+/// than painted into the window's canvas.
+///
+/// It has to be, for the same reason Quick View does: the card is dragged, and
+/// a card painted into the window's buffer cannot be dragged past the window's
+/// edge — there are no pixels out there to draw on. Clamping it to the window
+/// was a way of hiding that, not a design.
+///
+/// A surface also settles what the card is made of. The frosted material only
+/// means anything here: the compositor blurs and tints what is actually behind
+/// the *window*, where a blur painted into the window's own buffer can only
+/// sample the listing the card is already covering — which is why the card
+/// read as the same colour on the same colour.
+///
+/// `OTTO_FILES_PALETTE_SURFACE=0` goes back to painting it into the window.
+pub fn palette_on_surface() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        !matches!(
+            std::env::var("OTTO_FILES_PALETTE_SURFACE").as_deref(),
+            Ok("0") | Ok("false")
+        )
+    })
+}
+
 /// Whether the subsurface path is enabled for this process.
 pub fn enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var_os("OTTO_FILES_PANE_SUBS").is_some())
+}
+
+/// A hairline of slack around the card, so an anti-aliased edge is not clipped
+/// by the surface it is drawn into.
+const PALETTE_MARGIN: f32 = 1.0;
+
+/// What the palette's surface needs in order to paint and place itself.
+///
+/// The card is measured in window points on both sides of this seam — the
+/// geometry helpers in [`view`] all measure from the window's edges, and the
+/// host hit-tests in the same space — so the surface's own coordinates are
+/// arrived at by a single translate rather than by a second set of rects.
+pub struct PaletteFrame {
+    /// Where the card rests before any drag.
+    pub resting: Rect,
+    /// Where it actually is, once dragged.
+    pub card: Rect,
+    /// The non-editable prefix in front of the field, while an argument is
+    /// being answered.
+    pub prompt: Option<String>,
+    /// Shown in place of the list.
+    pub message: Option<String>,
+    pub rows: Vec<crate::app::PaletteRowData>,
+}
+
+impl PaletteFrame {
+    /// Borrow the owned text as the view wants it.
+    fn data(&self) -> view::PaletteData<'_> {
+        view::PaletteData {
+            prompt: self.prompt.as_deref(),
+            rows: self
+                .rows
+                .iter()
+                .map(|row| view::PaletteRow {
+                    kind: row.kind,
+                    title: &row.title,
+                    badge: row.badge.as_deref(),
+                    subtitle: row.subtitle.as_deref(),
+                    shortcut: row.shortcut.as_deref(),
+                    highlighted: row.highlighted,
+                })
+                .collect(),
+            message: self.message.as_deref(),
+            on_surface: true,
+        }
+    }
 }
 
 /// One column's surface and what it currently holds.
@@ -113,6 +184,25 @@ pub struct PaneSurfaces {
     pan: Option<PaneSurface>,
     /// The Quick View panel, in a surface of its own over everything.
     quickview: Option<PaneSurface>,
+    /// The command palette, in a surface of its own so it can be dragged clear
+    /// of the window. See [`palette_on_surface`].
+    palette: Option<PaneSurface>,
+    /// The display the palette may be dragged around, in window points, and
+    /// whether an answer has been asked for and not yet arrived.
+    ///
+    /// The client is never told where its own window is, so this is the only
+    /// way to know how far the card may go before it leaves the screen — the
+    /// clamp the window's own edges used to stand in for.
+    palette_display: Option<Rect>,
+    palette_asked: bool,
+    /// The palette's pointer, on a surface that does not move.
+    ///
+    /// Transparent, input-only, the size of the display, and stacked over the
+    /// card while the palette is up. Every press and every motion the palette
+    /// cares about arrives here, in a frame that stays put for the length of
+    /// a drag — which is what makes the drag exact. See [`Self::sync_palette`]
+    /// for why the card cannot take its own pointer.
+    catcher: Option<PaneSurface>,
     /// The docked preview column's video player, in a surface of its own so
     /// its per-frame repaints never touch the toplevel. Sized to the video's
     /// shape, placed over the column's stage; see [`Self::sync_preview_video`].
@@ -166,6 +256,10 @@ impl PaneSurfaces {
             panes: Vec::new(),
             pan: None,
             quickview: None,
+            palette: None,
+            palette_display: None,
+            palette_asked: false,
+            catcher: None,
             preview_video: None,
             quickview_placement: None,
             quickview_awaiting: false,
@@ -326,6 +420,8 @@ impl PaneSurfaces {
         let overlays = [
             self.preview_video.as_ref(),
             self.pan.as_ref(),
+            self.palette.as_ref(),
+            self.catcher.as_ref(),
             self.quickview.as_ref(),
         ];
         for (index, pane) in self.panes.iter().map(Some).chain(overlays).enumerate() {
@@ -375,13 +471,214 @@ impl PaneSurfaces {
         // The *old* rect stays in force until the new answer lands. Nulling it
         // here is what made the panel snap to the window's centre and back.
         if self.quickview_awaiting {
-            if let Some(rect) = centered_display(pane, self.scale) {
+            if let Some(rect) = display_rect(pane, self.scale) {
                 self.quickview_display = Some(rect);
                 self.quickview_awaiting = false;
             }
         }
         self.quickview_display
             .map(|display| quickview::resting_in(display, session.expanded))
+    }
+
+    /// The command palette, on a surface of its own.
+    ///
+    /// Painted into the window the card could not be dragged past the window's
+    /// edge, and its material could not blur anything but the listing it was
+    /// covering. Here the compositor owns both: the card goes where it is put,
+    /// and the frost samples the desktop behind the window.
+    ///
+    /// It takes its own pointer input, like Quick View and for the same
+    /// reason — dragged clear of the window, the card is over pixels the
+    /// toplevel is never told about. The keyboard is untouched: a subsurface
+    /// takes no keyboard focus, so the palette's keys keep arriving at the
+    /// toplevel exactly as they always have.
+    /// Called on its own rather than from [`Self::sync`], because painting the
+    /// card needs the palette borrowed mutably — its text field renders itself
+    /// — and the `Frame` the rest of this module works from holds the browser
+    /// borrowed for as long as it lives.
+    pub fn sync_palette(
+        &mut self,
+        parent: &WlSurface,
+        theme: &otto_kit::theme::Theme,
+        (width, height): (f32, f32),
+        palette: Option<&PaletteFrame>,
+        paint_field: impl FnOnce(&skia_safe::Canvas),
+    ) -> bool {
+        let Some(palette) = palette else {
+            // Asked afresh on the next open: the window may have been moved
+            // to another display in between.
+            self.palette_asked = false;
+            // The catcher is dropped rather than pooled: it is the size of the
+            // display, and a buffer that size is not worth holding for the
+            // next Ctrl+P.
+            let had_catcher = self.catcher.take().is_some();
+            return self
+                .palette
+                .as_mut()
+                .map(PaneSurface::hide)
+                .unwrap_or(false)
+                | had_catcher;
+        };
+        let rect = palette.card.with_outset((PALETTE_MARGIN, PALETTE_MARGIN));
+
+        if self.palette.is_none() {
+            self.palette = Self::create(parent, rect);
+            self.stack_dirty = true;
+            if let Some(pane) = self.palette.as_mut() {
+                Self::style_palette(pane, self.scale);
+                // The card keeps the empty input region `create` gave it. Its
+                // pointer is answered by the catcher below, never by the card
+                // itself: pointer positions arrive relative to the surface
+                // under the pointer, and a surface that is being dragged is a
+                // moving ruler — each motion event re-applies a correction
+                // that is already in flight, and the card runs away.
+            }
+        }
+        let mut painted = self.sync_palette_catcher(parent, width, height);
+        let scale = self.scale;
+        if let Some(pane) = self.palette.as_mut() {
+            painted |= pane.show();
+            pane.place(rect, scale);
+
+            // No content key here, unlike every other surface in this module:
+            // the field paints itself through the callback, so this side
+            // cannot tell whether the text changed. The frame-callback
+            // throttle is what keeps that from costing anything — a repaint
+            // only happens when the compositor has asked for a frame.
+            use wayland_client::Proxy;
+            if AppContext::frame_in_flight(&pane.surface.wl_surface().id()) {
+                self.pending = true;
+            } else {
+                // The card is drawn where it *rests*, in window points, and
+                // the drag is carried entirely by the surface's position.
+                // Drawing the dragged rect into a surface that had already
+                // been moved would apply the offset twice.
+                let shift = (
+                    PALETTE_MARGIN - palette.resting.left,
+                    PALETTE_MARGIN - palette.resting.top,
+                );
+                let data = palette.data();
+                pane.surface.draw(|canvas| {
+                    canvas.clear(skia_safe::Color::TRANSPARENT);
+                    canvas.save();
+                    canvas.translate(shift);
+                    view::draw_palette(canvas, theme, width, &data);
+                    // The field's text, over the box the card left for it —
+                    // the same two-step the rename and location fields take.
+                    // Still in window points, inside the same translate, so
+                    // the caller works in one coordinate space rather than
+                    // two.
+                    paint_field(canvas);
+                    canvas.restore();
+                });
+                painted = true;
+            }
+        }
+        // On every path, not only the painting one: the catcher may have just
+        // been created, and it has to land above the card before the first
+        // press or that press goes to the card's empty region instead.
+        self.restack(parent);
+        painted
+    }
+
+    /// The palette's material, handed to the compositor once.
+    ///
+    /// The frost is the point of the surface as much as the dragging is. The
+    /// compositor has the pixels behind the window and blurs *and tints* them,
+    /// which is what lifts the card off a listing of the same colour; it also
+    /// casts the shadow outside the card's bounds, where a shadow is actually
+    /// visible. Neither is possible in the window's own buffer.
+    fn style_palette(pane: &PaneSurface, scale: f32) {
+        let Some(style) = pane.surface.layer() else {
+            return;
+        };
+        // Physical pixels, like every other measurement this protocol takes.
+        let scale = scale as f64;
+        // Matches the radius the card paints itself with, so the blur and the
+        // shadow follow the corners instead of squaring them off.
+        style.set_corner_radius(14.0 * scale);
+        style.set_shadow(0.28, 24.0 * scale, 0.0, 8.0 * scale, 0.0, 0.0, 0.0);
+        style.set_blend_mode(otto_kit::protocols::otto_surface_style_v1::BlendMode::BackgroundBlur);
+    }
+
+    /// The surface the palette's pointer arrives on, and where that surface
+    /// sits in window points — the catcher, not the card. The pointer callback
+    /// adds the rect's origin to what the compositor reports and is back in
+    /// window points, against a rect that does not change under it mid-drag.
+    pub fn palette_target(&self) -> Option<(ObjectId, Rect)> {
+        use wayland_client::Proxy;
+        let pane = self.catcher.as_ref().filter(|pane| !pane.hidden)?;
+        Some((pane.surface.wl_surface().id(), pane.rect))
+    }
+
+    /// Keep the catcher covering the display — or the window, until the
+    /// compositor has said where the display is.
+    ///
+    /// It is never moved during a drag: its rect only changes when the answer
+    /// about the display arrives, which is once, at the start of a session,
+    /// before anyone has had time to take hold of anything.
+    fn sync_palette_catcher(&mut self, parent: &WlSurface, width: f32, height: f32) -> bool {
+        let rect = self
+            .palette_display
+            .unwrap_or_else(|| Rect::from_wh(width, height));
+        if self.catcher.is_none() {
+            self.catcher = Self::create(parent, rect);
+            self.stack_dirty = true;
+            if std::env::var_os("OTTO_FILES_PALETTE_TRACE").is_some() {
+                use wayland_client::Proxy;
+                eprintln!(
+                    "palette catcher created: {:?} rect={rect:?}",
+                    self.catcher.as_ref().map(|p| p.surface.wl_surface().id())
+                );
+            }
+            if let Some(pane) = self.catcher.as_mut() {
+                pane.takes_input = true;
+                pane.accept_input(true);
+                pane.surface.commit();
+            }
+        }
+        let scale = self.scale;
+        let Some(pane) = self.catcher.as_mut() else {
+            return false;
+        };
+        let mut painted = pane.show();
+        let resized = pane.place(rect, scale);
+        if resized && std::env::var_os("OTTO_FILES_PALETTE_TRACE").is_some() {
+            eprintln!("palette catcher placed: rect={rect:?}");
+        }
+        // Painted once per size: there is nothing on it, but a surface with no
+        // buffer is not mapped and takes no input.
+        if resized || pane.key == 0 {
+            pane.key = 1;
+            pane.surface.draw(|canvas| {
+                canvas.clear(skia_safe::Color::TRANSPARENT);
+            });
+            painted = true;
+        }
+        painted
+    }
+
+    /// The display the palette is on, in window points, or `None` until the
+    /// compositor has answered.
+    ///
+    /// Asked once per opening. The answer is relative to the window, so it
+    /// only means anything for as long as the window stays put — which for the
+    /// length of one palette session it does.
+    pub fn palette_display(&mut self) -> Option<Rect> {
+        use wayland_client::Proxy;
+        let pane = self.palette.as_ref()?;
+        let style = pane.surface.layer()?;
+        if !self.palette_asked {
+            self.palette_asked = true;
+            // Clear before asking, so a stale answer cannot be mistaken for
+            // the new one.
+            AppContext::clear_output_frame(&style.id());
+            style.request_output_frame();
+        }
+        if let Some(rect) = display_rect(pane, self.scale) {
+            self.palette_display = Some(rect);
+        }
+        self.palette_display
     }
 
     /// The Quick View panel.
@@ -1051,7 +1348,7 @@ mod qv_trace {
 /// surface is created, and the reply lands a round trip later, so the first
 /// frame or two of an entrance are still centred on the window. Those frames
 /// are the smallest ones, at the file's icon, so the correction is invisible.
-fn centered_display(pane: &PaneSurface, scale: f32) -> Option<Rect> {
+fn display_rect(pane: &PaneSurface, scale: f32) -> Option<Rect> {
     use wayland_client::Proxy;
 
     let style = pane.surface.layer()?;

--- a/components/otto-files/src/remembered.rs
+++ b/components/otto-files/src/remembered.rs
@@ -1,0 +1,135 @@
+//! What the window remembers between runs, in
+//! `$XDG_STATE_HOME/otto/files.toml` (`~/.local/state/otto/files.toml`).
+//!
+//! State, not configuration: nothing here is something a person writes by
+//! hand, so it lives apart from `~/.config/otto/files.toml` — which is
+//! theirs, comments and all, and which this module never rewrites. The whole
+//! file is optional and losing it costs nothing but a remembered position.
+//!
+//! ```toml
+//! [palette]
+//! # How far the command palette was last dragged from where it opens, in
+//! # window points.
+//! offset = [-320.0, 210.0]
+//! ```
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Remembered {
+    #[serde(default)]
+    pub palette: Palette,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Palette {
+    /// Where the palette was last left, as an offset from where it opens.
+    /// Relative rather than absolute because the window moves and resizes
+    /// between runs, and "the same distance from its resting place" survives
+    /// that where "the same corner of the screen" would not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<(f32, f32)>,
+}
+
+impl Remembered {
+    /// Read the state file, if it is there. Anything wrong with it is a
+    /// warning and the defaults.
+    pub fn load() -> Self {
+        let Some(path) = state_path() else {
+            return Self::default();
+        };
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(err) => {
+                tracing::warn!("could not read {}: {err}", path.display());
+                return Self::default();
+            }
+        };
+        match toml::from_str(&text) {
+            Ok(remembered) => remembered,
+            Err(err) => {
+                tracing::warn!("could not parse {}: {err}", path.display());
+                Self::default()
+            }
+        }
+    }
+
+    /// Write the state file, creating the directory on the way. Quiet on
+    /// failure: a position that could not be remembered is not worth an
+    /// error in the user's face.
+    pub fn save(&self) {
+        let Some(path) = state_path() else {
+            return;
+        };
+        let text = match toml::to_string(self) {
+            Ok(text) => text,
+            Err(err) => {
+                tracing::warn!("could not serialise state: {err}");
+                return;
+            }
+        };
+        if let Some(dir) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(dir) {
+                tracing::warn!("could not create {}: {err}", dir.display());
+                return;
+            }
+        }
+        if let Err(err) = std::fs::write(&path, text) {
+            tracing::warn!("could not write {}: {err}", path.display());
+        }
+    }
+}
+
+/// Where the state file is, honouring `XDG_STATE_HOME`. `OTTO_FILES_STATE`
+/// overrides the whole path, for tests and for running two copies side by
+/// side.
+fn state_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("OTTO_FILES_STATE") {
+        return Some(PathBuf::from(path));
+    }
+    let base = std::env::var("XDG_STATE_HOME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|home| PathBuf::from(home).join(".local").join("state"))
+        })?;
+    Some(base.join("otto").join("files.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_offset_survives_a_round_trip_and_nothing_else_is_written() {
+        let remembered = Remembered {
+            palette: Palette {
+                offset: Some((-320.0, 210.5)),
+            },
+        };
+        let text = toml::to_string(&remembered).unwrap();
+        assert!(text.contains("offset"));
+        let back: Remembered = toml::from_str(&text).unwrap();
+        assert_eq!(back, remembered);
+
+        let empty = toml::to_string(&Remembered::default()).unwrap();
+        let back: Remembered = toml::from_str(&empty).unwrap();
+        assert_eq!(back.palette.offset, None);
+    }
+
+    #[test]
+    fn a_file_from_the_future_still_reads() {
+        let back: Remembered = toml::from_str(
+            "[palette]\noffset = [1.0, 2.0]\nsomething_new = true\n[other]\nx = 1\n",
+        )
+        .unwrap();
+        assert_eq!(back.palette.offset, Some((1.0, 2.0)));
+    }
+}

--- a/components/otto-files/src/rename.rs
+++ b/components/otto-files/src/rename.rs
@@ -1,0 +1,688 @@
+//! Renaming several files at once from one pattern.
+//!
+//! The pattern is the new name with holes in it, and the holes are filled from
+//! each file in turn: its number in the selection, its original name, or parts
+//! of that name picked out by position. Nothing here touches the disk — it
+//! turns names into names, so the palette can show the outcome as it is typed
+//! and the host can carry it out afterwards from the same answer.
+//!
+//! ## The pattern
+//!
+//! Plain text stands for itself. Between braces:
+//!
+//! - `{name}` — the original name without its extension; `{ext}` — the
+//!   extension without its dot.
+//! - `{n}` — the file's number in the selection, from 1. `{n:3}` pads it to
+//!   three digits, `{n@10}` starts counting at ten; both may be combined.
+//! - `{1}`, `{2}` … — the words of the original name, counted from 1, split
+//!   wherever it has a space, an underscore, a dash or a dot; `{-1}` is the
+//!   last. `{2..}`, `{1..3}` and `{..-2}` take a run of them, joined by a
+//!   space — so `IMG_2024_Paris` gives `{3}` = `Paris` and `{2..}` =
+//!   `2024 Paris`.
+//! - `{name:1..4}` — the characters of the original name by position, the
+//!   same way: `{name:5..}` from the fifth on, `{name:-3..}` the last three.
+//!
+//! Positions are counted from one, ranges include both ends, and a negative
+//! position counts from the back — one rule for words and characters alike.
+//!
+//! A brace that does not spell one of these is left exactly as typed, so a
+//! half-written hole reads as what it is rather than vanishing. If the pattern
+//! names no extension — no `{ext}` and no dot anywhere in it — the original
+//! extension is kept, which is what "`Holiday {n}`" means nine times in ten.
+
+/// One file's outcome under a pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rename {
+    pub old: String,
+    pub new: String,
+    pub state: State,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// The pattern leaves this name as it is.
+    Same,
+    /// A new name, and it is free.
+    Changed,
+    /// The new name is taken — by another file in the same batch, or by
+    /// something already in the directory that is not being renamed.
+    Conflict,
+    /// The pattern made no usable name at all: empty, or with a slash in it.
+    Invalid,
+}
+
+/// Work out what every name becomes.
+///
+/// `names` are the files in the order they are numbered; `existing` is
+/// everything else in the directory, so a new name that would land on a file
+/// outside the batch is caught before anything moves.
+pub fn plan(names: &[String], pattern: &str, existing: &[String]) -> Vec<Rename> {
+    let mut out: Vec<Rename> = names
+        .iter()
+        .enumerate()
+        .map(|(index, old)| {
+            let new = expand(pattern, old, index + 1);
+            let state = if new == *old {
+                State::Same
+            } else if new.is_empty() || new.contains('/') || new == "." || new == ".." {
+                State::Invalid
+            } else {
+                State::Changed
+            };
+            Rename {
+                old: old.clone(),
+                new,
+                state,
+            }
+        })
+        .collect();
+
+    // A name is taken if another file in the batch ends up with it too, or if
+    // something that is staying put already has it. A file keeping its own
+    // name takes nothing from anyone.
+    for i in 0..out.len() {
+        if out[i].state != State::Changed {
+            continue;
+        }
+        let taken_in_batch = out
+            .iter()
+            .enumerate()
+            .any(|(j, other)| j != i && other.new == out[i].new && other.state != State::Invalid);
+        let taken_outside = existing
+            .iter()
+            .any(|name| *name == out[i].new && !names.contains(name));
+        if taken_in_batch || taken_outside {
+            out[i].state = State::Conflict;
+        }
+    }
+    out
+}
+
+/// Fill one name's holes.
+pub fn expand(pattern: &str, original: &str, number: usize) -> String {
+    let (stem, ext) = split_ext(original);
+    let mut out = String::new();
+    let mut rest = pattern;
+    let mut names_ext = false;
+    // Only a dot in the pattern's *own* text names an extension — the dots
+    // inside `{2..}` or `{name:1..3}` are part of the hole.
+    let mut literal_dot = false;
+    while let Some(open) = rest.find('{') {
+        literal_dot |= rest[..open].contains('.');
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        match after.find('}') {
+            Some(close) => {
+                let hole = &after[..close];
+                match fill(hole, stem, ext, number) {
+                    Some(text) => {
+                        names_ext |= hole.trim() == "ext";
+                        out.push_str(&text);
+                    }
+                    // Not a hole this module knows: left as typed.
+                    None => {
+                        out.push('{');
+                        out.push_str(hole);
+                        out.push('}');
+                    }
+                }
+                rest = &after[close + 1..];
+            }
+            None => {
+                literal_dot |= rest[open..].contains('.');
+                out.push_str(&rest[open..]);
+                rest = "";
+            }
+        }
+    }
+    literal_dot |= rest.contains('.');
+    out.push_str(rest);
+
+    if !names_ext && !literal_dot && !ext.is_empty() && !out.is_empty() {
+        out.push('.');
+        out.push_str(ext);
+    }
+    out
+}
+
+/// What one hole stands for, or `None` for something that is not a hole.
+fn fill(hole: &str, stem: &str, ext: &str, number: usize) -> Option<String> {
+    let hole = hole.trim();
+    if hole == "name" {
+        return Some(stem.to_string());
+    }
+    if hole == "ext" {
+        return Some(ext.to_string());
+    }
+    if let Some(spec) = hole.strip_prefix("name:") {
+        let chars: Vec<char> = stem.chars().collect();
+        let (from, to) = parse_range(spec, chars.len())?;
+        return Some(chars[from..to].iter().collect());
+    }
+    if let Some(spec) = hole.strip_prefix('n') {
+        return fill_number(spec, number);
+    }
+    // Words: `{2}`, `{-1}`, `{2..}`, `{1..3}`, `{..-2}`.
+    let words = words(stem);
+    let (from, to) = parse_range(hole, words.len())?;
+    Some(words[from..to].join(" "))
+}
+
+/// `{n}`, with `:W` for zero-padding to `W` digits and `@S` to start at `S`,
+/// in either order.
+fn fill_number(spec: &str, number: usize) -> Option<String> {
+    let mut width = 0usize;
+    let mut start = 1i64;
+    let mut rest = spec;
+    while !rest.is_empty() {
+        let (key, tail) = rest.split_at(1);
+        let digits: String = tail
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '-')
+            .collect();
+        if digits.is_empty() {
+            return None;
+        }
+        match key {
+            ":" => width = digits.parse().ok()?,
+            "@" => start = digits.parse().ok()?,
+            _ => return None,
+        }
+        rest = &tail[digits.len()..];
+    }
+    let value = start + number as i64 - 1;
+    Some(format!("{value:0width$}"))
+}
+
+/// A one-based, inclusive range over `len` things — a single position, a run,
+/// or an open end — with negatives counted from the back. `None` for a spec
+/// that is not one, or one that lies entirely outside; a run clipped by the
+/// end is simply shorter.
+fn parse_range(spec: &str, len: usize) -> Option<(usize, usize)> {
+    let resolve = |text: &str, default: i64| -> Option<i64> {
+        if text.is_empty() {
+            return Some(default);
+        }
+        let value: i64 = text.parse().ok()?;
+        if value == 0 {
+            return None;
+        }
+        Some(if value < 0 {
+            len as i64 + 1 + value
+        } else {
+            value
+        })
+    };
+    let (from, to) = match spec.split_once("..") {
+        Some((a, b)) => (resolve(a, 1)?, resolve(b, len as i64)?),
+        None => {
+            let one = resolve(spec, 0)?;
+            (one, one)
+        }
+    };
+    let from = from.max(1);
+    let to = to.min(len as i64);
+    if from > to || len == 0 {
+        // A position past the end names nothing — the hole fills with
+        // nothing rather than failing, so `{5}` on a three-word name is
+        // empty, not an error.
+        return Some((0, 0));
+    }
+    Some((from as usize - 1, to as usize))
+}
+
+/// The name split where a person would: at spaces, underscores, dashes and
+/// dots. Empty pieces — two underscores in a row — do not count.
+fn words(stem: &str) -> Vec<&str> {
+    stem.split([' ', '_', '-', '.'])
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
+/// Stem and extension, the way the browser reads them: a leading dot is part
+/// of the name, not an extension.
+fn split_ext(name: &str) -> (&str, &str) {
+    match name.rfind('.') {
+        Some(dot) if dot > 0 => (&name[..dot], &name[dot + 1..]),
+        _ => (name, ""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn the_number_counts_from_one_and_the_extension_is_kept() {
+        assert_eq!(expand("Holiday {n}", "IMG_001.jpg", 1), "Holiday 1.jpg");
+        assert_eq!(expand("Holiday {n}", "IMG_002.jpg", 2), "Holiday 2.jpg");
+        assert_eq!(expand("Holiday {n}", "notes", 3), "Holiday 3");
+    }
+
+    #[test]
+    fn padding_and_a_start_can_be_asked_for_in_either_order() {
+        assert_eq!(expand("{n:3}", "a.txt", 7), "007.txt");
+        assert_eq!(expand("{n@10}", "a.txt", 1), "10.txt");
+        assert_eq!(expand("{n:3@10}", "a.txt", 2), "011.txt");
+        assert_eq!(expand("{n@10:3}", "a.txt", 2), "011.txt");
+    }
+
+    #[test]
+    fn the_original_name_and_extension_are_holes_too() {
+        assert_eq!(expand("{name}-small", "photo.jpg", 1), "photo-small.jpg");
+        assert_eq!(expand("{name}.png", "photo.jpg", 1), "photo.png");
+        assert_eq!(expand("{name}.{ext}.bak", "photo.jpg", 1), "photo.jpg.bak");
+        assert_eq!(expand("{ext}-{name}", "photo.jpg", 1), "jpg-photo");
+    }
+
+    #[test]
+    fn words_are_picked_by_number() {
+        let original = "IMG_2024_Paris.jpg";
+        assert_eq!(expand("{3} {n}", original, 4), "Paris 4.jpg");
+        assert_eq!(expand("{2..}", original, 1), "2024 Paris.jpg");
+        assert_eq!(expand("{1..2}", original, 1), "IMG 2024.jpg");
+        assert_eq!(expand("{-1}", original, 1), "Paris.jpg");
+        assert_eq!(expand("{..-2}", original, 1), "IMG 2024.jpg");
+        // A word past the end is nothing — and a name that is nothing gets no
+        // extension bolted onto it either.
+        assert_eq!(expand("{5}", original, 1), "");
+    }
+
+    #[test]
+    fn characters_are_picked_by_position() {
+        assert_eq!(expand("{name:1..3}", "photograph.jpg", 1), "pho.jpg");
+        assert_eq!(expand("{name:5..}", "IMG_2024.jpg", 1), "2024.jpg");
+        assert_eq!(expand("{name:..-5}", "photo_old.jpg", 1), "photo.jpg");
+        assert_eq!(expand("{name:..-4}", "photo_old.jpg", 1), "photo_.jpg");
+        assert_eq!(expand("{name:-3..}", "photo_old.jpg", 1), "old.jpg");
+    }
+
+    #[test]
+    fn what_is_not_a_hole_is_left_as_typed() {
+        assert_eq!(expand("{na", "a.txt", 1), "{na.txt");
+        assert_eq!(expand("{what}", "a.txt", 1), "{what}.txt");
+        assert_eq!(expand("a { b", "a.txt", 1), "a { b.txt");
+        assert_eq!(expand("", "a.txt", 1), "");
+    }
+
+    #[test]
+    fn a_leading_dot_is_a_name_not_an_extension() {
+        assert_eq!(expand("{name}", ".bashrc", 1), ".bashrc");
+        assert_eq!(expand("{n}", ".bashrc", 1), "1");
+    }
+
+    #[test]
+    fn the_plan_tells_same_changed_and_taken_apart() {
+        let out = plan(
+            &names(&["a.jpg", "b.jpg", "c.jpg"]),
+            "x{n}",
+            &names(&["x2.jpg", "other.txt"]),
+        );
+        assert_eq!(out[0].new, "x1.jpg");
+        assert_eq!(out[0].state, State::Changed);
+        assert_eq!(out[1].state, State::Conflict, "x2.jpg is already there");
+        assert_eq!(out[2].state, State::Changed);
+
+        let out = plan(&names(&["a.jpg", "b.jpg"]), "same", &[]);
+        assert!(out.iter().all(|r| r.state == State::Conflict));
+
+        let out = plan(&names(&["a.jpg"]), "{name}", &names(&["a.jpg"]));
+        assert_eq!(out[0].state, State::Same, "keeping a name takes nothing");
+
+        let out = plan(&names(&["a.jpg", "b.jpg"]), "b", &[]);
+        assert_eq!(out[0].state, State::Conflict, "b.jpg belongs to the batch");
+        assert_eq!(out[1].state, State::Same);
+    }
+
+    #[test]
+    fn a_chain_is_fine_because_the_host_renames_through_temporary_names() {
+        // 1→2 and 2→3: a plain rename in that order would overwrite 2 before
+        // it moved, so the host goes through temporary names. Here that means
+        // a name another file is *leaving* is not taken.
+        let out = plan(&names(&["1.txt", "2.txt"]), "{n@2}", &[]);
+        assert_eq!(out[0].new, "2.txt");
+        assert_eq!(out[0].state, State::Changed);
+        assert_eq!(out[1].new, "3.txt");
+        assert_eq!(out[1].state, State::Changed);
+    }
+
+    #[test]
+    fn an_empty_or_slashed_name_is_invalid() {
+        let out = plan(&names(&["a.jpg"]), "{5}", &[]);
+        assert_eq!(out[0].new, "");
+        assert_eq!(out[0].state, State::Invalid);
+        let out = plan(&names(&["a"]), "x/y", &[]);
+        assert_eq!(out[0].state, State::Invalid);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The command
+// ---------------------------------------------------------------------------
+
+use std::path::PathBuf;
+
+use crate::command::{
+    ArgKind, ArgSpec, Command, CommandProvider, Effect, Group, Preview, PreviewRow, Request,
+    Situation,
+};
+use crate::model::Change;
+
+/// The provider's namespace, and so the prefix on its one command's id.
+pub const NAMESPACE: &str = "rename";
+/// The command's id in full.
+pub const RENAME_MANY: &str = "rename:many";
+
+/// "Rename N Items", as a provider of its own.
+///
+/// Built through the command seam rather than into the browser, on purpose:
+/// this is the shape a script would take — the selection in, one line of text
+/// as the argument, a dry run to show while it is typed, and what changed
+/// handed back for undo — and having a built-in take exactly that shape is
+/// what keeps the seam honest before anything lives on the far side of it.
+/// Nothing here reaches into the window; it only ever sees a [`Situation`].
+pub struct RenameProvider;
+
+impl RenameProvider {
+    /// The files the command works on, in the order they are numbered — the
+    /// order they were selected in the listing, which is the order the person
+    /// can see.
+    fn names(situation: &Situation) -> Vec<String> {
+        situation
+            .selection
+            .iter()
+            .filter_map(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn plan_for(request: &Request, situation: &Situation) -> Vec<Rename> {
+        let pattern = request.arg.as_deref().unwrap_or_default();
+        plan(&Self::names(situation), pattern, &situation.siblings)
+    }
+
+    /// The summary line: what the plan comes to, and the first thing wrong
+    /// with it if anything is.
+    fn summary(plan: &[Rename]) -> String {
+        let conflicts = plan.iter().filter(|r| r.state == State::Conflict).count();
+        let invalid = plan.iter().filter(|r| r.state == State::Invalid).count();
+        let changed = plan.iter().filter(|r| r.state == State::Changed).count();
+        if invalid > 0 {
+            otto_kit::t_owned!("files-rename-invalid", count = invalid as i64)
+        } else if conflicts > 0 {
+            otto_kit::t_owned!("files-rename-conflicts", count = conflicts as i64)
+        } else if changed == 0 {
+            otto_kit::t_owned!("files-rename-preview-unchanged")
+        } else {
+            otto_kit::t_owned!(
+                "files-rename-preview",
+                count = changed as i64,
+                total = plan.len() as i64
+            )
+        }
+    }
+}
+
+impl CommandProvider for RenameProvider {
+    fn namespace(&self) -> &'static str {
+        NAMESPACE
+    }
+
+    fn commands(&self, situation: &Situation) -> Vec<Command> {
+        if situation.trash || situation.selection.is_empty() {
+            return Vec::new();
+        }
+        let count = situation.selection.len();
+        let title = if count > 1 {
+            otto_kit::t_owned!("files-rename-many", count = count as i64)
+        } else {
+            otto_kit::t_owned!("files-rename-pattern")
+        };
+        vec![Command::new(RENAME_MANY, title, Group::File)
+            .with_keywords(["batch", "pattern", "number", "sequence", "rename"])
+            .with_arg(
+                ArgSpec::new(
+                    otto_kit::t_owned!("files-command-rename-many-prompt"),
+                    otto_kit::t_owned!("files-command-arg-pattern"),
+                    ArgKind::Text,
+                )
+                .with_initial("{name}")
+                .with_placeholder("Holiday {n}")
+                // A dry run, not a rename: shown, and nothing moves until
+                // Return.
+                .previewed(),
+            )]
+    }
+
+    fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
+        if request.id != RENAME_MANY {
+            return None;
+        }
+        let plan = Self::plan_for(request, situation);
+        if plan.is_empty() {
+            return None;
+        }
+        Some(Preview {
+            note: Some(Self::summary(&plan)),
+            rows: plan
+                .into_iter()
+                .map(|rename| PreviewRow {
+                    conflict: matches!(rename.state, State::Conflict | State::Invalid),
+                    from: rename.old,
+                    to: rename.new,
+                })
+                .collect(),
+        })
+    }
+
+    fn run(&mut self, request: &Request, situation: &Situation) -> Result<Effect, String> {
+        if request.id != RENAME_MANY {
+            return Err(format!("{} is not mine", request.id));
+        }
+        let plan = Self::plan_for(request, situation);
+        if plan
+            .iter()
+            .any(|r| matches!(r.state, State::Conflict | State::Invalid))
+        {
+            return Err(Self::summary(&plan));
+        }
+        let moves: Vec<(PathBuf, PathBuf)> = situation
+            .selection
+            .iter()
+            .zip(&plan)
+            .filter(|(_, rename)| rename.state == State::Changed)
+            .map(|(path, rename)| (path.clone(), path.with_file_name(&rename.new)))
+            .collect();
+        if moves.is_empty() {
+            return Err(otto_kit::t_owned!("files-rename-preview-unchanged"));
+        }
+        let changes = rename_all(&moves)?;
+        Ok(Effect {
+            status: Some(otto_kit::t_owned!(
+                "files-renamed-count",
+                count = changes.len() as i64
+            )),
+            undo_label: Some(otto_kit::t!("files-undo-rename")),
+            changes,
+            reload: true,
+        })
+    }
+}
+
+/// Carry the moves out, through temporary names.
+///
+/// Two passes rather than one, because a batch may hand one file the name
+/// another is about to give up — `1 → 2, 2 → 3` — and renaming in place, in
+/// either order, would overwrite. Everything is first moved aside under a
+/// name nobody has, then to where it is going; a failure in the second pass
+/// puts back what has moved so far, so the directory is never left half way.
+fn rename_all(moves: &[(PathBuf, PathBuf)]) -> Result<Vec<Change>, String> {
+    let tag = std::process::id();
+    let aside: Vec<PathBuf> = moves
+        .iter()
+        .enumerate()
+        .map(|(i, (from, _))| from.with_file_name(format!(".otto-rename-{tag}-{i}")))
+        .collect();
+
+    let mut done = Vec::new();
+    for ((from, _), temp) in moves.iter().zip(&aside) {
+        if let Err(err) = std::fs::rename(from, temp) {
+            undo_moves(&done);
+            return Err(otto_kit::t_owned!(
+                "files-rename-failed",
+                error = err.to_string()
+            ));
+        }
+        done.push((from.clone(), temp.clone()));
+    }
+    let mut landed = Vec::new();
+    for ((from, to), temp) in moves.iter().zip(&aside) {
+        if let Err(err) = std::fs::rename(temp, to) {
+            undo_moves(&landed);
+            undo_moves(&done);
+            return Err(otto_kit::t_owned!(
+                "files-rename-failed",
+                error = err.to_string()
+            ));
+        }
+        landed.push((temp.clone(), to.clone()));
+        let _ = from;
+    }
+    Ok(moves
+        .iter()
+        .map(|(from, to)| Change::Moved {
+            from: from.clone(),
+            to: to.clone(),
+        })
+        .collect())
+}
+
+/// Best effort: put a run of `(from, to)` moves back, last first.
+fn undo_moves(moves: &[(PathBuf, PathBuf)]) {
+    for (from, to) in moves.iter().rev() {
+        let _ = std::fs::rename(to, from);
+    }
+}
+
+#[cfg(test)]
+mod provider_tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// A directory of our own under the system temp dir, removed on drop.
+    struct TempDir(PathBuf);
+    impl TempDir {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "otto-files-rename-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn situation(dir: &Path, names: &[&str], siblings: &[&str]) -> Situation {
+        Situation {
+            path: dir.to_path_buf(),
+            selection: names.iter().map(|n| dir.join(n)).collect(),
+            siblings: siblings.iter().map(|s| s.to_string()).collect(),
+            has_entries: true,
+            ..Situation::default()
+        }
+    }
+
+    #[test]
+    fn it_is_offered_for_a_selection_and_never_in_the_trash() {
+        let dir = Path::new("/tmp/x");
+        assert!(RenameProvider
+            .commands(&situation(dir, &[], &[]))
+            .is_empty());
+        let one = RenameProvider.commands(&situation(dir, &["a.txt"], &["a.txt"]));
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].id, RENAME_MANY);
+        assert!(one[0].arg.as_ref().is_some_and(|arg| arg.preview));
+        let mut trash = situation(dir, &["a.txt"], &[]);
+        trash.trash = true;
+        assert!(RenameProvider.commands(&trash).is_empty());
+    }
+
+    #[test]
+    fn the_preview_is_the_plan_with_a_summary() {
+        let dir = Path::new("/tmp/x");
+        let s = situation(
+            dir,
+            &["IMG_1.jpg", "IMG_2.jpg"],
+            &["IMG_1.jpg", "IMG_2.jpg", "x2.jpg"],
+        );
+        let request = Request::new(RENAME_MANY, Some("x{n}".into()));
+        let preview = RenameProvider.preview(&request, &s).unwrap();
+        assert_eq!(preview.rows[0].to, "x1.jpg");
+        assert!(!preview.rows[0].conflict);
+        assert!(preview.rows[1].conflict, "x2.jpg is already there");
+        assert_eq!(
+            preview.note.as_deref(),
+            Some(otto_kit::t_owned!("files-rename-conflicts", count = 1).as_str())
+        );
+    }
+
+    #[test]
+    fn running_renames_through_temporary_names_and_reports_the_moves() {
+        let dir = TempDir::new();
+        for name in ["1.txt", "2.txt"] {
+            std::fs::write(dir.path().join(name), name).unwrap();
+        }
+        let s = situation(dir.path(), &["1.txt", "2.txt"], &["1.txt", "2.txt"]);
+        // 1 → 2 and 2 → 3: the chain a naive loop would break.
+        let request = Request::new(RENAME_MANY, Some("{n@2}".into()));
+        let effect = RenameProvider.run(&request, &s).unwrap();
+        assert_eq!(effect.changes.len(), 2);
+        assert!(effect.reload);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("2.txt")).unwrap(),
+            "1.txt"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("3.txt")).unwrap(),
+            "2.txt"
+        );
+        assert!(!dir.path().join("1.txt").exists());
+        assert!(std::fs::read_dir(dir.path()).unwrap().all(|e| !e
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".otto-rename")));
+    }
+
+    #[test]
+    fn a_conflict_refuses_and_touches_nothing() {
+        let dir = TempDir::new();
+        for name in ["a.txt", "b.txt", "x1.txt"] {
+            std::fs::write(dir.path().join(name), name).unwrap();
+        }
+        let s = situation(
+            dir.path(),
+            &["a.txt", "b.txt"],
+            &["a.txt", "b.txt", "x1.txt"],
+        );
+        let request = Request::new(RENAME_MANY, Some("x{n}".into()));
+        assert!(RenameProvider.run(&request, &s).is_err());
+        assert!(dir.path().join("a.txt").exists());
+        assert!(dir.path().join("b.txt").exists());
+    }
+}

--- a/components/otto-files/src/rename.rs
+++ b/components/otto-files/src/rename.rs
@@ -433,15 +433,13 @@ impl CommandProvider for RenameProvider {
     }
 
     fn commands(&self, situation: &Situation) -> Vec<Command> {
-        if situation.trash || situation.selection.is_empty() {
+        // A batch, by definition: one file has the plain Rename, and offering
+        // a pattern for it would put two renames in the list for one thing.
+        if situation.trash || situation.selection.len() < 2 {
             return Vec::new();
         }
         let count = situation.selection.len();
-        let title = if count > 1 {
-            otto_kit::t_owned!("files-rename-many", count = count as i64)
-        } else {
-            otto_kit::t_owned!("files-rename-pattern")
-        };
+        let title = otto_kit::t_owned!("files-rename-many", count = count as i64);
         vec![Command::new(RENAME_MANY, title, Group::File)
             .with_keywords(["batch", "pattern", "number", "sequence", "rename"])
             .with_arg(
@@ -608,16 +606,21 @@ mod provider_tests {
     }
 
     #[test]
-    fn it_is_offered_for_a_selection_and_never_in_the_trash() {
+    fn it_is_offered_for_several_files_and_never_for_one_or_in_the_trash() {
         let dir = Path::new("/tmp/x");
         assert!(RenameProvider
             .commands(&situation(dir, &[], &[]))
             .is_empty());
-        let one = RenameProvider.commands(&situation(dir, &["a.txt"], &["a.txt"]));
-        assert_eq!(one.len(), 1);
-        assert_eq!(one[0].id, RENAME_MANY);
-        assert!(one[0].arg.as_ref().is_some_and(|arg| arg.preview));
-        let mut trash = situation(dir, &["a.txt"], &[]);
+        // One file has the plain Rename; a pattern is for a batch.
+        assert!(RenameProvider
+            .commands(&situation(dir, &["a.txt"], &["a.txt"]))
+            .is_empty());
+        let two =
+            RenameProvider.commands(&situation(dir, &["a.txt", "b.txt"], &["a.txt", "b.txt"]));
+        assert_eq!(two.len(), 1);
+        assert_eq!(two[0].id, RENAME_MANY);
+        assert!(two[0].arg.as_ref().is_some_and(|arg| arg.preview));
+        let mut trash = situation(dir, &["a.txt", "b.txt"], &[]);
         trash.trash = true;
         assert!(RenameProvider.commands(&trash).is_empty());
     }

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -279,12 +279,16 @@ impl Scene {
     fn sync_materials(&mut self, f: &Frame) {
         let dark = view::is_dark();
         // Translucent only while there is a blur to be translucent over. See
-        // [`view::opaque`].
+        // [`view::opaque`]. Where the compositor has no blur to offer at all,
+        // the panels take a solid shade of their own rather than the white of
+        // the content they frame.
         let fill = |color: skia_safe::Color| {
             paint_color(if f.blurred {
                 color
-            } else {
+            } else if otto_kit::backdrop::blur_available() {
                 view::opaque(color)
+            } else {
+                view::solid_panel_material()
             })
         };
         let previous = self.materials;

--- a/components/otto-files/src/scene.rs
+++ b/components/otto-files/src/scene.rs
@@ -1055,6 +1055,7 @@ mod tests {
             drop_target: None,
             marquee: None,
             path_bar: Vec::new(),
+            path_bar_note: None,
             path_bar_h: view::PATH_BAR_H,
             path_crumb_hover: None,
             path_entry: false,

--- a/components/otto-files/src/scripts.rs
+++ b/components/otto-files/src/scripts.rs
@@ -22,7 +22,7 @@
 //!     "group": "file",
 //!     "when": { "targets": "some", "extensions": ["zip"], "kinds": "files" },
 //!     "arg": { "prompt": "Archive name", "label": "name",
-//!              "placeholder": "Archive.zip", "initial": "{stem}.zip",
+//!              "placeholder": "Archive.zip", "initial": "Archive.zip",
 //!              "preview": true },
 //!     "undo": "Compress"
 //! } ] }
@@ -59,9 +59,14 @@
 //! nothing:
 //!
 //! ```json
-//! { "rows": [ { "from": "a.png", "to": "Holiday.zip", "conflict": false } ],
-//!   "note": "2 items into Holiday.zip" }
+//! { "rows": [ { "from": "a.png", "to": "a.jpg", "conflict": false } ],
+//!   "note": "2 items converted" }
 //! ```
+//!
+//! A row is what one target would become; a row with no `to` just names the
+//! target — for a command whose outcome is one thing made of them all, like
+//! an archive, the rows say what goes in and the note says where. A person
+//! can toggle a row out of the run.
 //!
 //! A run answers with what it did, and the host records the changes for undo:
 //!
@@ -82,8 +87,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command as Process, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -352,6 +358,7 @@ struct PreviewReply {
 #[derive(Debug, Deserialize)]
 struct PreviewRowReply {
     from: String,
+    #[serde(default)]
     to: String,
     #[serde(default)]
     conflict: bool,
@@ -619,6 +626,9 @@ pub struct ScriptProvider {
     /// Runs in flight report here.
     finished: Receiver<Result<Effect, String>>,
     report: Sender<Result<Effect, String>>,
+    /// How many runs are still going — what they did changes what is
+    /// offered next (an Undo), so the provider is not settled until they land.
+    running: Arc<AtomicUsize>,
 }
 
 impl ScriptProvider {
@@ -648,6 +658,7 @@ impl ScriptProvider {
             discovering: Mutex::new(discovering),
             finished,
             report,
+            running: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -761,6 +772,11 @@ impl CommandProvider for ScriptProvider {
             .collect()
     }
 
+    fn settled(&self) -> bool {
+        self.take_discovered();
+        self.discovering.lock().unwrap().is_none() && self.running.load(Ordering::Acquire) == 0
+    }
+
     fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
         let command = self.find(&request.id)?;
         let input = self.input(&command, request, situation);
@@ -801,12 +817,18 @@ impl CommandProvider for ScriptProvider {
         let report = self.report.clone();
         let locale = self.locale.clone();
         let title = command.described.title.get(&locale);
-        std::thread::Builder::new()
+        let running = Arc::clone(&self.running);
+        running.fetch_add(1, Ordering::AcqRel);
+        let spawned = std::thread::Builder::new()
             .name("files-script-run".into())
             .spawn(move || {
                 let _ = report.send(Self::run_now(&command, &locale, &input));
-            })
-            .map_err(|err| err.to_string())?;
+                running.fetch_sub(1, Ordering::AcqRel);
+            });
+        if let Err(err) = spawned {
+            self.running.fetch_sub(1, Ordering::AcqRel);
+            return Err(err.to_string());
+        }
         // The palette closes on this; what the script did arrives through
         // `poll`, and the status line says so meanwhile.
         Ok(Effect {
@@ -1088,7 +1110,12 @@ esac
         let request = Request::new("scripts:zip.compress", Some("Bundle".into()));
         let preview = provider.preview(&request, &situation).unwrap();
         assert_eq!(preview.rows.len(), 2);
-        assert_eq!(preview.rows[0].to, "Bundle.zip");
+        assert_eq!(preview.rows[0].from, "a.txt");
+        assert_eq!(
+            preview.rows[0].to, "",
+            "an archive's rows only name what goes in"
+        );
+        assert_eq!(preview.note.as_deref(), Some("2 items into “Bundle.zip”"));
         provider.run(&request, &situation).unwrap();
         let effect = wait_for(&mut provider).unwrap();
         assert!(dir.0.join("Bundle.zip").is_file());
@@ -1101,13 +1128,15 @@ esac
             .map(|c| c.id)
             .collect();
         assert!(offered.contains(&"scripts:unzip.extract".to_string()));
-        let request = Request::new("scripts:unzip.extract", Some("{stem}-out".into()));
+        // Extracting asks nothing: each archive goes into a folder named
+        // after it.
+        let request = Request::new("scripts:unzip.extract", None);
         let preview = provider.preview(&request, &situation).unwrap();
-        assert_eq!(preview.rows[0].to, "Bundle-out/");
+        assert_eq!(preview.rows[0].to, "Bundle/");
         assert!(!preview.rows[0].conflict);
         provider.run(&request, &situation).unwrap();
         wait_for(&mut provider).unwrap();
-        assert!(dir.0.join("Bundle-out/Photos/b.txt").is_file());
+        assert!(dir.0.join("Bundle/Photos/b.txt").is_file());
 
         // Running again would land on the folder that is now there.
         let preview = provider.preview(&request, &situation).unwrap();

--- a/components/otto-files/src/scripts.rs
+++ b/components/otto-files/src/scripts.rs
@@ -1,0 +1,1052 @@
+//! Commands that live outside the process, in
+//! `$XDG_CONFIG_HOME/otto/files-scripts/` (`~/.config/otto/files-scripts/`).
+//!
+//! One more provider on the command seam, with a process boundary in the
+//! middle: every executable in that directory is a script that describes its
+//! commands once, is asked for a dry run while an argument is typed, and is
+//! run with the situation and the request handed over as data. The first two,
+//! to prove the boundary, are zip and unzip — see `components/otto-files/scripts/`.
+//!
+//! # The protocol
+//!
+//! A script is called with one word on its command line and, for the last two,
+//! a JSON object on standard input. It answers with JSON on standard output.
+//!
+//! `script describe` — once, when the window starts:
+//!
+//! ```json
+//! { "commands": [ {
+//!     "id": "compress",
+//!     "title": "Compress to Zip",
+//!     "keywords": ["archive", "zip"],
+//!     "group": "file",
+//!     "when": { "targets": "some", "extensions": ["zip"], "kinds": "files" },
+//!     "arg": { "prompt": "Archive name", "label": "name",
+//!              "placeholder": "Archive.zip", "initial": "{stem}.zip",
+//!              "preview": true },
+//!     "undo": "Compress"
+//! } ] }
+//! ```
+//!
+//! Everything but `id` and `title` is optional. `when` is the whole of what
+//! decides whether the command is offered, so that opening the palette never
+//! runs a script: `targets` is `"some"` (default), `"one"`, `"none"` or
+//! `"any"`; `extensions` requires every target to carry one of them;
+//! `kinds` is `"files"`, `"folders"` or `"any"`. A command with no `arg`
+//! runs on Return; one with an `arg` opens the field, and with `preview`
+//! set is asked for a dry run after every keystroke.
+//!
+//! `script preview` and `script run` — with this on standard input:
+//!
+//! ```json
+//! { "command": "compress", "arg": "Holiday.zip",
+//!   "targets": ["/home/me/Pictures/a.png", "/home/me/Pictures/b.png"],
+//!   "situation": { "path": "/home/me/Pictures", "selection": [...], ... } }
+//! ```
+//!
+//! `targets` is the selection or, when nothing is selected, the item under
+//! the cursor — what the command acts on. `situation` is the window's
+//! [`Situation`] in full. A preview answers with what it would do and must do
+//! nothing:
+//!
+//! ```json
+//! { "rows": [ { "from": "a.png", "to": "Holiday.zip", "conflict": false } ],
+//!   "note": "2 items into Holiday.zip" }
+//! ```
+//!
+//! A run answers with what it did, and the host records the changes for undo:
+//!
+//! ```json
+//! { "status": "Compressed 2 items",
+//!   "changes": [ { "kind": "created", "path": "/home/me/Pictures/Holiday.zip" },
+//!                { "kind": "moved", "from": "...", "to": "..." } ],
+//!   "reload": true }
+//! ```
+//!
+//! A non-zero exit is a failure, and the last line of standard error is what
+//! the person reads. Describing and previewing are held to a short deadline,
+//! since one runs at startup and the other under the keyboard; a run takes as
+//! long as it takes, on a worker thread, and its effect arrives through
+//! [`CommandProvider::poll`].
+
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command as Process, Stdio};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::command::{
+    ArgKind, ArgSpec, Command, CommandProvider, Effect, Group, Preview, PreviewRow, Request,
+    Situation,
+};
+use crate::model::Change;
+
+/// The provider's namespace, and so the prefix on every script command's id.
+pub const NAMESPACE: &str = "scripts";
+
+/// How long a script may take to describe itself.
+const DESCRIBE_DEADLINE: Duration = Duration::from_secs(3);
+/// How long a dry run may take. It runs under the keyboard, so a script that
+/// cannot answer in this is treated as having nothing to show.
+const PREVIEW_DEADLINE: Duration = Duration::from_millis(600);
+
+// ---------------------------------------------------------------------------
+// What a script says about itself
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize)]
+struct Description {
+    #[serde(default)]
+    commands: Vec<Described>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+struct Described {
+    id: String,
+    title: String,
+    #[serde(default)]
+    keywords: Vec<String>,
+    #[serde(default)]
+    group: GroupName,
+    #[serde(default)]
+    when: When,
+    #[serde(default)]
+    arg: Option<DescribedArg>,
+    /// What to call the run in the undo history. The title when absent.
+    #[serde(default)]
+    undo: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum GroupName {
+    Go,
+    #[default]
+    File,
+    Edit,
+    View,
+}
+
+impl From<GroupName> for Group {
+    fn from(name: GroupName) -> Self {
+        match name {
+            GroupName::Go => Group::Go,
+            GroupName::File => Group::File,
+            GroupName::Edit => Group::Edit,
+            GroupName::View => Group::View,
+        }
+    }
+}
+
+/// The conditions under which a command is offered, checked against the
+/// situation and nothing else.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+struct When {
+    targets: Targets,
+    /// Every target must end in one of these, compared without case and
+    /// without the dot.
+    extensions: Vec<String>,
+    kinds: Kinds,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Targets {
+    /// One or more.
+    #[default]
+    Some,
+    One,
+    None,
+    Any,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Kinds {
+    #[default]
+    Any,
+    Files,
+    Folders,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+struct DescribedArg {
+    prompt: String,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    placeholder: Option<String>,
+    #[serde(default)]
+    initial: Option<String>,
+    #[serde(default)]
+    preview: bool,
+}
+
+/// One command a script offers, with the script it came from.
+#[derive(Debug, Clone, PartialEq)]
+struct ScriptCommand {
+    script: PathBuf,
+    /// `scripts:<script>.<id>` — the script's file name keeps two scripts'
+    /// commands apart.
+    full_id: String,
+    described: Described,
+}
+
+impl ScriptCommand {
+    fn offered(&self, situation: &Situation, targets: &[PathBuf]) -> bool {
+        let when = &self.described.when;
+        let count_ok = match when.targets {
+            Targets::Some => !targets.is_empty(),
+            Targets::One => targets.len() == 1,
+            Targets::None => targets.is_empty(),
+            Targets::Any => true,
+        };
+        if !count_ok {
+            return false;
+        }
+        if !when.extensions.is_empty() {
+            let wanted: Vec<String> = when
+                .extensions
+                .iter()
+                .map(|e| e.trim_start_matches('.').to_ascii_lowercase())
+                .collect();
+            let all = targets.iter().all(|target| {
+                target
+                    .extension()
+                    .map(|ext| ext.to_string_lossy().to_ascii_lowercase())
+                    .is_some_and(|ext| wanted.contains(&ext))
+            });
+            if !all {
+                return false;
+            }
+        }
+        match when.kinds {
+            Kinds::Any => true,
+            // Only the cursor's kind is known without I/O; a selection is
+            // taken at its word when it is more than the cursor.
+            Kinds::Files => !(targets.len() == 1 && situation.cursor_is_dir),
+            Kinds::Folders => targets.len() == 1 && situation.cursor_is_dir,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let d = &self.described;
+        let mut command = Command::new(&self.full_id, &d.title, Group::from(d.group))
+            .with_keywords(d.keywords.iter().cloned());
+        if let Some(arg) = &d.arg {
+            let mut spec = ArgSpec::new(
+                &arg.prompt,
+                arg.label
+                    .clone()
+                    .unwrap_or_else(|| otto_kit::t_owned!("files-command-arg-name")),
+                ArgKind::Text,
+            );
+            if let Some(placeholder) = &arg.placeholder {
+                spec = spec.with_placeholder(placeholder);
+            }
+            if let Some(initial) = &arg.initial {
+                spec = spec.with_initial(initial);
+            }
+            if arg.preview {
+                spec = spec.previewed();
+            }
+            command = command.with_arg(spec);
+        }
+        command
+    }
+}
+
+// ---------------------------------------------------------------------------
+// What crosses the boundary
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct Input<'a> {
+    command: &'a str,
+    arg: Option<&'a str>,
+    targets: &'a [PathBuf],
+    situation: &'a Situation,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PreviewReply {
+    #[serde(default)]
+    rows: Vec<PreviewRowReply>,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PreviewRowReply {
+    from: String,
+    to: String,
+    #[serde(default)]
+    conflict: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RunReply {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    changes: Vec<ChangeReply>,
+    #[serde(default)]
+    reload: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ChangeReply {
+    Moved { from: PathBuf, to: PathBuf },
+    Created { path: PathBuf },
+}
+
+impl From<ChangeReply> for Change {
+    fn from(reply: ChangeReply) -> Self {
+        match reply {
+            ChangeReply::Moved { from, to } => Change::Moved { from, to },
+            ChangeReply::Created { path } => Change::Created { path },
+        }
+    }
+}
+
+/// The selection, or the item under the cursor when nothing is selected.
+fn targets_of(situation: &Situation) -> Vec<PathBuf> {
+    if !situation.selection.is_empty() {
+        return situation.selection.clone();
+    }
+    situation
+        .cursor_name
+        .as_ref()
+        .map(|name| vec![situation.path.join(name)])
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Running scripts
+// ---------------------------------------------------------------------------
+
+struct Outcome {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+impl Outcome {
+    /// The line a person reads when the script refused: the last thing it
+    /// said on stderr, or the fact that it said nothing.
+    fn complaint(&self) -> String {
+        self.stderr
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| otto_kit::t_owned!("files-script-failed-quietly"))
+    }
+}
+
+/// Run `script verb` with `input` on stdin. With a deadline, a script that
+/// overruns is killed and the outcome is a failure.
+fn call(
+    script: &Path,
+    verb: &str,
+    input: Option<&[u8]>,
+    deadline: Option<Duration>,
+) -> Result<Outcome, String> {
+    let mut child = Process::new(script)
+        .arg(verb)
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("{}: {err}", script.display()))?;
+
+    if let (Some(bytes), Some(mut stdin)) = (input, child.stdin.take()) {
+        // A script that exits without reading gets a broken pipe here, and
+        // its exit status is the story, not the write.
+        let _ = stdin.write_all(bytes);
+    }
+
+    let stdout = child.stdout.take().map(drain);
+    let stderr = child.stderr.take().map(drain);
+
+    let status = match deadline {
+        Some(deadline) => wait_until(&mut child, deadline),
+        None => child.wait().ok(),
+    };
+    let Some(status) = status else {
+        // Killed for overrunning. Anything it started may still hold the
+        // pipes open, so the readers are left to finish on their own rather
+        // than waited for.
+        return Ok(Outcome {
+            success: false,
+            stdout: String::new(),
+            stderr: otto_kit::t_owned!("files-script-timed-out"),
+        });
+    };
+    Ok(Outcome {
+        success: status.success(),
+        stdout: stdout.and_then(|h| h.join().ok()).unwrap_or_default(),
+        stderr: stderr.and_then(|h| h.join().ok()).unwrap_or_default(),
+    })
+}
+
+fn drain(mut pipe: impl Read + Send + 'static) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut text = String::new();
+        let _ = pipe.read_to_string(&mut text);
+        text
+    })
+}
+
+/// Wait for the child up to `deadline`; `None` if it had to be killed.
+fn wait_until(child: &mut Child, deadline: Duration) -> Option<std::process::ExitStatus> {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if started.elapsed() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+/// Ask one script what it offers.
+fn describe(script: &Path) -> Vec<ScriptCommand> {
+    let stem = script
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let outcome = match call(script, "describe", None, Some(DESCRIBE_DEADLINE)) {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            tracing::warn!("files-scripts: {err}");
+            return Vec::new();
+        }
+    };
+    if !outcome.success {
+        tracing::warn!(
+            "files-scripts: {} would not describe itself: {}",
+            script.display(),
+            outcome.complaint()
+        );
+        return Vec::new();
+    }
+    let description: Description = match serde_json::from_str(&outcome.stdout) {
+        Ok(description) => description,
+        Err(err) => {
+            tracing::warn!(
+                "files-scripts: {} described itself badly: {err}",
+                script.display()
+            );
+            return Vec::new();
+        }
+    };
+    description
+        .commands
+        .into_iter()
+        .map(|described| ScriptCommand {
+            script: script.to_path_buf(),
+            full_id: format!("{NAMESPACE}:{stem}.{}", described.id),
+            described,
+        })
+        .collect()
+}
+
+/// Every executable in `dir`, by name, described.
+fn discover(dir: &Path) -> Vec<ScriptCommand> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut scripts: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            !path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with('.'))
+        })
+        .filter(|path| {
+            std::fs::metadata(path)
+                .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+        .collect();
+    scripts.sort();
+    scripts.iter().flat_map(|script| describe(script)).collect()
+}
+
+/// Where the scripts are, honouring `XDG_CONFIG_HOME`. `OTTO_FILES_SCRIPTS`
+/// overrides the whole path, for tests and for trying a directory out.
+pub fn scripts_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("OTTO_FILES_SCRIPTS") {
+        return Some(PathBuf::from(path));
+    }
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|home| PathBuf::from(home).join(".config"))
+        })?;
+    Some(base.join("otto").join("files-scripts"))
+}
+
+/// A `&'static str` for an undo label that came out of a script.
+///
+/// The undo stack names its steps with static strings. There are as many of
+/// these as there are script commands, so keeping them for the life of the
+/// process is bounded, and the same label is only ever kept once.
+fn keep(label: &str) -> &'static str {
+    static KEPT: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
+    let mut kept = KEPT.get_or_init(Default::default).lock().unwrap();
+    if let Some(existing) = kept.get(label) {
+        return existing;
+    }
+    let leaked: &'static str = Box::leak(label.to_owned().into_boxed_str());
+    kept.insert(leaked);
+    leaked
+}
+
+// ---------------------------------------------------------------------------
+// The provider
+// ---------------------------------------------------------------------------
+
+/// The scripts directory, as a provider.
+pub struct ScriptProvider {
+    /// What has been described so far. Behind a mutex because the seam asks
+    /// for commands through `&self` and discovery lands from another thread.
+    commands: Mutex<Vec<ScriptCommand>>,
+    /// Discovery in flight, drained the first time it is asked for.
+    discovering: Mutex<Option<Receiver<Vec<ScriptCommand>>>>,
+    /// Runs in flight report here.
+    finished: Receiver<Result<Effect, String>>,
+    report: Sender<Result<Effect, String>>,
+}
+
+impl ScriptProvider {
+    /// The provider over the configured directory. Discovery starts now, on
+    /// its own thread, so the window's start is not held up by a slow script
+    /// and Ctrl+P finds whatever has answered by then.
+    pub fn new() -> Self {
+        Self::over(scripts_dir())
+    }
+
+    fn over(dir: Option<PathBuf>) -> Self {
+        let (report, finished) = mpsc::channel();
+        let discovering = dir.map(|dir| {
+            let (tx, rx) = mpsc::channel();
+            std::thread::Builder::new()
+                .name("files-scripts".into())
+                .spawn(move || {
+                    let _ = tx.send(discover(&dir));
+                })
+                .expect("spawn discovery thread");
+            rx
+        });
+        Self {
+            commands: Mutex::new(Vec::new()),
+            discovering: Mutex::new(discovering),
+            finished,
+            report,
+        }
+    }
+
+    /// The provider over `dir`, with discovery already done. For tests.
+    #[cfg(test)]
+    fn discovered(dir: &Path) -> Self {
+        let provider = Self::over(None);
+        *provider.commands.lock().unwrap() = discover(dir);
+        provider
+    }
+
+    fn take_discovered(&self) {
+        let mut discovering = self.discovering.lock().unwrap();
+        let Some(rx) = discovering.as_ref() else {
+            return;
+        };
+        if let Ok(found) = rx.try_recv() {
+            *self.commands.lock().unwrap() = found;
+            *discovering = None;
+        }
+    }
+
+    fn find(&self, id: &str) -> Option<ScriptCommand> {
+        self.take_discovered();
+        self.commands
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|command| command.full_id == id)
+            .cloned()
+    }
+
+    fn input(command: &ScriptCommand, request: &Request, situation: &Situation) -> Vec<u8> {
+        let targets = targets_of(situation);
+        let input = Input {
+            command: &command.described.id,
+            arg: request.arg.as_deref(),
+            targets: &targets,
+            situation,
+        };
+        serde_json::to_vec(&input).unwrap_or_default()
+    }
+
+    /// Run `command` to completion and turn what it says into an effect.
+    fn run_now(command: &ScriptCommand, input: &[u8]) -> Result<Effect, String> {
+        let outcome = call(&command.script, "run", Some(input), None)?;
+        if !outcome.success {
+            return Err(outcome.complaint());
+        }
+        let reply: RunReply = if outcome.stdout.trim().is_empty() {
+            RunReply::default()
+        } else {
+            serde_json::from_str(&outcome.stdout).map_err(|err| {
+                format!(
+                    "{}: {err}",
+                    command
+                        .script
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                )
+            })?
+        };
+        let changes: Vec<Change> = reply.changes.into_iter().map(Change::from).collect();
+        let label = command
+            .described
+            .undo
+            .as_deref()
+            .unwrap_or(&command.described.title);
+        Ok(Effect {
+            status: reply.status,
+            undo_label: (!changes.is_empty()).then(|| keep(label)),
+            changes,
+            reload: reply.reload,
+        })
+    }
+}
+
+impl Default for ScriptProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandProvider for ScriptProvider {
+    fn namespace(&self) -> &'static str {
+        NAMESPACE
+    }
+
+    fn commands(&self, situation: &Situation) -> Vec<Command> {
+        // Scripts act on real paths in a real directory; the Trash and
+        // Recent are neither.
+        if situation.trash || situation.recent {
+            return Vec::new();
+        }
+        self.take_discovered();
+        let targets = targets_of(situation);
+        self.commands
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|command| command.offered(situation, &targets))
+            .map(ScriptCommand::command)
+            .collect()
+    }
+
+    fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
+        let command = self.find(&request.id)?;
+        let input = Self::input(&command, request, situation);
+        let outcome = call(
+            &command.script,
+            "preview",
+            Some(&input),
+            Some(PREVIEW_DEADLINE),
+        )
+        .ok()?;
+        if !outcome.success {
+            return Some(Preview {
+                rows: Vec::new(),
+                note: Some(outcome.complaint()),
+            });
+        }
+        let reply: PreviewReply = serde_json::from_str(&outcome.stdout).ok()?;
+        Some(Preview {
+            rows: reply
+                .rows
+                .into_iter()
+                .map(|row| PreviewRow {
+                    from: row.from,
+                    to: row.to,
+                    conflict: row.conflict,
+                })
+                .collect(),
+            note: reply.note,
+        })
+    }
+
+    fn run(&mut self, request: &Request, situation: &Situation) -> Result<Effect, String> {
+        let command = self
+            .find(&request.id)
+            .ok_or_else(|| format!("{} is not a script here", request.id))?;
+        let input = Self::input(&command, request, situation);
+        let report = self.report.clone();
+        let title = command.described.title.clone();
+        std::thread::Builder::new()
+            .name("files-script-run".into())
+            .spawn(move || {
+                let _ = report.send(Self::run_now(&command, &input));
+            })
+            .map_err(|err| err.to_string())?;
+        // The palette closes on this; what the script did arrives through
+        // `poll`, and the status line says so meanwhile.
+        Ok(Effect {
+            status: Some(otto_kit::t_owned!("files-script-running", title = title)),
+            ..Effect::default()
+        })
+    }
+
+    fn poll(&mut self) -> Vec<Result<Effect, String>> {
+        self.finished.try_iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    struct Dir(PathBuf);
+
+    impl Dir {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "otto-files-scripts-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn script(&self, name: &str, body: &str) -> PathBuf {
+            let path = self.0.join(name);
+            std::fs::write(&path, format!("#!/bin/sh\n{body}")).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            path
+        }
+    }
+
+    impl Drop for Dir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A script that offers one previewed command and, when run, creates a
+    /// file named by its argument next to the first target.
+    const TOUCH: &str = r#"
+case "$1" in
+  describe)
+    printf '%s' '{"commands":[{"id":"touch","title":"Touch a File","keywords":["create"],
+      "when":{"targets":"some","extensions":["txt"]},
+      "arg":{"prompt":"File name","initial":"{stem}.out","preview":true},"undo":"Touch"}]}'
+    ;;
+  preview)
+    input=$(cat)
+    arg=$(printf '%s' "$input" | sed 's/.*"arg":"\([^"]*\)".*/\1/')
+    printf '{"rows":[{"from":"first","to":"%s","conflict":false}],"note":"would touch %s"}' "$arg" "$arg"
+    ;;
+  run)
+    input=$(cat)
+    arg=$(printf '%s' "$input" | sed 's/.*"arg":"\([^"]*\)".*/\1/')
+    dir=$(printf '%s' "$input" | sed 's/.*"path":"\([^"]*\)".*/\1/')
+    : > "$dir/$arg"
+    printf '{"status":"touched %s","changes":[{"kind":"created","path":"%s/%s"}],"reload":true}' "$arg" "$dir" "$arg"
+    ;;
+esac
+"#;
+
+    fn situation(dir: &Path, selection: &[&str]) -> Situation {
+        Situation {
+            path: dir.to_path_buf(),
+            selection: selection.iter().map(|name| dir.join(name)).collect(),
+            cursor_name: Some("notes.txt".into()),
+            has_entries: true,
+            ..Situation::default()
+        }
+    }
+
+    #[test]
+    fn a_script_is_described_once_and_offered_on_its_conditions() {
+        let dir = Dir::new("describe");
+        dir.script("touch", TOUCH);
+        let provider = ScriptProvider::discovered(&dir.0);
+
+        let offered = provider.commands(&situation(&dir.0, &["a.txt", "b.TXT"]));
+        assert_eq!(offered.len(), 1);
+        let command = &offered[0];
+        assert_eq!(command.id, "scripts:touch.touch");
+        assert_eq!(command.title, "Touch a File");
+        assert_eq!(command.namespace(), Some("scripts"));
+        let arg = command.arg.as_ref().expect("takes an argument");
+        assert!(arg.preview);
+        assert_eq!(arg.initial.as_deref(), Some("{stem}.out"));
+
+        // The wrong extension, the Trash and Recent all keep it away.
+        assert!(provider.commands(&situation(&dir.0, &["a.png"])).is_empty());
+        assert!(provider
+            .commands(&Situation {
+                trash: true,
+                ..situation(&dir.0, &["a.txt"])
+            })
+            .is_empty());
+        assert!(provider
+            .commands(&Situation {
+                recent: true,
+                ..situation(&dir.0, &["a.txt"])
+            })
+            .is_empty());
+    }
+
+    #[test]
+    fn the_cursor_stands_in_for_an_empty_selection() {
+        let dir = Dir::new("cursor");
+        dir.script("touch", TOUCH);
+        let provider = ScriptProvider::discovered(&dir.0);
+        let offered = provider.commands(&situation(&dir.0, &[]));
+        assert_eq!(offered.len(), 1, "notes.txt under the cursor is a target");
+        assert!(provider
+            .commands(&Situation {
+                cursor_name: None,
+                ..situation(&dir.0, &[])
+            })
+            .is_empty());
+    }
+
+    #[test]
+    fn a_preview_is_the_scripts_dry_run() {
+        let dir = Dir::new("preview");
+        dir.script("touch", TOUCH);
+        let provider = ScriptProvider::discovered(&dir.0);
+        let preview = provider
+            .preview(
+                &Request::new("scripts:touch.touch", Some("hello.out".into())),
+                &situation(&dir.0, &["a.txt"]),
+            )
+            .expect("a preview");
+        assert_eq!(preview.rows.len(), 1);
+        assert_eq!(preview.rows[0].to, "hello.out");
+        assert_eq!(preview.note.as_deref(), Some("would touch hello.out"));
+        assert!(
+            !dir.0.join("hello.out").exists(),
+            "a preview changes nothing"
+        );
+    }
+
+    #[test]
+    fn a_run_finishes_later_and_lands_through_poll() {
+        let dir = Dir::new("run");
+        dir.script("touch", TOUCH);
+        let mut provider = ScriptProvider::discovered(&dir.0);
+        let situation = situation(&dir.0, &["a.txt"]);
+        let first = provider
+            .run(
+                &Request::new("scripts:touch.touch", Some("made.out".into())),
+                &situation,
+            )
+            .expect("accepted");
+        assert!(
+            first.changes.is_empty(),
+            "nothing is recorded until it lands"
+        );
+        assert!(first.status.is_some());
+
+        let landed = wait_for(&mut provider);
+        let effect = landed.expect("the script succeeded");
+        assert_eq!(effect.status.as_deref(), Some("touched made.out"));
+        assert_eq!(effect.undo_label, Some("Touch"));
+        assert!(effect.reload);
+        assert!(matches!(
+            effect.changes.as_slice(),
+            [Change::Created { path }] if path == &dir.0.join("made.out")
+        ));
+        assert!(dir.0.join("made.out").exists());
+    }
+
+    #[test]
+    fn a_script_that_fails_is_read_from_its_last_line_of_stderr() {
+        let dir = Dir::new("fail");
+        dir.script(
+            "grumpy",
+            r#"
+case "$1" in
+  describe) printf '%s' '{"commands":[{"id":"no","title":"No"}]}' ;;
+  run) echo "thinking..." >&2; echo "not today" >&2; exit 3 ;;
+esac
+"#,
+        );
+        let mut provider = ScriptProvider::discovered(&dir.0);
+        let situation = situation(&dir.0, &["a.txt"]);
+        provider
+            .run(&Request::new("scripts:grumpy.no", None), &situation)
+            .unwrap();
+        assert_eq!(wait_for(&mut provider).unwrap_err(), "not today");
+    }
+
+    #[test]
+    fn a_script_that_cannot_describe_itself_is_left_out() {
+        let dir = Dir::new("bad");
+        dir.script("broken", "printf 'this is not json'");
+        dir.script("silent", "exit 1");
+        dir.script("fine", r#"[ "$1" = describe ] && printf '%s' '{"commands":[{"id":"ok","title":"OK","when":{"targets":"none"}}]}'"#);
+        std::fs::write(dir.0.join("notes.txt"), "not a script").unwrap();
+        let provider = ScriptProvider::discovered(&dir.0);
+        let offered = provider.commands(&Situation {
+            path: dir.0.clone(),
+            ..Situation::default()
+        });
+        assert_eq!(offered.len(), 1);
+        assert_eq!(offered[0].id, "scripts:fine.ok");
+    }
+
+    #[test]
+    fn a_slow_dry_run_is_given_up_on() {
+        let dir = Dir::new("slow");
+        dir.script(
+            "slow",
+            r#"
+case "$1" in
+  describe) printf '%s' '{"commands":[{"id":"s","title":"Slow","arg":{"prompt":"x","preview":true}}]}' ;;
+  preview) sleep 5; printf '{"rows":[]}' ;;
+esac
+"#,
+        );
+        let provider = ScriptProvider::discovered(&dir.0);
+        let started = Instant::now();
+        let preview = provider.preview(
+            &Request::new("scripts:slow.s", Some("x".into())),
+            &situation(&dir.0, &["a.txt"]),
+        );
+        assert!(started.elapsed() < Duration::from_secs(3));
+        let preview = preview.expect("a note saying so");
+        assert!(preview.rows.is_empty());
+        assert!(preview.note.is_some());
+    }
+
+    #[test]
+    fn a_missing_directory_offers_nothing() {
+        let provider = ScriptProvider::discovered(Path::new("/nonexistent/otto-files-scripts"));
+        assert!(provider
+            .commands(&situation(Path::new("/tmp"), &["a.txt"]))
+            .is_empty());
+    }
+
+    /// The shipped samples, through the provider: zip the fixture, then
+    /// unzip what came out. Skipped where `zip` is not installed.
+    #[test]
+    fn the_shipped_zip_and_unzip_scripts_round_trip() {
+        if !["zip", "unzip", "python3"].iter().all(|tool| {
+            std::process::Command::new("sh")
+                .args(["-c", &format!("command -v {tool}")])
+                .stdout(Stdio::null())
+                .status()
+                .is_ok_and(|s| s.success())
+        }) {
+            eprintln!("zip, unzip or python3 missing; skipping");
+            return;
+        }
+        let shipped = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts");
+        let dir = Dir::new("shipped");
+        std::fs::write(dir.0.join("a.txt"), "a").unwrap();
+        std::fs::create_dir(dir.0.join("Photos")).unwrap();
+        std::fs::write(dir.0.join("Photos/b.txt"), "b").unwrap();
+        let mut provider = ScriptProvider::discovered(&shipped);
+
+        let situation = situation(&dir.0, &["a.txt", "Photos"]);
+        let offered: Vec<String> = provider
+            .commands(&situation)
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert!(offered.contains(&"scripts:zip.compress".to_string()));
+        assert!(
+            !offered.contains(&"scripts:unzip.extract".to_string()),
+            "not everything selected is a .zip"
+        );
+
+        let request = Request::new("scripts:zip.compress", Some("Bundle".into()));
+        let preview = provider.preview(&request, &situation).unwrap();
+        assert_eq!(preview.rows.len(), 2);
+        assert_eq!(preview.rows[0].to, "Bundle.zip");
+        provider.run(&request, &situation).unwrap();
+        let effect = wait_for(&mut provider).unwrap();
+        assert!(dir.0.join("Bundle.zip").is_file());
+        assert_eq!(effect.undo_label, Some("Compress"));
+
+        let situation = situation_with(&dir.0, &["Bundle.zip"]);
+        let offered: Vec<String> = provider
+            .commands(&situation)
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert!(offered.contains(&"scripts:unzip.extract".to_string()));
+        let request = Request::new("scripts:unzip.extract", Some("{stem}-out".into()));
+        let preview = provider.preview(&request, &situation).unwrap();
+        assert_eq!(preview.rows[0].to, "Bundle-out/");
+        assert!(!preview.rows[0].conflict);
+        provider.run(&request, &situation).unwrap();
+        wait_for(&mut provider).unwrap();
+        assert!(dir.0.join("Bundle-out/Photos/b.txt").is_file());
+
+        // Running again would land on the folder that is now there.
+        let preview = provider.preview(&request, &situation).unwrap();
+        assert!(preview.rows[0].conflict);
+        provider.run(&request, &situation).unwrap();
+        assert!(wait_for(&mut provider).is_err());
+    }
+
+    fn situation_with(dir: &Path, selection: &[&str]) -> Situation {
+        Situation {
+            cursor_name: selection.first().map(|s| s.to_string()),
+            ..situation(dir, selection)
+        }
+    }
+
+    fn wait_for(provider: &mut ScriptProvider) -> Result<Effect, String> {
+        let started = Instant::now();
+        loop {
+            if let Some(result) = provider.poll().pop() {
+                return result;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(10),
+                "the run never landed"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}

--- a/components/otto-files/src/scripts.rs
+++ b/components/otto-files/src/scripts.rs
@@ -28,6 +28,15 @@
 //! } ] }
 //! ```
 //!
+//! Every string a person reads — `title`, `undo`, the `arg`'s `prompt`,
+//! `label`, `placeholder` and `initial` — may instead be an object keyed by
+//! locale, `{ "en": "Compress to Zip", "it": "Comprimi in Zip" }`; the host
+//! picks the window's locale, then the same language, then English.
+//! `keywords` may be keyed the same way, and every locale's words match.
+//! The locale is also handed to the script itself, as `OTTO_LOCALE` in the
+//! environment on every call and as `locale` in the JSON below, for what it
+//! says back at preview and run time.
+//!
 //! Everything but `id` and `title` is optional. `when` is the whole of what
 //! decides whether the command is offered, so that opening the palette never
 //! runs a script: `targets` is `"some"` (default), `"one"`, `"none"` or
@@ -39,7 +48,7 @@
 //! `script preview` and `script run` — with this on standard input:
 //!
 //! ```json
-//! { "command": "compress", "arg": "Holiday.zip",
+//! { "command": "compress", "arg": "Holiday.zip", "locale": "en-GB",
 //!   "targets": ["/home/me/Pictures/a.png", "/home/me/Pictures/b.png"],
 //!   "situation": { "path": "/home/me/Pictures", "selection": [...], ... } }
 //! ```
@@ -69,7 +78,7 @@
 //! long as it takes, on a worker thread, and its effect arrives through
 //! [`CommandProvider::poll`].
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command as Process, Stdio};
@@ -104,12 +113,67 @@ struct Description {
     commands: Vec<Described>,
 }
 
+/// A string a person reads, given once or once per locale:
+/// `"title": "Compress to Zip"` or
+/// `"title": { "en": "Compress to Zip", "it": "Comprimi in Zip" }`.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum Text {
+    One(String),
+    ByLocale(BTreeMap<String, String>),
+}
+
+impl Text {
+    /// The string for `locale`: the exact tag, then the same language, then
+    /// English, then whatever was given first. Case does not matter and `_`
+    /// reads as `-`, so `pt_BR` finds `pt-BR`.
+    fn get(&self, locale: &str) -> String {
+        match self {
+            Text::One(text) => text.clone(),
+            Text::ByLocale(map) => {
+                let wanted = locale.replace('_', "-").to_ascii_lowercase();
+                let language = wanted.split('-').next().unwrap_or_default().to_owned();
+                let pick = |test: &dyn Fn(&str) -> bool| {
+                    map.iter()
+                        .find(|(tag, _)| test(&tag.replace('_', "-").to_ascii_lowercase()))
+                        .map(|(_, text)| text.clone())
+                };
+                pick(&|tag| tag == wanted)
+                    .or_else(|| pick(&|tag| tag.split('-').next() == Some(&language)))
+                    .or_else(|| pick(&|tag| tag.split('-').next() == Some("en")))
+                    .or_else(|| map.values().next().cloned())
+                    .unwrap_or_default()
+            }
+        }
+    }
+}
+
+/// Keywords, likewise: one list, or one per locale.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum Words {
+    One(Vec<String>),
+    ByLocale(BTreeMap<String, Vec<String>>),
+}
+
+impl Words {
+    /// Every locale's words at once: a keyword is never shown, only matched,
+    /// so a person who thinks of the command in another language still finds
+    /// it.
+    fn all(&self) -> Vec<String> {
+        match self {
+            Words::One(words) => words.clone(),
+            Words::ByLocale(map) => map.values().flatten().cloned().collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 struct Described {
     id: String,
-    title: String,
+    title: Text,
     #[serde(default)]
-    keywords: Vec<String>,
+    keywords: Option<Words>,
     #[serde(default)]
     group: GroupName,
     #[serde(default)]
@@ -118,7 +182,7 @@ struct Described {
     arg: Option<DescribedArg>,
     /// What to call the run in the undo history. The title when absent.
     #[serde(default)]
-    undo: Option<String>,
+    undo: Option<Text>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
@@ -176,13 +240,13 @@ enum Kinds {
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 struct DescribedArg {
-    prompt: String,
+    prompt: Text,
     #[serde(default)]
-    label: Option<String>,
+    label: Option<Text>,
     #[serde(default)]
-    placeholder: Option<String>,
+    placeholder: Option<Text>,
     #[serde(default)]
-    initial: Option<String>,
+    initial: Option<Text>,
     #[serde(default)]
     preview: bool,
 }
@@ -234,23 +298,24 @@ impl ScriptCommand {
         }
     }
 
-    fn command(&self) -> Command {
+    fn command(&self, locale: &str) -> Command {
         let d = &self.described;
-        let mut command = Command::new(&self.full_id, &d.title, Group::from(d.group))
-            .with_keywords(d.keywords.iter().cloned());
+        let mut command = Command::new(&self.full_id, d.title.get(locale), Group::from(d.group))
+            .with_keywords(d.keywords.as_ref().map(Words::all).unwrap_or_default());
         if let Some(arg) = &d.arg {
             let mut spec = ArgSpec::new(
-                &arg.prompt,
+                arg.prompt.get(locale),
                 arg.label
-                    .clone()
+                    .as_ref()
+                    .map(|label| label.get(locale))
                     .unwrap_or_else(|| otto_kit::t_owned!("files-command-arg-name")),
                 ArgKind::Text,
             );
             if let Some(placeholder) = &arg.placeholder {
-                spec = spec.with_placeholder(placeholder);
+                spec = spec.with_placeholder(placeholder.get(locale));
             }
             if let Some(initial) = &arg.initial {
-                spec = spec.with_initial(initial);
+                spec = spec.with_initial(initial.get(locale));
             }
             if arg.preview {
                 spec = spec.previewed();
@@ -269,6 +334,9 @@ impl ScriptCommand {
 struct Input<'a> {
     command: &'a str,
     arg: Option<&'a str>,
+    /// The window's locale, as a BCP 47 tag, so what a script says back is
+    /// in the person's language. Also in the environment as `OTTO_LOCALE`.
+    locale: &'a str,
     targets: &'a [PathBuf],
     situation: &'a Situation,
 }
@@ -356,11 +424,13 @@ impl Outcome {
 fn call(
     script: &Path,
     verb: &str,
+    locale: &str,
     input: Option<&[u8]>,
     deadline: Option<Duration>,
 ) -> Result<Outcome, String> {
     let mut child = Process::new(script)
         .arg(verb)
+        .env("OTTO_LOCALE", locale)
         .stdin(if input.is_some() {
             Stdio::piped()
         } else {
@@ -428,12 +498,12 @@ fn wait_until(child: &mut Child, deadline: Duration) -> Option<std::process::Exi
 }
 
 /// Ask one script what it offers.
-fn describe(script: &Path) -> Vec<ScriptCommand> {
+fn describe(script: &Path, locale: &str) -> Vec<ScriptCommand> {
     let stem = script
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let outcome = match call(script, "describe", None, Some(DESCRIBE_DEADLINE)) {
+    let outcome = match call(script, "describe", locale, None, Some(DESCRIBE_DEADLINE)) {
         Ok(outcome) => outcome,
         Err(err) => {
             tracing::warn!("files-scripts: {err}");
@@ -470,7 +540,7 @@ fn describe(script: &Path) -> Vec<ScriptCommand> {
 }
 
 /// Every executable in `dir`, by name, described.
-fn discover(dir: &Path) -> Vec<ScriptCommand> {
+fn discover(dir: &Path, locale: &str) -> Vec<ScriptCommand> {
     use std::os::unix::fs::PermissionsExt;
 
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -491,7 +561,10 @@ fn discover(dir: &Path) -> Vec<ScriptCommand> {
         })
         .collect();
     scripts.sort();
-    scripts.iter().flat_map(|script| describe(script)).collect()
+    scripts
+        .iter()
+        .flat_map(|script| describe(script, locale))
+        .collect()
 }
 
 /// Where the scripts are, honouring `XDG_CONFIG_HOME`. `OTTO_FILES_SCRIPTS`
@@ -535,6 +608,9 @@ fn keep(label: &str) -> &'static str {
 
 /// The scripts directory, as a provider.
 pub struct ScriptProvider {
+    /// The window's locale, told to every script and used to pick among
+    /// the texts a description gives per locale.
+    locale: String,
     /// What has been described so far. Behind a mutex because the seam asks
     /// for commands through `&self` and discovery lands from another thread.
     commands: Mutex<Vec<ScriptCommand>>,
@@ -550,22 +626,24 @@ impl ScriptProvider {
     /// its own thread, so the window's start is not held up by a slow script
     /// and Ctrl+P finds whatever has answered by then.
     pub fn new() -> Self {
-        Self::over(scripts_dir())
+        Self::over(scripts_dir(), otto_kit::i18n::current_locale())
     }
 
-    fn over(dir: Option<PathBuf>) -> Self {
+    fn over(dir: Option<PathBuf>, locale: String) -> Self {
         let (report, finished) = mpsc::channel();
         let discovering = dir.map(|dir| {
             let (tx, rx) = mpsc::channel();
+            let locale = locale.clone();
             std::thread::Builder::new()
                 .name("files-scripts".into())
                 .spawn(move || {
-                    let _ = tx.send(discover(&dir));
+                    let _ = tx.send(discover(&dir, &locale));
                 })
                 .expect("spawn discovery thread");
             rx
         });
         Self {
+            locale,
             commands: Mutex::new(Vec::new()),
             discovering: Mutex::new(discovering),
             finished,
@@ -576,8 +654,13 @@ impl ScriptProvider {
     /// The provider over `dir`, with discovery already done. For tests.
     #[cfg(test)]
     fn discovered(dir: &Path) -> Self {
-        let provider = Self::over(None);
-        *provider.commands.lock().unwrap() = discover(dir);
+        Self::discovered_in(dir, "en-GB")
+    }
+
+    #[cfg(test)]
+    fn discovered_in(dir: &Path, locale: &str) -> Self {
+        let provider = Self::over(None, locale.to_owned());
+        *provider.commands.lock().unwrap() = discover(dir, locale);
         provider
     }
 
@@ -602,11 +685,12 @@ impl ScriptProvider {
             .cloned()
     }
 
-    fn input(command: &ScriptCommand, request: &Request, situation: &Situation) -> Vec<u8> {
+    fn input(&self, command: &ScriptCommand, request: &Request, situation: &Situation) -> Vec<u8> {
         let targets = targets_of(situation);
         let input = Input {
             command: &command.described.id,
             arg: request.arg.as_deref(),
+            locale: &self.locale,
             targets: &targets,
             situation,
         };
@@ -614,8 +698,8 @@ impl ScriptProvider {
     }
 
     /// Run `command` to completion and turn what it says into an effect.
-    fn run_now(command: &ScriptCommand, input: &[u8]) -> Result<Effect, String> {
-        let outcome = call(&command.script, "run", Some(input), None)?;
+    fn run_now(command: &ScriptCommand, locale: &str, input: &[u8]) -> Result<Effect, String> {
+        let outcome = call(&command.script, "run", locale, Some(input), None)?;
         if !outcome.success {
             return Err(outcome.complaint());
         }
@@ -637,11 +721,12 @@ impl ScriptProvider {
         let label = command
             .described
             .undo
-            .as_deref()
-            .unwrap_or(&command.described.title);
+            .as_ref()
+            .unwrap_or(&command.described.title)
+            .get(locale);
         Ok(Effect {
             status: reply.status,
-            undo_label: (!changes.is_empty()).then(|| keep(label)),
+            undo_label: (!changes.is_empty()).then(|| keep(&label)),
             changes,
             reload: reply.reload,
         })
@@ -672,16 +757,17 @@ impl CommandProvider for ScriptProvider {
             .unwrap()
             .iter()
             .filter(|command| command.offered(situation, &targets))
-            .map(ScriptCommand::command)
+            .map(|command| command.command(&self.locale))
             .collect()
     }
 
     fn preview(&self, request: &Request, situation: &Situation) -> Option<Preview> {
         let command = self.find(&request.id)?;
-        let input = Self::input(&command, request, situation);
+        let input = self.input(&command, request, situation);
         let outcome = call(
             &command.script,
             "preview",
+            &self.locale,
             Some(&input),
             Some(PREVIEW_DEADLINE),
         )
@@ -711,13 +797,14 @@ impl CommandProvider for ScriptProvider {
         let command = self
             .find(&request.id)
             .ok_or_else(|| format!("{} is not a script here", request.id))?;
-        let input = Self::input(&command, request, situation);
+        let input = self.input(&command, request, situation);
         let report = self.report.clone();
-        let title = command.described.title.clone();
+        let locale = self.locale.clone();
+        let title = command.described.title.get(&locale);
         std::thread::Builder::new()
             .name("files-script-run".into())
             .spawn(move || {
-                let _ = report.send(Self::run_now(&command, &input));
+                let _ = report.send(Self::run_now(&command, &locale, &input));
             })
             .map_err(|err| err.to_string())?;
         // The palette closes on this; what the script did arrives through
@@ -1027,6 +1114,47 @@ esac
         assert!(preview.rows[0].conflict);
         provider.run(&request, &situation).unwrap();
         assert!(wait_for(&mut provider).is_err());
+    }
+
+    #[test]
+    fn a_script_may_speak_several_languages() {
+        let dir = Dir::new("l10n");
+        dir.script(
+            "hello",
+            r#"
+case "$1" in
+  describe)
+    printf '%s' '{"commands":[{"id":"hi","title":{"en":"Say Hello","it":"Saluta","pt-BR":"Diga oi"},
+      "keywords":{"en":["greet"],"it":["ciao"]},
+      "arg":{"prompt":{"en":"To whom","it":"A chi"},"placeholder":"..."}}]}'
+    ;;
+  preview) printf '{"note":"%s"}' "$OTTO_LOCALE" ;;
+esac
+"#,
+        );
+        let situation = situation(&dir.0, &["a.txt"]);
+
+        let italian = ScriptProvider::discovered_in(&dir.0, "it-IT");
+        let command = italian.commands(&situation).remove(0);
+        assert_eq!(command.title, "Saluta");
+        assert_eq!(command.arg.as_ref().unwrap().prompt, "A chi");
+        assert!(command.keywords.contains(&"greet".to_string()));
+        assert!(command.keywords.contains(&"ciao".to_string()));
+
+        let brazilian = ScriptProvider::discovered_in(&dir.0, "pt_BR");
+        assert_eq!(brazilian.commands(&situation).remove(0).title, "Diga oi");
+
+        let german = ScriptProvider::discovered_in(&dir.0, "de");
+        assert_eq!(german.commands(&situation).remove(0).title, "Say Hello");
+
+        // The script itself is told, too.
+        let preview = italian
+            .preview(
+                &Request::new("scripts:hello.hi", Some("x".into())),
+                &situation,
+            )
+            .unwrap();
+        assert_eq!(preview.note.as_deref(), Some("it-IT"));
     }
 
     fn situation_with(dir: &Path, selection: &[&str]) -> Situation {

--- a/components/otto-files/src/thumbnails.rs
+++ b/components/otto-files/src/thumbnails.rs
@@ -42,6 +42,14 @@ pub const MAX_IN_FLIGHT: usize = 4;
 /// resident.
 pub const CAPACITY: usize = 512;
 
+/// How many bytes of decoded thumbnails to keep, whatever their count.
+///
+/// The count assumes a grid cell's worth of pixels each; a thumbnail that
+/// came back larger — a decoder that could not sample, a shared-cache entry
+/// at a bigger size than asked — would make 512 of them gigabytes. The
+/// budget is the ceiling the count was standing in for.
+pub const BUDGET_BYTES: usize = 96 << 20;
+
 /// Where one file's thumbnail has got to.
 enum State {
     /// Somebody is looking for it.
@@ -61,6 +69,16 @@ struct Slot {
     modified: Option<SystemTime>,
     /// Insertion order, for eviction.
     stamp: u64,
+}
+
+impl Slot {
+    /// The decoded bytes this slot holds resident.
+    fn bytes(&self) -> usize {
+        match &self.state {
+            State::Ready(image) => image.width() as usize * image.height() as usize * 4,
+            _ => 0,
+        }
+    }
 }
 
 /// One file to fetch a thumbnail for.
@@ -88,6 +106,8 @@ pub enum Found {
 #[derive(Default)]
 pub struct Store {
     slots: HashMap<PathBuf, Slot>,
+    /// Decoded bytes held by the `Ready` slots, kept against [`BUDGET_BYTES`].
+    bytes: usize,
     in_flight: usize,
     clock: u64,
     /// Bumped whenever something lands that changes what a pane would draw.
@@ -204,14 +224,15 @@ impl Store {
     fn insert(&mut self, path: PathBuf, modified: Option<SystemTime>, state: State) {
         self.clock = self.clock.wrapping_add(1);
         let stamp = self.clock;
-        self.slots.insert(
-            path,
-            Slot {
-                state,
-                modified,
-                stamp,
-            },
-        );
+        let slot = Slot {
+            state,
+            modified,
+            stamp,
+        };
+        self.bytes += slot.bytes();
+        if let Some(replaced) = self.slots.insert(path, slot) {
+            self.bytes = self.bytes.saturating_sub(replaced.bytes());
+        }
         self.evict();
     }
 
@@ -222,7 +243,7 @@ impl Store {
     /// folder, where insertion order and recency are near enough the same
     /// thing.
     fn evict(&mut self) {
-        while self.slots.len() > CAPACITY {
+        while self.slots.len() > CAPACITY || self.bytes > BUDGET_BYTES {
             let Some(oldest) = self
                 .slots
                 .iter()
@@ -235,7 +256,13 @@ impl Store {
             else {
                 return;
             };
-            self.slots.remove(&oldest);
+            self.remove(&oldest);
+        }
+    }
+
+    fn remove(&mut self, path: &Path) {
+        if let Some(slot) = self.slots.remove(path) {
+            self.bytes = self.bytes.saturating_sub(slot.bytes());
         }
     }
 
@@ -243,6 +270,7 @@ impl Store {
     /// have changed under every path at once.
     pub fn clear(&mut self) {
         self.slots.clear();
+        self.bytes = 0;
         // In-flight jobs are deliberately still counted: they are still
         // running, and their results will be dropped on arrival by the mtime
         // check. Zeroing the count here would let the ceiling be exceeded.
@@ -419,6 +447,35 @@ mod tests {
 
         store.finish(PathBuf::from("/tmp/b"), mtime, Found::Thumbnail(image()));
         assert_ne!(store.epoch(), before);
+    }
+
+    /// A handful of full-frame pictures is over the budget long before the
+    /// count is: the oldest go, whatever the count says.
+    #[test]
+    fn evicts_by_bytes_before_count() {
+        let mut store = Store::new();
+        let big = || {
+            let info = skia::ImageInfo::new_n32_premul((2880, 1920), None);
+            let bytes = vec![0u8; 2880 * 1920 * 4];
+            skia::images::raster_from_data(&info, skia::Data::new_copy(&bytes), 2880 * 4).unwrap()
+        };
+        let per = 2880 * 1920 * 4;
+        let fits = BUDGET_BYTES / per;
+        for i in 0..fits + 3 {
+            store.insert(
+                PathBuf::from(format!("/tmp/shot-{i}.png")),
+                None,
+                State::Ready(big()),
+            );
+        }
+        assert!(store.bytes <= BUDGET_BYTES, "{} bytes held", store.bytes);
+        assert_eq!(store.slots.len(), fits);
+        assert!(!store.slots.contains_key(Path::new("/tmp/shot-0.png")));
+        assert!(store
+            .slots
+            .contains_key(Path::new(&format!("/tmp/shot-{}.png", fits + 2))));
+        store.clear();
+        assert_eq!(store.bytes, 0);
     }
 
     #[test]

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3092,30 +3092,10 @@ pub struct PaletteData<'a> {
     /// popup material is used instead, which is what the compositor's blur
     /// expects to sit under.
     pub on_surface: bool,
-}
-
-/// Which rows are on screen, given where the highlight is.
-///
-/// Scrolls by the least that puts the highlight back in view, so arrowing
-/// through a long list moves one row at a time rather than jumping a page.
-pub fn palette_window(
-    len: usize,
-    highlight: Option<usize>,
-    first: usize,
-    max: usize,
-) -> std::ops::Range<usize> {
-    if len <= max {
-        return 0..len;
-    }
-    let mut first = first.min(len - max);
-    if let Some(highlight) = highlight {
-        if highlight < first {
-            first = highlight;
-        } else if highlight >= first + max {
-            first = highlight + 1 - max;
-        }
-    }
-    first..(first + max).min(len)
+    /// The list's scroll view, when the host runs one: where the rows have
+    /// scrolled to, how far past an end they are stretched, and how much of
+    /// the bar to show. `None` draws the rows where they lie.
+    pub scroll: Option<ScrollState>,
 }
 
 fn palette_row_h(kind: PaletteRowKind) -> f32 {
@@ -3131,11 +3111,50 @@ pub fn palette_rect(width: f32, rows: &[PaletteRow<'_>], message: bool) -> Rect 
     let w = PALETTE_W.min(width - 48.0).max(240.0);
     let left = (width - w - PALETTE_RIGHT_INSET).max(0.0);
     let mut height = PALETTE_FIELD_H;
-    let body: f32 = rows.iter().map(|row| palette_row_h(row.kind)).sum();
+    let body = palette_list_h(rows);
     if body > 0.0 || message {
         height += PALETTE_PAD * 2.0 + if message { PALETTE_ROW_H } else { body };
     }
     Rect::from_xywh(left, PALETTE_TOP, w, height)
+}
+
+/// How tall the whole list is, laid out end to end.
+pub fn palette_content_h(rows: &[PaletteRow<'_>]) -> f32 {
+    rows.iter().map(|row| palette_row_h(row.kind)).sum()
+}
+
+/// How tall the list's *viewport* is: the whole list up to
+/// [`PALETTE_MAX_ROWS`] rows' worth, past which it scrolls.
+pub fn palette_list_h(rows: &[PaletteRow<'_>]) -> f32 {
+    palette_content_h(rows).min(PALETTE_MAX_ROWS as f32 * PALETTE_ROW_H)
+}
+
+/// The list's viewport: the band under the field the rows scroll through.
+pub fn palette_list_rect(width: f32, rows: &[PaletteRow<'_>], message: bool) -> Rect {
+    let card = palette_rect(width, rows, message);
+    Rect::from_xywh(
+        card.left + PALETTE_PAD,
+        card.top + PALETTE_FIELD_H + PALETTE_PAD,
+        card.width() - PALETTE_PAD * 2.0,
+        palette_list_h(rows),
+    )
+}
+
+/// The least the list has to scroll from `offset` for `row` — a rect in the
+/// list's own, unscrolled coordinates — to be wholly inside `viewport`.
+///
+/// By the least, so arrowing through a long list moves it one row at a time
+/// rather than jumping a page; a row already in view leaves it where it is.
+pub fn palette_reveal(row: Rect, viewport: Rect, offset: f32) -> f32 {
+    let top = row.top - viewport.top;
+    let bottom = row.bottom - viewport.top;
+    if top < offset {
+        top
+    } else if bottom > offset + viewport.height() {
+        bottom - viewport.height()
+    } else {
+        offset
+    }
 }
 
 /// The field, inset in the card's top band.
@@ -3270,6 +3289,35 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
         return;
     }
 
+    match data.scroll {
+        // The rows scroll under the field: drawn where they lie in the list,
+        // shifted and clipped by the view — which also paints the bar and
+        // shows the stretch past either end, since a stretched offset simply
+        // moves them further than the content allows.
+        Some(state) => {
+            // The renderer hands over a canvas in the *content's* own
+            // coordinates — the list's first row at the origin — while the row
+            // rects are measured from the window's corner like everything
+            // else in this file. Shift by the viewport's origin so the two
+            // agree, and the offset the renderer applied does the scrolling.
+            let viewport = state.viewport();
+            otto_kit::components::scroll::ScrollRenderer::draw(
+                canvas,
+                &state,
+                theme,
+                |canvas, _visible| {
+                    canvas.translate((-viewport.left, -viewport.top));
+                    draw_palette_rows(canvas, theme, width, data);
+                },
+            )
+        }
+        None => draw_palette_rows(canvas, theme, width, data),
+    }
+}
+
+fn draw_palette_rows(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteData<'_>) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
     for (index, row) in data.rows.iter().enumerate() {
         let rect = palette_row_rect(width, &data.rows, index);
         if row.kind == PaletteRowKind::Heading {
@@ -6131,34 +6179,40 @@ mod geometry_tests {
         }
     }
 
-    /// A short list is all on screen, and does not scroll at all.
-    #[test]
-    fn a_short_palette_list_does_not_scroll() {
-        assert_eq!(palette_window(4, Some(3), 0, PALETTE_MAX_ROWS), 0..4);
-    }
-
-    /// A long one scrolls by the least that brings the highlight back — one
-    /// row per arrow key, not a page.
-    #[test]
-    fn the_palette_scrolls_the_least_that_shows_the_highlight() {
-        let max = 5;
-        assert_eq!(palette_window(20, Some(4), 0, max), 0..5);
-        assert_eq!(palette_window(20, Some(5), 0, max), 1..6);
-        assert_eq!(palette_window(20, Some(6), 1, max), 2..7);
-        // Back up, and it scrolls the other way by one.
-        assert_eq!(palette_window(20, Some(1), 2, max), 1..6);
-    }
-
-    /// The window never runs off the end, however far the remembered scroll is.
-    #[test]
-    fn the_palette_window_stays_inside_the_list() {
-        let window = palette_window(12, None, 99, 5);
-        assert_eq!(window, 7..12);
-    }
-
     /// The card hangs off the right edge and tucks under the header — over its
     /// lower part, so the panel reads as belonging to this window, but clear
     /// of the title and the traffic lights above it.
+    #[test]
+    fn the_list_scrolls_the_least_that_shows_the_row() {
+        let viewport = Rect::from_xywh(0.0, 100.0, 500.0, 320.0);
+        // Ten rows of 32 fit exactly; the eleventh is out of view below.
+        let row = |i: f32| Rect::from_xywh(0.0, 100.0 + i * 32.0, 500.0, 32.0);
+        assert_eq!(palette_reveal(row(3.0), viewport, 0.0), 0.0);
+        assert_eq!(palette_reveal(row(10.0), viewport, 0.0), 32.0);
+        assert_eq!(palette_reveal(row(11.0), viewport, 32.0), 64.0);
+        // And back up: a row above the window brings it to the top.
+        assert_eq!(palette_reveal(row(1.0), viewport, 64.0), 32.0);
+    }
+
+    #[test]
+    fn a_long_list_is_capped_and_scrolls_rather_than_growing() {
+        let rows: Vec<PaletteRow<'_>> = (0..30)
+            .map(|_| PaletteRow {
+                kind: PaletteRowKind::Item,
+                title: "x",
+                badge: None,
+                subtitle: None,
+                shortcut: None,
+                highlighted: false,
+            })
+            .collect();
+        let list = palette_list_rect(1200.0, &rows, false);
+        assert_eq!(list.height(), PALETTE_MAX_ROWS as f32 * PALETTE_ROW_H);
+        assert!(palette_content_h(&rows) > list.height());
+        let card = palette_rect(1200.0, &rows, false);
+        assert_eq!(card.bottom, list.bottom + PALETTE_PAD);
+    }
+
     #[test]
     fn the_palette_overlaps_the_header_and_hangs_off_the_right_edge() {
         let rows = [item("Copy")];

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3234,11 +3234,15 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
             .render(canvas);
 
         if let Some(badge) = row.badge {
+            // The row's own size, not a footnote: it is part of the same
+            // phrase as the title — "Go to Path › path" — and a smaller run
+            // reads as an annotation about the row rather than as the rest of
+            // what the row says.
             let advance = styles::BODY.font().measure_str(row.title, None).0;
             Label::new(badge)
-                .with_style(styles::FOOTNOTE)
+                .with_style(styles::BODY)
                 .with_color(dim_color)
-                .centered_on(title_x + advance + 10.0, rect.center_y() + 1.0)
+                .centered_on(title_x + advance + 10.0, rect.center_y())
                 .render(canvas);
         }
 

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3056,6 +3056,11 @@ pub enum PaletteRowKind {
     Heading,
     /// Something that can be picked — a command, or an answer to an argument.
     Item,
+    /// One line of a dry run: the row's title is what a thing would become,
+    /// its subtitle what it is now. Read, not picked. `conflict` says the
+    /// outcome is not possible as things stand, and the line is drawn to say
+    /// so.
+    Preview { conflict: bool },
 }
 
 /// One line of the palette's list, ready to draw.
@@ -3101,7 +3106,7 @@ pub struct PaletteData<'a> {
 fn palette_row_h(kind: PaletteRowKind) -> f32 {
     match kind {
         PaletteRowKind::Heading => PALETTE_HEADING_H,
-        PaletteRowKind::Item => PALETTE_ROW_H,
+        PaletteRowKind::Item | PaletteRowKind::Preview { .. } => PALETTE_ROW_H,
     }
 }
 
@@ -3113,9 +3118,21 @@ pub fn palette_rect(width: f32, rows: &[PaletteRow<'_>], message: bool) -> Rect 
     let mut height = PALETTE_FIELD_H;
     let body = palette_list_h(rows);
     if body > 0.0 || message {
-        height += PALETTE_PAD * 2.0 + if message { PALETTE_ROW_H } else { body };
+        height += PALETTE_PAD * 2.0 + body + palette_footer_h(rows, message);
     }
     Rect::from_xywh(left, PALETTE_TOP, w, height)
+}
+
+/// The line the message takes: the whole body when there are no rows — it
+/// stands in for the list — and a footer under the list when there are, so a
+/// dry run can be summed up beneath its lines.
+pub fn palette_footer_h(rows: &[PaletteRow<'_>], message: bool) -> f32 {
+    if message {
+        PALETTE_ROW_H
+    } else {
+        let _ = rows;
+        0.0
+    }
 }
 
 /// How tall the whole list is, laid out end to end.
@@ -3278,15 +3295,19 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
     }
 
     if let Some(message) = data.message {
+        // Under the rows when there are rows, in their place when there are
+        // none: either way the last line of the card.
         Label::new(message)
             .with_style(styles::BODY)
             .with_color(theme.text_secondary)
             .centered_on(
                 card.left + PALETTE_PAD + 8.0,
-                card.top + PALETTE_FIELD_H + PALETTE_PAD + PALETTE_ROW_H / 2.0,
+                card.bottom - PALETTE_PAD - PALETTE_ROW_H / 2.0,
             )
             .render(canvas);
-        return;
+        if data.rows.is_empty() {
+            return;
+        }
     }
 
     match data.scroll {
@@ -3325,6 +3346,41 @@ fn draw_palette_rows(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteD
                 .with_style(styles::FOOTNOTE_EMPHASIZED)
                 .with_color(theme.text_tertiary)
                 .centered_on(rect.left + 8.0, rect.center_y() + 3.0)
+                .render(canvas);
+            continue;
+        }
+        if let PaletteRowKind::Preview { conflict } = row.kind {
+            // "old → new": what it is, dimmed, then what it would become — in
+            // the palette's red when it cannot, so the one line that would
+            // stop the whole batch is the one that stands out.
+            let font = styles::BODY.font();
+            let mut x = rect.left + 8.0;
+            if let Some(from) = row.subtitle {
+                Label::new(from)
+                    .with_style(styles::BODY)
+                    .with_color(theme.text_tertiary)
+                    .centered_on(x, rect.center_y())
+                    .render(canvas);
+                x += font.measure_str(from, None).0 + 8.0;
+                Label::new("→")
+                    .with_style(styles::BODY)
+                    .with_color(theme.text_tertiary)
+                    .centered_on(x, rect.center_y())
+                    .render(canvas);
+                x += font.measure_str("→", None).0 + 8.0;
+            }
+            Label::new(row.title)
+                .with_style(if conflict {
+                    styles::BODY_EMPHASIZED
+                } else {
+                    styles::BODY
+                })
+                .with_color(if conflict {
+                    theme.accent_red
+                } else {
+                    theme.text_primary
+                })
+                .centered_on(x, rect.center_y())
                 .render(canvas);
             continue;
         }
@@ -6192,6 +6248,41 @@ mod geometry_tests {
         assert_eq!(palette_reveal(row(11.0), viewport, 32.0), 64.0);
         // And back up: a row above the window brings it to the top.
         assert_eq!(palette_reveal(row(1.0), viewport, 64.0), 32.0);
+    }
+
+    #[test]
+    fn a_dry_run_line_is_not_a_target_and_its_summary_sits_under_the_list() {
+        let rows = vec![
+            PaletteRow {
+                kind: PaletteRowKind::Preview { conflict: false },
+                title: "Holiday 1.jpg",
+                badge: None,
+                subtitle: Some("IMG_001.jpg"),
+                shortcut: None,
+                highlighted: false,
+            },
+            PaletteRow {
+                kind: PaletteRowKind::Preview { conflict: true },
+                title: "Holiday 2.jpg",
+                badge: None,
+                subtitle: Some("IMG_002.jpg"),
+                shortcut: None,
+                highlighted: false,
+            },
+        ];
+        let rect = palette_row_rect(1200.0, &rows, 0);
+        assert_eq!(
+            palette_row_at(rect.center_x(), rect.center_y(), 1200.0, &rows),
+            None
+        );
+        let bare = palette_rect(1200.0, &rows, false);
+        let noted = palette_rect(1200.0, &rows, true);
+        assert_eq!(noted.height(), bare.height() + PALETTE_ROW_H);
+        // The list itself does not move to make room: the footer is below it.
+        assert_eq!(
+            palette_list_rect(1200.0, &rows, true),
+            palette_list_rect(1200.0, &rows, false)
+        );
     }
 
     #[test]

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2999,11 +2999,12 @@ pub const PALETTE_FIELD_H: f32 = 46.0;
 pub const PALETTE_ROW_H: f32 = 32.0;
 pub const PALETTE_HEADING_H: f32 = 26.0;
 pub const PALETTE_PAD: f32 = 8.0;
-/// How far down the window the card's top edge sits: just clear of the header,
-/// so the location and the view switcher stay readable behind it. Near the top
-/// rather than centred, so what is being typed does not move when the list
-/// under it grows.
-pub const PALETTE_TOP: f32 = HEADER_H + 6.0;
+/// How far down the window the card's top edge rests, before any drag. Over
+/// the lower part of the header rather than clear of it: the panel belongs to
+/// this window, and tucking it under the title says so. Near the top rather
+/// than centred, so what is being typed does not move when the list under it
+/// grows.
+pub const PALETTE_TOP: f32 = HEADER_H - 30.0;
 /// How far the card's right edge sits from the window's. Nearly flush: the
 /// panel belongs to this window, and hanging it off the right keeps the
 /// sidebar and the first column in view beside it.
@@ -6097,12 +6098,18 @@ mod geometry_tests {
         assert_eq!(window, 7..12);
     }
 
-    /// The card hangs off the right edge, clear of the header.
+    /// The card hangs off the right edge and tucks under the header — over its
+    /// lower part, so the panel reads as belonging to this window, but clear
+    /// of the title and the traffic lights above it.
     #[test]
-    fn the_palette_sits_under_the_header_and_near_the_right_edge() {
+    fn the_palette_overlaps_the_header_and_hangs_off_the_right_edge() {
         let rows = [item("Copy")];
         let card = palette_rect(1200.0, &rows, false);
-        assert!(card.top >= HEADER_H, "the header stays readable");
+        assert!(card.top < HEADER_H, "it tucks under the header");
+        assert!(
+            card.top > HEADER_H / 2.0,
+            "but not so far up that it covers the title"
+        );
         assert_eq!(card.right, 1200.0 - PALETTE_RIGHT_INSET);
     }
 

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3044,6 +3044,17 @@ pub struct PaletteData<'a> {
     /// Shown in place of the list: why the last attempt did not work, or that
     /// nothing matches.
     pub message: Option<&'a str>,
+    /// Whether the card is being drawn into a surface of its own rather than
+    /// into the window's buffer.
+    ///
+    /// On its own surface the compositor owns the material: it blurs what is
+    /// actually behind the window, tints it for legibility and casts the
+    /// shadow outside the card's bounds — none of which this canvas can do,
+    /// because a blur painted here can only sample the window's own pixels.
+    /// So the shadow and the opaque ground are dropped and the translucent
+    /// popup material is used instead, which is what the compositor's blur
+    /// expects to sit under.
+    pub on_surface: bool,
 }
 
 /// Which rows are on screen, given where the highlight is.
@@ -3146,23 +3157,33 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
     let card = palette_rect(width, &data.rows, message);
 
     // A shadow rather than a dim over the window: the palette is not modal,
-    // and dimming the listing behind it would say that it was.
-    paint.set_color(theme.shadow);
-    paint.set_mask_filter(skia_safe::MaskFilter::blur(
-        skia_safe::BlurStyle::Normal,
-        14.0,
-        false,
-    ));
-    canvas.draw_rrect(
-        RRect::new_rect_xy(card.with_offset((0.0, 6.0)), 14.0, 14.0),
-        &paint,
-    );
-    paint.set_mask_filter(None);
+    // and dimming the listing behind it would say that it was. Painted here
+    // only while the card is in the window's buffer — on its own surface the
+    // compositor casts it, and outside the card's bounds, which is the one
+    // place a shadow is worth having.
+    if !data.on_surface {
+        paint.set_color(theme.shadow);
+        paint.set_mask_filter(skia_safe::MaskFilter::blur(
+            skia_safe::BlurStyle::Normal,
+            14.0,
+            false,
+        ));
+        canvas.draw_rrect(
+            RRect::new_rect_xy(card.with_offset((0.0, 6.0)), 14.0, 14.0),
+            &paint,
+        );
+        paint.set_mask_filter(None);
+    }
 
-    // Filled in, not the translucent material: the material is meant to sit
-    // over the compositor's blur, and this card is inside the window's own
-    // surface with nothing behind it but the listing it is covering.
-    paint.set_color(content_ground());
+    // The translucent material when the compositor is blurring behind this
+    // surface, and filled in when the card is inside the window's own buffer:
+    // there the material would be a tint over the listing it is covering,
+    // with no blur underneath to justify it.
+    paint.set_color(if data.on_surface {
+        theme.material_popup
+    } else {
+        content_ground()
+    });
     canvas.draw_rrect(RRect::new_rect_xy(card, 14.0, 14.0), &paint);
 
     // The hairline is what says the card is above the listing rather than part

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2999,9 +2999,15 @@ pub const PALETTE_FIELD_H: f32 = 46.0;
 pub const PALETTE_ROW_H: f32 = 32.0;
 pub const PALETTE_HEADING_H: f32 = 26.0;
 pub const PALETTE_PAD: f32 = 8.0;
-/// How far down the window the card's top edge sits. Near the top rather than
-/// centred: what is being typed should not move when the list under it grows.
-pub const PALETTE_TOP: f32 = 64.0;
+/// How far down the window the card's top edge sits: just clear of the header,
+/// so the location and the view switcher stay readable behind it. Near the top
+/// rather than centred, so what is being typed does not move when the list
+/// under it grows.
+pub const PALETTE_TOP: f32 = HEADER_H + 6.0;
+/// How far the card's right edge sits from the window's. Nearly flush: the
+/// panel belongs to this window, and hanging it off the right keeps the
+/// sidebar and the first column in view beside it.
+pub const PALETTE_RIGHT_INSET: f32 = 12.0;
 /// The most rows on screen at once. Past this the list scrolls under the
 /// highlight — a card taller than this stops reading as a card.
 pub const PALETTE_MAX_ROWS: usize = 10;
@@ -3074,7 +3080,7 @@ fn palette_row_h(kind: PaletteRowKind) -> f32 {
 /// one-match query are not the same box.
 pub fn palette_rect(width: f32, rows: &[PaletteRow<'_>], message: bool) -> Rect {
     let w = PALETTE_W.min(width - 48.0).max(240.0);
-    let left = ((width - w) / 2.0).max(0.0);
+    let left = (width - w - PALETTE_RIGHT_INSET).max(0.0);
     let mut height = PALETTE_FIELD_H;
     let body: f32 = rows.iter().map(|row| palette_row_h(row.kind)).sum();
     if body > 0.0 || message {
@@ -6089,6 +6095,24 @@ mod geometry_tests {
     fn the_palette_window_stays_inside_the_list() {
         let window = palette_window(12, None, 99, 5);
         assert_eq!(window, 7..12);
+    }
+
+    /// The card hangs off the right edge, clear of the header.
+    #[test]
+    fn the_palette_sits_under_the_header_and_near_the_right_edge() {
+        let rows = [item("Copy")];
+        let card = palette_rect(1200.0, &rows, false);
+        assert!(card.top >= HEADER_H, "the header stays readable");
+        assert_eq!(card.right, 1200.0 - PALETTE_RIGHT_INSET);
+    }
+
+    /// A window too narrow for the card still gets one, hard against the left.
+    #[test]
+    fn a_narrow_window_still_gets_a_card() {
+        let rows = [item("Copy")];
+        let card = palette_rect(200.0, &rows, false);
+        assert!(card.left >= 0.0);
+        assert!(card.width() > 0.0);
     }
 
     /// The field does not move when the list under it grows: the card grows

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3140,7 +3140,7 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
 
     // A shadow rather than a dim over the window: the palette is not modal,
     // and dimming the listing behind it would say that it was.
-    paint.set_color(Color::from_argb(0x40, 0, 0, 0));
+    paint.set_color(theme.shadow);
     paint.set_mask_filter(skia_safe::MaskFilter::blur(
         skia_safe::BlurStyle::Normal,
         14.0,
@@ -3155,8 +3155,22 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
     // Filled in, not the translucent material: the material is meant to sit
     // over the compositor's blur, and this card is inside the window's own
     // surface with nothing behind it but the listing it is covering.
-    paint.set_color(opaque(panel_material()));
+    paint.set_color(content_ground());
     canvas.draw_rrect(RRect::new_rect_xy(card, 14.0, 14.0), &paint);
+
+    // The hairline is what says the card is above the listing rather than part
+    // of it: the ground is the same colour on both sides of the edge, exactly
+    // as it is around the Get Info panel. On its own surface the compositor
+    // draws this; here the card is inside the window's own buffer, so it is
+    // painted.
+    paint.set_color(theme.hairline());
+    paint.set_style(skia_safe::paint::Style::Stroke);
+    paint.set_stroke_width(Theme::HAIRLINE_WIDTH);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(card.with_inset((0.5, 0.5)), 14.0, 14.0),
+        &paint,
+    );
+    paint.set_style(skia_safe::paint::Style::Fill);
 
     let field = palette_field_rect(width);
     if let Some(prompt) = data.prompt {

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3271,9 +3271,11 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
     // The translucent material when the compositor is blurring behind this
     // surface, and filled in when the card is inside the window's own buffer:
     // there the material would be a tint over the listing it is covering,
-    // with no blur underneath to justify it.
+    // with no blur underneath to justify it. On a surface of its own it is
+    // still filled in wherever the compositor cannot frost a subsurface — see
+    // `Theme::card_material`.
     paint.set_color(if data.on_surface {
-        otto_kit::frosting::material(theme.material_popup)
+        otto_kit::frosting::material(theme.card_material())
     } else {
         content_ground()
     });
@@ -5015,6 +5017,22 @@ pub fn panel_material() -> Color {
     } else {
         Color::from_argb(0xF2, 0xFF, 0xFF, 0xFF)
     }
+}
+
+/// The chrome's material on a compositor with no blur at all.
+///
+/// [`opaque`] of [`panel_material`] is the content's own white, which is right
+/// for a moment — an unfocused window whose frost comes back on the next
+/// click — and wrong for good: sidebar, header and listing merge into one
+/// sheet. This is the toolkit's solid sidebar shade instead.
+pub fn solid_panel_material() -> Color {
+    let dark = matches!(current_color_scheme(), ColorScheme::Dark);
+    let mut theme = if dark {
+        Theme::dark_palette()
+    } else {
+        Theme::light_palette()
+    };
+    theme.with_solid_materials(dark).material_sidebar
 }
 
 pub fn row_colors(theme: &Theme, selected: bool) -> (Color, Color) {

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -1880,8 +1880,21 @@ pub fn path_crumb_at(
         .filter(|&index| crumbs[index].is_dir)
 }
 
+/// Where the strip's caption ends and the trail must stop: the bar's right
+/// edge less the caption and its padding, or the bar's right edge when there
+/// is no caption.
+pub fn path_bar_trail_right(bar: Rect, note: Option<&str>) -> f32 {
+    match note {
+        Some(note) => {
+            let width = styles::FOOTNOTE.font().measure_str(note, None).0;
+            bar.right - PATH_BAR_PAD - width - PATH_BAR_PAD
+        }
+        None => bar.right,
+    }
+}
+
 fn draw_path_bar(canvas: &Canvas, f: &Frame) {
-    if f.path_bar.is_empty() {
+    if f.path_bar.is_empty() && f.path_bar_note.is_none() {
         return;
     }
     let theme = f.theme;
@@ -1902,8 +1915,29 @@ fn draw_path_bar(canvas: &Canvas, f: &Frame) {
         &paint,
     );
 
+    // The selection count, at the trailing end, in the trail's quieter tone:
+    // a fact about the listing, not a step through it.
+    if let Some(note) = f.path_bar_note.as_deref() {
+        let width = styles::FOOTNOTE.font().measure_str(note, None).0;
+        Label::new(note)
+            .with_style(styles::FOOTNOTE)
+            .with_color(theme.text_secondary)
+            .centered_on(bar.right - PATH_BAR_PAD - width, bar.center_y())
+            .render(canvas);
+    }
+    if f.path_bar.is_empty() {
+        return;
+    }
+
     canvas.save();
-    canvas.clip_rect(bar, ClipOp::Intersect, true);
+    // The trail stops short of the caption rather than running under it.
+    let trail = Rect::from_ltrb(
+        bar.left,
+        bar.top,
+        path_bar_trail_right(bar, f.path_bar_note.as_deref()),
+        bar.bottom,
+    );
+    canvas.clip_rect(trail, ClipOp::Intersect, true);
 
     let last = f.path_bar.len() - 1;
     for (index, (crumb, rect)) in f.path_bar.iter().zip(&rects).enumerate() {
@@ -2679,6 +2713,9 @@ pub struct Frame<'a> {
     /// The crumb under the pointer, drawn lit — it leads somewhere, and a
     /// thing that can be clicked should say so before it is.
     pub path_crumb_hover: Option<usize>,
+    /// A caption at the strip's trailing end: how much is selected, while
+    /// anything is. The trail gives way to it rather than running under it.
+    pub path_bar_note: Option<String>,
 }
 
 impl Frame<'_> {
@@ -6419,6 +6456,18 @@ mod geometry_tests {
     /// The trail runs left to right in path order, each crumb clear of the
     /// one before it, and the whole row inside the strip it is drawn on.
     #[test]
+    fn the_trail_gives_way_to_the_selection_count() {
+        let bar = path_bar_rect(1100.0, 700.0, 0.0);
+        assert_eq!(path_bar_trail_right(bar, None), bar.right);
+        let with = path_bar_trail_right(bar, Some("3 of 61 selected"));
+        assert!(
+            with < bar.right - 60.0,
+            "the caption needs its width and padding"
+        );
+        assert!(with > bar.left, "the caption never eats the whole strip");
+    }
+
+    #[test]
     fn the_path_bar_lays_its_crumbs_out_in_order() {
         let crumbs = vec![
             crumb("/", true),
@@ -7071,6 +7120,7 @@ mod geometry_tests {
             path_bar: Vec::new(),
             path_bar_h: PATH_BAR_H,
             path_crumb_hover: None,
+            path_bar_note: None,
             path_entry: false,
             width: 1100.0,
             height,

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2447,6 +2447,23 @@ pub fn pane_content_height_in(
 /// the geometry a "scroll the cursor into view" needs; the other half is the
 /// pane's viewport height, from [`pane_viewport`].
 pub fn item_span(width: f32, height: f32, mode: ViewMode, index: usize) -> (f32, f32) {
+    item_span_in(width, height, mode, GridSections::FLAT, index)
+}
+
+/// [`item_span`] against a sectioned grid — Recent, whose day headings push
+/// every tile below them further down than the flat lattice says.
+pub fn item_span_in(
+    width: f32,
+    height: f32,
+    mode: ViewMode,
+    sections: &GridSections,
+    index: usize,
+) -> (f32, f32) {
+    if mode == ViewMode::Grid && !sections.is_flat() {
+        let area = content_viewport(width, height, mode);
+        let cell = grid_cell_rect_in(area, sections, index, 0.0);
+        return (cell.top - area.top, CELL_H);
+    }
     match mode {
         ViewMode::List => (index as f32 * ROW_H, ROW_H),
         // Miller rows start a little way down the pane.

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3273,7 +3273,7 @@ pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteDa
     // there the material would be a tint over the listing it is covering,
     // with no blur underneath to justify it.
     paint.set_color(if data.on_surface {
-        theme.material_popup
+        otto_kit::frosting::material(theme.material_popup)
     } else {
         content_ground()
     });

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -3057,10 +3057,11 @@ pub enum PaletteRowKind {
     /// Something that can be picked — a command, or an answer to an argument.
     Item,
     /// One line of a dry run: the row's title is what a thing would become,
-    /// its subtitle what it is now. Read, not picked. `conflict` says the
-    /// outcome is not possible as things stand, and the line is drawn to say
-    /// so.
-    Preview { conflict: bool },
+    /// its subtitle what it is now. Not picked, but toggled: a click or Space
+    /// leaves the thing out of the run. `conflict` says the outcome is not
+    /// possible as things stand, `excluded` that the line has been toggled
+    /// off; each is drawn to say so.
+    Preview { conflict: bool, excluded: bool },
 }
 
 /// One line of the palette's list, ready to draw.
@@ -3212,8 +3213,10 @@ pub fn palette_row_rect(width: f32, rows: &[PaletteRow<'_>], index: usize) -> Re
 pub fn palette_row_at(x: f32, y: f32, width: f32, rows: &[PaletteRow<'_>]) -> Option<usize> {
     let point = Point::new(x, y);
     (0..rows.len()).find(|&index| {
-        rows[index].kind == PaletteRowKind::Item
-            && palette_row_rect(width, rows, index).contains(point)
+        matches!(
+            rows[index].kind,
+            PaletteRowKind::Item | PaletteRowKind::Preview { .. }
+        ) && palette_row_rect(width, rows, index).contains(point)
     })
 }
 
@@ -3349,22 +3352,69 @@ fn draw_palette_rows(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteD
                 .render(canvas);
             continue;
         }
-        if let PaletteRowKind::Preview { conflict } = row.kind {
-            // "old → new": what it is, dimmed, then what it would become — in
-            // the palette's red when it cannot, so the one line that would
-            // stop the whole batch is the one that stands out.
+        if let PaletteRowKind::Preview { conflict, excluded } = row.kind {
+            // "● old → new": what it is, dimmed, then what it would become —
+            // in the palette's red when it cannot, so the one line that would
+            // stop the whole batch is the one that stands out. A line toggled
+            // out keeps only its name, struck through, behind a hollow mark.
+            if row.highlighted {
+                paint.set_color(accent(theme));
+                canvas.draw_rrect(RRect::new_rect_xy(rect, 7.0, 7.0), &paint);
+            }
+            let (strong, dim, red) = if row.highlighted {
+                (
+                    Color::WHITE,
+                    Color::from_argb(0xC8, 0xFF, 0xFF, 0xFF),
+                    Color::WHITE,
+                )
+            } else {
+                (theme.text_primary, theme.text_tertiary, theme.accent_red)
+            };
             let font = styles::BODY.font();
             let mut x = rect.left + 8.0;
+
+            // The mark: a disc for a line in the run, a ring for one left out.
+            let mark = Point::new(x + 4.0, rect.center_y());
+            let mut mark_paint = Paint::default();
+            mark_paint.set_anti_alias(true);
+            mark_paint.set_color(if excluded { dim } else { strong });
+            if excluded {
+                mark_paint.set_style(skia_safe::PaintStyle::Stroke);
+                mark_paint.set_stroke_width(1.5);
+                canvas.draw_circle(mark, 3.5, &mark_paint);
+            } else {
+                canvas.draw_circle(mark, 4.0, &mark_paint);
+            }
+            x += 8.0 + 10.0;
+
+            if excluded {
+                let name = row.subtitle.unwrap_or(row.title);
+                Label::new(name)
+                    .with_style(styles::BODY)
+                    .with_color(dim)
+                    .centered_on(x, rect.center_y())
+                    .render(canvas);
+                let advance = font.measure_str(name, None).0;
+                let mut strike = Paint::default();
+                strike.set_color(dim);
+                strike.set_stroke_width(1.0);
+                canvas.draw_line(
+                    Point::new(x, rect.center_y()),
+                    Point::new(x + advance, rect.center_y()),
+                    &strike,
+                );
+                continue;
+            }
             if let Some(from) = row.subtitle {
                 Label::new(from)
                     .with_style(styles::BODY)
-                    .with_color(theme.text_tertiary)
+                    .with_color(dim)
                     .centered_on(x, rect.center_y())
                     .render(canvas);
                 x += font.measure_str(from, None).0 + 8.0;
                 Label::new("→")
                     .with_style(styles::BODY)
-                    .with_color(theme.text_tertiary)
+                    .with_color(dim)
                     .centered_on(x, rect.center_y())
                     .render(canvas);
                 x += font.measure_str("→", None).0 + 8.0;
@@ -3375,11 +3425,7 @@ fn draw_palette_rows(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteD
                 } else {
                     styles::BODY
                 })
-                .with_color(if conflict {
-                    theme.accent_red
-                } else {
-                    theme.text_primary
-                })
+                .with_color(if conflict { red } else { strong })
                 .centered_on(x, rect.center_y())
                 .render(canvas);
             continue;
@@ -6251,10 +6297,13 @@ mod geometry_tests {
     }
 
     #[test]
-    fn a_dry_run_line_is_not_a_target_and_its_summary_sits_under_the_list() {
+    fn a_dry_run_line_can_be_hit_and_its_summary_sits_under_the_list() {
         let rows = vec![
             PaletteRow {
-                kind: PaletteRowKind::Preview { conflict: false },
+                kind: PaletteRowKind::Preview {
+                    conflict: false,
+                    excluded: false,
+                },
                 title: "Holiday 1.jpg",
                 badge: None,
                 subtitle: Some("IMG_001.jpg"),
@@ -6262,7 +6311,10 @@ mod geometry_tests {
                 highlighted: false,
             },
             PaletteRow {
-                kind: PaletteRowKind::Preview { conflict: true },
+                kind: PaletteRowKind::Preview {
+                    conflict: true,
+                    excluded: false,
+                },
                 title: "Holiday 2.jpg",
                 badge: None,
                 subtitle: Some("IMG_002.jpg"),
@@ -6270,10 +6322,11 @@ mod geometry_tests {
                 highlighted: false,
             },
         ];
-        let rect = palette_row_rect(1200.0, &rows, 0);
+        let rect = palette_row_rect(1200.0, &rows, 1);
         assert_eq!(
             palette_row_at(rect.center_x(), rect.center_y(), 1200.0, &rows),
-            None
+            Some(1),
+            "a line is something to toggle, so it is something to hit"
         );
         let bare = palette_rect(1200.0, &rows, false);
         let noted = palette_rect(1200.0, &rows, true);

--- a/components/otto-files/src/view.rs
+++ b/components/otto-files/src/view.rs
@@ -2985,6 +2985,277 @@ pub fn draw_confirm(
     );
 }
 
+// ---------------------------------------------------------------------------
+// The command palette
+// ---------------------------------------------------------------------------
+//
+// A card near the top of the window: a field, and under it either the
+// commands on offer or the answers to the argument being typed. Geometry
+// first, drawing second, so the hit test reads the same rects the paint does.
+// See `specs/file-command-palette.md`.
+
+pub const PALETTE_W: f32 = 560.0;
+pub const PALETTE_FIELD_H: f32 = 46.0;
+pub const PALETTE_ROW_H: f32 = 32.0;
+pub const PALETTE_HEADING_H: f32 = 26.0;
+pub const PALETTE_PAD: f32 = 8.0;
+/// How far down the window the card's top edge sits. Near the top rather than
+/// centred: what is being typed should not move when the list under it grows.
+pub const PALETTE_TOP: f32 = 64.0;
+/// The most rows on screen at once. Past this the list scrolls under the
+/// highlight — a card taller than this stops reading as a card.
+pub const PALETTE_MAX_ROWS: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaletteRowKind {
+    /// A group's name, in the resting list. Never highlighted.
+    Heading,
+    /// Something that can be picked — a command, or an answer to an argument.
+    Item,
+}
+
+/// One line of the palette's list, ready to draw.
+pub struct PaletteRow<'a> {
+    pub kind: PaletteRowKind,
+    pub title: &'a str,
+    /// The group a ranked row came from, or the argument a command will ask
+    /// for. Dim, right after the title.
+    pub badge: Option<&'a str>,
+    /// A second, dimmer fact — a place's path. Right-aligned.
+    pub subtitle: Option<&'a str>,
+    /// The chord this is also bound to. Right-aligned, dimmest.
+    pub shortcut: Option<&'a str>,
+    pub highlighted: bool,
+}
+
+/// What the palette is showing.
+pub struct PaletteData<'a> {
+    /// The non-editable prefix in front of the field, while an argument is
+    /// being answered.
+    pub prompt: Option<&'a str>,
+    pub rows: Vec<PaletteRow<'a>>,
+    /// Shown in place of the list: why the last attempt did not work, or that
+    /// nothing matches.
+    pub message: Option<&'a str>,
+}
+
+/// Which rows are on screen, given where the highlight is.
+///
+/// Scrolls by the least that puts the highlight back in view, so arrowing
+/// through a long list moves one row at a time rather than jumping a page.
+pub fn palette_window(
+    len: usize,
+    highlight: Option<usize>,
+    first: usize,
+    max: usize,
+) -> std::ops::Range<usize> {
+    if len <= max {
+        return 0..len;
+    }
+    let mut first = first.min(len - max);
+    if let Some(highlight) = highlight {
+        if highlight < first {
+            first = highlight;
+        } else if highlight >= first + max {
+            first = highlight + 1 - max;
+        }
+    }
+    first..(first + max).min(len)
+}
+
+fn palette_row_h(kind: PaletteRowKind) -> f32 {
+    match kind {
+        PaletteRowKind::Heading => PALETTE_HEADING_H,
+        PaletteRowKind::Item => PALETTE_ROW_H,
+    }
+}
+
+/// The card. Its height follows what is in it, so an empty query and a
+/// one-match query are not the same box.
+pub fn palette_rect(width: f32, rows: &[PaletteRow<'_>], message: bool) -> Rect {
+    let w = PALETTE_W.min(width - 48.0).max(240.0);
+    let left = ((width - w) / 2.0).max(0.0);
+    let mut height = PALETTE_FIELD_H;
+    let body: f32 = rows.iter().map(|row| palette_row_h(row.kind)).sum();
+    if body > 0.0 || message {
+        height += PALETTE_PAD * 2.0 + if message { PALETTE_ROW_H } else { body };
+    }
+    Rect::from_xywh(left, PALETTE_TOP, w, height)
+}
+
+/// The field, inset in the card's top band.
+///
+/// Independent of what is in the list: the card grows downwards, so the field
+/// does not move when the list under it does.
+pub fn palette_field_rect(width: f32) -> Rect {
+    let card = palette_rect(width, &[], false);
+    Rect::from_ltrb(
+        card.left + 14.0,
+        card.top,
+        card.right - 14.0,
+        card.top + PALETTE_FIELD_H,
+    )
+}
+
+/// Where row `index` of `rows` is drawn.
+pub fn palette_row_rect(width: f32, rows: &[PaletteRow<'_>], index: usize) -> Rect {
+    let card = palette_rect(width, rows, false);
+    let top: f32 = rows[..index]
+        .iter()
+        .map(|row| palette_row_h(row.kind))
+        .sum();
+    let y = card.top + PALETTE_FIELD_H + PALETTE_PAD + top;
+    Rect::from_xywh(
+        card.left + PALETTE_PAD,
+        y,
+        card.width() - PALETTE_PAD * 2.0,
+        palette_row_h(rows[index].kind),
+    )
+}
+
+/// Which row of the palette is under `(x, y)`, if any.
+///
+/// `None` covers both "the card, but not a row" and "outside the card
+/// altogether" — the caller tells them apart with [`palette_rect`], because
+/// only one of them closes the palette.
+pub fn palette_row_at(x: f32, y: f32, width: f32, rows: &[PaletteRow<'_>]) -> Option<usize> {
+    let point = Point::new(x, y);
+    (0..rows.len()).find(|&index| {
+        rows[index].kind == PaletteRowKind::Item
+            && palette_row_rect(width, rows, index).contains(point)
+    })
+}
+
+/// Draw the card over the finished window.
+///
+/// The field's *text* is not painted here — the text input owns its caret and
+/// selection and paints them itself, the same two-step the rename and path
+/// fields take. This draws the box it goes in.
+pub fn draw_palette(canvas: &Canvas, theme: &Theme, width: f32, data: &PaletteData<'_>) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    let message = data.message.is_some();
+    let card = palette_rect(width, &data.rows, message);
+
+    // A shadow rather than a dim over the window: the palette is not modal,
+    // and dimming the listing behind it would say that it was.
+    paint.set_color(Color::from_argb(0x40, 0, 0, 0));
+    paint.set_mask_filter(skia_safe::MaskFilter::blur(
+        skia_safe::BlurStyle::Normal,
+        14.0,
+        false,
+    ));
+    canvas.draw_rrect(
+        RRect::new_rect_xy(card.with_offset((0.0, 6.0)), 14.0, 14.0),
+        &paint,
+    );
+    paint.set_mask_filter(None);
+
+    // Filled in, not the translucent material: the material is meant to sit
+    // over the compositor's blur, and this card is inside the window's own
+    // surface with nothing behind it but the listing it is covering.
+    paint.set_color(opaque(panel_material()));
+    canvas.draw_rrect(RRect::new_rect_xy(card, 14.0, 14.0), &paint);
+
+    let field = palette_field_rect(width);
+    if let Some(prompt) = data.prompt {
+        Label::new(prompt)
+            .with_style(styles::BODY_EMPHASIZED)
+            .with_color(theme.text_secondary)
+            .centered_on(field.left, field.center_y())
+            .render(canvas);
+    }
+
+    // The hairline under the field, drawn only when there is something below
+    // it to be separated from.
+    if !data.rows.is_empty() || message {
+        paint.set_color(theme.fill_tertiary);
+        paint.set_stroke_width(1.0);
+        canvas.draw_line(
+            Point::new(card.left, card.top + PALETTE_FIELD_H),
+            Point::new(card.right, card.top + PALETTE_FIELD_H),
+            &paint,
+        );
+    }
+
+    if let Some(message) = data.message {
+        Label::new(message)
+            .with_style(styles::BODY)
+            .with_color(theme.text_secondary)
+            .centered_on(
+                card.left + PALETTE_PAD + 8.0,
+                card.top + PALETTE_FIELD_H + PALETTE_PAD + PALETTE_ROW_H / 2.0,
+            )
+            .render(canvas);
+        return;
+    }
+
+    for (index, row) in data.rows.iter().enumerate() {
+        let rect = palette_row_rect(width, &data.rows, index);
+        if row.kind == PaletteRowKind::Heading {
+            Label::new(row.title)
+                .with_style(styles::FOOTNOTE_EMPHASIZED)
+                .with_color(theme.text_tertiary)
+                .centered_on(rect.left + 8.0, rect.center_y() + 3.0)
+                .render(canvas);
+            continue;
+        }
+
+        if row.highlighted {
+            paint.set_color(accent(theme));
+            canvas.draw_rrect(RRect::new_rect_xy(rect, 7.0, 7.0), &paint);
+        }
+        let (title_color, dim_color) = if row.highlighted {
+            (Color::WHITE, Color::from_argb(0xC8, 0xFF, 0xFF, 0xFF))
+        } else {
+            (theme.text_primary, theme.text_tertiary)
+        };
+
+        let title_x = rect.left + 8.0;
+        Label::new(row.title)
+            .with_style(styles::BODY)
+            .with_color(title_color)
+            .centered_on(title_x, rect.center_y())
+            .render(canvas);
+
+        if let Some(badge) = row.badge {
+            let advance = styles::BODY.font().measure_str(row.title, None).0;
+            Label::new(badge)
+                .with_style(styles::FOOTNOTE)
+                .with_color(dim_color)
+                .centered_on(title_x + advance + 10.0, rect.center_y() + 1.0)
+                .render(canvas);
+        }
+
+        // The right edge, filled from the outside in: the shortcut hard
+        // against it, then whatever second fact the row has.
+        let mut right = rect.right - 8.0;
+        if let Some(shortcut) = row.shortcut {
+            let advance = styles::FOOTNOTE.font().measure_str(shortcut, None).0;
+            Label::new(shortcut)
+                .with_style(styles::FOOTNOTE)
+                .with_color(dim_color)
+                .centered_on(right - advance, rect.center_y() + 1.0)
+                .render(canvas);
+            right -= advance + 12.0;
+        }
+        if let Some(subtitle) = row.subtitle {
+            let font = styles::FOOTNOTE.font();
+            let available = right - title_x - 120.0;
+            if available > 40.0 {
+                let text = ellipsize(&font, subtitle, available);
+                let advance = font.measure_str(&text, None).0;
+                Label::new(text)
+                    .with_style(styles::FOOTNOTE)
+                    .with_color(dim_color)
+                    .centered_on(right - advance, rect.center_y() + 1.0)
+                    .render(canvas);
+            }
+        }
+    }
+}
+
 /// The preview pane's content, as a closure the scene records into its own
 /// layer's cached picture.
 ///
@@ -4424,6 +4695,19 @@ pub fn save_field_style(theme: Theme) -> TextInputStyle {
 
 /// The path entry's field. Like the save field, the box is drawn by the
 /// header underneath, so the input paints no ground of its own.
+/// The palette's field: bare, like the location bar's, and a size up — it is
+/// the thing being looked at while the panel is open.
+pub fn palette_field_style(theme: Theme) -> TextInputStyle {
+    let mut style = TextInputStyle::with_theme(theme);
+    style.background = Color::TRANSPARENT;
+    // No ring: the card is the focus, and a box drawn inside a box that is
+    // already the only thing taking keys says nothing.
+    style.focus_ring_width = 0.0;
+    style.horizontal_padding = 0.0;
+    style.text_style = styles::TITLE_3;
+    style
+}
+
 pub fn path_field_style(theme: Theme) -> TextInputStyle {
     let mut style = TextInputStyle::with_theme(theme);
     style.background = Color::TRANSPARENT;
@@ -5753,6 +6037,75 @@ mod fit_tests {
 
 #[cfg(test)]
 mod geometry_tests {
+    fn item(title: &str) -> PaletteRow<'_> {
+        PaletteRow {
+            kind: PaletteRowKind::Item,
+            title,
+            badge: None,
+            subtitle: None,
+            shortcut: None,
+            highlighted: false,
+        }
+    }
+
+    /// A short list is all on screen, and does not scroll at all.
+    #[test]
+    fn a_short_palette_list_does_not_scroll() {
+        assert_eq!(palette_window(4, Some(3), 0, PALETTE_MAX_ROWS), 0..4);
+    }
+
+    /// A long one scrolls by the least that brings the highlight back — one
+    /// row per arrow key, not a page.
+    #[test]
+    fn the_palette_scrolls_the_least_that_shows_the_highlight() {
+        let max = 5;
+        assert_eq!(palette_window(20, Some(4), 0, max), 0..5);
+        assert_eq!(palette_window(20, Some(5), 0, max), 1..6);
+        assert_eq!(palette_window(20, Some(6), 1, max), 2..7);
+        // Back up, and it scrolls the other way by one.
+        assert_eq!(palette_window(20, Some(1), 2, max), 1..6);
+    }
+
+    /// The window never runs off the end, however far the remembered scroll is.
+    #[test]
+    fn the_palette_window_stays_inside_the_list() {
+        let window = palette_window(12, None, 99, 5);
+        assert_eq!(window, 7..12);
+    }
+
+    /// The field does not move when the list under it grows: the card grows
+    /// downwards, so what is being typed stays put.
+    #[test]
+    fn the_palette_field_does_not_move_with_the_list() {
+        let empty = palette_field_rect(900.0);
+        let rows = [item("Copy"), item("Paste"), item("Undo")];
+        let card = palette_rect(900.0, &rows, false);
+        assert_eq!(palette_field_rect(900.0), empty);
+        assert!(card.bottom > empty.bottom, "the card grows downwards");
+    }
+
+    /// A heading is read, never clicked.
+    #[test]
+    fn a_palette_heading_is_not_a_target() {
+        let rows = [
+            PaletteRow {
+                kind: PaletteRowKind::Heading,
+                ..item("Go")
+            },
+            item("Up"),
+        ];
+        let heading = palette_row_rect(900.0, &rows, 0);
+        assert_eq!(
+            palette_row_at(heading.center_x(), heading.center_y(), 900.0, &rows),
+            None
+        );
+        let row = palette_row_rect(900.0, &rows, 1);
+        assert_eq!(
+            palette_row_at(row.center_x(), row.center_y(), 900.0, &rows),
+            Some(1)
+        );
+    }
+
     use super::*;
 
     /// The search field shares the header's trailing edge with the view

--- a/components/otto-kit/src/app_runner/context.rs
+++ b/components/otto-kit/src/app_runner/context.rs
@@ -288,6 +288,9 @@ pub struct AppContextData {
     pub data_device_manager:
         Option<smithay_client_toolkit::data_device_manager::DataDeviceManagerState>,
     pub data_device: Option<smithay_client_toolkit::data_device_manager::data_device::DataDevice>,
+    /// `ext_background_effect_manager_v1`, the blur a compositor without
+    /// Otto's surface style may still offer. See [`crate::backdrop`].
+    pub(crate) background_effect: Option<crate::backdrop::Binding>,
     pub display_ptr: *mut std::ffi::c_void,
 }
 
@@ -425,6 +428,16 @@ impl<'a> AppContext<'a> {
                 .fractional_scale_manager
                 .as_ref()
                 .map(|r| &*(r as *const WpFractionalScaleManagerV1))
+        })
+    }
+
+    pub fn background_effect_manager() -> Option<&'static wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1>{
+        use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1;
+        Self::with_global(|ctx| unsafe {
+            ctx.data
+                .background_effect
+                .as_ref()
+                .map(|binding| &*(&binding.manager as *const ExtBackgroundEffectManagerV1))
         })
     }
 

--- a/components/otto-kit/src/app_runner/mod.rs
+++ b/components/otto-kit/src/app_runner/mod.rs
@@ -546,6 +546,11 @@ impl<A: App + 'static> AppRunnerWithType<A> {
         // Binding at 3 is what the hold hooks need, and a compositor offering
         // less simply leaves both unbound rather than half-working.
         let pointer_gestures: Option<ZwpPointerGesturesV1> = globals.bind(&qh, 3..=3, ()).ok();
+        // Which blur the materials can count on — Otto's surface style, the
+        // standard background effect, or none — settled before any surface
+        // or theme is made.
+        let background_effect =
+            crate::backdrop::init(&conn, &globals, surface_style_manager.is_some());
 
         // Get display pointer for creating surfaces
         let display_ptr = conn.backend().display_ptr() as *mut std::ffi::c_void;
@@ -584,6 +589,7 @@ impl<A: App + 'static> AppRunnerWithType<A> {
             pointer_gestures,
             data_device_manager,
             data_device: None,
+            background_effect,
             display_ptr,
         });
 
@@ -1903,6 +1909,7 @@ wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_pr
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore ZwpPointerGesturesV1);
+wayland_client::delegate_noop!(@<A: App + 'static> AppData<A>: ignore wayland_protocols::ext::background_effect::v1::client::ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1);
 
 impl<A: App + 'static> Dispatch<ZwpPointerGesturePinchV1, ()> for AppData<A> {
     fn event(

--- a/components/otto-kit/src/backdrop.rs
+++ b/components/otto-kit/src/backdrop.rs
@@ -137,7 +137,11 @@ pub(crate) struct Binding {
 /// The manager is bound on a queue of its own so its capabilities can be read
 /// with a roundtrip before the application is ready, without dispatching
 /// anything of the application's early.
-pub(crate) fn init(conn: &Connection, globals: &GlobalList, surface_style: bool) -> Option<Binding> {
+pub(crate) fn init(
+    conn: &Connection,
+    globals: &GlobalList,
+    surface_style: bool,
+) -> Option<Binding> {
     let mut queue = conn.new_event_queue::<Probe>();
     let qh = queue.handle();
     let manager = globals
@@ -277,11 +281,17 @@ mod tests {
 
     #[test]
     fn the_override_only_steps_down() {
-        assert_eq!(resolve(true, true, Some("effect")), Backdrop::BackgroundEffect);
+        assert_eq!(
+            resolve(true, true, Some("effect")),
+            Backdrop::BackgroundEffect
+        );
         assert_eq!(resolve(true, false, Some("effect")), Backdrop::None);
         assert_eq!(resolve(false, true, Some("none")), Backdrop::None);
         assert_eq!(resolve(false, false, Some("effect")), Backdrop::None);
-        assert_eq!(resolve(false, true, Some("style")), Backdrop::BackgroundEffect);
+        assert_eq!(
+            resolve(false, true, Some("style")),
+            Backdrop::BackgroundEffect
+        );
     }
 
     #[test]

--- a/components/otto-kit/src/backdrop.rs
+++ b/components/otto-kit/src/backdrop.rs
@@ -1,0 +1,309 @@
+//! What the compositor can put behind a translucent surface.
+//!
+//! The toolkit's materials are translucent by design: they are meant to tint a
+//! blurred backdrop, not the bare pixels behind a window. Otto blurs through
+//! `otto_surface_style_v1`. Other compositors — KWin among them — offer the
+//! standard `ext_background_effect_v1`, which blurs a region of a surface and
+//! does nothing else: no tint, no rounding, no shadow. A compositor with
+//! neither has nothing to be translucent over, and the materials are filled in
+//! instead (see [`crate::theme::Theme::light`]).
+//!
+//! Decided once, at connection time, like the display scale: a surface picks
+//! its material when it is created and does not re-derive it later.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use wayland_client::backend::ObjectId;
+use wayland_client::globals::GlobalList;
+use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum};
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1::{self, ExtBackgroundEffectManagerV1},
+    ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
+};
+
+use crate::app_runner::AppContext;
+
+/// Where a translucent material gets its blur from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backdrop {
+    /// Otto's `otto_surface_style_v1`: blur, tint, corners and shadow.
+    SurfaceStyle,
+    /// The standard `ext_background_effect_v1`: blur behind a region, and
+    /// nothing else.
+    BackgroundEffect,
+    /// No blur at all. Materials are opaque.
+    None,
+}
+
+const UNKNOWN: u8 = 0;
+const SURFACE_STYLE: u8 = 1;
+const BACKGROUND_EFFECT: u8 = 2;
+const NONE: u8 = 3;
+
+static BACKDROP: AtomicU8 = AtomicU8::new(UNKNOWN);
+
+/// The backdrop this client settled on when it connected.
+///
+/// Before a connection — unit tests, a theme built at startup — this answers
+/// [`Backdrop::SurfaceStyle`], so nothing changes for code that never talks
+/// to a compositor.
+pub fn current() -> Backdrop {
+    match BACKDROP.load(Ordering::Relaxed) {
+        BACKGROUND_EFFECT => Backdrop::BackgroundEffect,
+        NONE => Backdrop::None,
+        _ => Backdrop::SurfaceStyle,
+    }
+}
+
+/// Whether anything will blur behind a translucent material.
+pub fn blur_available() -> bool {
+    current() != Backdrop::None
+}
+
+/// Whether a subsurface can be frosted over its own window.
+///
+/// Only Otto's surface style blurs what is directly under a subsurface. The
+/// standard background effect blurs behind the *window*: KWin composites the
+/// blur first and the whole surface tree over it, so a translucent card on a
+/// subsurface shows the window's own content through it, sharp.
+pub fn blurs_behind_subsurfaces() -> bool {
+    current() == Backdrop::SurfaceStyle
+}
+
+/// Pick the backdrop from what the compositor offers.
+///
+/// `OTTO_KIT_BACKDROP=effect|none` steps down from what is there, to look at a
+/// fallback on a compositor that would otherwise not use it. It never steps
+/// up: asking for `effect` where the global is missing still gets `none`.
+fn resolve(surface_style: bool, effect_blur: bool, requested: Option<&str>) -> Backdrop {
+    let offered = if surface_style {
+        Backdrop::SurfaceStyle
+    } else if effect_blur {
+        Backdrop::BackgroundEffect
+    } else {
+        Backdrop::None
+    };
+    match requested {
+        Some("none") => Backdrop::None,
+        Some("effect") if offered == Backdrop::SurfaceStyle => {
+            if effect_blur {
+                Backdrop::BackgroundEffect
+            } else {
+                Backdrop::None
+            }
+        }
+        _ => offered,
+    }
+}
+
+/// Collects the manager's capabilities during the startup roundtrip.
+#[derive(Default)]
+pub(crate) struct Probe {
+    blur: bool,
+}
+
+impl Dispatch<ExtBackgroundEffectManagerV1, ()> for Probe {
+    fn event(
+        state: &mut Self,
+        _: &ExtBackgroundEffectManagerV1,
+        event: ext_background_effect_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            state.blur = match flags {
+                WEnum::Value(flags) => {
+                    flags.contains(ext_background_effect_manager_v1::Capability::Blur)
+                }
+                WEnum::Unknown(bits) => bits & 1 != 0,
+            };
+        }
+    }
+}
+
+/// What the connection holds on to: the manager, and the queue its events
+/// arrive on, kept alive so a later capability change has somewhere to land.
+pub(crate) struct Binding {
+    pub manager: ExtBackgroundEffectManagerV1,
+    _queue: EventQueue<Probe>,
+}
+
+/// Bind `ext_background_effect_manager_v1` and settle [`current`].
+///
+/// The manager is bound on a queue of its own so its capabilities can be read
+/// with a roundtrip before the application is ready, without dispatching
+/// anything of the application's early.
+pub(crate) fn init(conn: &Connection, globals: &GlobalList, surface_style: bool) -> Option<Binding> {
+    let mut queue = conn.new_event_queue::<Probe>();
+    let qh = queue.handle();
+    let manager = globals
+        .bind::<ExtBackgroundEffectManagerV1, _, _>(&qh, 1..=1, ())
+        .ok();
+    // The capabilities are sent on bind; one roundtrip is enough to have them.
+    let mut probe = Probe::default();
+    if manager.is_some() {
+        let _ = queue.roundtrip(&mut probe);
+    }
+    let requested = std::env::var("OTTO_KIT_BACKDROP").ok();
+    let backdrop = resolve(surface_style, probe.blur, requested.as_deref());
+    store(backdrop);
+    tracing::debug!(?backdrop, "backdrop");
+    manager.map(|manager| Binding {
+        manager,
+        _queue: queue,
+    })
+}
+
+fn store(backdrop: Backdrop) {
+    BACKDROP.store(
+        match backdrop {
+            Backdrop::SurfaceStyle => SURFACE_STYLE,
+            Backdrop::BackgroundEffect => BACKGROUND_EFFECT,
+            Backdrop::None => NONE,
+        },
+        Ordering::Relaxed,
+    );
+}
+
+/// The part of a surface to blur behind, in surface-local points.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BlurShape {
+    /// All of it. The compositor clips the region to the surface.
+    Whole,
+    /// A rounded rectangle — a card inside a surface that also carries its
+    /// margin.
+    RoundedRect {
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        radius: f32,
+    },
+}
+
+impl BlurShape {
+    /// The shape as the rectangles a `wl_region` is made of.
+    ///
+    /// A region cannot be round, so the corners are stepped a row at a time.
+    /// Blurring a square corner would show as a faint frosted tab outside the
+    /// card's painted rounding.
+    pub fn rects(&self) -> Vec<(i32, i32, i32, i32)> {
+        match *self {
+            BlurShape::Whole => vec![(0, 0, i32::MAX / 2, i32::MAX / 2)],
+            BlurShape::RoundedRect {
+                x,
+                y,
+                width,
+                height,
+                radius,
+            } => {
+                let (x, y) = (x.round() as i32, y.round() as i32);
+                let (w, h) = (width.round() as i32, height.round() as i32);
+                let r = (radius.round() as i32).clamp(0, w.min(h) / 2);
+                let mut rects = Vec::with_capacity(2 * r as usize + 1);
+                for row in 0..r {
+                    let dy = r as f32 - row as f32 - 0.5;
+                    let inset = r - ((r * r) as f32 - dy * dy).max(0.0).sqrt().round() as i32;
+                    let span = w - 2 * inset;
+                    if span > 0 {
+                        rects.push((x + inset, y + row, span, 1));
+                        rects.push((x + inset, y + h - 1 - row, span, 1));
+                    }
+                }
+                if h - 2 * r > 0 {
+                    rects.push((x, y + r, w, h - 2 * r));
+                }
+                rects
+            }
+        }
+    }
+}
+
+thread_local! {
+    /// One effect object per surface — the protocol allows no more.
+    static EFFECTS: RefCell<HashMap<ObjectId, ExtBackgroundEffectSurfaceV1>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Blur behind `shape` of `surface`, or stop blurring with `None`.
+///
+/// Only acts under [`Backdrop::BackgroundEffect`]; Otto's surfaces carry their
+/// blur on the surface style. Double-buffered: it lands with the surface's
+/// next commit, which is the caller's.
+pub fn set_blur(surface: &WlSurface, shape: Option<BlurShape>) {
+    if current() != Backdrop::BackgroundEffect {
+        return;
+    }
+    let Some(manager) = AppContext::background_effect_manager() else {
+        return;
+    };
+    let qh = AppContext::queue_handle();
+    EFFECTS.with(|effects| {
+        let mut effects = effects.borrow_mut();
+        effects.retain(|_, effect| effect.is_alive());
+        let effect = effects
+            .entry(surface.id())
+            .or_insert_with(|| manager.get_background_effect(surface, qh, ()));
+        match shape {
+            Some(shape) => {
+                let region = AppContext::compositor_state()
+                    .wl_compositor()
+                    .create_region(qh, ());
+                for (x, y, w, h) in shape.rects() {
+                    region.add(x, y, w, h);
+                }
+                effect.set_blur_region(Some(&region));
+                region.destroy();
+            }
+            None => effect.set_blur_region(None),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_the_surface_style() {
+        assert_eq!(resolve(true, true, None), Backdrop::SurfaceStyle);
+        assert_eq!(resolve(false, true, None), Backdrop::BackgroundEffect);
+        assert_eq!(resolve(false, false, None), Backdrop::None);
+    }
+
+    #[test]
+    fn the_override_only_steps_down() {
+        assert_eq!(resolve(true, true, Some("effect")), Backdrop::BackgroundEffect);
+        assert_eq!(resolve(true, false, Some("effect")), Backdrop::None);
+        assert_eq!(resolve(false, true, Some("none")), Backdrop::None);
+        assert_eq!(resolve(false, false, Some("effect")), Backdrop::None);
+        assert_eq!(resolve(false, true, Some("style")), Backdrop::BackgroundEffect);
+    }
+
+    #[test]
+    fn a_rounded_region_stays_inside_its_card() {
+        let shape = BlurShape::RoundedRect {
+            x: 10.0,
+            y: 20.0,
+            width: 100.0,
+            height: 60.0,
+            radius: 14.0,
+        };
+        let rects = shape.rects();
+        let area: i32 = rects.iter().map(|&(_, _, w, h)| w * h).sum();
+        // Less than the square card by roughly the four corners' (1 - π/4)r².
+        let square = 100 * 60;
+        let corners = (4.0 * (1.0 - std::f32::consts::FRAC_PI_4) * 14.0 * 14.0) as i32;
+        assert!((square - corners - area).abs() < 60, "area {area}");
+        for &(x, y, w, h) in &rects {
+            assert!(x >= 10 && y >= 20 && x + w <= 110 && y + h <= 80);
+        }
+        // The very first row is inset, the middle band is full width.
+        assert!(rects[0].0 > 10);
+        assert!(rects.iter().any(|&(x, _, w, _)| x == 10 && w == 100));
+    }
+}

--- a/components/otto-kit/src/components/context_menu/context_menu.rs
+++ b/components/otto-kit/src/components/context_menu/context_menu.rs
@@ -1452,36 +1452,51 @@ impl ContextMenu {
     // === Utilities ===
 
     fn apply_surface_effects(style: &ContextMenuStyle, popup: &PopupSurface) {
-        if let Some(scene_surface) = popup.base_surface().surface_style() {
-            // The renderer already paints `style.background_color()` into the
-            // buffer. Setting it on the scene layer as well composites it
-            // twice, so a translucent material lands far more opaque than the
-            // same menu drawn compositor-side (the dock's).
-            // Shadow geometry is in physical pixels, so it scales with the
-            // output; values match the compositor-side menus (the dock's) so a
-            // menu looks the same wherever it is drawn. The corner radius does
-            // NOT get scaled here — it has to agree with the rounding the
-            // renderer paints into the buffer, and scaling it makes the bar's
-            // menus visibly rounder than the dock's.
-            let scale = crate::app_runner::context::AppContext::fractional_scale();
-            let shadow = style.theme.shadow;
-            scene_surface.set_corner_radius(style.corner_radius as f64);
-            scene_surface.set_masks_to_bounds(ClipMode::Enabled);
-            scene_surface.set_shadow(
-                shadow.a() as f64 / 255.0,
-                16.0 * scale,
-                0.0,
-                4.0 * scale,
-                shadow.r() as f64 / 255.0,
-                shadow.g() as f64 / 255.0,
-                shadow.b() as f64 / 255.0,
+        let Some(scene_surface) = popup.base_surface().surface_style() else {
+            // Without Otto's surface style the menu paints its own rounded
+            // body, and the most another compositor can add is the blur
+            // behind it — following that rounding, not the square surface.
+            let (width, height) = popup.base_surface().size();
+            crate::backdrop::set_blur(
+                popup.wl_surface(),
+                Some(crate::backdrop::BlurShape::RoundedRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: width as f32,
+                    height: height as f32,
+                    radius: style.corner_radius,
+                }),
             );
-            scene_surface.set_blend_mode(if crate::frosting::enabled() {
-                BlendMode::BackgroundBlur
-            } else {
-                BlendMode::Normal
-            });
-        }
+            return;
+        };
+        // The renderer already paints `style.background_color()` into the
+        // buffer. Setting it on the scene layer as well composites it
+        // twice, so a translucent material lands far more opaque than the
+        // same menu drawn compositor-side (the dock's).
+        // Shadow geometry is in physical pixels, so it scales with the
+        // output; values match the compositor-side menus (the dock's) so a
+        // menu looks the same wherever it is drawn. The corner radius does
+        // NOT get scaled here — it has to agree with the rounding the
+        // renderer paints into the buffer, and scaling it makes the bar's
+        // menus visibly rounder than the dock's.
+        let scale = crate::app_runner::context::AppContext::fractional_scale();
+        let shadow = style.theme.shadow;
+        scene_surface.set_corner_radius(style.corner_radius as f64);
+        scene_surface.set_masks_to_bounds(ClipMode::Enabled);
+        scene_surface.set_shadow(
+            shadow.a() as f64 / 255.0,
+            16.0 * scale,
+            0.0,
+            4.0 * scale,
+            shadow.r() as f64 / 255.0,
+            shadow.g() as f64 / 255.0,
+            shadow.b() as f64 / 255.0,
+        );
+        scene_surface.set_blend_mode(if crate::frosting::enabled() {
+            BlendMode::BackgroundBlur
+        } else {
+            BlendMode::Normal
+        });
     }
 
     // === State Access ===

--- a/components/otto-kit/src/components/window/mod.rs
+++ b/components/otto-kit/src/components/window/mod.rs
@@ -306,15 +306,39 @@ impl Window {
     /// all: under a compositor that carries no surface style, or with the blur
     /// switched off, this does nothing.
     pub fn set_frost(&self, frosted: bool) {
+        let frosted = frosted && self.blur_wanted.load(Ordering::Relaxed);
         let Some(style) = self.surface_style() else {
+            if self.frosted.swap(frosted, Ordering::Relaxed) != frosted {
+                self.set_effect_blur(frosted);
+            }
             return;
         };
-        let frosted =
-            frosted && self.blur_wanted.load(Ordering::Relaxed) && crate::frosting::enabled();
+        let frosted = frosted && crate::frosting::enabled();
         if self.frosted.swap(frosted, Ordering::Relaxed) == frosted {
             return;
         }
         self.set_blend_mode(&style, frosted);
+    }
+
+    /// The frost on a compositor without Otto's surface style, through
+    /// `ext_background_effect_v1` where it is offered. There is no tint and no
+    /// fade on that side: the application's materials are painted into the
+    /// buffer, so the blur is all there is to switch.
+    ///
+    /// Committed here, because the region only lands with a commit and a
+    /// window whose blur changes need not have anything new to draw.
+    fn set_effect_blur(&self, frosted: bool) {
+        if crate::backdrop::current() != crate::backdrop::Backdrop::BackgroundEffect {
+            return;
+        }
+        let Some(surface) = self.wl_surface() else {
+            return;
+        };
+        crate::backdrop::set_blur(
+            &surface,
+            frosted.then_some(crate::backdrop::BlurShape::Whole),
+        );
+        surface.commit();
     }
 
     /// The colour the compositor tints the frost with.
@@ -357,6 +381,13 @@ impl Window {
     /// Either way the opaque tint is the cover the blur is switched under.
     fn update_material(&self, animate: bool) {
         let Some(style) = self.surface_style() else {
+            // The material is painted into the buffer here, so all that
+            // follows focus is the blur, and — for a window that fades its own
+            // materials — only its arrival: the application times the leaving.
+            let frost = self.wants_frost();
+            if frost || !self.fades_own_material.load(Ordering::Relaxed) {
+                self.set_frost(frost);
+            }
             return;
         };
         let Some(material) = self.material.read().ok().and_then(|m| *m) else {

--- a/components/otto-kit/src/icon_theme.rs
+++ b/components/otto-kit/src/icon_theme.rs
@@ -1,11 +1,23 @@
-//! Icon theme detection via the freedesktop Settings portal.
+//! Icon theme detection.
 //!
-//! Queries `org.freedesktop.appearance icon-theme` on startup and watches for
-//! `SettingChanged` signals, keeping a global string up to date.
+//! Otto publishes its icon theme as `org.freedesktop.appearance icon-theme` on
+//! the settings portal. That key is Otto's own: neither the KDE nor the GNOME
+//! portal sets it, and an empty theme name makes every lookup search `hicolor`
+//! alone — which ships no `folder` and no mimetype icons, so a file listing
+//! draws without any. Under another desktop the theme is taken from where that
+//! desktop keeps it instead:
 //!
-//! Any otto-kit app gets the compositor's configured icon theme via
-//! `current_icon_theme()`.
+//! 1. the portal's `org.freedesktop.appearance icon-theme` (Otto);
+//! 2. the portal's desktop namespaces — `org.gnome.desktop.interface
+//!    icon-theme` (GNOME), `org.kde.kdeglobals.Icons Theme` (Plasma);
+//! 3. the files those desktops write — `kdeglobals`, GTK's `settings.ini` —
+//!    read synchronously at startup, so the first frame already has icons;
+//! 4. the first of Breeze or Adwaita that is installed.
+//!
+//! A theme is only taken if it is actually installed. Any otto-kit app gets the
+//! result through `current_icon_theme()`.
 
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, RwLock};
 use zbus::zvariant::{OwnedValue, Value};
 
@@ -24,8 +36,24 @@ pub fn current_icon_theme() -> Option<String> {
     }
 }
 
-/// Spawn a background tokio task that:
-/// 1. Reads the initial `icon-theme` from the XDG Settings portal.
+/// Replace the theme, dropping every icon resolved against the old one.
+fn set_theme(theme: String) {
+    {
+        let mut current = ICON_THEME.write().unwrap();
+        if *current == theme {
+            return;
+        }
+        *current = theme;
+    }
+    // Every cached icon — and every cached miss — answers for the theme that
+    // has just been replaced.
+    crate::icons::clear_cache();
+    crate::portal_runtime::theme_changed();
+}
+
+/// Settle on a theme from the desktop's own files, and spawn a background task
+/// that:
+/// 1. Reads the theme from the XDG Settings portal.
 /// 2. Subscribes to `SettingChanged` and updates the value on every change.
 ///
 /// Safe to call multiple times — only one watcher is ever active.
@@ -34,6 +62,14 @@ pub fn spawn_icon_theme_watcher() {
     static STARTED: LazyLock<AtomicBool> = LazyLock::new(|| AtomicBool::new(false));
     if STARTED.swap(true, Ordering::SeqCst) {
         return;
+    }
+
+    // Before the portal answers — and in place of it, where there is none.
+    if current_icon_theme().is_none() {
+        if let Some(theme) = desktop_file_theme().or_else(installed_default_theme) {
+            tracing::debug!("icon-theme from the desktop's files: {theme}");
+            set_theme(theme);
+        }
     }
 
     crate::portal_runtime::spawn("icon-theme-watcher", async move {
@@ -51,6 +87,14 @@ fn extract_string(val: Value<'_>) -> Option<String> {
         _ => None,
     }
 }
+
+/// Where the portal carries an icon theme, most specific first. Otto's key
+/// wins over a desktop's own wherever both are answered.
+const PORTAL_KEYS: [(&str, &str); 3] = [
+    ("org.freedesktop.appearance", "icon-theme"),
+    ("org.gnome.desktop.interface", "icon-theme"),
+    ("org.kde.kdeglobals.Icons", "Theme"),
+];
 
 async fn run_watcher() -> Result<(), zbus::Error> {
     use zbus::{proxy, Connection};
@@ -70,20 +114,22 @@ async fn run_watcher() -> Result<(), zbus::Error> {
     let conn = Connection::session().await?;
     let proxy = SettingsProxy::new(&conn).await?;
 
-    // Read initial value.
-    match proxy.read("org.freedesktop.appearance", "icon-theme").await {
-        Ok(owned) => {
-            let val: Value<'_> = owned.into();
-            if let Some(theme) = extract_string(val) {
-                tracing::debug!("icon-theme initial value: {theme}");
-                *ICON_THEME.write().unwrap() = theme;
-                // Anything resolved before the portal answered was looked up
-                // in whatever theme the lookup crate picked for itself.
-                crate::icons::clear_cache();
-                crate::portal_runtime::theme_changed();
+    // The rank of the key the current theme came from; a change under a less
+    // specific key does not override a more specific one.
+    let mut source = PORTAL_KEYS.len();
+    for (rank, (namespace, key)) in PORTAL_KEYS.iter().enumerate() {
+        match proxy.read(namespace, key).await {
+            Ok(owned) => {
+                let val: Value<'_> = owned.into();
+                if let Some(theme) = extract_string(val).filter(|t| is_installed(t)) {
+                    tracing::debug!("icon-theme initial value from {namespace}: {theme}");
+                    set_theme(theme);
+                    source = rank;
+                    break;
+                }
             }
+            Err(e) => tracing::debug!("icon-theme read of {namespace} failed: {e}"),
         }
-        Err(e) => tracing::debug!("icon-theme read failed (portal absent?): {e}"),
     }
 
     // Watch for changes via zbus signal stream.
@@ -94,17 +140,135 @@ async fn run_watcher() -> Result<(), zbus::Error> {
             break;
         };
         let args = signal.args()?;
-        if args.namespace == "org.freedesktop.appearance" && args.key == "icon-theme" {
-            if let Some(theme) = extract_string(args.value) {
-                tracing::debug!("icon-theme changed to: {theme}");
-                *ICON_THEME.write().unwrap() = theme;
-                // Every cached icon — and every cached miss — answers for the
-                // theme that has just been replaced.
-                crate::icons::clear_cache();
-                crate::portal_runtime::theme_changed();
-            }
+        let Some(rank) = PORTAL_KEYS
+            .iter()
+            .position(|(namespace, key)| args.namespace == *namespace && args.key == *key)
+        else {
+            continue;
+        };
+        if rank > source {
+            continue;
+        }
+        if let Some(theme) = extract_string(args.value).filter(|t| is_installed(t)) {
+            tracing::debug!("icon-theme changed to: {theme}");
+            source = rank;
+            set_theme(theme);
         }
     }
 
     Ok(())
+}
+
+/// The theme the running desktop wrote down for itself, if it did.
+fn desktop_file_theme() -> Option<String> {
+    let config = config_home()?;
+    let kde = std::env::var("XDG_CURRENT_DESKTOP")
+        .map(|desktops| desktops.split(':').any(|d| d.eq_ignore_ascii_case("KDE")))
+        .unwrap_or(false);
+    let kdeglobals = || {
+        std::fs::read_to_string(config.join("kdeglobals"))
+            .ok()
+            .and_then(|text| ini_value(&text, "Icons", "Theme"))
+    };
+    let gtk = || {
+        ["gtk-4.0", "gtk-3.0"].iter().find_map(|dir| {
+            std::fs::read_to_string(config.join(dir).join("settings.ini"))
+                .ok()
+                .and_then(|text| ini_value(&text, "Settings", "gtk-icon-theme-name"))
+        })
+    };
+    let found = if kde {
+        // Plasma's own default when kdeglobals names none.
+        kdeglobals().or_else(|| Some("breeze".to_string()))
+    } else {
+        gtk()
+    };
+    found.filter(|theme| is_installed(theme))
+}
+
+/// A complete theme to fall back on, where the desktop names none that is
+/// installed. Anything is better than `hicolor` alone.
+fn installed_default_theme() -> Option<String> {
+    ["breeze", "Adwaita"]
+        .into_iter()
+        .find(|theme| is_installed(theme))
+        .map(str::to_string)
+}
+
+fn config_home() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+}
+
+/// Whether a theme called `name` has an `index.theme` anywhere icons are
+/// looked for.
+fn is_installed(name: &str) -> bool {
+    if name.is_empty() || name.contains('/') {
+        return false;
+    }
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        roots.push(home.join(".icons"));
+    }
+    let data_home = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/share")));
+    roots.extend(data_home.map(|d| d.join("icons")));
+    let data_dirs = std::env::var("XDG_DATA_DIRS")
+        .ok()
+        .filter(|dirs| !dirs.is_empty())
+        .unwrap_or_else(|| "/usr/local/share:/usr/share".to_string());
+    roots.extend(
+        data_dirs
+            .split(':')
+            .filter(|d| !d.is_empty())
+            .map(|d| Path::new(d).join("icons")),
+    );
+    roots
+        .iter()
+        .any(|root| root.join(name).join("index.theme").is_file())
+}
+
+/// `key` in `[group]` of an INI-style file — the format of both `kdeglobals`
+/// and GTK's `settings.ini`.
+fn ini_value(text: &str, group: &str, key: &str) -> Option<String> {
+    let mut in_group = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            in_group = name == group;
+            continue;
+        }
+        if !in_group {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        if k.trim() == key {
+            let v = v.trim().trim_matches('"');
+            return (!v.is_empty()).then(|| v.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ini_value;
+
+    #[test]
+    fn reads_a_key_from_its_own_group_only() {
+        let kdeglobals = "[General]\nTheme=wrong\n\n[Icons]\nTheme=WhiteSur\n\n[KDE]\nTheme=also-wrong\n";
+        assert_eq!(ini_value(kdeglobals, "Icons", "Theme").as_deref(), Some("WhiteSur"));
+        let gtk = "[Settings]\ngtk-theme-name=Adwaita\ngtk-icon-theme-name = \"Newaita\"\n";
+        assert_eq!(
+            ini_value(gtk, "Settings", "gtk-icon-theme-name").as_deref(),
+            Some("Newaita")
+        );
+        assert_eq!(ini_value(gtk, "Icons", "Theme"), None);
+    }
 }

--- a/components/otto-kit/src/icon_theme.rs
+++ b/components/otto-kit/src/icon_theme.rs
@@ -262,8 +262,12 @@ mod tests {
 
     #[test]
     fn reads_a_key_from_its_own_group_only() {
-        let kdeglobals = "[General]\nTheme=wrong\n\n[Icons]\nTheme=WhiteSur\n\n[KDE]\nTheme=also-wrong\n";
-        assert_eq!(ini_value(kdeglobals, "Icons", "Theme").as_deref(), Some("WhiteSur"));
+        let kdeglobals =
+            "[General]\nTheme=wrong\n\n[Icons]\nTheme=WhiteSur\n\n[KDE]\nTheme=also-wrong\n";
+        assert_eq!(
+            ini_value(kdeglobals, "Icons", "Theme").as_deref(),
+            Some("WhiteSur")
+        );
         let gtk = "[Settings]\ngtk-theme-name=Adwaita\ngtk-icon-theme-name = \"Newaita\"\n";
         assert_eq!(
             ini_value(gtk, "Settings", "gtk-icon-theme-name").as_deref(),

--- a/components/otto-kit/src/lib.rs
+++ b/components/otto-kit/src/lib.rs
@@ -4,6 +4,7 @@ pub mod testing;
 pub mod accent;
 pub mod accessibility;
 pub mod app_runner;
+pub mod backdrop;
 pub mod clipboard;
 pub mod color_scheme;
 pub mod common;

--- a/components/otto-kit/src/preview/mod.rs
+++ b/components/otto-kit/src/preview/mod.rs
@@ -873,7 +873,7 @@ pub fn human_size(bytes: u64) -> String {
 /// The material a preview sits on. Exposed so the compositor and an
 /// application can paint the same ground.
 pub fn background(theme: &Theme) -> Color {
-    theme.material_popup
+    theme.card_material()
 }
 
 #[cfg(test)]

--- a/components/otto-kit/src/theme.rs
+++ b/components/otto-kit/src/theme.rs
@@ -93,12 +93,71 @@ impl Theme {
 
     /// Light theme, with the user's accent folded in.
     pub fn light() -> Self {
-        Self::light_palette().with_system_accent()
+        Self::light_palette()
+            .with_system_accent()
+            .with_system_backdrop(false)
     }
 
     /// Dark theme, with the user's accent folded in.
     pub fn dark() -> Self {
-        Self::dark_palette().with_system_accent()
+        Self::dark_palette()
+            .with_system_accent()
+            .with_system_backdrop(true)
+    }
+
+    /// Fill the materials in where nothing blurs behind them.
+    ///
+    /// A translucent material over bare pixels is not a lighter version of
+    /// itself: it is whatever sits behind the surface showing through, and the
+    /// text on top loses its contrast to it. See [`crate::backdrop`].
+    fn with_system_backdrop(mut self, dark: bool) -> Self {
+        if !crate::backdrop::blur_available() {
+            self.with_solid_materials(dark);
+        }
+        self
+    }
+
+    /// Replace the translucent materials with opaque ones.
+    ///
+    /// Not the same hues made opaque: the light materials are near-white, and
+    /// filled in they would be indistinguishable from the content they frame.
+    /// Each lands a shade off the content ground instead, so a sidebar still
+    /// reads as a sidebar and a menu still reads as lifted off the window.
+    /// Highlights and selections are tints laid over these, and stay as they
+    /// are.
+    pub fn with_solid_materials(&mut self, dark: bool) -> &mut Self {
+        if dark {
+            self.material_titlebar = Color::from_rgb(0x2A, 0x2A, 0x2C);
+            self.material_sidebar = Color::from_rgb(0x25, 0x25, 0x27);
+            self.material_medium = Color::from_rgb(0x2A, 0x2A, 0x2C);
+            self.material_popup = Color::from_rgb(0x2E, 0x2E, 0x30);
+        } else {
+            self.material_titlebar = Color::from_rgb(0xE8, 0xE8, 0xEB);
+            self.material_sidebar = Color::from_rgb(0xEC, 0xEC, 0xEF);
+            self.material_medium = Color::from_rgb(0xF0, 0xF0, 0xF3);
+            self.material_popup = Color::from_rgb(0xF8, 0xF8, 0xF9);
+        }
+        self
+    }
+
+    /// The material for a card on a subsurface of the window it floats over —
+    /// a command palette, a preview panel.
+    ///
+    /// `material_popup` where the compositor can frost what is under the card,
+    /// and its solid form everywhere else: see
+    /// [`crate::backdrop::blurs_behind_subsurfaces`].
+    pub fn card_material(&self) -> Color {
+        if crate::backdrop::blurs_behind_subsurfaces() {
+            return self.material_popup;
+        }
+        let popup = self.material_popup;
+        let dark = popup.r() < 0x80;
+        let mut theme = if dark {
+            Self::dark_palette()
+        } else {
+            Self::light_palette()
+        };
+        theme.with_solid_materials(dark).material_popup
     }
 
     /// The light palette exactly as designed, with Otto's own blue as the
@@ -233,5 +292,29 @@ fn mute(color: Color) -> Color {
 impl Default for Theme {
     fn default() -> Self {
         Self::light()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solid_materials_are_opaque_and_off_the_content_ground() {
+        for (dark, mut theme, ground) in [
+            (false, Theme::light_palette(), Color::WHITE),
+            (true, Theme::dark_palette(), Color::from_rgb(0x1C, 0x1C, 0x1E)),
+        ] {
+            theme.with_solid_materials(dark);
+            for material in [
+                theme.material_titlebar,
+                theme.material_sidebar,
+                theme.material_medium,
+                theme.material_popup,
+            ] {
+                assert_eq!(material.a(), 0xFF);
+                assert_ne!(material, ground);
+            }
+        }
     }
 }

--- a/components/otto-kit/src/theme.rs
+++ b/components/otto-kit/src/theme.rs
@@ -303,7 +303,11 @@ mod tests {
     fn solid_materials_are_opaque_and_off_the_content_ground() {
         for (dark, mut theme, ground) in [
             (false, Theme::light_palette(), Color::WHITE),
-            (true, Theme::dark_palette(), Color::from_rgb(0x1C, 0x1C, 0x1E)),
+            (
+                true,
+                Theme::dark_palette(),
+                Color::from_rgb(0x1C, 0x1C, 0x1E),
+            ),
         ] {
             theme.with_solid_materials(dark);
             for material in [

--- a/components/otto-quickview/src/decode/image.rs
+++ b/components/otto-quickview/src/decode/image.rs
@@ -72,7 +72,14 @@ pub fn raster(file: &mut File, request: &Request) -> PreviewPayload {
         }
     };
 
-    match to_pixels(&image, intrinsic) {
+    // A codec that cannot sample — PNG has no sample size at all — has just
+    // handed back the whole picture whatever was asked for, and a screenshot
+    // requested as a 256-pixel thumbnail would otherwise go down the pipe and
+    // into the caller's cache at 22 MB. Fit it into the target here, where
+    // the resample costs one pass in the worker rather than a resident
+    // full-size copy in the browser for as long as the thumbnail lives.
+    let fit = fit_within(scaled, target);
+    match to_pixels_at(&image, intrinsic, fit) {
         Some(pixels) => PreviewPayload::Pixels {
             pixels,
             pages: 1,
@@ -80,6 +87,20 @@ pub fn raster(file: &mut File, request: &Request) -> PreviewPayload {
         },
         None => payload::unavailable(otto_kit::t_owned!("quickview-error-image-readback")),
     }
+}
+
+/// `size` shrunk, aspect kept, until it fits in `bounds`. Never grown.
+fn fit_within(size: ISize, bounds: ISize) -> ISize {
+    if size.width <= bounds.width && size.height <= bounds.height {
+        return size;
+    }
+    let scale = (bounds.width as f32 / size.width as f32)
+        .min(bounds.height as f32 / size.height as f32)
+        .min(1.0);
+    ISize::new(
+        ((size.width as f32 * scale).round() as i32).max(1),
+        ((size.height as f32 * scale).round() as i32).max(1),
+    )
 }
 
 /// SVG, rendered at the size it will be shown rather than at some nominal one,
@@ -204,8 +225,13 @@ fn too_large(intrinsic: ISize, request: &Request) -> PreviewPayload {
 /// Copy a decoded image out into a plain premultiplied RGBA buffer, which is
 /// all the wire format and the drawing side know about.
 pub(crate) fn to_pixels(image: &skia_safe::Image, intrinsic: ISize) -> Option<Pixels> {
-    let width = image.width().max(0) as u32;
-    let height = image.height().max(0) as u32;
+    to_pixels_at(image, intrinsic, image.dimensions())
+}
+
+/// Read `image` back at `size`, resampling on the way when the two differ.
+fn to_pixels_at(image: &skia_safe::Image, intrinsic: ISize, size: ISize) -> Option<Pixels> {
+    let width = size.width.max(0) as u32;
+    let height = size.height.max(0) as u32;
     let info = ImageInfo::new(
         (width as i32, height as i32),
         skia_safe::ColorType::RGBA8888,
@@ -214,26 +240,87 @@ pub(crate) fn to_pixels(image: &skia_safe::Image, intrinsic: ISize) -> Option<Pi
     );
     let row_bytes = width as usize * 4;
     let mut data = vec![0u8; row_bytes * height as usize];
-    image
-        .read_pixels(
+    let read = if size == image.dimensions() {
+        image.read_pixels(
             &info,
             &mut data,
             row_bytes,
             (0, 0),
             skia_safe::image::CachingHint::Disallow,
         )
-        .then_some(Pixels {
-            width,
-            height,
-            intrinsic_width: intrinsic.width.max(0) as u32,
-            intrinsic_height: intrinsic.height.max(0) as u32,
-            data,
-        })
+    } else {
+        let target = skia_safe::Pixmap::new(&info, &mut data, row_bytes)?;
+        image.scale_pixels(
+            &target,
+            skia_safe::SamplingOptions::new(
+                skia_safe::FilterMode::Linear,
+                skia_safe::MipmapMode::Linear,
+            ),
+            skia_safe::image::CachingHint::Disallow,
+        )
+    };
+    read.then_some(Pixels {
+        width,
+        height,
+        intrinsic_width: intrinsic.width.max(0) as u32,
+        intrinsic_height: intrinsic.height.max(0) as u32,
+        data,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// PNG cannot be decoded at a sample size, so without a resample a big
+    /// one would come back whole however small the request.
+    #[test]
+    fn a_png_asked_for_small_comes_back_small() {
+        let mut surface = skia_safe::surfaces::raster_n32_premul((1200, 900)).unwrap();
+        surface.canvas().clear(skia_safe::Color::RED);
+        let png = surface
+            .image_snapshot()
+            .encode(None, skia_safe::EncodedImageFormat::PNG, 100)
+            .unwrap();
+        let path =
+            std::env::temp_dir().join(format!("otto-quickview-fit-{}.png", std::process::id()));
+        std::fs::write(&path, png.as_bytes()).unwrap();
+        let mut file = File::open(&path).unwrap();
+        let request = Request {
+            width: 128,
+            height: 128,
+            ..Request::default()
+        };
+        let payload = raster(&mut file, &request);
+        let _ = std::fs::remove_file(&path);
+        let PreviewPayload::Pixels { pixels, .. } = payload else {
+            panic!("pixels expected");
+        };
+        assert_eq!((pixels.width, pixels.height), (128, 96));
+        assert_eq!(
+            (pixels.intrinsic_width, pixels.intrinsic_height),
+            (1200, 900)
+        );
+        assert_eq!(pixels.data.len(), 128 * 96 * 4);
+        // Still red after the resample, and premultiplied opaque.
+        assert_eq!(&pixels.data[..4], &[255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn fitting_keeps_the_aspect_and_never_grows() {
+        assert_eq!(
+            fit_within(ISize::new(2880, 1920), ISize::new(256, 256)),
+            ISize::new(256, 171)
+        );
+        assert_eq!(
+            fit_within(ISize::new(100, 80), ISize::new(256, 256)),
+            ISize::new(100, 80)
+        );
+        assert_eq!(
+            fit_within(ISize::new(1000, 4000), ISize::new(512, 512)),
+            ISize::new(128, 512)
+        );
+    }
 
     #[test]
     fn target_never_exceeds_the_source() {

--- a/resources/locales/de.ftl
+++ b/resources/locales/de.ftl
@@ -508,6 +508,117 @@ files-month-nov = Nov.
 files-month-dec = Dez.
 
 
+## Files — commands
+
+files-new-folder-with-selection = Neuer Ordner mit Auswahl
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Neuer Ordner mit { $count } Objekt
+       *[other] Neuer Ordner mit { $count } Objekten
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Befehl ausführen
+files-palette-no-matches = Kein Befehl passt
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Befehlspalette, { $count } Befehl
+       *[other] Befehlspalette, { $count } Befehle
+    }
+
+files-command-group-go = Gehe zu
+files-command-group-file = Ablage
+files-command-group-edit = Bearbeiten
+files-command-group-view = Darstellung
+
+files-command-back = Zurück
+files-command-forward = Vorwärts
+files-command-up = Nach oben
+files-command-go-to-path = Gehe zu Pfad
+files-command-go-to-place = Gehe zu Ort
+files-command-undo = Rückgängig
+files-command-select-all = Alles auswählen
+files-command-select-matching = Passende auswählen
+files-command-move-to = In Ordner verschieben
+files-command-change-view = Darstellung ändern
+files-command-sort-by = Sortieren nach
+files-command-show-hidden = Versteckte Dateien einblenden
+files-command-hide-hidden = Versteckte Dateien ausblenden
+files-command-quick-look = Übersicht
+files-command-search = Suchen
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Gehe zu Pfad
+files-command-go-to-place-prompt = Gehe zu Ort
+files-command-rename-prompt = Umbenennen in
+files-command-new-folder-prompt = Neuer Ordner namens
+files-command-change-view-prompt = Darstellung
+files-command-sort-by-prompt = Sortieren nach
+files-command-search-prompt = Suchen nach
+files-command-select-matching-prompt = Passende auswählen
+files-command-move-to-prompt = Verschieben nach
+files-command-rename-many-prompt = Umbenennen in
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = Pfad
+files-command-arg-place = Ort
+files-command-arg-name = Name
+files-command-arg-view = Darstellung
+files-command-arg-sort = Kriterium
+files-command-arg-query = Text
+files-command-arg-pattern = Muster
+
+files-view-list = Liste
+files-view-grid = Raster
+files-view-columns = Spalten
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = So kann eine Datei nicht heißen
+files-no-pattern = Ein Muster eingeben, etwa *.png
+files-nothing-matches = Nichts passt zu „{ $pattern }“
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = { $count } Objekte umbenennen
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Benennt { $count } von { $total } um
+files-rename-preview-unchanged = Nichts würde sich ändern
+files-rename-conflicts = { $count ->
+    [one] Ein Name ist bereits vergeben
+   *[other] { $count } Namen sind bereits vergeben
+}
+files-rename-invalid = { $count ->
+    [one] Ein Name wäre leer
+   *[other] { $count } Namen wären leer
+}
+files-renamed-count = { $count } Objekte umbenannt
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = { $title } wird ausgeführt…
+files-script-failed-quietly = Das Skript ist ohne Begründung fehlgeschlagen
+files-script-timed-out = Das Skript hat zu lange gebraucht
+files-nothing-selected = Nichts ist ausgewählt
+files-cant-move-into-itself = Ein Ordner kann nicht in sich selbst verschoben werden
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } Objekt ausgewählt
+       *[other] { $count } Objekte ausgewählt
+    }
+files-name-taken = „{ $name }“ ist dort bereits vorhanden
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = Neuer Ordner mit Auswahl
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -315,6 +315,8 @@ files-command-go-to-path = Go to Path
 files-command-go-to-place = Go to Place
 files-command-undo = Undo
 files-command-select-all = Select All
+files-command-select-matching = Select Matching
+files-command-move-to = Move to Folder
 files-command-change-view = Change View
 files-command-sort-by = Sort By
 files-command-show-hidden = Show Hidden Files
@@ -331,6 +333,8 @@ files-command-new-folder-prompt = New folder named
 files-command-change-view-prompt = View
 files-command-sort-by-prompt = Sort by
 files-command-search-prompt = Search for
+files-command-select-matching-prompt = Select matching
+files-command-move-to-prompt = Move to
 
 # The one-word name of what a command is asking for, shown dimmed after its
 # title in the list.
@@ -340,12 +344,23 @@ files-command-arg-name = name
 files-command-arg-view = view
 files-command-arg-sort = key
 files-command-arg-query = text
+files-command-arg-pattern = pattern
 
 files-view-list = List
 files-view-grid = Grid
 files-view-columns = Columns
 # Refused when a name could not belong to a file — empty, or with a slash in it.
 files-name-invalid = That isn’t a name a file can have
+files-no-pattern = Type a pattern, such as *.png
+files-nothing-matches = Nothing matches “{ $pattern }”
+files-nothing-selected = Nothing is selected
+files-cant-move-into-itself = A folder can’t be moved into itself
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } item selected
+       *[other] { $count } items selected
+    }
 files-name-taken = “{ $name }” is already there
 
 ## Files — sidebar and columns

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -291,6 +291,63 @@ files-delete-count-immediately =
     }
 
 
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Run a command
+files-palette-no-matches = No command matches
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Command palette, { $count } command
+       *[other] Command palette, { $count } commands
+    }
+
+files-command-group-go = Go
+files-command-group-file = File
+files-command-group-edit = Edit
+files-command-group-view = View
+
+files-command-back = Back
+files-command-forward = Forward
+files-command-up = Up
+files-command-go-to-path = Go to Path
+files-command-go-to-place = Go to Place
+files-command-undo = Undo
+files-command-select-all = Select All
+files-command-change-view = Change View
+files-command-sort-by = Sort By
+files-command-show-hidden = Show Hidden Files
+files-command-hide-hidden = Hide Hidden Files
+files-command-quick-look = Quick Look
+files-command-search = Search
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Go to path
+files-command-go-to-place-prompt = Go to place
+files-command-rename-prompt = Rename to
+files-command-new-folder-prompt = New folder named
+files-command-change-view-prompt = View
+files-command-sort-by-prompt = Sort by
+files-command-search-prompt = Search for
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = path
+files-command-arg-place = place
+files-command-arg-name = name
+files-command-arg-view = view
+files-command-arg-sort = key
+files-command-arg-query = text
+
+files-view-list = List
+files-view-grid = Grid
+files-view-columns = Columns
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = That isn’t a name a file can have
+files-name-taken = “{ $name }” is already there
+
 ## Files — sidebar and columns
 
 files-places = Places

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -365,7 +365,6 @@ files-nothing-matches = Nothing matches “{ $pattern }”
 
 # Renaming a selection from one pattern — see `rename.rs` for the pattern.
 files-rename-many = Rename { $count } Items
-files-rename-pattern = Rename with Pattern
 # The dry run's summary line under the palette's rows.
 files-rename-preview = Renames { $count } of { $total }
 files-rename-preview-unchanged = Nothing would change

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -378,6 +378,11 @@ files-rename-invalid = { $count ->
    *[other] { $count } names would be empty
 }
 files-renamed-count = Renamed { $count } items
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Running { $title }…
+files-script-failed-quietly = The script failed without saying why
+files-script-timed-out = The script took too long
 files-nothing-selected = Nothing is selected
 files-cant-move-into-itself = A folder can’t be moved into itself
 # $count is how many entries a pattern selected.

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -273,6 +273,14 @@ files-info-window-title = Info
 
 files-get-info = Get Info
 files-new-folder = New Folder
+files-new-folder-with-selection = New Folder with Selection
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] New Folder with { $count } Item
+       *[other] New Folder with { $count } Items
+    }
 files-move-to-trash = Move to Trash
 # $count is always two or more; the single-item case uses files-move-to-trash.
 files-move-count-to-trash =
@@ -453,6 +461,7 @@ files-undid = Undid { $label }
 files-undo-move = Move
 files-undo-copy = Copy
 files-undo-delete = Delete
+files-undo-new-folder-with-selection = New Folder with Selection
 files-undo-rename = Rename
 # $name is a file or folder name, already wrapped in quotation marks.
 files-renamed-to = Renamed to “{ $name }”

--- a/resources/locales/en-GB.ftl
+++ b/resources/locales/en-GB.ftl
@@ -343,6 +343,7 @@ files-command-sort-by-prompt = Sort by
 files-command-search-prompt = Search for
 files-command-select-matching-prompt = Select matching
 files-command-move-to-prompt = Move to
+files-command-rename-many-prompt = Rename to
 
 # The one-word name of what a command is asking for, shown dimmed after its
 # title in the list.
@@ -361,6 +362,22 @@ files-view-columns = Columns
 files-name-invalid = That isn’t a name a file can have
 files-no-pattern = Type a pattern, such as *.png
 files-nothing-matches = Nothing matches “{ $pattern }”
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = Rename { $count } Items
+files-rename-pattern = Rename with Pattern
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Renames { $count } of { $total }
+files-rename-preview-unchanged = Nothing would change
+files-rename-conflicts = { $count ->
+    [one] One name is already taken
+   *[other] { $count } names are already taken
+}
+files-rename-invalid = { $count ->
+    [one] One name would be empty
+   *[other] { $count } names would be empty
+}
+files-renamed-count = Renamed { $count } items
 files-nothing-selected = Nothing is selected
 files-cant-move-into-itself = A folder can’t be moved into itself
 # $count is how many entries a pattern selected.

--- a/resources/locales/es.ftl
+++ b/resources/locales/es.ftl
@@ -515,6 +515,122 @@ files-month-nov = nov
 files-month-dec = dic
 
 
+## Files — commands
+
+files-new-folder-with-selection = Nueva carpeta con la selección
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Nueva carpeta con { $count } elemento
+        [many] Nueva carpeta con { $count } elementos
+       *[other] Nueva carpeta con { $count } elementos
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Ejecutar un comando
+files-palette-no-matches = Ningún comando coincide
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Paleta de comandos, { $count } comando
+        [many] Paleta de comandos, { $count } comandos
+       *[other] Paleta de comandos, { $count } comandos
+    }
+
+files-command-group-go = Ir
+files-command-group-file = Archivo
+files-command-group-edit = Edición
+files-command-group-view = Visualización
+
+files-command-back = Atrás
+files-command-forward = Adelante
+files-command-up = Subir
+files-command-go-to-path = Ir a la ruta
+files-command-go-to-place = Ir al lugar
+files-command-undo = Deshacer
+files-command-select-all = Seleccionar todo
+files-command-select-matching = Seleccionar coincidencias
+files-command-move-to = Mover a la carpeta
+files-command-change-view = Cambiar vista
+files-command-sort-by = Ordenar por
+files-command-show-hidden = Mostrar archivos ocultos
+files-command-hide-hidden = Ocultar archivos ocultos
+files-command-quick-look = Vista rápida
+files-command-search = Buscar
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Ir a la ruta
+files-command-go-to-place-prompt = Ir al lugar
+files-command-rename-prompt = Cambiar nombre a
+files-command-new-folder-prompt = Nueva carpeta llamada
+files-command-change-view-prompt = Vista
+files-command-sort-by-prompt = Ordenar por
+files-command-search-prompt = Buscar
+files-command-select-matching-prompt = Seleccionar coincidencias
+files-command-move-to-prompt = Mover a
+files-command-rename-many-prompt = Cambiar nombre a
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = ruta
+files-command-arg-place = lugar
+files-command-arg-name = nombre
+files-command-arg-view = vista
+files-command-arg-sort = criterio
+files-command-arg-query = texto
+files-command-arg-pattern = patrón
+
+files-view-list = Lista
+files-view-grid = Cuadrícula
+files-view-columns = Columnas
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = Un archivo no puede llamarse así
+files-no-pattern = Escribe un patrón, como *.png
+files-nothing-matches = Nada coincide con «{ $pattern }»
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = Cambiar el nombre de { $count } elementos
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Cambia { $count } de { $total }
+files-rename-preview-unchanged = No cambiaría nada
+files-rename-conflicts = { $count ->
+    [one] Un nombre ya está en uso
+    [many] { $count } nombres ya están en uso
+   *[other] { $count } nombres ya están en uso
+}
+files-rename-invalid = { $count ->
+    [one] Un nombre quedaría vacío
+    [many] { $count } nombres quedarían vacíos
+   *[other] { $count } nombres quedarían vacíos
+}
+files-renamed-count = Se cambió el nombre de { $count } elementos
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Ejecutando { $title }…
+files-script-failed-quietly = El script falló sin decir por qué
+files-script-timed-out = El script tardó demasiado
+files-nothing-selected = No hay nada seleccionado
+files-cant-move-into-itself = Una carpeta no se puede mover dentro de sí misma
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } elemento seleccionado
+        [many] { $count } elementos seleccionados
+       *[other] { $count } elementos seleccionados
+    }
+files-name-taken = «{ $name }» ya está ahí
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = Nueva carpeta con la selección
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/fr.ftl
+++ b/resources/locales/fr.ftl
@@ -515,6 +515,132 @@ files-month-nov = nov.
 files-month-dec = déc.
 
 
+## Files — commands (command palette additions)
+
+files-new-folder-with-selection = Nouveau dossier avec la sélection
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Nouveau dossier avec { $count } élément
+        [many] Nouveau dossier avec { $count } éléments
+       *[other] Nouveau dossier avec { $count } éléments
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Exécuter une commande
+files-palette-no-matches = Aucune commande ne correspond
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Palette de commandes, { $count } commande
+        [many] Palette de commandes, { $count } commandes
+       *[other] Palette de commandes, { $count } commandes
+    }
+
+files-command-group-go = Aller
+files-command-group-file = Fichier
+files-command-group-edit = Édition
+files-command-group-view = Présentation
+
+files-command-back = Précédent
+files-command-forward = Suivant
+files-command-up = Dossier parent
+files-command-go-to-path = Aller au chemin
+files-command-go-to-place = Aller à l’emplacement
+files-command-undo = Annuler
+files-command-select-all = Tout sélectionner
+files-command-select-matching = Sélectionner par motif
+files-command-move-to = Déplacer vers un dossier
+files-command-change-view = Changer de présentation
+files-command-sort-by = Trier par
+files-command-show-hidden = Afficher les fichiers masqués
+files-command-hide-hidden = Masquer les fichiers masqués
+files-command-quick-look = Coup d’œil
+files-command-search = Rechercher
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Aller au chemin
+files-command-go-to-place-prompt = Aller à l’emplacement
+files-command-rename-prompt = Renommer en
+files-command-new-folder-prompt = Nouveau dossier nommé
+files-command-change-view-prompt = Présentation
+files-command-sort-by-prompt = Trier par
+files-command-search-prompt = Rechercher
+files-command-select-matching-prompt = Sélectionner par motif
+files-command-move-to-prompt = Déplacer vers
+files-command-rename-many-prompt = Renommer en
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = chemin
+files-command-arg-place = emplacement
+files-command-arg-name = nom
+files-command-arg-view = présentation
+files-command-arg-sort = critère
+files-command-arg-query = texte
+files-command-arg-pattern = motif
+
+files-view-list = Liste
+files-view-grid = Grille
+files-view-columns = Colonnes
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = Ce nom ne convient pas à un fichier
+files-no-pattern = Saisir un motif, par exemple *.png
+files-nothing-matches = Rien ne correspond à « { $pattern } »
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many =
+    { $count ->
+        [one] Renommer { $count } élément
+        [many] Renommer { $count } éléments
+       *[other] Renommer { $count } éléments
+    }
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Renomme { $count } sur { $total }
+files-rename-preview-unchanged = Rien ne changerait
+files-rename-conflicts = { $count ->
+    [one] Un nom est déjà pris
+    [many] { $count } noms sont déjà pris
+   *[other] { $count } noms sont déjà pris
+}
+files-rename-invalid = { $count ->
+    [one] Un nom serait vide
+    [many] { $count } noms seraient vides
+   *[other] { $count } noms seraient vides
+}
+files-renamed-count =
+    { $count ->
+        [one] { $count } élément renommé
+        [many] { $count } éléments renommés
+       *[other] { $count } éléments renommés
+    }
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Exécution de { $title }…
+files-script-failed-quietly = Le script a échoué sans dire pourquoi
+files-script-timed-out = Le script a mis trop de temps
+files-nothing-selected = Rien n’est sélectionné
+files-cant-move-into-itself = Un dossier ne peut pas être déplacé dans lui-même
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } élément sélectionné
+        [many] { $count } éléments sélectionnés
+       *[other] { $count } éléments sélectionnés
+    }
+files-name-taken = « { $name } » est déjà là
+
+
+## Files — status (command palette additions)
+
+files-undo-new-folder-with-selection = Nouveau dossier avec la sélection
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/it.ftl
+++ b/resources/locales/it.ftl
@@ -516,6 +516,127 @@ files-month-nov = Nov
 files-month-dec = Dic
 
 
+## Files — commands
+
+files-new-folder-with-selection = Nuova cartella con la selezione
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Nuova cartella con { $count } elemento
+        [many] Nuova cartella con { $count } elementi
+       *[other] Nuova cartella con { $count } elementi
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Esegui un comando
+files-palette-no-matches = Nessun comando corrisponde
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Riquadro comandi, { $count } comando
+        [many] Riquadro comandi, { $count } comandi
+       *[other] Riquadro comandi, { $count } comandi
+    }
+
+files-command-group-go = Vai
+files-command-group-file = File
+files-command-group-edit = Modifica
+files-command-group-view = Vista
+
+files-command-back = Indietro
+files-command-forward = Avanti
+files-command-up = Cartella superiore
+files-command-go-to-path = Vai al percorso
+files-command-go-to-place = Vai alla risorsa
+files-command-undo = Annulla
+files-command-select-all = Seleziona tutto
+files-command-select-matching = Seleziona corrispondenti
+files-command-move-to = Sposta nella cartella
+files-command-change-view = Cambia vista
+files-command-sort-by = Ordina per
+files-command-show-hidden = Mostra i file nascosti
+files-command-hide-hidden = Nascondi i file nascosti
+files-command-quick-look = Vista rapida
+files-command-search = Cerca
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Vai al percorso
+files-command-go-to-place-prompt = Vai alla risorsa
+files-command-rename-prompt = Rinomina in
+files-command-new-folder-prompt = Nome della nuova cartella
+files-command-change-view-prompt = Vista
+files-command-sort-by-prompt = Ordina per
+files-command-search-prompt = Cerca
+files-command-select-matching-prompt = Seleziona corrispondenti
+files-command-move-to-prompt = Sposta in
+files-command-rename-many-prompt = Rinomina in
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = percorso
+files-command-arg-place = risorsa
+files-command-arg-name = nome
+files-command-arg-view = vista
+files-command-arg-sort = criterio
+files-command-arg-query = testo
+files-command-arg-pattern = modello
+
+files-view-list = Elenco
+files-view-grid = Griglia
+files-view-columns = Colonne
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = Non è un nome che un file possa avere
+files-no-pattern = Scrivi un modello, ad esempio *.png
+files-nothing-matches = Nessuna corrispondenza con “{ $pattern }”
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many =
+    { $count ->
+        [one] Rinomina { $count } elemento
+        [many] Rinomina { $count } elementi
+       *[other] Rinomina { $count } elementi
+    }
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Ne rinomina { $count } su { $total }
+files-rename-preview-unchanged = Non cambierebbe nulla
+files-rename-conflicts = { $count ->
+    [one] Un nome è già in uso
+    [many] { $count } nomi sono già in uso
+   *[other] { $count } nomi sono già in uso
+}
+files-rename-invalid = { $count ->
+    [one] Un nome risulterebbe vuoto
+    [many] { $count } nomi risulterebbero vuoti
+   *[other] { $count } nomi risulterebbero vuoti
+}
+files-renamed-count = Rinominati { $count } elementi
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Esecuzione di { $title }…
+files-script-failed-quietly = Lo script si è interrotto senza dire perché
+files-script-timed-out = Lo script ha impiegato troppo tempo
+files-nothing-selected = Nessun elemento selezionato
+files-cant-move-into-itself = Una cartella non si può spostare dentro sé stessa
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } elemento selezionato
+        [many] { $count } elementi selezionati
+       *[other] { $count } elementi selezionati
+    }
+files-name-taken = “{ $name }” è già presente
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = Nuova cartella con la selezione
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/ja.ftl
+++ b/resources/locales/ja.ftl
@@ -497,6 +497,111 @@ files-month-oct = 10月
 files-month-nov = 11月
 files-month-dec = 12月
 
+## Files — commands
+
+files-new-folder-with-selection = 選択項目から新規フォルダ
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+       *[other] { $count } 項目から新規フォルダ
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = コマンドを実行
+files-palette-no-matches = 一致するコマンドはありません
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+       *[other] コマンドパレット、{ $count } 個のコマンド
+    }
+
+files-command-group-go = 移動
+files-command-group-file = ファイル
+files-command-group-edit = 編集
+files-command-group-view = 表示
+
+files-command-back = 戻る
+files-command-forward = 進む
+files-command-up = 上へ
+files-command-go-to-path = パスへ移動
+files-command-go-to-place = 場所へ移動
+files-command-undo = 取り消す
+files-command-select-all = すべてを選択
+files-command-select-matching = 一致する項目を選択
+files-command-move-to = フォルダへ移動
+files-command-change-view = 表示を変更
+files-command-sort-by = 並べ替え
+files-command-show-hidden = 隠しファイルを表示
+files-command-hide-hidden = 隠しファイルを非表示
+files-command-quick-look = クイックルック
+files-command-search = 検索
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = パスへ移動
+files-command-go-to-place-prompt = 場所へ移動
+files-command-rename-prompt = 新しい名前
+files-command-new-folder-prompt = 新規フォルダ名
+files-command-change-view-prompt = 表示
+files-command-sort-by-prompt = 並べ替え
+files-command-search-prompt = 検索
+files-command-select-matching-prompt = 一致する項目
+files-command-move-to-prompt = 移動先
+files-command-rename-many-prompt = 新しい名前
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = パス
+files-command-arg-place = 場所
+files-command-arg-name = 名前
+files-command-arg-view = 表示
+files-command-arg-sort = 基準
+files-command-arg-query = テキスト
+files-command-arg-pattern = パターン
+
+files-view-list = リスト
+files-view-grid = グリッド
+files-view-columns = カラム
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = ファイルに使える名前ではありません
+files-no-pattern = パターンを入力（例：*.png）
+files-nothing-matches = 「{ $pattern }」に一致する項目はありません
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = { $count } 項目を名称変更
+# The dry run's summary line under the palette's rows.
+files-rename-preview = { $total } 項目中 { $count } 項目を名称変更
+files-rename-preview-unchanged = 変更はありません
+files-rename-conflicts = { $count ->
+   *[other] { $count } 個の名前はすでに使われています
+}
+files-rename-invalid = { $count ->
+   *[other] { $count } 個の名前が空になります
+}
+files-renamed-count = { $count } 項目を名称変更しました
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = { $title }を実行中…
+files-script-failed-quietly = スクリプトは理由を示さずに失敗しました
+files-script-timed-out = スクリプトに時間がかかりすぎました
+files-nothing-selected = 何も選択されていません
+files-cant-move-into-itself = フォルダを自分自身の中には移動できません
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+       *[other] { $count } 項目を選択
+    }
+files-name-taken = 「{ $name }」はすでにあります
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = 選択項目から新規フォルダ
+
 
 ## Bar
 ##

--- a/resources/locales/pl.ftl
+++ b/resources/locales/pl.ftl
@@ -526,6 +526,139 @@ files-month-oct = paź
 files-month-nov = lis
 files-month-dec = gru
 
+## Files — commands
+
+files-new-folder-with-selection = Nowy folder z zaznaczeniem
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Nowy folder z { $count } elementem
+        [few] Nowy folder z { $count } elementami
+        [many] Nowy folder z { $count } elementami
+       *[other] Nowy folder z { $count } elementami
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Uruchom polecenie
+files-palette-no-matches = Brak pasujących poleceń
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Paleta poleceń, { $count } polecenie
+        [few] Paleta poleceń, { $count } polecenia
+        [many] Paleta poleceń, { $count } poleceń
+       *[other] Paleta poleceń, { $count } polecenia
+    }
+
+files-command-group-go = Idź
+files-command-group-file = Plik
+files-command-group-edit = Edycja
+files-command-group-view = Widok
+
+files-command-back = Wstecz
+files-command-forward = Naprzód
+files-command-up = W górę
+files-command-go-to-path = Przejdź do ścieżki
+files-command-go-to-place = Przejdź do miejsca
+files-command-undo = Cofnij
+files-command-select-all = Zaznacz wszystko
+files-command-select-matching = Zaznacz pasujące
+files-command-move-to = Przenieś do folderu
+files-command-change-view = Zmień widok
+files-command-sort-by = Sortuj według
+files-command-show-hidden = Pokaż ukryte pliki
+files-command-hide-hidden = Ukryj ukryte pliki
+files-command-quick-look = Szybki podgląd
+files-command-search = Szukaj
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Przejdź do ścieżki
+files-command-go-to-place-prompt = Przejdź do miejsca
+files-command-rename-prompt = Zmień nazwę na
+files-command-new-folder-prompt = Nowy folder o nazwie
+files-command-change-view-prompt = Widok
+files-command-sort-by-prompt = Sortuj według
+files-command-search-prompt = Szukaj
+files-command-select-matching-prompt = Zaznacz pasujące
+files-command-move-to-prompt = Przenieś do
+files-command-rename-many-prompt = Zmień nazwę na
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = ścieżka
+files-command-arg-place = miejsce
+files-command-arg-name = nazwa
+files-command-arg-view = widok
+files-command-arg-sort = klucz
+files-command-arg-query = tekst
+files-command-arg-pattern = wzorzec
+
+files-view-list = Lista
+files-view-grid = Siatka
+files-view-columns = Kolumny
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = To nie jest nazwa, którą może mieć plik
+files-no-pattern = Wpisz wzorzec, na przykład *.png
+files-nothing-matches = Nic nie pasuje do „{ $pattern }”
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many =
+    { $count ->
+        [one] Zmień nazwę { $count } elementu
+        [few] Zmień nazwy { $count } elementów
+        [many] Zmień nazwy { $count } elementów
+       *[other] Zmień nazwy { $count } elementów
+    }
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Zmienia nazwy { $count } z { $total }
+files-rename-preview-unchanged = Nic by się nie zmieniło
+files-rename-conflicts = { $count ->
+    [one] Jedna nazwa jest już zajęta
+    [few] { $count } nazwy są już zajęte
+    [many] { $count } nazw jest już zajętych
+   *[other] { $count } nazwy jest już zajętych
+}
+files-rename-invalid = { $count ->
+    [one] Jedna nazwa byłaby pusta
+    [few] { $count } nazwy byłyby puste
+    [many] { $count } nazw byłoby pustych
+   *[other] { $count } nazwy byłoby pustych
+}
+files-renamed-count =
+    { $count ->
+        [one] Zmieniono nazwę { $count } elementu
+        [few] Zmieniono nazwy { $count } elementów
+        [many] Zmieniono nazwy { $count } elementów
+       *[other] Zmieniono nazwy { $count } elementów
+    }
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Uruchamianie { $title }…
+files-script-failed-quietly = Skrypt zakończył się błędem bez podania powodu
+files-script-timed-out = Skrypt trwał za długo
+files-nothing-selected = Nic nie jest zaznaczone
+files-cant-move-into-itself = Folderu nie można przenieść do niego samego
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] Zaznaczono { $count } element
+        [few] Zaznaczono { $count } elementy
+        [many] Zaznaczono { $count } elementów
+       *[other] Zaznaczono { $count } elementu
+    }
+files-name-taken = „{ $name }” już tam jest
+
+
+## Files — status
+
+# $label is a command name — Move, Copy, Delete — from the files-undo-* keys.
+files-undo-new-folder-with-selection = Utworzenie folderu z zaznaczeniem
+
 
 ## Bar
 ##

--- a/resources/locales/pt-BR.ftl
+++ b/resources/locales/pt-BR.ftl
@@ -515,6 +515,122 @@ files-month-nov = Nov
 files-month-dec = Dez
 
 
+## Files — commands (palette additions)
+
+files-new-folder-with-selection = Nova pasta com a seleção
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Nova pasta com { $count } item
+        [many] Nova pasta com { $count } itens
+       *[other] Nova pasta com { $count } itens
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Executar um comando
+files-palette-no-matches = Nenhum comando corresponde
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Paleta de comandos, { $count } comando
+        [many] Paleta de comandos, { $count } comandos
+       *[other] Paleta de comandos, { $count } comandos
+    }
+
+files-command-group-go = Ir
+files-command-group-file = Arquivo
+files-command-group-edit = Editar
+files-command-group-view = Visualizar
+
+files-command-back = Voltar
+files-command-forward = Avançar
+files-command-up = Pasta superior
+files-command-go-to-path = Ir para o caminho
+files-command-go-to-place = Ir para o local
+files-command-undo = Desfazer
+files-command-select-all = Selecionar tudo
+files-command-select-matching = Selecionar correspondentes
+files-command-move-to = Mover para a pasta
+files-command-change-view = Alterar visualização
+files-command-sort-by = Ordenar por
+files-command-show-hidden = Mostrar arquivos ocultos
+files-command-hide-hidden = Ocultar arquivos ocultos
+files-command-quick-look = Visualização rápida
+files-command-search = Buscar
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Ir para o caminho
+files-command-go-to-place-prompt = Ir para o local
+files-command-rename-prompt = Renomear para
+files-command-new-folder-prompt = Nova pasta chamada
+files-command-change-view-prompt = Visualização
+files-command-sort-by-prompt = Ordenar por
+files-command-search-prompt = Buscar por
+files-command-select-matching-prompt = Selecionar correspondentes a
+files-command-move-to-prompt = Mover para
+files-command-rename-many-prompt = Renomear para
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = caminho
+files-command-arg-place = local
+files-command-arg-name = nome
+files-command-arg-view = visualização
+files-command-arg-sort = chave
+files-command-arg-query = texto
+files-command-arg-pattern = padrão
+
+files-view-list = Lista
+files-view-grid = Grade
+files-view-columns = Colunas
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = Esse não é um nome que um arquivo possa ter
+files-no-pattern = Digite um padrão, como *.png
+files-nothing-matches = Nada corresponde a “{ $pattern }”
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = Renomear { $count } itens
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Renomeia { $count } de { $total }
+files-rename-preview-unchanged = Nada mudaria
+files-rename-conflicts = { $count ->
+    [one] Um nome já está em uso
+    [many] { $count } nomes já estão em uso
+   *[other] { $count } nomes já estão em uso
+}
+files-rename-invalid = { $count ->
+    [one] Um nome ficaria vazio
+    [many] { $count } nomes ficariam vazios
+   *[other] { $count } nomes ficariam vazios
+}
+files-renamed-count = { $count } itens renomeados
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Executando { $title }…
+files-script-failed-quietly = O script falhou sem dizer por quê
+files-script-timed-out = O script demorou demais
+files-nothing-selected = Nada está selecionado
+files-cant-move-into-itself = Uma pasta não pode ser movida para dentro de si mesma
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] { $count } item selecionado
+        [many] { $count } itens selecionados
+       *[other] { $count } itens selecionados
+    }
+files-name-taken = “{ $name }” já está lá
+
+
+## Files — status (palette additions)
+
+files-undo-new-folder-with-selection = Nova pasta com a seleção
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/ru.ftl
+++ b/resources/locales/ru.ftl
@@ -521,6 +521,139 @@ files-month-nov = нояб.
 files-month-dec = дек.
 
 
+## Files — commands (continued)
+
+files-new-folder-with-selection = Новая папка с выбранными элементами
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+        [one] Новая папка с { $count } элементом
+        [few] Новая папка с { $count } элементами
+        [many] Новая папка с { $count } элементами
+       *[other] Новая папка с { $count } элементами
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = Выполнить команду
+files-palette-no-matches = Нет подходящих команд
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+        [one] Палитра команд, { $count } команда
+        [few] Палитра команд, { $count } команды
+        [many] Палитра команд, { $count } команд
+       *[other] Палитра команд, { $count } команды
+    }
+
+files-command-group-go = Переход
+files-command-group-file = Файл
+files-command-group-edit = Правка
+files-command-group-view = Вид
+
+files-command-back = Назад
+files-command-forward = Вперёд
+files-command-up = Вверх
+files-command-go-to-path = Перейти к пути
+files-command-go-to-place = Перейти к месту
+files-command-undo = Отменить
+files-command-select-all = Выбрать все
+files-command-select-matching = Выбрать по шаблону
+files-command-move-to = Переместить в папку
+files-command-change-view = Изменить вид
+files-command-sort-by = Сортировать по
+files-command-show-hidden = Показать скрытые файлы
+files-command-hide-hidden = Скрыть скрытые файлы
+files-command-quick-look = Быстрый просмотр
+files-command-search = Поиск
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = Перейти к пути
+files-command-go-to-place-prompt = Перейти к месту
+files-command-rename-prompt = Переименовать в
+files-command-new-folder-prompt = Имя новой папки
+files-command-change-view-prompt = Вид
+files-command-sort-by-prompt = Сортировать по
+files-command-search-prompt = Найти
+files-command-select-matching-prompt = Выбрать по шаблону
+files-command-move-to-prompt = Переместить в
+files-command-rename-many-prompt = Переименовать в
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = путь
+files-command-arg-place = место
+files-command-arg-name = имя
+files-command-arg-view = вид
+files-command-arg-sort = критерий
+files-command-arg-query = текст
+files-command-arg-pattern = шаблон
+
+files-view-list = Список
+files-view-grid = Сетка
+files-view-columns = Колонки
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = Такое имя файлу не подходит
+files-no-pattern = Введите шаблон, например *.png
+files-nothing-matches = Ничто не соответствует «{ $pattern }»
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many =
+    { $count ->
+        [one] Переименовать { $count } элемент
+        [few] Переименовать { $count } элемента
+        [many] Переименовать { $count } элементов
+       *[other] Переименовать { $count } элемента
+    }
+# The dry run's summary line under the palette's rows.
+files-rename-preview = Переименует { $count } из { $total }
+files-rename-preview-unchanged = Ничего не изменится
+files-rename-conflicts = { $count ->
+    [one] { $count } имя уже занято
+    [few] { $count } имени уже заняты
+    [many] { $count } имён уже заняты
+   *[other] { $count } имени уже заняты
+}
+files-rename-invalid = { $count ->
+    [one] { $count } имя окажется пустым
+    [few] { $count } имени окажутся пустыми
+    [many] { $count } имён окажутся пустыми
+   *[other] { $count } имени окажутся пустыми
+}
+files-renamed-count =
+    { $count ->
+        [one] Переименован { $count } элемент
+        [few] Переименовано { $count } элемента
+        [many] Переименовано { $count } элементов
+       *[other] Переименовано { $count } элемента
+    }
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = Выполняется { $title }…
+files-script-failed-quietly = Скрипт завершился с ошибкой без объяснения
+files-script-timed-out = Скрипт выполнялся слишком долго
+files-nothing-selected = Ничего не выбрано
+files-cant-move-into-itself = Папку нельзя переместить в саму себя
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+        [one] Выбран { $count } элемент
+        [few] Выбрано { $count } элемента
+        [many] Выбрано { $count } элементов
+       *[other] Выбрано { $count } элемента
+    }
+files-name-taken = «{ $name }» уже существует
+
+
+## Files — status (continued)
+
+files-undo-new-folder-with-selection = Создание папки с выбранными элементами
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/resources/locales/uk.ftl
+++ b/resources/locales/uk.ftl
@@ -521,6 +521,133 @@ files-month-oct = жовт.
 files-month-nov = лист.
 files-month-dec = груд.
 
+## Files — commands
+
+files-new-folder-with-selection = Нова папка з вибраним
+# $count завжди два або більше; для одного елемента використовується
+# files-new-folder-with-selection.
+files-new-folder-with-count = Нова папка з { $count } елементами
+
+
+## Files — command palette
+
+# Панель, що відкривається через Ctrl+P: кілька літер назви команди — і вона
+# виконується.
+files-palette-placeholder = Виконати команду
+files-palette-no-matches = Немає відповідних команд
+# $count — скільки команд пропонує палітра; оголошується під час відкриття.
+files-palette-opened =
+    { $count ->
+        [one] Палітра команд, { $count } команда
+        [few] Палітра команд, { $count } команди
+        [many] Палітра команд, { $count } команд
+       *[other] Палітра команд, { $count } команди
+    }
+
+files-command-group-go = Перехід
+files-command-group-file = Файл
+files-command-group-edit = Редагування
+files-command-group-view = Вигляд
+
+files-command-back = Назад
+files-command-forward = Вперед
+files-command-up = Вгору
+files-command-go-to-path = Перейти до шляху
+files-command-go-to-place = Перейти до місця
+files-command-undo = Скасувати
+files-command-select-all = Вибрати все
+files-command-select-matching = Вибрати за шаблоном
+files-command-move-to = Перемістити до папки
+files-command-change-view = Змінити вигляд
+files-command-sort-by = Сортувати за
+files-command-show-hidden = Показати приховані файли
+files-command-hide-hidden = Сховати приховані файли
+files-command-quick-look = Швидкий перегляд
+files-command-search = Пошук
+
+# Нередагований префікс, який поле палітри носить, поки вводиться аргумент.
+# Після нього додаються двокрапка і пробіл.
+files-command-go-to-path-prompt = Перейти до шляху
+files-command-go-to-place-prompt = Перейти до місця
+files-command-rename-prompt = Перейменувати на
+files-command-new-folder-prompt = Нова папка з назвою
+files-command-change-view-prompt = Вигляд
+files-command-sort-by-prompt = Сортувати за
+files-command-search-prompt = Шукати
+files-command-select-matching-prompt = Вибрати за шаблоном
+files-command-move-to-prompt = Перемістити до
+files-command-rename-many-prompt = Перейменувати на
+
+# Назва того, що команда просить, одним словом — показується приглушено після
+# її заголовка у списку.
+files-command-arg-path = шлях
+files-command-arg-place = місце
+files-command-arg-name = назва
+files-command-arg-view = вигляд
+files-command-arg-sort = ключ
+files-command-arg-query = текст
+files-command-arg-pattern = шаблон
+
+files-view-list = Список
+files-view-grid = Сітка
+files-view-columns = Стовпці
+# Відмова, коли назва не могла б належати файлу — порожня або з похилою рискою.
+files-name-invalid = Файл не може мати таку назву
+files-no-pattern = Введіть шаблон, наприклад *.png
+files-nothing-matches = Нічого не відповідає «{ $pattern }»
+
+# Перейменування вибраного за одним шаблоном — сам шаблон див. у `rename.rs`.
+files-rename-many =
+    { $count ->
+        [one] Перейменувати { $count } елемент
+        [few] Перейменувати { $count } елементи
+        [many] Перейменувати { $count } елементів
+       *[other] Перейменувати { $count } елемента
+    }
+# Підсумковий рядок пробного запуску під рядками палітри.
+files-rename-preview = Перейменує { $count } з { $total }
+files-rename-preview-unchanged = Нічого не зміниться
+files-rename-conflicts = { $count ->
+    [one] Одна назва вже зайнята
+    [few] { $count } назви вже зайняті
+    [many] { $count } назв вже зайняті
+   *[other] { $count } назви вже зайняті
+}
+files-rename-invalid = { $count ->
+    [one] Одна назва була б порожня
+    [few] { $count } назви були б порожні
+    [many] { $count } назв були б порожні
+   *[other] { $count } назви були б порожні
+}
+files-renamed-count =
+    { $count ->
+        [one] Перейменовано { $count } елемент
+        [few] Перейменовано { $count } елементи
+        [many] Перейменовано { $count } елементів
+       *[other] Перейменовано { $count } елемента
+    }
+
+# Скрипти в ~/.config/otto/files-scripts/; див. components/otto-files/src/scripts.rs.
+files-script-running = Виконується { $title }…
+files-script-failed-quietly = Скрипт завершився без пояснення причини
+files-script-timed-out = Скрипт виконувався надто довго
+files-nothing-selected = Нічого не вибрано
+files-cant-move-into-itself = Папку не можна перемістити в себе саму
+# $count — скільки записів вибрав шаблон.
+files-selected-count =
+    { $count ->
+        [one] Вибрано { $count } елемент
+        [few] Вибрано { $count } елементи
+        [many] Вибрано { $count } елементів
+       *[other] Вибрано { $count } елемента
+    }
+files-name-taken = «{ $name }» тут уже є
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = створення папки з вибраним
+
 
 ## Bar
 ##

--- a/resources/locales/zh-CN.ftl
+++ b/resources/locales/zh-CN.ftl
@@ -498,6 +498,114 @@ files-month-nov = 11月
 files-month-dec = 12月
 
 
+## Files — commands
+
+files-new-folder-with-selection = 用所选项目新建文件夹
+# $count is always two or more; the single-item case uses
+# files-new-folder-with-selection.
+files-new-folder-with-count =
+    { $count ->
+       *[other] 用 { $count } 个项目新建文件夹
+    }
+
+
+## Files — command palette
+
+# The panel opened with Ctrl+P: type a few letters of a command's name to run it.
+files-palette-placeholder = 运行命令
+files-palette-no-matches = 没有匹配的命令
+# $count is how many commands the palette is offering; announced when it opens.
+files-palette-opened =
+    { $count ->
+       *[other] 命令面板，{ $count } 个命令
+    }
+
+files-command-group-go = 前往
+files-command-group-file = 文件
+files-command-group-edit = 编辑
+files-command-group-view = 显示
+
+files-command-back = 后退
+files-command-forward = 前进
+files-command-up = 上一级
+files-command-go-to-path = 前往路径
+files-command-go-to-place = 前往位置
+files-command-undo = 撤销
+files-command-select-all = 全选
+files-command-select-matching = 选择匹配项
+files-command-move-to = 移到文件夹
+files-command-change-view = 更改视图
+files-command-sort-by = 排序方式
+files-command-show-hidden = 显示隐藏文件
+files-command-hide-hidden = 不显示隐藏文件
+files-command-quick-look = 快速查看
+files-command-search = 搜索
+
+# The non-editable prefix the palette's field wears while an argument is being
+# typed. A colon and a space are added after it.
+files-command-go-to-path-prompt = 前往路径
+files-command-go-to-place-prompt = 前往位置
+files-command-rename-prompt = 重命名为
+files-command-new-folder-prompt = 新文件夹名称
+files-command-change-view-prompt = 视图
+files-command-sort-by-prompt = 排序方式
+files-command-search-prompt = 搜索
+files-command-select-matching-prompt = 选择匹配
+files-command-move-to-prompt = 移到
+files-command-rename-many-prompt = 重命名为
+
+# The one-word name of what a command is asking for, shown dimmed after its
+# title in the list.
+files-command-arg-path = 路径
+files-command-arg-place = 位置
+files-command-arg-name = 名称
+files-command-arg-view = 视图
+files-command-arg-sort = 依据
+files-command-arg-query = 文本
+files-command-arg-pattern = 模式
+
+files-view-list = 列表
+files-view-grid = 网格
+files-view-columns = 分栏
+# Refused when a name could not belong to a file — empty, or with a slash in it.
+files-name-invalid = 这不是文件可以使用的名称
+files-no-pattern = 输入一个模式，例如 *.png
+files-nothing-matches = 没有与“{ $pattern }”匹配的项目
+
+# Renaming a selection from one pattern — see `rename.rs` for the pattern.
+files-rename-many = 重命名 { $count } 个项目
+# The dry run's summary line under the palette's rows.
+files-rename-preview = 将重命名 { $total } 个中的 { $count } 个
+files-rename-preview-unchanged = 不会有任何变化
+files-rename-conflicts =
+    { $count ->
+       *[other] { $count } 个名称已被占用
+    }
+files-rename-invalid =
+    { $count ->
+       *[other] { $count } 个名称将为空
+    }
+files-renamed-count = 已重命名 { $count } 个项目
+
+# Scripts in ~/.config/otto/files-scripts/; see components/otto-files/src/scripts.rs.
+files-script-running = 正在运行{ $title }…
+files-script-failed-quietly = 脚本失败，未说明原因
+files-script-timed-out = 脚本耗时过长
+files-nothing-selected = 没有选择任何项目
+files-cant-move-into-itself = 文件夹无法移到其自身中
+# $count is how many entries a pattern selected.
+files-selected-count =
+    { $count ->
+       *[other] 已选择 { $count } 个项目
+    }
+files-name-taken = “{ $name }”已存在
+
+
+## Files — status
+
+files-undo-new-folder-with-selection = 用所选项目新建文件夹
+
+
 ## Bar
 ##
 ## The menu bar across the top of the screen.

--- a/specs/context-menus.md
+++ b/specs/context-menus.md
@@ -32,6 +32,7 @@ Context menus are hierarchical popup menus that display items for user selection
 5. Items are rendered with a rounded-rect highlight when selected. Separators are not selectable.
 6. Disabled items are rendered with reduced opacity and do not respond to user interaction.
 6a. The menu background uses the theme's popup material, which is more opaque than the chrome materials used for bars and sidebars: a menu floats over arbitrary window content and its labels must stay readable against it.
+6b. Under a compositor offering only a standard blur protocol (`ext_background_effect_v1`'s blur capability, e.g. KWin 6.7) rather than Otto's own surface style, a menu is still frosted: because it is an `xdg_popup` — its own surface, not a subsurface of a window — it can set a blur region of its own, shaped to the menu's own rounded rect. Under a compositor offering neither protocol, the popup material is drawn at full opacity in a shade a step off the content ground instead, per otto-kit's window-focus fallback, and stays that way regardless of focus.
 
 ### Keyboard Navigation
 

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -1407,6 +1407,10 @@ With [quickview.md](./quickview.md), recorded so they are not reopened:
   scaled decode it was making anyway, at the standard buckets only.
 - The cache is **small images only**. Full-resolution decoding is each
   consumer's own business; the cache never serves it and never brokers it.
+- The browser's in-memory thumbnail store is bounded **by bytes as well as by
+  count**. The count assumes a grid cell's worth of pixels each; the byte
+  budget is what actually holds when a thumbnail comes back larger than
+  asked, so a screenshots folder cannot fill memory with resident frames.
 - File-type detection lives in **otto-kit**, not otto-files, and splits into
   name-based (display, filters, associations) and content-based (decoder
   dispatch). Content never overrides the name for display.

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -442,7 +442,10 @@ and a superseded search is abandoned through a generation counter rather than
 interrupted — the same contract `Directory` already has. A query is debounced,
 so holding a key down costs one search rather than one per character. Until the
 answer lands the pane says it is working; it never invents rows to fill the
-gap.
+gap. Navigating away before the answer lands — to a place, Home, a typed path,
+by any route — discards it: the results pane and its search die together, the
+window shows the folder it was sent to, and the search or Recent listing is
+left behind Back, not still standing over the folder.
 
 **One source: the desktop's index.** Both scopes, and Recent, are answered by
 **LocalSearch (TinySPARQL)** over D-Bus. There is no second implementation to

--- a/specs/file-browser.md
+++ b/specs/file-browser.md
@@ -221,6 +221,10 @@ the answer to "what am I actually looking at", without a trip to Get Info.
 - **What it spells out** — the one thing selected in the active column. With
   nothing selected, or with several things selected, there is no single path
   to give and it falls back to that column's own directory.
+- **The count** — while anything is selected, the strip's trailing end says
+  how much: "3 of 61 selected". One item counts too, unlike the header, which
+  only speaks up past one — the bar is where the selection is read at a
+  glance. The trail stops short of the caption rather than running under it.
 - **Naming** — every crumb is what the thing is called on disk. The root is
   `/`, wearing the volume icon: naming it in words would mean inventing a
   name — a hostname, "Computer" — where every other crumb is a fact. The home

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -283,6 +283,12 @@ the palette adds no new capability.
   the field, where a space is a space, and what was toggled out stays out.
   The provider never learns of the toggle: it is asked about a smaller
   selection, and the host threads its lines back among the names left out.
+- **The right-click menu offers the providers' commands too.** After the
+  window's own items, the menu asks the same registry the palette does and
+  lists whatever applies to the selection — scripts, the pattern rename — so
+  a script is never palette-only. A command with an argument is shown with
+  an ellipsis and opens the palette in its field, initial value and dry run
+  included; one without runs at once.
 - **Availability is computed against a snapshot, not the live browser.** A
   provider is asked for its commands with a description of the situation —
   where the window is, what is selected, whether it is the Trash, what the

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -49,9 +49,11 @@ a path to go to or a new name to give a file.
 - The card's top band — the line being typed — is the handle: pressing there
   and dragging moves the panel, including when that band hangs off the
   window. It is clamped to the *display*, so it can never be put somewhere it
-  holds the keyboard from out of sight. A fresh open always puts it back where
-  it belongs; a panel that reappeared wherever it was last left would be a
-  placement to undo before the window could be read.
+  holds the keyboard from out of sight. The next open finds the card where it
+  was last dropped — kept for the session, and in
+  `$XDG_STATE_HOME/otto/files.toml` across runs, as an offset from where it
+  opens so that a window moved or resized in between still gets a sensible
+  place — and brought back inside the bounds if the window has shrunk.
 - The palette is unavailable in the file picker, whose window is answering a
   request rather than managing files.
 - Escape closes it, in one step, without running anything. Ctrl+P while it is
@@ -162,6 +164,7 @@ the palette adds no new capability.
 | Edit | Select Matching | glob pattern, shown as it is typed |
 | File | Move to Folder | path (folders only) |
 | File | New Folder with Selection | name, optional; empty means the default |
+| File | Rename N Items / Rename with Pattern | pattern, shown as a dry run while it is typed |
 | View | List View, Grid View, Column View | — (the one already on is not offered) |
 | View | Change View | choice of the three |
 | View | Sort By | choice of sort keys |
@@ -173,6 +176,33 @@ the palette adds no new capability.
   Trash, Undo with an empty stack.
 - A command's title reflects what it would do to the current selection where
   the menus already do so — "Move 3 Items to Trash".
+
+### Renaming a selection from a pattern
+
+- Offered whenever anything is selected, outside the Trash: "Rename 3 Items",
+  or "Rename with Pattern" for one. The argument is the new name with holes in
+  it, filled from each file in turn; it opens as `{name}` so that Return with
+  nothing typed changes nothing.
+- The holes: `{name}` and `{ext}` are the original name and extension; `{n}`
+  is the file's number in the selection from 1, `{n:3}` padded, `{n@10}`
+  started at ten; `{1}`, `{2}`, `{-1}` are the words of the original name
+  split at spaces, underscores, dashes and dots, and `{2..}`, `{1..3}`,
+  `{..-2}` runs of them; `{name:1..4}` picks characters by position the same
+  way. Positions count from one, ranges include both ends, negatives count
+  from the back — one rule throughout. A brace that spells none of these is
+  left as typed, so a half-written hole reads as what it is.
+- A pattern that names no extension — no `{ext}` and no dot in its own text —
+  keeps each file's extension: `Holiday {n}` on `IMG_001.jpg` is
+  `Holiday 1.jpg`.
+- The list under the field is the dry run, one line per file — `IMG_001.jpg →
+  Holiday 1.jpg` — with the summary beneath it: "Renames 3 of 3", or the first
+  thing wrong. A name already taken, by another file in the batch or by
+  something in the folder that is not being renamed, is drawn in red and the
+  summary says so; Return then refuses and nothing moves. A name another file
+  is *giving up* is not taken: `1 → 2, 2 → 3` is fine, because the renames go
+  through temporary names.
+- Running it is one undo entry. The dry run's lines are read, not picked:
+  the arrows do nothing on them and Return runs the command.
 
 ### Where the list scrolls
 
@@ -202,6 +232,22 @@ the palette adds no new capability.
   written down as data — otherwise the later extension system needs the seam
   rebuilt rather than reused. The built-in commands are one provider, with no
   privileges the seam does not give every provider.
+- **The seam carries a dry run out and the outcome back, both as data.** A
+  provider may answer `preview(request, situation)` with lines and a summary
+  for the palette to show as the argument is typed, and `run` answers with an
+  *effect*: a status line, and the moves and creations the host records for
+  undo. The host applies an effect in one place; nothing a provider does
+  reaches the window any other way. Rename is built this way, in-process, as
+  the proof — it is exactly the shape a script takes.
+- **Scripts live in `~/.config/otto/files-scripts/`** (under
+  `$XDG_CONFIG_HOME`). A script is one more provider on the same seam, in
+  another process: it describes its commands once, at startup, with the
+  conditions they need — a selection, certain extensions — so that gathering
+  commands on Ctrl+P still touches no disk; it is asked for a dry run and to
+  run with the situation and the request as data. The first two, to prove the
+  boundary, are zip and unzip. Slow scripts — OCR, conversion — will need to
+  finish later and report progress; the effect is data so that can be added
+  without reshaping it.
 - **Availability is computed against a snapshot, not the live browser.** A
   provider is asked for its commands with a description of the situation —
   where the window is, what is selected, whether it is the Trash, what the

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -134,8 +134,11 @@ a path to go to or a new name to give a file.
   again rather than leaving the last, narrower one standing.
 - Abandoning the palette — Escape, a click outside, losing focus — puts back
   exactly what was there when it opened. Running the command keeps the answer.
-- A partial argument that matches nothing leaves the restored state standing
-  and says nothing: it is half-typed, not wrong.
+- The palette says what the argument is doing as it is typed, in the line
+  where an error would go: "3 of 61 selected" for a pattern, and "Nothing
+  matches" when it picks nothing. That is a note, not an error — a half-typed
+  pattern is not wrong — and the next key clears it along with the question it
+  answered. The restored state stands underneath either way.
 
 ### The first set of commands
 

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -240,14 +240,24 @@ the palette adds no new capability.
   reaches the window any other way. Rename is built this way, in-process, as
   the proof — it is exactly the shape a script takes.
 - **Scripts live in `~/.config/otto/files-scripts/`** (under
-  `$XDG_CONFIG_HOME`). A script is one more provider on the same seam, in
-  another process: it describes its commands once, at startup, with the
-  conditions they need — a selection, certain extensions — so that gathering
-  commands on Ctrl+P still touches no disk; it is asked for a dry run and to
-  run with the situation and the request as data. The first two, to prove the
-  boundary, are zip and unzip. Slow scripts — OCR, conversion — will need to
-  finish later and report progress; the effect is data so that can be added
-  without reshaping it.
+  `$XDG_CONFIG_HOME`; `OTTO_FILES_SCRIPTS` overrides the directory). Every
+  executable there is one more provider on the same seam, in another process
+  (`scripts.rs`, which documents the wire format). At startup, on a thread of
+  its own, each is asked once to `describe` its commands together with the
+  conditions they need — how many targets, which extensions, files or folders
+  — so that Ctrl+P still touches no disk: the host checks the conditions
+  against the situation itself. A command's ids are `scripts:<script>.<id>`.
+  A script is asked to `preview` (a dry run, under a deadline of well under a
+  second, since it runs under the keyboard) and to `run`, each with the
+  request, the targets and the whole situation as JSON on stdin; a run's
+  changes come back as data and are recorded for undo exactly as an
+  in-process provider's are. A run happens on a worker thread and its effect
+  lands through the provider's `poll` on the browser's idle tick, so a slow
+  script never holds the window; the status line says it is running
+  meanwhile. A non-zero exit is a failure, and the last line of stderr is the
+  message shown. The two shipped samples, `components/otto-files/scripts/zip`
+  and `unzip`, are the proof of the boundary and the template for the next
+  ones (conversion, OCR).
 - **Availability is computed against a snapshot, not the live browser.** A
   provider is asked for its commands with a description of the situation —
   where the window is, what is selected, whether it is the Trash, what the

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -39,8 +39,8 @@ a path to go to or a new name to give a file.
 
 ### Opening and closing
 
-- Ctrl+P opens the palette. It opens over the browser window, centred near the
-  top, and takes the keyboard whole while it is up.
+- Ctrl+P opens the palette. It opens over the browser window, just below the
+  header and near its right edge, and takes the keyboard whole while it is up.
 - The palette is unavailable in the file picker, whose window is answering a
   request rather than managing files.
 - Escape closes it, in one step, without running anything. Ctrl+P while it is
@@ -69,7 +69,9 @@ a path to go to or a new name to give a file.
   takes an argument shows its argument label after the title, dimmed, as
   `Go to Path  ›  path`.
 - A query matching nothing shows a single dim line saying so, and Return does
-  nothing.
+  nothing. This is about the *command* list only: an argument with no
+  completions — a name, a pattern, any free text — has none by nature, and says
+  nothing about it.
 
 ### Running a command
 
@@ -108,6 +110,20 @@ a path to go to or a new name to give a file.
   place) opens argument mode with all of them listed and the current one
   highlighted, so it can be answered with one arrow key and Return.
 
+### Showing an argument as it is typed
+
+- A command may declare that its argument can be *shown* while it is being
+  written. Only a command whose effect is something displayed — a selection, a
+  filter — may do so; a command that touches files may not, because there is no
+  half-typed rename.
+- Such an argument is applied after every keystroke, answered afresh from the
+  state the palette opened on. Deleting a character therefore widens the answer
+  again rather than leaving the last, narrower one standing.
+- Abandoning the palette — Escape, a click outside, losing focus — puts back
+  exactly what was there when it opened. Running the command keeps the answer.
+- A partial argument that matches nothing leaves the restored state standing
+  and says nothing: it is half-typed, not wrong.
+
 ### The first set of commands
 
 Every command below is one the window already carries out by some other means;
@@ -125,6 +141,8 @@ the palette adds no new capability.
 | File | Move to Trash | — |
 | File | Put Back, Delete Immediately, Empty Trash | — (Trash only) |
 | Edit | Cut, Copy, Paste, Select All, Undo | — |
+| Edit | Select Matching | glob pattern, shown as it is typed |
+| File | Move to Folder | path (folders only) |
 | View | List View, Grid View, Column View | — (the one already on is not offered) |
 | View | Change View | choice of the three |
 | View | Sort By | choice of sort keys |
@@ -173,6 +191,11 @@ the palette adds no new capability.
   provider that needs to look at the disk offers what it already knows.
   Argument completion may touch the disk, and does so the way the location bar
   already does.
+- **Selecting by pattern matches the listing on screen**, not the directory:
+  hidden files stay out of it unless they are being shown, and a filtered
+  listing narrows what can be picked. Matching ignores case until the pattern
+  itself carries case — `*.png` finds `PHOTO.PNG`, `*.PNG` means only the
+  shouty one — which is the rule the file picker's own filters read by.
 - **The palette is not modal over the compositor**, only over its window: the
   window can still be moved, resized and closed while it is up, and closing the
   window closes the palette with it. It is drawn over a shadow rather than over

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -262,6 +262,15 @@ the palette adds no new capability.
   request) for what it says back. The two shipped samples,
   `components/otto-files/scripts/zip` and `unzip`, are the proof of the
   boundary and the template for the next ones (conversion, OCR).
+- **A dry run's lines can be toggled.** Down from the field moves the
+  highlight into the dry run, Space leaves the highlighted file out of the
+  run or brings it back, and a click on a line does the same; a line left
+  out keeps its name, struck through behind a hollow mark, so it can be
+  brought back. The dry run is made again without it — numbers close up,
+  conflicts clear — and Return runs on what is left in. Typing returns to
+  the field, where a space is a space, and what was toggled out stays out.
+  The provider never learns of the toggle: it is asked about a smaller
+  selection, and the host threads its lines back among the names left out.
 - **Availability is computed against a snapshot, not the live browser.** A
   provider is asked for its commands with a description of the situation —
   where the window is, what is selected, whether it is the Trash, what the

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -255,9 +255,13 @@ the palette adds no new capability.
   lands through the provider's `poll` on the browser's idle tick, so a slow
   script never holds the window; the status line says it is running
   meanwhile. A non-zero exit is a failure, and the last line of stderr is the
-  message shown. The two shipped samples, `components/otto-files/scripts/zip`
-  and `unzip`, are the proof of the boundary and the template for the next
-  ones (conversion, OCR).
+  message shown. Scripts speak the window's language: every text in a
+  description may be given per locale and the host picks (exact tag, then
+  language, then English), keywords in every language match, and the locale
+  is handed to the script on every call (`OTTO_LOCALE`, and `locale` in the
+  request) for what it says back. The two shipped samples,
+  `components/otto-files/scripts/zip` and `unzip`, are the proof of the
+  boundary and the template for the next ones (conversion, OCR).
 - **Availability is computed against a snapshot, not the live browser.** A
   provider is asked for its commands with a description of the situation —
   where the window is, what is selected, whether it is the Trash, what the

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -259,7 +259,11 @@ the palette adds no new capability.
   description may be given per locale and the host picks (exact tag, then
   language, then English), keywords in every language match, and the locale
   is handed to the script on every call (`OTTO_LOCALE`, and `locale` in the
-  request) for what it says back. The two shipped samples,
+  request) for what it says back. A dry-run line may carry only a name, for
+  a command whose outcome is one thing (an archive) rather than one per
+  target; and when a text argument opens on an initial value with an
+  extension, only the stem is selected, so typing replaces the name and
+  keeps the suffix. The two shipped samples,
   `components/otto-files/scripts/zip` and `unzip`, are the proof of the
   boundary and the template for the next ones (conversion, OCR).
 - **A resize is claimed after its buffer, never before.** The style

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -46,13 +46,12 @@ a path to go to or a new name to give a file.
   be dragged clear of the window entirely — off its edge, over the desktop —
   which a card painted into the window's own buffer cannot be, there being no
   pixels out there to draw on.
-- The whole card is a handle: pressing anywhere on it and dragging moves the
-  panel. Nothing on the card is clicked — rows are picked with the keyboard
-  only — so it can be caught wherever it happens to be, including the part of
-  it hanging off the window. It is clamped to the *display*, so it can never
-  be put somewhere it holds the keyboard from out of sight. A fresh open
-  always puts it back where it belongs; a panel that reappeared wherever it
-  was last left would be a placement to undo before the window could be read.
+- The card's top band — the line being typed — is the handle: pressing there
+  and dragging moves the panel, including when that band hangs off the
+  window. It is clamped to the *display*, so it can never be put somewhere it
+  holds the keyboard from out of sight. A fresh open always puts it back where
+  it belongs; a panel that reappeared wherever it was last left would be a
+  placement to undo before the window could be read.
 - The palette is unavailable in the file picker, whose window is answering a
   request rather than managing files.
 - Escape closes it, in one step, without running anything. Ctrl+P while it is
@@ -75,8 +74,11 @@ a path to go to or a new name to give a file.
 - While a query is present the list is flat and ranked, with the group shown as
   a dim badge on each row rather than as a heading.
 - Up and Down move the highlight; the list scrolls to keep it visible. Home and
-  End go to the ends. The pointer does not pick: a press on a row takes hold of
-  the card to drag it (see *Opening and closing*).
+  End go to the ends.
+- The pointer works the list the way it works a column: the row under it takes
+  the highlight as it moves, so Return always does what the pointer is resting
+  on; a click on a row picks it, exactly as Return on it would; a scroll over
+  the card scrolls the list.
 - Each row shows the command's title, its group badge, and — where it has one —
   the keyboard shortcut it is also bound to, right-aligned. A command that
   takes an argument shows its argument label after the title, dimmed, as
@@ -174,11 +176,15 @@ the palette adds no new capability.
 
 ### Where the list scrolls
 
-- At most ten rows are on screen. A longer list scrolls under the highlight, by
-  the least that brings the highlight back into view — so arrowing through it
-  moves one row at a time rather than a page.
-- The card grows downwards as the list grows: the field stays where it is, so
-  what is being typed never moves.
+- At most ten rows' worth of list is on screen; a longer list is a scroll view
+  under the field, the same one the columns run on — a touchpad fling carries
+  momentum, the rows stretch past either end and spring back, a notched wheel
+  steps, and the bar fades in while it moves and out when it stops.
+- The keyboard scrolls it by the least that brings the highlight back into
+  view, so arrowing through a long list moves one row at a time rather than a
+  page.
+- The card grows downwards as the list grows, up to that cap: the field stays
+  where it is, so what is being typed never moves.
 
 ### Accessibility
 

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -164,7 +164,7 @@ the palette adds no new capability.
 | Edit | Select Matching | glob pattern, shown as it is typed |
 | File | Move to Folder | path (folders only) |
 | File | New Folder with Selection | name, optional; empty means the default |
-| File | Rename N Items / Rename with Pattern | pattern, shown as a dry run while it is typed |
+| File | Rename N Items | pattern, shown as a dry run while it is typed; two or more selected |
 | View | List View, Grid View, Column View | — (the one already on is not offered) |
 | View | Change View | choice of the three |
 | View | Sort By | choice of sort keys |
@@ -179,8 +179,9 @@ the palette adds no new capability.
 
 ### Renaming a selection from a pattern
 
-- Offered whenever anything is selected, outside the Trash: "Rename 3 Items",
-  or "Rename with Pattern" for one. The argument is the new name with holes in
+- Offered when two or more items are selected, outside the Trash: "Rename 3
+  Items". One file has the plain Rename, and a pattern beside it would be two
+  renames in the list for one thing. The argument is the new name with holes in
   it, filled from each file in turn; it opens as `{name}` so that Return with
   nothing typed changes nothing.
 - The holes: `{name}` and `{ext}` are the original name and extension; `{n}`

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -1,0 +1,239 @@
+# File Browser Command Palette
+
+**Status:** draft
+**Related specs:** [file-browser.md](./file-browser.md), [launcher.md](./launcher.md), [context-menus.md](./context-menus.md)
+
+## Summary
+
+A keyboard panel inside the file browser, opened with Ctrl+P, that finds any
+command the window can carry out by typing a few letters of its name and runs
+it — including the commands that need something more said about them, such as
+a path to go to or a new name to give a file.
+
+## Goals
+
+- Reach every command the file browser already exposes in its menus, toolbar
+  and shortcuts without knowing where it lives or which chord it is bound to.
+- Rank commands by a typed fragment, tolerant of gaps and of the word order in
+  the command's name.
+- Let a command ask for an argument, and let the argument be typed in the same
+  field, with completion and a visible prompt saying what is being asked for.
+- Show only the commands that can actually run right now, and say why the
+  others are absent by simply not offering them.
+- Be extensible: the set of commands is data, gathered from providers, so a
+  later source of commands (scripts, extensions, another process) is another
+  provider and not another panel.
+
+## Non-Goals
+
+- Searching files. The palette finds *commands*; the launcher and type-ahead
+  find things on disk. A future provider may add file results, but the first
+  version does not.
+- Command history, aliases or user-defined bindings.
+- A remote or scripted provider. The seams for one are required (see
+  Constraints); the provider itself is not built here.
+- Replacing any existing chord, menu or context menu. The palette is an
+  additional way in, never the only one.
+
+## Behavior
+
+### Opening and closing
+
+- Ctrl+P opens the palette. It opens over the browser window, centred near the
+  top, and takes the keyboard whole while it is up.
+- The palette is unavailable in the file picker, whose window is answering a
+  request rather than managing files.
+- Escape closes it, in one step, without running anything. Ctrl+P while it is
+  open closes it too.
+- Clicking outside it closes it. Losing keyboard focus closes it.
+- Closing restores the selection, cursor and scroll position exactly as they
+  were: the palette never changes the browser by being open.
+
+### Searching
+
+- The palette opens with an empty query and a resting list: every currently
+  available command, grouped in a fixed order (Go, File, Edit, View),
+  each group under its name.
+- Typing filters and re-ranks. A query matches a command when its characters
+  appear in order in the command's title, its keywords, or its group name; a
+  match on the title outranks a match on anything else, a match at the start of
+  a word outranks one in the middle, and runs of adjacent characters outrank
+  scattered ones. A space in the query separates words rather than having to be
+  matched, so "mo tr" finds "Move to Trash".
+- While a query is present the list is flat and ranked, with the group shown as
+  a dim badge on each row rather than as a heading.
+- Up and Down move the highlight; the list scrolls to keep it visible. Home and
+  End go to the ends.
+- Each row shows the command's title, its group badge, and — where it has one —
+  the keyboard shortcut it is also bound to, right-aligned. A command that
+  takes an argument shows its argument label after the title, dimmed, as
+  `Go to Path  ›  path`.
+- A query matching nothing shows a single dim line saying so, and Return does
+  nothing.
+
+### Running a command
+
+- Return on the highlighted command runs it, if it takes no argument, and
+  closes the palette. The command's effect is exactly what the same command
+  from the menu or its chord would do, including its undo entry, its sound and
+  its status line.
+- If the highlighted command takes an argument, Return does not run it: it
+  enters argument mode, the same as Tab. A command cannot be run half-said.
+- Tab on the highlighted command always enters argument mode when it takes an
+  argument. On a command that takes none, Tab does nothing.
+
+### Argument mode
+
+- Entering argument mode replaces the query with a prompt: the command's name
+  as a non-editable prefix ending in a colon — `Go to path:` — followed by the
+  caret. What is typed from here is the argument, not a query.
+- The prompt carries the argument's placeholder as dim text when the argument
+  is still empty (`Go to path: ~/Documents`).
+- Backspace on an empty argument leaves argument mode and restores the query
+  that was typed, with the same command still highlighted. The prefix is never
+  edited character by character.
+- Escape in argument mode leaves argument mode the same way; a second Escape
+  closes the palette. Escape never runs anything.
+- Return runs the command with the argument as typed. An argument the command
+  rejects — a path that does not exist, an empty name — leaves the palette open
+  with the reason shown in place of the list, and the text still there to fix.
+- The rows below the prompt become the argument's completions rather than
+  commands: directory entries for a path, the choices for a choice argument,
+  the sidebar's places for a place argument. Up and Down move through them and
+  Return takes the highlighted one.
+- Tab in argument mode completes the argument against the highlighted
+  completion, extending the text to the longest unambiguous prefix when nothing
+  is highlighted — the same completion behaviour the location bar has.
+- An argument with a fixed set of choices (a view mode, a sort key, a sidebar
+  place) opens argument mode with all of them listed and the current one
+  highlighted, so it can be answered with one arrow key and Return.
+
+### The first set of commands
+
+Every command below is one the window already carries out by some other means;
+the palette adds no new capability.
+
+| Group | Command | Argument |
+| --- | --- | --- |
+| Go | Go Back, Go Forward, Go Up, Go Home | — |
+| Go | Go to Path | path (completed against the filesystem) |
+| Go | Go to Place | choice of sidebar places |
+| Go | Open | — (acts on the cursor entry) |
+| File | Get Info | — |
+| File | Rename | new name (pre-filled with the current one, whole) |
+| File | New Folder | name, optional; empty means the default name |
+| File | Move to Trash | — |
+| File | Put Back, Delete Immediately, Empty Trash | — (Trash only) |
+| Edit | Cut, Copy, Paste, Select All, Undo | — |
+| View | List View, Grid View, Column View | — (the one already on is not offered) |
+| View | Change View | choice of the three |
+| View | Sort By | choice of sort keys |
+| View | Show/Hide Hidden Files | — |
+| View | Quick Look | — |
+
+- A command whose preconditions are not met is not offered at all: Paste with
+  an empty clipboard, Move to Trash with nothing selected, Put Back outside the
+  Trash, Undo with an empty stack.
+- A command's title reflects what it would do to the current selection where
+  the menus already do so — "Move 3 Items to Trash".
+
+### Where the list scrolls
+
+- At most ten rows are on screen. A longer list scrolls under the highlight, by
+  the least that brings the highlight back into view — so arrowing through it
+  moves one row at a time rather than a page.
+- The card grows downwards as the list grows: the field stays where it is, so
+  what is being typed never moves.
+
+### Accessibility
+
+- The palette is announced when it opens, with the number of commands offered.
+- The highlighted row is announced as it changes, with its group and shortcut.
+- Entering argument mode announces the prompt; the completion list is announced
+  as a list of the same shape the location bar's is.
+
+## Constraints & Edge Cases
+
+- **The provider seam must survive going out of process.** Commands are
+  gathered from providers and identified by a stable string id; running one is
+  a request carrying that id and the argument as text. Nothing in the seam may
+  be a closure over browser state, a borrow, or a Rust type that cannot be
+  written down as data — otherwise the later extension system needs the seam
+  rebuilt rather than reused. The built-in commands are one provider, with no
+  privileges the seam does not give every provider.
+- **Availability is computed against a snapshot, not the live browser.** A
+  provider is asked for its commands with a description of the situation —
+  where the window is, what is selected, whether it is the Trash, what the
+  clipboard holds, what the undo stack holds — so a provider that does not live
+  in the process can answer the same question.
+- **Quick Look is the window's, not the browser's.** Its panel and its decode
+  belong to the shell around the listing, so that one command is handed back to
+  the host to carry out rather than run where the others are.
+- **Gathering commands must not do I/O.** The palette opens on a keystroke; a
+  provider that needs to look at the disk offers what it already knows.
+  Argument completion may touch the disk, and does so the way the location bar
+  already does.
+- **The palette is not modal over the compositor**, only over its window: the
+  window can still be moved, resized and closed while it is up, and closing the
+  window closes the palette with it. It is drawn over a shadow rather than over
+  a dimmed window, because a dim is how this window says *modal* and the
+  palette is not.
+- **A click outside the card closes the palette and stops there.** It must not
+  also select whatever file was underneath: the click that dismisses something
+  is spent on dismissing it.
+- **A command that opens something modal** — Get Info, Rename, the delete
+  confirmation — closes the palette first, so the two are never stacked.
+- **Rename from the palette** always asks for the name, pre-filled with the one
+  the file has and selected whole, and renames directly rather than opening the
+  in-place field. It takes the same undo entry the in-place rename does — both
+  go through one place, so they cannot drift apart. A name left unchanged is
+  not a rename.
+- **New Folder given a name** creates exactly that folder, and fails if the
+  name is taken — unlike the toolbar's New Folder, which picks a free name
+  itself. Quietly creating "reports 2" would be answering a different question
+  from the one that was asked. Given no name it falls back to the toolbar's
+  behaviour, default name and in-place rename included.
+- **Ctrl+P is free in the browser today.** It must remain unbound in the
+  picker, where the palette does not exist.
+- Localisation: titles, keywords and prompts are catalogue strings. Matching
+  runs against the localised title, and against the catalogue's keywords for
+  that locale.
+
+## Rationale
+
+- **Tab rather than Space to take an argument.** A space is a legal character
+  in the middle of a fuzzy query — "move to trash" is typed with spaces — so
+  space cannot also mean "commit to this command". Tab is already the
+  completion key in the location bar, and means the same thing here: take what
+  is offered and carry on typing.
+- **Return does not run an argument-taking command.** Running "Go to Path" with
+  no path is either an error or a silent no-op, and both are worse than simply
+  landing in the field that was going to be needed anyway. Making Return and
+  Tab agree here means a user who only ever presses Return still gets the right
+  behaviour.
+- **A non-editable prompt prefix rather than an inline `>` syntax.** The prefix
+  is generated from the command, so it can be localised, can say what kind of
+  answer is wanted, and cannot be corrupted by editing. It also keeps the query
+  recoverable: Backspace out of the argument and the search is exactly as it
+  was.
+- **Grouped when resting, flat when searching.** The resting list is a map of
+  what the window can do and is read by eye; a ranked list is read by position
+  and headings only get in its way.
+- **Unavailable commands are hidden, not greyed.** A greyed row is a row the
+  ranking still has to place and the arrow keys still have to skip. The palette
+  is a fast path, not a reference.
+- **Data-shaped providers from the start.** The extension system is not
+  designed yet, but the shape it needs from the palette is knowable now: string
+  ids, a situation snapshot, text arguments. Building the built-in commands
+  through that seam is what keeps the second provider from being a rewrite.
+
+## Open Questions
+
+- Should the palette remember the last command run and pre-highlight it on the
+  next open? Useful for repeats, but it makes the same keystrokes do different
+  things on different days.
+- Should a path argument accept a bare fragment and search for it, rather than
+  requiring a path that resolves? That edges into file search, which is a
+  non-goal here.
+- Where does a future provider's command go in the group order, and can a
+  provider name a group of its own?

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -348,6 +348,16 @@ the palette adds no new capability.
   already covering — which is why the card read as the same colour on the same
   colour, and why a hairline was needed to say where its edge was. The hairline
   stays, over the frost rather than in place of it.
+- **Under a compositor without Otto's surface style, the card is not
+  frosted, even where a standard blur protocol is available.** The card is a
+  subsurface of the palette's own window, and a standard blur protocol blurs
+  what is behind the *window*, not behind one of its subsurfaces — turning it
+  on here would let the window's own listing show sharp through a
+  translucent card. The card instead draws the theme's solid popup material,
+  which is the same opaque colour whether the compositor offers no blur
+  protocol at all or offers the standard one and simply cannot be asked to
+  blur behind a subsurface. Otto's own windows are unaffected: this is the
+  fallback path only.
 - **A click outside the card closes the palette and stops there.** It must not
   also select whatever file was underneath: the click that dismisses something
   is spent on dismissing it.

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -262,6 +262,14 @@ the palette adds no new capability.
   request) for what it says back. The two shipped samples,
   `components/otto-files/scripts/zip` and `unzip`, are the proof of the
   boundary and the template for the next ones (conversion, OCR).
+- **A resize is claimed after its buffer, never before.** The style
+  protocol applies a size the moment the request arrives, so telling the
+  compositor a new size while the old buffer is still attached has it draw
+  the old pixels stretched into the new bounds until the paint lands — the
+  card visibly stretches as the list grows and shrinks under typing. A pane
+  surface therefore holds a resize as a pending claim and sends the size and
+  position right behind the paint that carries the matching buffer, in the
+  same flush; a move alone is claimed at once.
 - **A dry run's lines can be toggled.** Down from the field moves the
   highlight into the dry run, Space leaves the highlighted file out of the
   run or brings it back, and a click on a line does the same; a line left

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -42,11 +42,17 @@ a path to go to or a new name to give a file.
 - Ctrl+P opens the palette. It opens over the browser window, tucked under the
   lower part of the header and near its right edge, and takes the keyboard
   whole while it is up.
-- The card's top band — the line being typed — is a handle: dragging it moves
-  the panel. It is clamped to the window, so it can never be put somewhere it
-  holds the keyboard from out of sight. A fresh open always puts it back where
-  it belongs; a panel that reappeared wherever it was last left would be a
-  placement to undo before the window could be read.
+- The card is a surface of its own, not paint on the window. It may therefore
+  be dragged clear of the window entirely — off its edge, over the desktop —
+  which a card painted into the window's own buffer cannot be, there being no
+  pixels out there to draw on.
+- The whole card is a handle: pressing anywhere on it and dragging moves the
+  panel. Nothing on the card is clicked — rows are picked with the keyboard
+  only — so it can be caught wherever it happens to be, including the part of
+  it hanging off the window. It is clamped to the *display*, so it can never
+  be put somewhere it holds the keyboard from out of sight. A fresh open
+  always puts it back where it belongs; a panel that reappeared wherever it
+  was last left would be a placement to undo before the window could be read.
 - The palette is unavailable in the file picker, whose window is answering a
   request rather than managing files.
 - Escape closes it, in one step, without running anything. Ctrl+P while it is
@@ -69,7 +75,8 @@ a path to go to or a new name to give a file.
 - While a query is present the list is flat and ranked, with the group shown as
   a dim badge on each row rather than as a heading.
 - Up and Down move the highlight; the list scrolls to keep it visible. Home and
-  End go to the ends.
+  End go to the ends. The pointer does not pick: a press on a row takes hold of
+  the card to drag it (see *Opening and closing*).
 - Each row shows the command's title, its group badge, and — where it has one —
   the keyboard shortcut it is also bound to, right-aligned. A command that
   takes an argument shows its argument label after the title, dimmed, as
@@ -215,6 +222,35 @@ the palette adds no new capability.
   window closes the palette with it. It is drawn over a shadow rather than over
   a dimmed window, because a dim is how this window says *modal* and the
   palette is not.
+- **The card is a subsurface, not a popup.** Both escape the window; only one
+  can be dragged. A popup's position belongs to the compositor — it is moved by
+  handing back a new positioner and waiting for the answer, a round trip per
+  motion event, and the compositor's constraint adjustment may put it somewhere
+  other than where it was dropped. A subsurface's position is the client's, so
+  the card lands where it is put. A subsurface also takes no keyboard focus,
+  which is what lets the palette's keys go on arriving at the toplevel exactly
+  as they did when it was painted into the window.
+- **The pointer is taken on a surface that does not move.** Pointer positions
+  arrive relative to the surface under the pointer, so a surface that is being
+  dragged is a moving ruler: each motion event re-applies a correction that is
+  already in flight, and the card runs away from the hand. The card therefore
+  takes no pointer input of its own. An invisible, input-only surface the size
+  of the display sits over it while the palette is up and never moves; every
+  press and every drag is measured against that, and the card follows exactly.
+  A press on it outside the card is the click that dismisses the palette.
+- **How far it may be dragged has to be asked for.** A client is never told
+  where its own window sits, so the display's edges are not knowable from
+  inside; the compositor is asked once per opening, and until it answers the
+  window's own edges stand in — the old limit, wrong only in being too strict.
+  The answer is relative to the window and so means nothing once the window
+  moves, which for the length of one palette session it does not.
+- **The material belongs to the compositor.** On its own surface the card is
+  frosted: the compositor blurs and tints what is actually behind the *window*,
+  and casts the shadow outside the card's bounds. Neither is possible in the
+  window's own buffer, where a blur can only sample the listing the card is
+  already covering — which is why the card read as the same colour on the same
+  colour, and why a hairline was needed to say where its edge was. The hairline
+  stays, over the frost rather than in place of it.
 - **A click outside the card closes the palette and stops there.** It must not
   also select whatever file was underneath: the click that dismisses something
   is spent on dismissing it.
@@ -253,6 +289,11 @@ the palette adds no new capability.
   answer is wanted, and cannot be corrupted by editing. It also keeps the query
   recoverable: Backspace out of the argument and the search is exactly as it
   was.
+- **A surface rather than a clamp.** The card was held inside the window
+  because it was painted there, and the clamp was presented as a courtesy —
+  keeping the panel findable — when it was really the shape of the buffer
+  showing through. Giving the card its own surface removes the reason, and the
+  courtesy survives on its own terms as a clamp to the display.
 - **Grouped when resting, flat when searching.** The resting list is a map of
   what the window can do and is read by eye; a ranked list is read by position
   and headings only get in its way.

--- a/specs/file-command-palette.md
+++ b/specs/file-command-palette.md
@@ -39,8 +39,14 @@ a path to go to or a new name to give a file.
 
 ### Opening and closing
 
-- Ctrl+P opens the palette. It opens over the browser window, just below the
-  header and near its right edge, and takes the keyboard whole while it is up.
+- Ctrl+P opens the palette. It opens over the browser window, tucked under the
+  lower part of the header and near its right edge, and takes the keyboard
+  whole while it is up.
+- The card's top band — the line being typed — is a handle: dragging it moves
+  the panel. It is clamped to the window, so it can never be put somewhere it
+  holds the keyboard from out of sight. A fresh open always puts it back where
+  it belongs; a panel that reappeared wherever it was last left would be a
+  placement to undo before the window could be read.
 - The palette is unavailable in the file picker, whose window is answering a
   request rather than managing files.
 - Escape closes it, in one step, without running anything. Ctrl+P while it is
@@ -143,6 +149,7 @@ the palette adds no new capability.
 | Edit | Cut, Copy, Paste, Select All, Undo | — |
 | Edit | Select Matching | glob pattern, shown as it is typed |
 | File | Move to Folder | path (folders only) |
+| File | New Folder with Selection | name, optional; empty means the default |
 | View | List View, Grid View, Column View | — (the one already on is not offered) |
 | View | Change View | choice of the three |
 | View | Sort By | choice of sort keys |
@@ -191,6 +198,13 @@ the palette adds no new capability.
   provider that needs to look at the disk offers what it already knows.
   Argument completion may touch the disk, and does so the way the location bar
   already does.
+- **Gathering the selection into a new folder is one operation.** The folder
+  and the moves into it take a single undo entry, recorded so that taking it
+  back walks them in the right order: the files come out first, and the folder
+  — empty again — goes last. If nothing could be moved in, the folder is
+  removed rather than left behind as the only trace of a command that failed.
+  It is offered in the context menu as well as the palette; from the menu the
+  folder takes the default name and lands in rename.
 - **Selecting by pattern matches the listing on screen**, not the directory:
   hidden files stay out of it unless they are being shown, and a filtered
   listing narrows what can be picked. Matching ignores case until the pattern

--- a/specs/otto-kit-window-focus.md
+++ b/specs/otto-kit-window-focus.md
@@ -129,6 +129,20 @@ close, and quitting a bar or an island on Cmd+W would be a surprise.
   carry Otto's surface style, the request is silently unavailable — the
   materials must be filled in for the whole run rather than only while the
   window is unfocused.
+- **A standard blur protocol is a second, weaker source of the same effect.**
+  Under a compositor offering `ext_background_effect_v1`'s blur capability
+  (KWin 6.7 verified) instead of Otto's surface style, a kit window still
+  requests and drops a blurred backdrop on focus exactly as it does under
+  Otto: a whole-surface region while focused, none while unfocused, materials
+  filled in whenever there is none. A window picks whichever of the two
+  protocols the compositor actually offers once, at connect time, and never
+  mixes them.
+- **Under neither protocol, the fill-in colour changes rather than the
+  behaviour.** With no blur available at all (GNOME/mutter verified), the
+  materials that would otherwise be translucent over a blur are opaque for
+  the whole run in a shade a step off the content ground, not the plain
+  opaque white the atomicity rule elsewhere assumes — the same rule, applied
+  with a different opaque colour underneath.
 - **Controls stay live while unfocused.** Gray is a colour, not a disabled
   state: a press on a background window's close control still closes it.
 - **A window with no traffic lights is unaffected by that part.** A dialog that

--- a/specs/quickview.md
+++ b/specs/quickview.md
@@ -650,7 +650,11 @@ matching this text.
 - **A 200 MP image** is never decoded at full resolution. The worker decodes at
   the smallest sample size that still exceeds twice the window's pixel size, and
   refuses above a fixed pixel budget when the codec cannot decode scaled, in
-  which case the file gets a metadata card. **Zooming re-decodes** rather than
+  which case the file gets a metadata card. A codec that cannot sample at
+  all — PNG — decodes whole within that budget and is then **resampled to fit
+  the requested size in the worker**, so what crosses the pipe and what the
+  caller keeps is never larger than was asked for: a full-frame screenshot
+  requested as a thumbnail arrives as a thumbnail. **Zooming re-decodes** rather than
   upscaling the fit-sized decode: past roughly 1:1 the worker decodes the
   visible region at a finer sample size, so zooming into a large photograph
   shows detail instead of blur. The previous frame stays on screen while that

--- a/specs/quickview.md
+++ b/specs/quickview.md
@@ -247,6 +247,15 @@ token, background-blurred, with the desktop's corner radius and shadow. It reads
 as the same kind of surface as the bar's menus and the launcher's card, because
 it is.
 
+Under a compositor without Otto's surface style, the panel is not blurred: it
+is a subsurface of the host's own window, and a standard blur protocol only
+ever blurs behind the *window*, never behind one of its subsurfaces, so
+turning it on here would show the host's own file listing sharp through a
+translucent panel. The panel draws the theme's solid popup material instead —
+the same fallback the command palette uses for the same reason — under either
+a compositor with no blur protocol at all or one that offers only the
+standard, window-level one.
+
 Dismissal: space, Escape, the close control, a click outside the panel, or the
 host closing it for any reason of its own. The embedded panel has no focus-loss
 rule of its own — the host's window losing focus is the host's business, and a


### PR DESCRIPTION
## Summary

A command palette for Otto Files, opened with Ctrl+P, that reaches every command the window carries out by typing a few letters, plus a way to add commands with scripts.

- **Palette**: fuzzy ranking of every menu, toolbar and shortcut command; commands that need an argument (a path, a new name, a pattern) take it in the same field with shell-style completion. Only commands that apply to the current selection are offered.
- **Own surface**: the palette is a subsurface with frost, shadow and corners from `otto_surface_style_v1`, draggable clear of the window. Resizes are claimed after the buffer that carries them, so the card never stretches while typing.
- **Dry runs**: batch rename from a pattern, select by pattern, gather into a new folder and move to a folder all show what they would do before they do it. Individual lines can be toggled out of the run (click, or Down + Space) and the preview re-plans for the smaller selection.
- **Scripts as commands**: executables in `~/.config/otto/files-scripts/` describe themselves once at startup and run on a worker thread with a dry-run preview. Texts may be per-locale maps and the window's locale reaches the script. Two samples ship: `zip` and `unzip`.
- **Context menu**: provider commands, scripts included, appear in the right-click menu and open through the palette when they need an argument.
- **Recent and search**: going to Recent from the palette closes an open search; keyboard reveal in Recent scrolls to the right row.
- **Thumbnails**: PNG decodes are fitted to the requested size in the worker and the store is budgeted by bytes, which fixes the memory growth that could exhaust RAM on a folder of screenshots.

Spec: `specs/file-command-palette.md` (new), with updates to `file-browser.md`, `quickview.md` and `context-menus.md`.

## Test plan

- [x] `cargo test -p otto-files --lib`
- [x] Ctrl+P, type, Return; arguments with Tab completion; Escape at each level
- [x] Rename with pattern on several files, toggling lines out of the dry run
- [x] `zip` / `unzip` scripts from the palette and from the context menu, in English and Italian
- [x] Drag the palette off the window; type while results change size
- [x] Browse a folder of large PNG screenshots and watch RSS stay flat

https://claude.ai/code/session_01YFcNuFL5azJUxtoDE6H7ef
